### PR TITLE
Delete topics will fail in the mirrored topic in target cluster

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -680,9 +680,28 @@ public abstract class TopicCommand {
         public void deleteTopic(TopicCommandOptions opts) throws ExecutionException, InterruptedException {
             List<String> topics = getTopics(opts.topic(), opts.excludeInternalTopics());
             ensureTopicExists(topics, opts.topic(), !opts.ifExists());
+            ensureTopicIsNotReadOnly(topics);
             adminClient.deleteTopics(List.copyOf(topics),
                 new DeleteTopicsOptions().retryOnQuotaViolation(false)
             ).all().get();
+        }
+
+        private void ensureTopicIsNotReadOnly(List<String> topics) throws ExecutionException, InterruptedException {
+            if (topics.isEmpty()) {
+                return;
+            }
+            Map<ConfigResource, KafkaFuture<Config>> allConfigs = adminClient.describeConfigs(
+                topics.stream()
+                    .map(name -> new ConfigResource(ConfigResource.Type.TOPIC, name))
+                    .collect(Collectors.toList())
+            ).values();
+            for (String topicName : topics) {
+                Config config = allConfigs.get(new ConfigResource(ConfigResource.Type.TOPIC, topicName)).get();
+                if (config.get(TopicConfig.READ_ONLY_CONFIG) != null &&
+                    config.get(TopicConfig.READ_ONLY_CONFIG).value().equals("true")) {
+                    throw new IllegalArgumentException("Topic '" + topicName + "' is a read-only topic and cannot be deleted.");
+                }
+            }
         }
 
         public List<String> getTopics(Optional<String> topicIncludeList, boolean excludeInternalTopics) throws ExecutionException, InterruptedException {


### PR DESCRIPTION
Add a new validator to check whether the topic config read.only is set to true. If it is, we should throw an exception and prevent the topic from being deleted.

local test:
```
./bin/kafka-topics.sh --bootstrap-server localhost:9094 --delete --topic quickstart-events 
Error while executing topic command : Topic 'quickstart-events' is a read-only topic and cannot be deleted.
[2025-09-03 21:43:36,804] ERROR java.lang.IllegalArgumentException: Topic 'quickstart-events' is a read-only topic and cannot be deleted.
	at org.apache.kafka.tools.TopicCommand$TopicService.ensureTopicIsNotReadOnly(TopicCommand.java:702)
	at org.apache.kafka.tools.TopicCommand$TopicService.deleteTopic(TopicCommand.java:683)
	at org.apache.kafka.tools.TopicCommand.execute(TopicCommand.java:116)
	at org.apache.kafka.tools.TopicCommand.mainNoExit(TopicCommand.java:93)
	at org.apache.kafka.tools.TopicCommand.main(TopicCommand.java:88)
 (org.apache.kafka.tools.TopicCommand)

```