### PR TITLE
fetch when source cluster leader change

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
@@ -224,7 +224,6 @@ public abstract class AbstractFetch implements Closeable {
 
             if (!partitionsWithUpdatedLeaderInfo.isEmpty()) {
                 List<Node> leaderNodes = new ArrayList<>();
-
                 for (FetchResponseData.NodeEndpoint e : response.data().nodeEndpoints()) {
                     Node node = new Node(e.nodeId(), e.host(), e.port(), e.rack());
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -131,6 +131,7 @@ public class FetchRequest extends AbstractRequest {
                 ", maxBytes=" + maxBytes +
                 ", currentLeaderEpoch=" + currentLeaderEpoch +
                 ", lastFetchedEpoch=" + lastFetchedEpoch +
+                ", readOnly=" + readOnly +
                 ')';
         }
     }

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -103,6 +103,13 @@ abstract class AbstractFetcherThread(name: String,
 
   protected def endOffsetForEpoch(topicPartition: TopicPartition, epoch: Int): Optional[OffsetAndEpoch]
 
+  protected def removeFetcherForPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
+    // do nothing
+    Map.empty
+  }
+
+  protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {}
+
   override def shutdown(): Unit = {
     initiateShutdown()
     inLock(partitionMapLock) {
@@ -244,6 +251,78 @@ abstract class AbstractFetcherThread(name: String,
     }
   }
 
+  private def updateLeaderEpochForReadOnly(fetchedEpochs: Map[TopicPartition, PartitionData]): Unit = {
+    val newStates: Map[TopicPartition, PartitionFetchState] = partitionStates.partitionStateMap.asScala
+      .map { case (topicPartition, currentFetchState) =>
+        val updatedInitFetchState = fetchedEpochs.get(topicPartition) match {
+          case Some(partitionData) =>
+//            val delayMs = currentFetchState.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds()))
+            // luke
+            // if we can't get the log from the log, assume it's starting from the beginning
+            val latestEpochInLog = latestEpochFromLog(topicPartition).orElse(0)
+            // (topicId: Option[Uuid], leader: BrokerEndPoint, currentLeaderEpoch: Int, initOffset: Long, readOnly: Boolean = false)
+
+            // leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId())
+            // InitialFetchState(
+            //              log.topicId.toScala,
+            //              new BrokerEndPoint(node.id, node.host, node.port),
+            //              partition.getLeaderEpoch,
+            //              initialFetchOffset(log),
+            //              remoteLeader
+            //InitialFetchState(currentFetchState.topicId().toScala, brokerEndpoint, partitionData.currentLeader().leaderEpoch(), currentFetchState.fetchOffset(), true)
+            new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
+              partitionData.currentLeader().leaderEpoch(), currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog), currentFetchState.delay(), currentFetchState.remoteFetch())
+          case None => currentFetchState
+        }
+        (topicPartition, updatedInitFetchState)
+      }
+    info("!!! updateLeaderEpochForReadOnly:" + newStates)
+    partitionStates.set(newStates.asJava)
+//    removeFetcherForPartitions(fetchedEpochs.keySet)
+//    addFetcherForPartitions(newStates)
+//    removePartitionsWithoutRemovePartitionState(fetchedEpochs.keySet)
+//    addPartitions()
+    // luke
+  }
+
+  private def recreateFetcherForReadOnly(fetchedEpochs: Map[TopicPartition, PartitionData]): Unit = {
+    val newStates: Map[TopicPartition, InitialFetchState] = partitionStates.partitionStateMap.asScala
+      .map { case (topicPartition, currentFetchState) =>
+        val updatedInitFetchState = fetchedEpochs.get(topicPartition) match {
+          case Some(partitionData) =>
+            //            val delayMs = currentFetchState.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds()))
+            // luke
+            // if we can't get the log from the log, assume it's starting from the beginning
+            //            val latestEpochInLog = latestEpochFromLog(topicPartition).orElse(0)
+            // (topicId: Option[Uuid], leader: BrokerEndPoint, currentLeaderEpoch: Int, initOffset: Long, readOnly: Boolean = false)
+            val leaderNode = if (leader.lastSeenEndpoints().isEmpty) Optional.empty() else Optional.of(leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId()))
+            val brokerEndpoint = if (leaderNode.isPresent) {
+              new org.apache.kafka.server.network.BrokerEndPoint(leaderNode.get.id(), leaderNode.get.host, leaderNode.get.port)
+            } else leader.brokerEndPoint()
+
+            // leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId())
+            // InitialFetchState(
+            //              log.topicId.toScala,
+            //              new BrokerEndPoint(node.id, node.host, node.port),
+            //              partition.getLeaderEpoch,
+            //              initialFetchOffset(log),
+            //              remoteLeader
+            InitialFetchState(currentFetchState.topicId().toScala, brokerEndpoint, partitionData.currentLeader().leaderEpoch(), currentFetchState.fetchOffset(), true)
+          //            (currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
+          //              leaderEpoch.leaderEpoch(), currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog), currentFetchState.delay(), currentFetchState.remoteFetch())
+          case None => InitialFetchState(currentFetchState.topicId().toScala, leader.brokerEndPoint(), currentFetchState.currentLeaderEpoch(), currentFetchState.fetchOffset(), true)
+        }
+        (topicPartition, updatedInitFetchState)
+      }
+    info("!!! recreateFetcherForReadOnly:" + newStates)
+    //    partitionStates.set(newStates.asJava)
+    removeFetcherForPartitions(fetchedEpochs.keySet)
+    addFetcherForPartitions(newStates)
+    //    removePartitionsWithoutRemovePartitionState(fetchedEpochs.keySet)
+    //    addPartitions()
+    // luke
+  }
+
   // Visible for testing
   private[server] def truncateToHighWatermark(partitions: Set[TopicPartition]): Unit = inLock(partitionMapLock) {
     val fetchOffsets = mutable.HashMap.empty[TopicPartition, OffsetTruncationState]
@@ -323,12 +402,13 @@ abstract class AbstractFetcherThread(name: String,
                                   fetchRequest: FetchRequest.Builder): Unit = {
     val partitionsWithError = mutable.Set[TopicPartition]()
     val divergingEndOffsets = mutable.Map.empty[TopicPartition, EpochEndOffset]
+    val readOnlyEndOffsets = mutable.Map.empty[TopicPartition, PartitionData]
+    val recreateFetchers = mutable.Map.empty[TopicPartition, PartitionData]
     var responseData: Map[TopicPartition, FetchData] = Map.empty
 
     try {
       info(s"!!! Sending fetch request $fetchRequest")
       responseData = leader.fetch(fetchRequest).asScala
-      info(s"!!! responded fetch request $responseData")
     } catch {
       case t: Throwable =>
         if (isRunning) {
@@ -425,13 +505,21 @@ abstract class AbstractFetcherThread(name: String,
                     partitionsWithError += topicPartition
 
                 case Errors.UNKNOWN_LEADER_EPOCH =>
-                  debug(s"Remote broker has a smaller leader epoch for partition $topicPartition than " +
-                    s"this replica's current leader epoch of ${currentFetchState.currentLeaderEpoch}.")
-                  partitionsWithError += topicPartition
+                  if (!currentFetchState.remoteFetch() && partitionData.currentLeader().leaderEpoch() > -1) {
+                    debug(s"Remote broker has a smaller leader epoch for partition $topicPartition than " +
+                      s"this replica's current leader epoch of ${currentFetchState.currentLeaderEpoch}.")
+                    partitionsWithError += topicPartition
+                  } else {
+                    readOnlyEndOffsets += topicPartition -> partitionData
+                  }
 
                 case Errors.FENCED_LEADER_EPOCH =>
-                  if (onPartitionFenced(topicPartition, fetchPartitionData.currentLeaderEpoch))
-                    partitionsWithError += topicPartition
+                  if (!currentFetchState.remoteFetch()) {
+                    if (onPartitionFenced(topicPartition, fetchPartitionData.currentLeaderEpoch))
+                      partitionsWithError += topicPartition
+                  } else {
+                    readOnlyEndOffsets += topicPartition -> partitionData
+                  }
 
                 case Errors.OFFSET_MOVED_TO_TIERED_STORAGE =>
                   debug(s"Received error ${Errors.OFFSET_MOVED_TO_TIERED_STORAGE}, " +
@@ -440,9 +528,13 @@ abstract class AbstractFetcherThread(name: String,
                     partitionsWithError += topicPartition
 
                 case Errors.NOT_LEADER_OR_FOLLOWER =>
-                  debug(s"Remote broker is not the leader for partition $topicPartition, which could indicate " +
-                    "that the partition is being moved")
-                  partitionsWithError += topicPartition
+                  if (!currentFetchState.remoteFetch()) {
+                    info(s"!!! Remote broker is not the leader for partition $topicPartition, which could indicate " +
+                      "that the partition is being moved")
+                    partitionsWithError += topicPartition
+                  } else {
+                    recreateFetchers += topicPartition -> partitionData
+                  }
 
                 case Errors.UNKNOWN_TOPIC_OR_PARTITION =>
                   warn(s"Received ${Errors.UNKNOWN_TOPIC_OR_PARTITION} from the leader for partition $topicPartition. " +
@@ -474,6 +566,10 @@ abstract class AbstractFetcherThread(name: String,
 
     if (divergingEndOffsets.nonEmpty)
       truncateOnFetchResponse(divergingEndOffsets)
+    if (readOnlyEndOffsets.nonEmpty)
+      updateLeaderEpochForReadOnly(readOnlyEndOffsets)
+    if (recreateFetchers.nonEmpty)
+      recreateFetcherForReadOnly(recreateFetchers)
     if (partitionsWithError.nonEmpty) {
       handlePartitionsWithErrors(partitionsWithError, "processFetchRequest")
     }
@@ -518,11 +614,18 @@ abstract class AbstractFetcherThread(name: String,
     } else if (leader.isTruncationOnFetchSupported) {
       // With old message format, `latestEpoch` will be empty and we use Truncating state
       // to truncate to high watermark.
-      val lastFetchedEpoch = if (initialFetchState.readOnly) latestEpochFromLog(tp) else latestEpoch(tp)
+      val latestEpochInLog = latestEpochFromLog(tp)
+      val lastFetchedEpoch: Optional[Integer] = if (initialFetchState.readOnly) {
+        if (latestEpochInLog.isPresent)
+          latestEpochInLog
+        else Optional.of(0) // this should only happen when no data in local log
+      } else latestEpoch(tp)
       val state = if (lastFetchedEpoch.isPresent) ReplicaState.FETCHING else ReplicaState.TRUNCATING
 
+      // if it's readonly, always assume it's 0 so that we can get the current leader epoch from fetch response
+      val leaderEpoch = if (initialFetchState.readOnly) 0 else initialFetchState.currentLeaderEpoch
       // TODO: the leader epoch should get from metadata request, currently, it's hardcode to 0
-      new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), 0,
+      new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), leaderEpoch,
         state, lastFetchedEpoch, initialFetchState.readOnly, 0)
     } else {
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
@@ -845,6 +948,17 @@ abstract class AbstractFetcherThread(name: String,
       topicPartitions.map { topicPartition =>
         val state = partitionStates.stateValue(topicPartition)
         partitionStates.remove(topicPartition)
+        fetcherLagStats.unregister(topicPartition)
+        topicPartition -> state
+      }.filter(_._2 != null).toMap
+    } finally partitionMapLock.unlock()
+  }
+
+  def removePartitionsWithoutRemovePartitionState(topicPartitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
+    partitionMapLock.lockInterruptibly()
+    try {
+      topicPartitions.map { topicPartition =>
+        val state = partitionStates.stateValue(topicPartition)
         fetcherLagStats.unregister(topicPartition)
         topicPartition -> state
       }.filter(_._2 != null).toMap

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -256,20 +256,8 @@ abstract class AbstractFetcherThread(name: String,
       .map { case (topicPartition, currentFetchState) =>
         val updatedInitFetchState = fetchedEpochs.get(topicPartition) match {
           case Some(partitionData) =>
-//            val delayMs = currentFetchState.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds()))
-            // luke
             // if we can't get the log from the log, assume it's starting from the beginning
             val latestEpochInLog = latestEpochFromLog(topicPartition).orElse(0)
-            // (topicId: Option[Uuid], leader: BrokerEndPoint, currentLeaderEpoch: Int, initOffset: Long, readOnly: Boolean = false)
-
-            // leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId())
-            // InitialFetchState(
-            //              log.topicId.toScala,
-            //              new BrokerEndPoint(node.id, node.host, node.port),
-            //              partition.getLeaderEpoch,
-            //              initialFetchOffset(log),
-            //              remoteLeader
-            //InitialFetchState(currentFetchState.topicId().toScala, brokerEndpoint, partitionData.currentLeader().leaderEpoch(), currentFetchState.fetchOffset(), true)
             new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
               partitionData.currentLeader().leaderEpoch(), currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog), currentFetchState.delay(), currentFetchState.remoteFetch())
           case None => currentFetchState
@@ -278,11 +266,6 @@ abstract class AbstractFetcherThread(name: String,
       }
     info("!!! updateLeaderEpochForReadOnly:" + newStates)
     partitionStates.set(newStates.asJava)
-//    removeFetcherForPartitions(fetchedEpochs.keySet)
-//    addFetcherForPartitions(newStates)
-//    removePartitionsWithoutRemovePartitionState(fetchedEpochs.keySet)
-//    addPartitions()
-    // luke
   }
 
   private def recreateFetcherForReadOnly(fetchedEpochs: Map[TopicPartition, PartitionData]): Unit = {
@@ -290,37 +273,18 @@ abstract class AbstractFetcherThread(name: String,
       .map { case (topicPartition, currentFetchState) =>
         val updatedInitFetchState = fetchedEpochs.get(topicPartition) match {
           case Some(partitionData) =>
-            //            val delayMs = currentFetchState.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds()))
-            // luke
-            // if we can't get the log from the log, assume it's starting from the beginning
-            //            val latestEpochInLog = latestEpochFromLog(topicPartition).orElse(0)
-            // (topicId: Option[Uuid], leader: BrokerEndPoint, currentLeaderEpoch: Int, initOffset: Long, readOnly: Boolean = false)
             val leaderNode = if (leader.lastSeenEndpoints().isEmpty) Optional.empty() else Optional.of(leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId()))
             val brokerEndpoint = if (leaderNode.isPresent) {
               new org.apache.kafka.server.network.BrokerEndPoint(leaderNode.get.id(), leaderNode.get.host, leaderNode.get.port)
             } else leader.brokerEndPoint()
-
-            // leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId())
-            // InitialFetchState(
-            //              log.topicId.toScala,
-            //              new BrokerEndPoint(node.id, node.host, node.port),
-            //              partition.getLeaderEpoch,
-            //              initialFetchOffset(log),
-            //              remoteLeader
             InitialFetchState(currentFetchState.topicId().toScala, brokerEndpoint, partitionData.currentLeader().leaderEpoch(), currentFetchState.fetchOffset(), true)
-          //            (currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
-          //              leaderEpoch.leaderEpoch(), currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog), currentFetchState.delay(), currentFetchState.remoteFetch())
           case None => InitialFetchState(currentFetchState.topicId().toScala, leader.brokerEndPoint(), currentFetchState.currentLeaderEpoch(), currentFetchState.fetchOffset(), true)
         }
         (topicPartition, updatedInitFetchState)
       }
     info("!!! recreateFetcherForReadOnly:" + newStates)
-    //    partitionStates.set(newStates.asJava)
     removeFetcherForPartitions(fetchedEpochs.keySet)
     addFetcherForPartitions(newStates)
-    //    removePartitionsWithoutRemovePartitionState(fetchedEpochs.keySet)
-    //    addPartitions()
-    // luke
   }
 
   // Visible for testing
@@ -529,7 +493,7 @@ abstract class AbstractFetcherThread(name: String,
 
                 case Errors.NOT_LEADER_OR_FOLLOWER =>
                   if (!currentFetchState.remoteFetch()) {
-                    info(s"!!! Remote broker is not the leader for partition $topicPartition, which could indicate " +
+                    info(s"Remote broker is not the leader for partition $topicPartition, which could indicate " +
                       "that the partition is being moved")
                     partitionsWithError += topicPartition
                   } else {
@@ -624,7 +588,6 @@ abstract class AbstractFetcherThread(name: String,
 
       // if it's readonly, always assume it's 0 so that we can get the current leader epoch from fetch response
       val leaderEpoch = if (initialFetchState.readOnly) 0 else initialFetchState.currentLeaderEpoch
-      // TODO: the leader epoch should get from metadata request, currently, it's hardcode to 0
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), leaderEpoch,
         state, lastFetchedEpoch, initialFetchState.readOnly, 0)
     } else {
@@ -948,17 +911,6 @@ abstract class AbstractFetcherThread(name: String,
       topicPartitions.map { topicPartition =>
         val state = partitionStates.stateValue(topicPartition)
         partitionStates.remove(topicPartition)
-        fetcherLagStats.unregister(topicPartition)
-        topicPartition -> state
-      }.filter(_._2 != null).toMap
-    } finally partitionMapLock.unlock()
-  }
-
-  def removePartitionsWithoutRemovePartitionState(topicPartitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
-    partitionMapLock.lockInterruptibly()
-    try {
-      topicPartitions.map { topicPartition =>
-        val state = partitionStates.stateValue(topicPartition)
         fetcherLagStats.unregister(topicPartition)
         topicPartition -> state
       }.filter(_._2 != null).toMap

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -476,6 +476,15 @@ class IncrementalFetchContext(private val time: Time,
         if (session.usesTopicIds)
           part.maybeResolveUnknownName(topicNames)
         fun(new TopicIdPartition(part.topicId, new TopicPartition(part.topic, part.partition)), part.reqData)
+        //new PartitionData(
+        //                        fetchTopic.topicId(),
+        //                        fetchPartition.fetchOffset(),
+        //                        fetchPartition.logStartOffset(),
+        //                        fetchPartition.partitionMaxBytes(),
+        //                        optionalEpoch(fetchPartition.currentLeaderEpoch()),
+        //                        optionalEpoch(fetchPartition.lastFetchedEpoch()),
+        //                        fetchTopic.readOnly()
+        //                    )
       }
     }
   }

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -476,15 +476,6 @@ class IncrementalFetchContext(private val time: Time,
         if (session.usesTopicIds)
           part.maybeResolveUnknownName(topicNames)
         fun(new TopicIdPartition(part.topicId, new TopicPartition(part.topic, part.partition)), part.reqData)
-        //new PartitionData(
-        //                        fetchTopic.topicId(),
-        //                        fetchPartition.fetchOffset(),
-        //                        fetchPartition.logStartOffset(),
-        //                        fetchPartition.partitionMaxBytes(),
-        //                        optionalEpoch(fetchPartition.currentLeaderEpoch()),
-        //                        optionalEpoch(fetchPartition.lastFetchedEpoch()),
-        //                        fetchTopic.readOnly()
-        //                    )
       }
     }
   }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -47,6 +47,7 @@ import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
+import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests._
@@ -640,6 +641,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       else
         Collections.emptyMap[Uuid, String]()
 
+    val containsReadOnlyTopics = fetchRequest.data().topics().stream().anyMatch(t => t.readOnly())
     val fetchData = fetchRequest.fetchData(topicNames)
     val forgottenTopics = fetchRequest.forgottenTopics(topicNames)
 
@@ -664,7 +666,8 @@ class KafkaApis(val requestChannel: RequestChannel,
           else if (!metadataCache.contains(topicIdPartition.topicPartition))
             erroneous += topicIdPartition -> FetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_OR_PARTITION)
           else
-            interesting += topicIdPartition -> data
+            interesting += topicIdPartition -> new PartitionData(data.topicId, data.fetchOffset, data.logStartOffset, data.maxBytes, data.currentLeaderEpoch, data.lastFetchedEpoch,
+              if (fetchData.containsKey(topicIdPartition)) fetchData.get(topicIdPartition).readOnly else false)
         }
         info("!!! interesting:" + interesting.mkString(","))
       } else {
@@ -757,7 +760,9 @@ class KafkaApis(val requestChannel: RequestChannel,
 
       if (fetchRequest.isFromFollower) {
         // We've already evaluated against the quota and are good to go. Just need to record it now.
-        val fetchResponse = fetchContext.updateAndGenerateResponseData(partitions, Seq.empty.asJava)
+        // luke
+        info("!!! nodeEndpoints:" + nodeEndpoints + containsReadOnlyTopics)
+        val fetchResponse = fetchContext.updateAndGenerateResponseData(partitions, if (containsReadOnlyTopics) nodeEndpoints.values.toSeq.asJava else Seq.empty.asJava)
         val responseSize = KafkaApis.sizeOfThrottledPartitions(versionId, fetchResponse, quotas.leader)
         quotas.leader.record(responseSize)
         val responsePartitionsSize = fetchResponse.data().responses().stream().mapToInt(_.partitions().size()).sum()

--- a/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
@@ -87,6 +87,7 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
           .setAbortedTransactions(abortedTransactions)
           .setRecords(data.records)
       }
+
     }
 
     val fetchData = request.fetchData(topicNames.asJava)

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -21,7 +21,7 @@ import java.util.{Collections, Optional}
 import kafka.utils.Logging
 import org.apache.kafka.clients.FetchSessionHandler
 import org.apache.kafka.common.errors.KafkaStorageException
-import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.common.{Node, TopicPartition, Uuid}
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.{OffsetForLeaderTopic, OffsetForLeaderTopicCollection}
@@ -33,6 +33,7 @@ import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.LeaderEndPoint
 import org.apache.kafka.server.{PartitionFetchState, ReplicaFetch, ResultWithPartitions}
 
+import java.util
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
@@ -63,6 +64,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
   private val minBytes = brokerConfig.replicaFetchMinBytes
   private val maxBytes = brokerConfig.replicaFetchResponseMaxBytes
   private val fetchSize = brokerConfig.replicaFetchMaxBytes
+  private val lastSeenEndpointList = new util.HashMap[Integer, Node]()
 
   override def isTruncationOnFetchSupported: Boolean = true
 
@@ -71,6 +73,8 @@ class RemoteLeaderEndPoint(logPrefix: String,
   override def close(): Unit = blockingSender.close()
 
   override def brokerEndPoint(): BrokerEndPoint = blockingSender.brokerEndPoint()
+
+  override def lastSeenEndpoints(): util.HashMap[Integer, Node] = lastSeenEndpointList
 
   override def fetch(fetchRequest: FetchRequest.Builder): java.util.Map[TopicPartition, FetchResponseData.PartitionData] = {
     val clientResponse = try {
@@ -81,6 +85,10 @@ class RemoteLeaderEndPoint(logPrefix: String,
         throw t
     }
     val fetchResponse = clientResponse.responseBody.asInstanceOf[FetchResponse]
+    info("!!! fetchResponse:" + fetchResponse)
+    lastSeenEndpointList.clear()
+    fetchResponse.data().nodeEndpoints().forEach(
+      node => lastSeenEndpointList.put(node.nodeId(), new Node(node.nodeId(), node.host(), node.port(), node.rack())))
     if (!fetchSessionHandler.handleResponse(fetchResponse, clientResponse.requestHeader().apiVersion())) {
       // If we had a session topic ID related error, throw it, otherwise return an empty fetch data map.
       if (fetchResponse.error == Errors.FETCH_SESSION_TOPIC_ID_ERROR) {

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -68,6 +68,14 @@ class ReplicaAlterLogDirsThread(name: String,
     replicaMgr.futureLocalLogOrException(topicPartition).endOffsetForEpoch(epoch)
   }
 
+  override protected def removeFetcherForPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
+    replicaMgr.replicaFetcherManager.removeFetcherForPartitions(partitions)
+  }
+
+  override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]) = {
+    replicaMgr.replicaFetcherManager.addFetcherForPartitions(partitionAndOffsets)
+  }
+
   // process fetched data
   override def processPartitionData(
     topicPartition: TopicPartition,

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -21,10 +21,10 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.FetchResponse
 import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.storage.internals.log.{LogAppendInfo, LogStartOffsetIncrementReason}
-import org.apache.kafka.server.LeaderEndPoint
+import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState}
 
 import java.util.Optional
-import scala.collection.mutable
+import scala.collection.{Map, mutable, Set}
 
 class ReplicaFetcherThread(name: String,
                            leader: LeaderEndPoint,
@@ -65,6 +65,14 @@ class ReplicaFetcherThread(name: String,
 
   override protected def endOffsetForEpoch(topicPartition: TopicPartition, epoch: Int): Optional[OffsetAndEpoch] = {
     replicaMgr.localLogOrException(topicPartition).endOffsetForEpoch(epoch)
+  }
+
+  override protected def removeFetcherForPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
+    replicaMgr.replicaFetcherManager.removeFetcherForPartitions(partitions)
+  }
+
+  override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]) = {
+    replicaMgr.replicaFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
   override def initiateShutdown(): Boolean = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -26,6 +26,7 @@ import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, FailedIsrU
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
+import org.apache.kafka.clients.{ClientUtils}
 import org.apache.kafka.common.{IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.{Plugin, Topic}
@@ -2531,29 +2532,41 @@ class ReplicaManager(val config: KafkaConfig,
       val partitionAndOffsets = new mutable.HashMap[TopicPartition, InitialFetchState]
 
       // luke
-      //if (remoteLeader) {
-//        partitionsToStartFetching.foreachEntry { (topicPartition, partition) =>
-//          val metadata = new Metadata(100, 1000, config.getLong(CommonClientConfigs.METADATA_MAX_AGE_CONFIG), logContext, new ClusterResourceListeners)
-//          val addresses = ClientUtils.parseAndValidateAddresses(config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG), config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG))
-//          metadata.bootstrap(addresses)
-//
-//          val logContext = new LogContext(String.format("[remote follower clientId=%s] ", localBrokerId))
-//          ClientUtils.createNetworkClient(config, this.metrics, "producer", logContext, new ApiVersions, time,
-//            1, metadata, null, null)
-//
-//          metadata.fetchMetadataSnapshot().cluster.leaderFor(topicPartition)
-//          //        partitionsToStartFetching.foreachEntry { (topicPartition, partition) =>
-//  //          val nodeOpt = getRemoteLeaderNode(partition)
-//        }
-     // } else {
 
       // TODO: the remote leader host should get from metadata request, currently, using localhost:9092
       partitionsToStartFetching.foreachEntry { (topicPartition, partition) =>
+
+//        val logContext = new LogContext(String.format("[remote follower clientId=%s] ", localBrokerId))
+////        val metadata = new Metadata(100, 1000, 300000, logContext, new ClusterResourceListeners)
+//        val addresses = ClientUtils.parseAndValidateAddresses(remoteBootstrapServers, "use_all_dns_ips")
+////
+////        metadata.bootstrap(addresses)
+//        val metadataManager: AdminMetadataManager = new AdminMetadataManager(logContext, 100, 1000, false)
+//        metadataManager.update(Cluster.bootstrap(addresses), time.milliseconds)
+//
+//        val networkClient = ClientUtils.createNetworkClient(config, "clientId", metrics, "admin-client", logContext, new ApiVersions, time, 1, TimeUnit.HOURS.toMillis(1).toInt, null, metadataManager.updater, new DefaultHostResolver
+//        , null, null)
+//
+//        val requestBuilder = new MetadataRequest.Builder(
+//          new MetadataRequestData().setTopics(util.Arrays.asList(new MetadataRequestData.MetadataRequestTopic().setName(partition.topic))).setAllowAutoTopicCreation(true))
+//        val clientRequest = networkClient.newClientRequest("3000", requestBuilder,
+//          time.milliseconds(), true)
+//        val response: MetadataResponse = NetworkClientUtils.sendAndReceive(networkClient, clientRequest, time)
+//        val now = time.milliseconds
+//
+//        if (response.topLevelError eq Errors.REBOOTSTRAP_REQUIRED) metadataManager.initiateRebootstrap()
+//        else metadataManager.update(response.buildCluster, now)
+//        metadataManager.fetchMetadataSnapshot().cluster.leaderFor(topicPartition)
+
         val nodeOpt = if (!remoteLeader)
           partition.leaderReplicaIdOpt
             .flatMap(leaderId => Option(newImage.cluster.broker(leaderId)))
             .flatMap(_.node(listenerName).toScala)
-        else Option.apply(new Node(2, "localhost", 9092))
+        else {
+          val remoteBootstrapServers = partition.remoteBootstrapServer.split(",").map(_.trim).toList.asJava
+          val addresses = ClientUtils.parseAndValidateAddresses(remoteBootstrapServers, "use_all_dns_ips")
+          Option.apply(new Node(3000, addresses.get(0).getHostString, addresses.get(0).getPort))
+        }
 
         nodeOpt match {
           case Some(node) =>

--- a/server/src/main/java/org/apache/kafka/server/LeaderEndPoint.java
+++ b/server/src/main/java/org/apache/kafka/server/LeaderEndPoint.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.server;
 
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition;
@@ -25,6 +26,8 @@ import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.server.common.OffsetAndEpoch;
 import org.apache.kafka.server.network.BrokerEndPoint;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -63,6 +66,11 @@ public interface LeaderEndPoint {
      * @return A map of topic partition -> fetch data
      */
     Map<TopicPartition, FetchResponseData.PartitionData> fetch(FetchRequest.Builder fetchRequest);
+
+    default Map<Integer, Node> lastSeenEndpoints() {
+        return Collections.emptyMap();
+    }
+
 
     /**
      * Fetches the epoch and log start offset of the given topic partition from the leader.

--- a/server/src/main/java/org/apache/kafka/server/LeaderEndPoint.java
+++ b/server/src/main/java/org/apache/kafka/server/LeaderEndPoint.java
@@ -27,7 +27,6 @@ import org.apache.kafka.server.common.OffsetAndEpoch;
 import org.apache.kafka.server.network.BrokerEndPoint;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 


### PR DESCRIPTION
Can continue to fetch when the source cluster leader changes.
From the log in the target node, I can see:

```
# create a fetcher to localhost:9092
[2025-08-27 17:45:39,915] INFO !!! create partition with readOnly true and remoteBootstrapServer localhost:9092 (kafka.server.ReplicaManager)
...
[2025-08-27 17:45:39,944] INFO [ReplicaFetcherManager on broker 4] !!! createFetcherThread: sourceBroker = BrokerEndPoint[id=3000, host=localhost, port=9092] fetcherId = 0 (kafka.server.ReplicaFetcherManager)
...
# errorCode 74 is FENCED_LEADER_EPOCH, with the correct currentLeader epoch
[2025-08-27 17:45:39,973] INFO [ReplicaFetcher replicaId=4, leaderId=3000, fetcherId=0] !!! fetchResponse:FetchResponseData(throttleTimeMs=0, errorCode=0, sessionId=174257231, responses=[FetchableTopicResponse(topic='', topicId=EnBUDV11QdOfQ7Lv-mlZow, partitions=[PartitionData(partitionIndex=0, errorCode=74, highWatermark=-1, lastStableOffset=-1, logStartOffset=-1, divergingEpoch=EpochEndOffset(epoch=-1, endOffset=-1), currentLeader=LeaderIdAndEpoch(leaderId=5, leaderEpoch=1), snapshotId=SnapshotId(endOffset=-1, epoch=-1), abortedTransactions=null, preferredReadReplica=-1, records=MemoryRecords(size=0, buffer=java.nio.HeapByteBuffer[pos=0 lim=0 cap=37]))])], nodeEndpoints=[NodeEndpoint(nodeId=5, host='localhost', port=9095, rack=null)]) (kafka.server.RemoteLeaderEndPoint)
...
# next fetch will fail with error code 6 (NOT_LEADER_OR_FOLLOWER) with the leader nodeEndpoints returned
[2025-08-27 17:45:39,980] INFO [ReplicaFetcher replicaId=4, leaderId=3000, fetcherId=0] !!! fetchResponse:FetchResponseData(throttleTimeMs=0, errorCode=0, sessionId=174257231, responses=[FetchableTopicResponse(topic='', topicId=EnBUDV11QdOfQ7Lv-mlZow, partitions=[PartitionData(partitionIndex=0, errorCode=6, highWatermark=-1, lastStableOffset=-1, logStartOffset=-1, divergingEpoch=EpochEndOffset(epoch=-1, endOffset=-1), currentLeader=LeaderIdAndEpoch(leaderId=5, leaderEpoch=1), snapshotId=SnapshotId(endOffset=-1, epoch=-1), abortedTransactions=null, preferredReadReplica=-1, records=MemoryRecords(size=0, buffer=java.nio.HeapByteBuffer[pos=0 lim=0 cap=37]))])], nodeEndpoints=[NodeEndpoint(nodeId=5, host='localhost', port=9095, rack=null)]) (kafka.server.RemoteLeaderEndPoint)

...
# remove the existing fetch thread and create a new one to the new leader (9095)
[2025-08-27 17:45:39,980] INFO [ReplicaFetcherManager on broker 4] Removed fetcher for partitions Set(quickstart-events-0) (kafka.server.ReplicaFetcherManager)
[2025-08-27 17:45:39,980] INFO [ReplicaFetcherManager on broker 4] !!! createFetcherThread: sourceBroker = BrokerEndPoint[id=5, host=localhost, port=9095] fetcherId = 0 (kafka.server.ReplicaFetcherManager)

...
# failed with 74 (FENCED_LEADER_EPOCH)
[2025-08-27 17:45:39,986] INFO [ReplicaFetcher replicaId=4, leaderId=5, fetcherId=0] !!! fetchResponse:FetchResponseData(throttleTimeMs=0, errorCode=0, sessionId=531106233, responses=[FetchableTopicResponse(topic='', topicId=EnBUDV11QdOfQ7Lv-mlZow, partitions=[PartitionData(partitionIndex=0, errorCode=74, highWatermark=-1, lastStableOffset=-1, logStartOffset=-1, divergingEpoch=EpochEndOffset(epoch=-1, endOffset=-1), currentLeader=LeaderIdAndEpoch(leaderId=5, leaderEpoch=1), snapshotId=SnapshotId(endOffset=-1, epoch=-1), abortedTransactions=null, preferredReadReplica=-1, records=MemoryRecords(size=0, buffer=java.nio.HeapByteBuffer[pos=0 lim=0 cap=37]))])], nodeEndpoints=[NodeEndpoint(nodeId=5, host='localhost', port=9095, rack=null)]) (kafka.server.RemoteLeaderEndPoint)

# later, the fetch will succeed with errorCode 0
[2025-08-27 17:45:39,987] INFO [ReplicaFetcher replicaId=4, leaderId=5, fetcherId=0] !!! fetchResponse:FetchResponseData(throttleTimeMs=0, errorCode=0, sessionId=531106233, responses=[FetchableTopicResponse(topic='', topicId=EnBUDV11QdOfQ7Lv-mlZow, partitions=[PartitionData(partitionIndex=0, errorCode=0, highWatermark=3, lastStableOffset=3, logStartOffset=0, divergingEpoch=EpochEndOffset(epoch=-1, endOffset=-1), currentLeader=LeaderIdAndEpoch(leaderId=-1, leaderEpoch=-1), snapshotId=SnapshotId(endOffset=-1, epoch=-1), abortedTransactions=null, preferredReadReplica=-1, records=MemoryRecords(size=92, buffer=java.nio.HeapByteBuffer[pos=0 lim=92 cap=95]))])], nodeEndpoints=[]) (kafka.server.RemoteLeaderEndPoint)

```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
