### PR TITLE
feat: change readonly to false

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -219,6 +219,10 @@ public class TopicConfig {
         "configuration. If message.timestamp.type=CreateTime, the message will be rejected if the difference in " +
         "timestamps exceeds this specified threshold. This configuration is ignored if message.timestamp.type=LogAppendTime.";
 
+    public static final String READ_ONLY_CONFIG = "read.only";
+    public static final String READ_ONLY_DOC = "This configuration is set to true if the it is a disaster recovery " +
+        "topic and should only be get data from a remote leader. Producers cannot append data to this topic.";
+
     /**
      * @deprecated down-conversion is not possible in Apache Kafka 4.0 and newer, hence this configuration is a no-op,
      *             and it is deprecated for removal in Apache Kafka 5.0.

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -26,6 +26,7 @@ import kafka.server._
 import kafka.server.share.DelayedShareFetch
 import kafka.utils.CoreUtils.{inReadLock, inWriteLock}
 import kafka.utils._
+import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.{DirectoryId, IsolationLevel, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState
@@ -122,21 +123,18 @@ object Partition {
   def apply(topicIdPartition: TopicIdPartition,
             time: Time,
             replicaManager: ReplicaManager,
-            readOnly: Boolean,
             remoteBootstrapServer: String): Partition = {
     Partition(
       topicPartition = topicIdPartition.topicPartition,
       topicId = Some(topicIdPartition.topicId),
       time = time,
       replicaManager = replicaManager,
-      readOnly = readOnly,
       remoteBootstrapServer = remoteBootstrapServer)
   }
   def apply(topicPartition: TopicPartition,
             time: Time,
             replicaManager: ReplicaManager,
             topicId: Option[Uuid] = None,
-            readOnly: Boolean = false,
             remoteBootstrapServer: String = ""): Partition = {
 
     val isrChangeListener = new AlterPartitionListener {
@@ -170,7 +168,6 @@ object Partition {
       metadataCache = replicaManager.metadataCache,
       logManager = replicaManager.logManager,
       alterIsrManager = replicaManager.alterPartitionManager,
-      readOnly = readOnly,
       remoteBootstrapServer = remoteBootstrapServer)
   }
 
@@ -325,7 +322,6 @@ class Partition(val topicPartition: TopicPartition,
                 logManager: LogManager,
                 alterIsrManager: AlterPartitionManager,
                 @volatile private var _topicId: Option[Uuid] = None, // TODO: merge topicPartition and _topicId into TopicIdPartition once TopicId persist in most of the code by KAFKA-16212
-                val readOnly: Boolean = false,
                 val remoteBootstrapServer: String = ""
                ) extends Logging with TopicPartitionLog {
 
@@ -1371,14 +1367,13 @@ class Partition(val topicPartition: TopicPartition,
 
   def appendRecordsToLeader(records: MemoryRecords, origin: AppendOrigin, requiredAcks: Int,
                             requestLocal: RequestLocal, verificationGuard: VerificationGuard = VerificationGuard.SENTINEL): LogAppendInfo = {
-    logger.info(s"!!! readOnly: ${readOnly}")
-    if (readOnly) {
-      throw new InvalidTopicException("Cannot append to read-only partition %s on broker %d"
-        .format(topicPartition, localBrokerId))
-    }
     val (info, leaderHWIncremented) = inReadLock(leaderIsrUpdateLock) {
       leaderLogIfLocal match {
         case Some(leaderLog) =>
+          if (leaderLog.config().getBoolean(TopicConfig.READ_ONLY_CONFIG)) {
+            throw new InvalidTopicException("Cannot append to read-only partition %s on broker %d"
+              .format(topicPartition, localBrokerId))
+          }
           val minIsr = effectiveMinIsr(leaderLog)
           val inSyncSize = partitionState.isr.size
 

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -21,6 +21,7 @@ import java.util.{Collections, Properties}
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.utils.Logging
 import org.apache.kafka.server.config.QuotaConfig
+import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.metrics.Quota._
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.server.ClientMetricsManager
@@ -49,6 +50,18 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
   private def updateLogConfig(topic: String,
                               topicConfig: Properties): Unit = {
     val logManager = replicaManager.logManager
+
+    if (!topicConfig.getProperty(TopicConfig.READ_ONLY_CONFIG).toBoolean) {
+      replicaManager.getPartitionByTopic(topic).forEach {
+        case HostedPartition.Online(partition) =>
+          logger.info(s"!!! partition.remoteBootstrapServer: ${partition.remoteBootstrapServer}")
+          if (partition.remoteBootstrapServer.nonEmpty) {
+            replicaManager.replicaFetcherManager.removeFetcherForPartitions(Set(partition.topicPartition))
+            replicaManager.replicaAlterLogDirsManager.removeFetcherForPartitions(Set(partition.topicPartition))
+          }
+        case _ =>
+      }
+    }
 
     val logs = logManager.logsByTopic(topic)
     val wasRemoteLogEnabled = logs.exists(_.remoteLogEnabled())

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -25,6 +25,7 @@ import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
+import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.{IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.{Plugin, Topic}
@@ -489,6 +490,13 @@ class ReplicaManager(val config: KafkaConfig,
 
   def getPartition(topicPartition: TopicPartition): HostedPartition = {
     Option(allPartitions.get(topicPartition)).getOrElse(HostedPartition.None)
+  }
+
+  def getPartitionByTopic(topic: String): util.List[HostedPartition] = {
+    allPartitions.entrySet().stream()
+      .filter(entry => entry.getKey.topic() == topic)
+      .map(entry => entry.getValue)
+      .collect(util.stream.Collectors.toList())
   }
 
   def isAddingReplica(topicPartition: TopicPartition, replicaId: Int): Boolean = {
@@ -2293,6 +2301,7 @@ class ReplicaManager(val config: KafkaConfig,
   private[kafka] def getOrCreatePartition(tp: TopicPartition,
                                           delta: TopicsDelta,
                                           topicId: Uuid): Option[(Partition, Boolean)] = {
+    val localChanges = delta.localChanges(config.nodeId)
     getPartition(tp) match {
       case HostedPartition.Offline(offlinePartition) =>
         if (offlinePartition.flatMap(p => p.topicId).contains(topicId)) {
@@ -2304,10 +2313,13 @@ class ReplicaManager(val config: KafkaConfig,
           stateChangeLogger.info(s"Creating new partition $tp with topic id " + s"$topicId." +
             s"A topic with the same name but different id exists but it resides in an offline log " +
             s"directory.")
-          val readOnly = delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).readOnly
-          val remoteBootstrapServer = delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).remoteBootstrapServers
-          logger.info(s"!!! create partition with readOnly ${readOnly} and remoteBootstrapServer ${remoteBootstrapServer}")
-          val partition = Partition(new TopicIdPartition(topicId, tp), time, this, readOnly, remoteBootstrapServer)
+          val remoteBootstrapServer = if (localChanges.readOnlyLeaders().containsKey(tp)) {
+            delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).remoteBootstrapServers
+          } else {
+            ""
+          }
+          logger.info("!!! create new partition: " + tp + " " + topicId + " " + remoteBootstrapServer)
+          val partition = Partition(new TopicIdPartition(topicId, tp), time, this, remoteBootstrapServer)
           allPartitions.put(tp, HostedPartition.Online(partition))
           Some(partition, true)
         }
@@ -2330,10 +2342,13 @@ class ReplicaManager(val config: KafkaConfig,
             s"$topicId.")
         }
         // it's a partition that we don't know about yet, so create it and mark it online
-        val readOnly = delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).readOnly
-        val remoteBootstrapServer = delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).remoteBootstrapServers
-        logger.info(s"!!! create partition with readOnly ${readOnly} and remoteBootstrapServer ${remoteBootstrapServer}")
-        val partition = Partition(new TopicIdPartition(topicId, tp), time, this, readOnly, remoteBootstrapServer)
+        val remoteBootstrapServer = if (localChanges.readOnlyLeaders().containsKey(tp)) {
+          delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).remoteBootstrapServers
+        } else {
+          ""
+        }
+        logger.info("!!! create new partition: " + tp + " " + topicId + " " + remoteBootstrapServer)
+        val partition = Partition(new TopicIdPartition(topicId, tp), time, this, remoteBootstrapServer)
         allPartitions.put(tp, HostedPartition.Online(partition))
         Some(partition, true)
     }
@@ -2455,6 +2470,12 @@ class ReplicaManager(val config: KafkaConfig,
     localFollowers.foreachEntry { (tp, info) =>
       getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
         try {
+          val readonly: Boolean = newImage.configs().configProperties(new ConfigResource(ConfigResource.Type.TOPIC, tp.topic)).getOrDefault(TopicConfig.READ_ONLY_CONFIG, "false").asInstanceOf[String].toBoolean
+          logger.info("!!! tp = " + tp + ", remoteLeader = " + remoteLeader + ", readonly = " + readonly)
+          if (remoteLeader && !readonly) {
+            // skip remote leader with read.only=false topic
+            return
+          }
           followerTopicSet.add(tp.topic)
 
           // We always update the follower state.
@@ -2464,17 +2485,19 @@ class ReplicaManager(val config: KafkaConfig,
           //   high watermark in the checkpoint file (see KAFKA-1647).
           val state = info.partition.toLeaderAndIsrPartitionState(tp, isNew)
           val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
-          val isNewLeaderEpoch = partition.makeFollower(state, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
+          val isNewLeaderEpoch = !remoteLeader && partition.makeFollower(state, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
           if (isInControlledShutdown && (info.partition.leader == NO_LEADER ||
               !info.partition.isr.contains(config.brokerId))) {
             // During controlled shutdown, replica with no leaders and replica
             // where this broker is not in the ISR are stopped.
             partitionsToStopFetching.put(tp, false)
-          } else if (isNewLeaderEpoch || remoteLeader) {
+          } else if (isNewLeaderEpoch) {
             // Invoke the follower transition listeners for the partition.
             partition.invokeOnBecomingFollowerListeners()
             // Otherwise, fetcher is restarted if the leader epoch has changed.
+            partitionsToStartFetching.put(tp, partition)
+          } else if (remoteLeader) {
             partitionsToStartFetching.put(tp, partition)
           }
 

--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -80,16 +80,7 @@ class AbstractPartitionTest {
 
     alterPartitionManager = TestUtils.createAlterIsrManager()
     alterPartitionListener = createIsrChangeListener()
-    partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager)
+    partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
 
     when(offsetCheckpoints.fetch(ArgumentMatchers.anyString, ArgumentMatchers.eq(topicPartition)))
       .thenReturn(Optional.empty[JLong])

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -271,16 +271,7 @@ class PartitionLockTest extends Logging {
     val alterIsrManager: AlterPartitionManager = mock(classOf[AlterPartitionManager])
 
     logManager.startup(Set.empty)
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => 1L,
-      mockTime,
-      isrChangeListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterIsrManager) {
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => 1L, mockTime, isrChangeListener, delayedOperations, metadataCache, logManager, alterIsrManager) {
 
       override def prepareIsrShrink(
         currentState: CommittedPartitionState,

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -428,17 +428,7 @@ class PartitionTest extends AbstractPartitionTest {
     val mockTime = new MockTime()
     val prevLeaderEpoch = 0
 
-    partition = new Partition(
-      topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager) {
+    partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager) {
 
       override def createLog(isNew: Boolean, isFutureReplica: Boolean, offsetCheckpoints: OffsetCheckpoints, topicId: Option[Uuid], targetLogDirectoryId: Option[Uuid]): UnifiedLog = {
         val log = super.createLog(isNew, isFutureReplica, offsetCheckpoints, None, None)
@@ -1305,16 +1295,7 @@ class PartitionTest extends AbstractPartitionTest {
   @Test
   def testIsUnderMinIsr(): Unit = {
     configRepository.setTopicConfig(topicPartition.topic, TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
-    partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager)
+    partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, topicId = None)
     partition.makeLeader(
       new JPartitionState()
@@ -1391,16 +1372,7 @@ class PartitionTest extends AbstractPartitionTest {
 
   @Test
   def testIsReplicaIsrEligibleWithEmptyReplicaMap(): Unit = {
-    val partition = spy(new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager))
+    val partition = spy(new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager))
 
     when(offsetCheckpoints.fetch(ArgumentMatchers.anyString, ArgumentMatchers.eq(topicPartition)))
       .thenReturn(Optional.empty[JLong])
@@ -1614,18 +1586,7 @@ class PartitionTest extends AbstractPartitionTest {
 
     addBrokerEpochToMockMetadataCache(metadataCache, replicas)
 
-    val partition = new Partition(
-      topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager
-    )
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
 
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
     assertTrue(
@@ -1716,18 +1677,7 @@ class PartitionTest extends AbstractPartitionTest {
       when(metadataCache.isBrokerFenced(remoteBrokerId)).thenReturn(!eligible)
     }
 
-    val partition = new Partition(
-      topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager
-    )
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
 
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
     assertTrue(partition.makeLeader(
@@ -1820,18 +1770,7 @@ class PartitionTest extends AbstractPartitionTest {
     when(metadataCache.isBrokerFenced(remoteBrokerId1)).thenReturn(false)
     when(metadataCache.isBrokerShuttingDown(remoteBrokerId1)).thenReturn(false)
 
-    val partition = new Partition(
-      topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager,
-    )
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
 
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
     assertTrue(partition.makeLeader(
@@ -1908,18 +1847,7 @@ class PartitionTest extends AbstractPartitionTest {
 
     addBrokerEpochToMockMetadataCache(metadataCache, replicas)
 
-    val partition = new Partition(
-      topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager
-    )
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
 
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
     assertTrue(partition.makeLeader(
@@ -1970,18 +1898,7 @@ class PartitionTest extends AbstractPartitionTest {
     val isr = util.List.of[Integer](brokerId)
 
     addBrokerEpochToMockMetadataCache(metadataCache, replicas)
-    val partition = new Partition(
-      topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager
-    )
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
 
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
     assertTrue(partition.makeLeader(
@@ -2121,18 +2038,7 @@ class PartitionTest extends AbstractPartitionTest {
     val metadataCache = mock(classOf[KRaftMetadataCache])
     addBrokerEpochToMockMetadataCache(metadataCache, replicas)
 
-    val partition = new Partition(
-      topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager
-    )
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
 
     assertTrue(partition.makeLeader(
@@ -2200,18 +2106,7 @@ class PartitionTest extends AbstractPartitionTest {
 
     addBrokerEpochToMockMetadataCache(metadataCache, replicas)
 
-    val partition = new Partition(
-      topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager
-    )
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
 
     assertTrue(partition.makeLeader(
@@ -2567,16 +2462,7 @@ class PartitionTest extends AbstractPartitionTest {
       brokerEpochSupplier = () => 0
     )
 
-    partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager)
+    partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
 
     val log = logManager.getOrCreateLog(topicPartition, topicId = topicId.toJava)
     seedLogData(log, numRecords = 10, leaderEpoch = 4)
@@ -2707,16 +2593,7 @@ class PartitionTest extends AbstractPartitionTest {
     checkTopicId(topicId, partition)
 
     // Create new Partition object for same topicPartition
-    val partition2 = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager)
+    val partition2 = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
 
     // partition2 should not yet be associated with the log, but should be able to get ID
     assertTrue(partition2.topicId.isDefined)
@@ -2749,16 +2626,7 @@ class PartitionTest extends AbstractPartitionTest {
     checkTopicId(topicId, partition)
 
     // Create new Partition object for same topicPartition
-    val partition2 = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      logManager,
-      alterPartitionManager)
+    val partition2 = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, logManager, alterPartitionManager)
 
     // partition2 should not yet be associated with the log, but should be able to get ID
     assertTrue(partition2.topicId.isDefined)
@@ -2830,10 +2698,7 @@ class PartitionTest extends AbstractPartitionTest {
   @Test
   def testUpdateAssignmentAndIsr(): Unit = {
     val topicPartition = new TopicPartition("test", 1)
-    val partition = new Partition(
-      topicPartition, 1000, 0, () => defaultBrokerEpoch(0),
-      Time.SYSTEM, mock(classOf[AlterPartitionListener]), mock(classOf[DelayedOperations]),
-      mock(classOf[KRaftMetadataCache]), mock(classOf[LogManager]), mock(classOf[AlterPartitionManager]))
+    val partition = new Partition(topicPartition, 1000, 0, () => defaultBrokerEpoch(0), Time.SYSTEM, mock(classOf[AlterPartitionListener]), mock(classOf[DelayedOperations]), mock(classOf[KRaftMetadataCache]), mock(classOf[LogManager]), mock(classOf[AlterPartitionManager]))
 
     val replicas = Seq(0, 1, 2, 3)
     val followers = Seq(1, 2, 3)
@@ -2904,16 +2769,7 @@ class PartitionTest extends AbstractPartitionTest {
       logDirs = Seq(logDir1, logDir2), defaultConfig = logConfig, configRepository = spyConfigRepository,
       cleanerConfig = new CleanerConfig(false), time = time)
     val spyLogManager = spy(logManager)
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
 
     partition.createLog(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = None, targetLogDirectoryId = None)
 
@@ -2942,16 +2798,7 @@ class PartitionTest extends AbstractPartitionTest {
       logManager.topicConfigUpdated(topicPartition.topic())
     }).when(spyLogManager).initializingLog(ArgumentMatchers.eq(topicPartition))
 
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
 
     partition.createLog(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = None, targetLogDirectoryId = None)
 
@@ -2983,16 +2830,7 @@ class PartitionTest extends AbstractPartitionTest {
       logManager.brokerConfigUpdated()
     }).when(spyLogManager).initializingLog(ArgumentMatchers.eq(topicPartition))
 
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
 
     partition.createLog(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = None, targetLogDirectoryId = None)
 
@@ -3723,16 +3561,7 @@ class PartitionTest extends AbstractPartitionTest {
       logDirs = Seq(logDir1, logDir2), defaultConfig = logConfig, configRepository = spyConfigRepository,
       cleanerConfig = new CleanerConfig(false), time = time)
     val spyLogManager = spy(logManager)
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
     val leaderEpoch = 1
     val replicas = util.List.of[Integer](brokerId, brokerId + 1)
     val isr = replicas
@@ -3766,16 +3595,7 @@ class PartitionTest extends AbstractPartitionTest {
       logDirs = Seq(logDir1, logDir2), defaultConfig = logConfig, configRepository = spyConfigRepository,
       cleanerConfig = new CleanerConfig(false), time = time)
     val spyLogManager = spy(logManager)
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
     val leaderEpoch = 1
     val replicas = util.List.of[Integer](brokerId, brokerId + 1)
     val isr = replicas
@@ -3809,16 +3629,7 @@ class PartitionTest extends AbstractPartitionTest {
       logDirs = Seq(logDir1, logDir2), defaultConfig = logConfig, configRepository = spyConfigRepository,
       cleanerConfig = new CleanerConfig(false), time = time)
     val spyLogManager = spy(logManager)
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
     val leaderEpoch = 1
     val replicas = util.List.of[Integer](brokerId, brokerId + 1)
     val isr = replicas
@@ -3852,16 +3663,7 @@ class PartitionTest extends AbstractPartitionTest {
       logDirs = Seq(logDir1, logDir2), defaultConfig = logConfig, configRepository = spyConfigRepository,
       cleanerConfig = new CleanerConfig(false), time = time)
     val spyLogManager = spy(logManager)
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
     val leaderEpoch = 1
     val replicas = util.List.of[Integer](brokerId, brokerId + 1)
     val isr = replicas
@@ -3895,16 +3697,7 @@ class PartitionTest extends AbstractPartitionTest {
       logDirs = Seq(logDir1, logDir2), defaultConfig = logConfig, configRepository = spyConfigRepository,
       cleanerConfig = new CleanerConfig(false), time = time)
     val spyLogManager = spy(logManager)
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
     val leaderEpoch = 1
     val replicas = util.List.of[Integer](brokerId, brokerId + 1)
     val isr = replicas
@@ -3939,16 +3732,7 @@ class PartitionTest extends AbstractPartitionTest {
       logDirs = Seq(logDir1, logDir2), defaultConfig = logConfig, configRepository = spyConfigRepository,
       cleanerConfig = new CleanerConfig(false), time = time)
     val spyLogManager = spy(logManager)
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
     val leaderEpoch = 1
     val replicas = util.List.of[Integer](brokerId, brokerId + 1)
     val isr = replicas
@@ -3991,16 +3775,7 @@ class PartitionTest extends AbstractPartitionTest {
 
     val delayedOperations = new DelayedOperations(topicId, topicPartition, produce, fetch, deleteRecords, shareFetch)
     val spyLogManager = spy(logManager)
-    val partition = new Partition(topicPartition,
-      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
-      localBrokerId = brokerId,
-      () => defaultBrokerEpoch(brokerId),
-      time,
-      alterPartitionListener,
-      delayedOperations,
-      metadataCache,
-      spyLogManager,
-      alterPartitionManager)
+    val partition = new Partition(topicPartition, replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT, localBrokerId = brokerId, () => defaultBrokerEpoch(brokerId), time, alterPartitionListener, delayedOperations, metadataCache, spyLogManager, alterPartitionManager)
     partition.tryCompleteDelayedRequests()
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -5388,7 +5388,7 @@ class ReplicaManagerTest {
       addPartitionsToTxnManager = Some(addPartitionsToTxnManager))
 
     try {
-      val spiedPartition = spy(Partition(tpId, time, replicaManager, false, ""))
+      val spiedPartition = spy(Partition(tpId, time, replicaManager, ""))
       replicaManager.addOnlinePartition(tp, spiedPartition)
 
       val leaderDelta = topicsCreateDelta(localId, isStartIdLeader = true, partitions = List(0, 1), List.empty, topic, topicIds(topic))

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -122,7 +122,7 @@ public class PartitionMakeFollowerBenchmark {
         AlterPartitionManager alterPartitionManager = Mockito.mock(AlterPartitionManager.class);
         partition = new Partition(tp, 100, 0, () -> -1, Time.SYSTEM,
             alterPartitionListener, delayedOperations,
-            Mockito.mock(MetadataCache.class), logManager, alterPartitionManager, topicId, false, "");
+            Mockito.mock(MetadataCache.class), logManager, alterPartitionManager, topicId, "");
         partition.createLogIfNotExists(true, false, offsetCheckpoints, topicId, Option.empty());
         executorService.submit((Runnable) () -> {
             SimpleRecord[] simpleRecords = new SimpleRecord[] {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -125,7 +125,7 @@ public class UpdateFollowerFetchStateBenchmark {
         partition = new Partition(topicPartition, 100,
                 0, () -> -1, Time.SYSTEM,
                 alterPartitionListener, delayedOperations,
-                Mockito.mock(MetadataCache.class), logManager, alterPartitionManager, topicId, false, "");
+                Mockito.mock(MetadataCache.class), logManager, alterPartitionManager, topicId, "");
         partition.makeLeader(partitionState, offsetCheckpoints, topicId, Option.empty());
         replica1 = partition.getReplica(1).get();
         replica2 = partition.getReplica(2).get();

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -53,7 +53,6 @@ public class PartitionRegistration {
         private LeaderRecoveryState leaderRecoveryState;
         private Integer leaderEpoch;
         private Integer partitionEpoch;
-        private boolean readonly;
         private String remoteBootstrapServers;
 
         public Builder setReplicas(int[] replicas) {
@@ -111,16 +110,8 @@ public class PartitionRegistration {
             return this;
         }
 
-        public Builder setReadOnly(boolean readonly) {
-            this.readonly = readonly;
-            return this;
-        }
-
         public Builder setRemoteBootstrapServers(String remoteBootstrapServers) {
             this.remoteBootstrapServers = remoteBootstrapServers;
-            if (!remoteBootstrapServers.isEmpty()) {
-                this.setReadOnly(true);
-            }
             return this;
         }
 
@@ -163,7 +154,6 @@ public class PartitionRegistration {
                 partitionEpoch,
                 elr,
                 lastKnownElr,
-                readonly,
                 remoteBootstrapServers
             );
         }
@@ -180,7 +170,6 @@ public class PartitionRegistration {
     public final LeaderRecoveryState leaderRecoveryState;
     public final int leaderEpoch;
     public final int partitionEpoch;
-    public final boolean readOnly;
     public final String remoteBootstrapServers;
 
     public static boolean electionWasUnclean(byte leaderRecoveryState) {
@@ -232,13 +221,12 @@ public class PartitionRegistration {
             record.partitionEpoch(),
             Replicas.toArray(record.eligibleLeaderReplicas()),
             Replicas.toArray(record.lastKnownElr()),
-                record.readOnly(),
-                record.remoteBootstrapServer());
+            record.remoteBootstrapServer());
     }
 
     private PartitionRegistration(int[] replicas, Uuid[] directories, int[] isr, int[] removingReplicas,
                                   int[] addingReplicas, int leader, LeaderRecoveryState leaderRecoveryState,
-                                  int leaderEpoch, int partitionEpoch, int[] elr, int[] lastKnownElr, boolean readOnly, String remoteBootstrapServers) {
+                                  int leaderEpoch, int partitionEpoch, int[] elr, int[] lastKnownElr, String remoteBootstrapServers) {
         Objects.requireNonNull(directories);
         if (directories.length > 0 && directories.length != replicas.length) {
             throw new IllegalArgumentException("The lengths for replicas and directories do not match.");
@@ -256,7 +244,6 @@ public class PartitionRegistration {
         // We could parse a lower version record without elr/lastKnownElr.
         this.elr = elr == null ? new int[0] : elr;
         this.lastKnownElr = lastKnownElr == null ? new int[0] : lastKnownElr;
-        this.readOnly = readOnly;
         this.remoteBootstrapServers = remoteBootstrapServers;
     }
 
@@ -299,7 +286,6 @@ public class PartitionRegistration {
             partitionEpoch + 1,
             newElr,
             newLastKnownElr,
-            record.readOnly(),
             record.remoteBootstrapServer().isBlank() ? remoteBootstrapServers : record.remoteBootstrapServer());
     }
 
@@ -411,7 +397,6 @@ public class PartitionRegistration {
             setLeaderRecoveryState(leaderRecoveryState.value()).
             setLeaderEpoch(leaderEpoch).
             setPartitionEpoch(partitionEpoch).
-            setReadOnly(readOnly).
             setRemoteBootstrapServer(remoteBootstrapServers);
         if (options.isEligibleLeaderReplicasEnabled()) {
             // The following are tagged fields, we should only set them when there are some contents, in order to save

--- a/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
@@ -52,8 +52,6 @@
     { "name": "LastKnownElr", "type": "[]int32", "default": "null", "entityType": "brokerId",
       "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 7,
       "about": "null if the LastKnownElr didn't change; the last known eligible leader replicas otherwise." },
-    { "name": "ReadOnly", "type": "bool", "versions": "2+", "default": false,
-      "about": "read only." },
     { "name": "RemoteBootstrapServer", "type": "string", "versions": "2+", "default": "",
       "about": "read only." }
   ]

--- a/metadata/src/main/resources/common/metadata/PartitionRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionRecord.json
@@ -50,8 +50,6 @@
     { "name": "LastKnownElr", "type": "[]int32", "default": "null", "entityType": "brokerId",
       "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 2,
       "about": "The last known eligible leader replicas of this partition." },
-    { "name": "ReadOnly", "type": "bool", "versions": "2+", "default": false,
-      "about": "read only." },
     { "name": "RemoteBootstrapServer", "type": "string", "versions": "2+", "default": "",
       "about": "read only." }
   ]

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -138,6 +138,7 @@ public class LogConfig extends AbstractConfig {
     public static final boolean DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE_CONFIG = false;
     public static final long DEFAULT_LOCAL_RETENTION_BYTES = -2; // It indicates the value to be derived from RetentionBytes
     public static final long DEFAULT_LOCAL_RETENTION_MS = -2; // It indicates the value to be derived from RetentionMs
+    public static final boolean DEFAULT_READ_ONLY = false;
 
     public static final String INTERNAL_SEGMENT_BYTES_CONFIG = "internal.segment.bytes";
     public static final String INTERNAL_SEGMENT_BYTES_DOC = "The maximum size of a single log file. This should be used for testing only.";
@@ -247,6 +248,7 @@ public class LogConfig extends AbstractConfig {
                         TopicConfig.LOCAL_LOG_RETENTION_BYTES_DOC)
                 .define(TopicConfig.REMOTE_LOG_COPY_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_COPY_DISABLE_DOC)
                 .define(TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_DOC)
+                .define(TopicConfig.READ_ONLY_CONFIG, BOOLEAN, DEFAULT_READ_ONLY, MEDIUM, TopicConfig.READ_ONLY_DOC)
                 .defineInternal(INTERNAL_SEGMENT_BYTES_CONFIG, INT, null, null, MEDIUM, INTERNAL_SEGMENT_BYTES_DOC);
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
@@ -132,6 +132,8 @@ public class ProducerAppendInfo {
             }
         } else {
             int currentLastSeq;
+            log.info("!!! updateEntry.isEmpty(): {}, producerEpoch: {}, currentEntry.producerEpoch(): {}",
+                    updatedEntry.isEmpty(), producerEpoch, currentEntry.producerEpoch());
             if (!updatedEntry.isEmpty())
                 currentLastSeq = updatedEntry.lastSeq();
             else if (producerEpoch == currentEntry.producerEpoch())

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -488,6 +488,9 @@ public abstract class TopicCommand {
 
                 Map<String, String> configsMap = topic.configsToAdd.stringPropertyNames().stream()
                     .collect(Collectors.toMap(name -> name, topic.configsToAdd::getProperty));
+                if (topic.opts.hasCreateMirrorOption()) {
+                    configsMap.put(TopicConfig.READ_ONLY_CONFIG, "true");
+                }
 
                 newTopic.configs(configsMap);
                 CreateTopicsResult createResult = adminClient.createTopics(Set.of(newTopic),


### PR DESCRIPTION
## Change

* Remove `readOnly` field from `PartitionRecord`.
* Use `read.only` topic config to determine whether a producer can append log.
* Only remote leader partition class has field `remoteBootstrapServers` data, because we need this data to determine whether to remote fetchers if `read.only` config changes to `false`.
* If a partition is a read only leader, it doesn't run `Partition#makeFollower`, because it changes partition state.

## Demo Command Change

* Create mirror topic: add `--config read.only=true`
```
./bin/kafka-topics.sh --createMirror --topic quickstart-events --bootstrap-server localhost:9094 --remote-bootstrap-server localhost:9092 --topic-id K2Wi9GDhSv6Agees1xgQ4A --config read.only=true
```

* Change topic `read.only` config
```
./bin/kafka-configs.sh --bootstrap-server localhost:9094 --alter --topic quickstart-events --add-config read.only=false
```

## Issue

After changing topic config `read.only` from `true` to `false`, it stops fetchers in the read only leader. However, the producer cannot append log cause of following error:
```
org.apache.kafka.common.errors.OutOfOrderSequenceException: Out of order sequence number for producer 0 at offset 3 in partition quickstart-events-0: 0 (incoming seq. number), 2 (current end sequence number)
```

The error is from https://github.com/apache/kafka/blob/a931f85835c35fae650e02594bc06cb42dc33c90/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java#L134-L148. The `currentLastSeq` is from `currentEntry.lastSeq()`. It looks like there is stale producer state which we need to remove. A workaround is to restart the target broker and producer can append log successfully.



