### PR TITLE
fix: Some fixes for consumer fetch

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -268,22 +268,25 @@ abstract class AbstractFetcherThread(name: String,
     partitionStates.set(newStates.asJava)
   }
 
-  private def recreateFetcherForReadOnly(fetchedEpochs: Map[TopicPartition, PartitionData]): Unit = {
-    val newStates: Map[TopicPartition, InitialFetchState] = partitionStates.partitionStateMap.asScala
-      .map { case (topicPartition, currentFetchState) =>
-        val updatedInitFetchState = fetchedEpochs.get(topicPartition) match {
+  private def maybeRecreateFetcherForReadOnly(fetchedEpochs: Map[TopicPartition, PartitionData]): Unit = {
+    var newStates: Map[TopicPartition, InitialFetchState] = scala.collection.mutable.Map.empty[TopicPartition, InitialFetchState]
+      partitionStates.partitionStateMap.asScala
+      .foreach { case (topicPartition, currentFetchState) =>
+        fetchedEpochs.get(topicPartition) match {
           case Some(partitionData) =>
             val leaderNode = if (leader.lastSeenEndpoints().isEmpty) Optional.empty() else Optional.of(leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId()))
-            val brokerEndpoint = if (leaderNode.isPresent) {
-              new org.apache.kafka.server.network.BrokerEndPoint(leaderNode.get.id(), leaderNode.get.host, leaderNode.get.port)
-            } else leader.brokerEndPoint()
-            InitialFetchState(currentFetchState.topicId().toScala, brokerEndpoint, partitionData.currentLeader().leaderEpoch(), currentFetchState.fetchOffset(), true)
-          case None => InitialFetchState(currentFetchState.topicId().toScala, leader.brokerEndPoint(), currentFetchState.currentLeaderEpoch(), currentFetchState.fetchOffset(), true)
+            // if leader node change, we need to update it.
+            // Note: we can't compare the node id because it might be different from the original node id (ex: replied as consumer id -1)
+            if (leaderNode.isPresent && (!leaderNode.get().host.equals(leader.brokerEndPoint().host()) ||
+              leaderNode.get().port != leader.brokerEndPoint().port)) {
+                val brokerEndpoint = new org.apache.kafka.server.network.BrokerEndPoint(leaderNode.get.id(), leaderNode.get.host, leaderNode.get.port)
+                newStates += topicPartition -> InitialFetchState(currentFetchState.topicId().toScala, brokerEndpoint, partitionData.currentLeader().leaderEpoch(), currentFetchState.fetchOffset(), true)
+            }
+          case _ =>
         }
-        (topicPartition, updatedInitFetchState)
       }
     info("!!! recreateFetcherForReadOnly:" + newStates)
-    removeFetcherForPartitions(fetchedEpochs.keySet)
+    removeFetcherForPartitions(newStates.keySet)
     addFetcherForPartitions(newStates)
   }
 
@@ -482,7 +485,9 @@ abstract class AbstractFetcherThread(name: String,
                     if (onPartitionFenced(topicPartition, fetchPartitionData.currentLeaderEpoch))
                       partitionsWithError += topicPartition
                   } else {
+                    // luke
                     readOnlyEndOffsets += topicPartition -> partitionData
+                    recreateFetchers += topicPartition -> partitionData
                   }
 
                 case Errors.OFFSET_MOVED_TO_TIERED_STORAGE =>
@@ -533,7 +538,7 @@ abstract class AbstractFetcherThread(name: String,
     if (readOnlyEndOffsets.nonEmpty)
       updateLeaderEpochForReadOnly(readOnlyEndOffsets)
     if (recreateFetchers.nonEmpty)
-      recreateFetcherForReadOnly(recreateFetchers)
+      maybeRecreateFetcherForReadOnly(recreateFetchers)
     if (partitionsWithError.nonEmpty) {
       handlePartitionsWithErrors(partitionsWithError, "processFetchRequest")
     }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -51,7 +51,8 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
                               topicConfig: Properties): Unit = {
     val logManager = replicaManager.logManager
 
-    if (!topicConfig.getProperty(TopicConfig.READ_ONLY_CONFIG).toBoolean) {
+    val readOnly = topicConfig.getProperty(TopicConfig.READ_ONLY_CONFIG)
+    if (readOnly != null && !readOnly.toBoolean) {
       replicaManager.getPartitionByTopic(topic).forEach {
         case HostedPartition.Online(partition) =>
           logger.info(s"!!! partition.remoteBootstrapServer: ${partition.remoteBootstrapServer}")

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2364,7 +2364,6 @@ class ReplicaManager(val config: KafkaConfig,
   def applyDelta(delta: TopicsDelta, newImage: MetadataImage): Unit = {
     // Before taking the lock, compute the local changes
     val localChanges = delta.localChanges(config.nodeId)
-    logger.info("!!! localchanges = " + localChanges)
     val metadataVersion = newImage.features().metadataVersionOrThrow()
 
     replicaStateChangeLock.synchronized {


### PR DESCRIPTION
1. saw this error when testing, fixing it:
```
[2025-08-29 10:34:47,706] INFO [DynamicConfigPublisher broker id=4] Updating topic __consumer_offsets with new configuration : compression.type -> producer,cleanup.policy -> compact,segment.bytes -> 104857600 (kafka.server.metadata.DynamicConfigPublisher)
[2025-08-29 10:34:47,706] ERROR Encountered metadata publishing fault: Error updating topic __consumer_offsets with new configuration: compression.type -> producer,cleanup.policy -> compact,segment.bytes -> 104857600 in MetadataDelta up to 2720 (org.apache.kafka.server.fault.LoggingFaultHandler)
java.lang.IllegalArgumentException: For input string: "null"
	at scala.collection.StringOps$.toBooleanImpl$extension(StringOps.scala:961) ~[scala-library-2.13.16.jar:?]
	at scala.collection.StringOps$.toBoolean$extension(StringOps.scala) ~[scala-library-2.13.16.jar:?]
	at kafka.server.TopicConfigHandler.updateLogConfig(ConfigHandler.scala:54) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.TopicConfigHandler.processConfigChanges(ConfigHandler.scala:123) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.metadata.DynamicConfigPublisher.$anonfun$onMetadataUpdate$3(DynamicConfigPublisher.scala:66) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at scala.Option.foreach(Option.scala:437) ~[scala-library-2.13.16.jar:?]
	at kafka.server.metadata.DynamicConfigPublisher.$anonfun$onMetadataUpdate$2(DynamicConfigPublisher.scala:61) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at java.base/java.util.HashMap$KeySet.forEach(HashMap.java:1008) ~[?:?]
	at kafka.server.metadata.DynamicConfigPublisher.$anonfun$onMetadataUpdate$1(DynamicConfigPublisher.scala:57) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.metadata.DynamicConfigPublisher.$anonfun$onMetadataUpdate$1$adapted(DynamicConfigPublisher.scala:56) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at scala.Option.foreach(Option.scala:437) ~[scala-library-2.13.16.jar:?]
	at kafka.server.metadata.DynamicConfigPublisher.onMetadataUpdate(DynamicConfigPublisher.scala:56) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.metadata.BrokerMetadataPublisher.onMetadataUpdate(BrokerMetadataPublisher.scala:218) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.image.loader.MetadataLoader.initializeNewPublishers(MetadataLoader.java:313) ~[kafka-metadata-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.image.loader.MetadataLoader.lambda$scheduleInitializeNewPublishers$0(MetadataLoader.java:270) ~[kafka-metadata-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.queue.KafkaEventQueue$EventContext.run(KafkaEventQueue.java:133) [kafka-server-common-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.queue.KafkaEventQueue$EventHandler.handleEvents(KafkaEventQueue.java:216) [kafka-server-common-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.queue.KafkaEventQueue$EventHandler.run(KafkaEventQueue.java:187) [kafka-server-common-4.2.0-SNAPSHOT.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:842) [?:?]
```

2. When truncation needed, the consumer needs to fetch from the leader, but somehow the error returned from the follower node is `OFFSET_OUT_OF_RANGE` without divergedEpoch info in fetchResponse. So, recreating the fetch thread if leader host/port change when FENCED_LEADER_EPOCH returned.
