### PR TITLE
allow store cluster-link type configs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
@@ -33,6 +33,7 @@ public final class ConfigResource {
      * Type of resource.
      */
     public enum Type {
+        CLUSTER_LINK((byte) 64),
         GROUP((byte) 32),
         CLIENT_METRICS((byte) 16),
         BROKER_LOGGER((byte) 8),

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -136,7 +136,7 @@ public enum ApiKeys {
     ALTER_SHARE_GROUP_OFFSETS(ApiMessageType.ALTER_SHARE_GROUP_OFFSETS),
     DELETE_SHARE_GROUP_OFFSETS(ApiMessageType.DELETE_SHARE_GROUP_OFFSETS),
     GET_REPLICA_LOG_INFO(ApiMessageType.GET_REPLICA_LOG_INFO),
-    CREATE_CLUSTER_LINK(ApiMessageType.CREATE_CLUSTER_LINK);
+    CREATE_CLUSTER_LINK(ApiMessageType.CREATE_CLUSTER_LINK, false, true);
 
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -294,7 +294,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
             case GET_REPLICA_LOG_INFO:
                 return GetReplicaLogInfoResponse.parse(readable, version);
             case CREATE_CLUSTER_LINK:
-                return GetReplicaLogInfoResponse.parse(readable, version);
+                return CreateClusterLinkResponse.parse(readable, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListConfigResourcesRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListConfigResourcesRequest.java
@@ -100,7 +100,8 @@ public class ListConfigResourcesRequest extends AbstractRequest {
                 ConfigResource.Type.BROKER.id(),
                 ConfigResource.Type.BROKER_LOGGER.id(),
                 ConfigResource.Type.CLIENT_METRICS.id(),
-                ConfigResource.Type.GROUP.id()
+                ConfigResource.Type.GROUP.id(),
+                ConfigResource.Type.CLUSTER_LINK.id()
             );
     }
 }

--- a/clients/src/main/resources/common/message/CreateClusterLinkRequest.json
+++ b/clients/src/main/resources/common/message/CreateClusterLinkRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey":94,
   "type": "request",
-  "listeners": ["broker"],
+  "listeners": ["broker", "controller"],
   "name": "CreateClusterLinkRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -75,6 +75,7 @@ object ConfigCommand extends Logging {
   private val UserType = ConfigType.USER.value
   private val ClientType = ConfigType.CLIENT.value
   private val IpType = ConfigType.IP.value
+  private val ClusterLinkType = ConfigType.CLUSTER_LINK.value
 
   def main(args: Array[String]): Unit = {
     try {
@@ -186,6 +187,7 @@ object ConfigCommand extends Logging {
           case ClientMetricsType => ConfigResource.Type.CLIENT_METRICS
           case BrokerType => ConfigResource.Type.BROKER
           case GroupType => ConfigResource.Type.GROUP
+          case ClusterLinkType => ConfigResource.Type.CLUSTER_LINK
           case _ => throw new IllegalArgumentException(s"$entityNameHead is not a valid entity-type.")
         }
         try {
@@ -331,7 +333,7 @@ object ConfigCommand extends Logging {
     val describeAll = opts.options.has(opts.allOpt)
 
     entityTypes.head match {
-      case TopicType | BrokerType | BrokerLoggerConfigType | ClientMetricsType | GroupType =>
+      case TopicType | BrokerType | BrokerLoggerConfigType | ClientMetricsType | GroupType | ClusterLinkType =>
         describeResourceConfig(adminClient, entityTypes.head, entityNames.headOption, describeAll)
       case UserType | ClientType =>
         describeClientQuotaAndUserScramCredentialConfigs(adminClient, entityTypes, entityNames)
@@ -373,6 +375,8 @@ object ConfigCommand extends Logging {
               System.out.println(s"The ${entityType.dropRight(1)} '$name' doesn't exist and doesn't have dynamic config.")
               return
             }
+          case ClusterLinkType =>
+
           case entityType => throw new IllegalArgumentException(s"Invalid entity type: $entityType")
         }
       }
@@ -390,6 +394,9 @@ object ConfigCommand extends Logging {
         case GroupType =>
           adminClient.listGroups().all.get.asScala.map(_.groupId).toSet ++
             adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all().get().asScala.map(_.name).toSet
+
+        case ClusterLinkType =>
+            adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.CLUSTER_LINK), new ListConfigResourcesOptions).all().get().asScala.map(_.name).toSet
         case entityType => throw new IllegalArgumentException(s"Invalid entity type: $entityType")
       })
 
@@ -451,6 +458,8 @@ object ConfigCommand extends Logging {
         (ConfigResource.Type.CLIENT_METRICS, Some(ConfigEntry.ConfigSource.DYNAMIC_CLIENT_METRICS_CONFIG))
       case GroupType =>
         (ConfigResource.Type.GROUP, Some(ConfigEntry.ConfigSource.DYNAMIC_GROUP_CONFIG))
+      case ClusterLinkType =>
+        (ConfigResource.Type.CLUSTER_LINK, Some(ConfigEntry.ConfigSource.DYNAMIC_BROKER_CONFIG))
       case entityType => throw new IllegalArgumentException(s"Invalid entity type: $entityType")
     }
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1038,6 +1038,7 @@ private[kafka] class Processor(
                   channel.principal, listenerName, securityProtocol, channel.channelMetadataRegistry.clientInformation,
                   isPrivilegedListener, channel.principalSerde)
 
+
                 val req = new RequestChannel.Request(processor = id, context = context,
                   startTimeNanos = nowNanos, memoryPool, receive.payload, requestChannel.metrics, None)
 

--- a/core/src/main/scala/kafka/server/ConfigHelper.scala
+++ b/core/src/main/scala/kafka/server/ConfigHelper.scala
@@ -40,6 +40,7 @@ import org.apache.kafka.server.logger.LoggingController
 import org.apache.kafka.server.metrics.ClientMetricsConfigs
 import org.apache.kafka.storage.internals.log.LogConfig
 
+import java.util
 import scala.collection.{Map, mutable}
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
@@ -53,7 +54,7 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
     val describeConfigsRequest = request.body[DescribeConfigsRequest]
     val (authorizedResources, unauthorizedResources) = describeConfigsRequest.data.resources.asScala.partition { resource =>
       ConfigResource.Type.forId(resource.resourceType) match {
-        case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER | ConfigResource.Type.CLIENT_METRICS =>
+        case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER | ConfigResource.Type.CLIENT_METRICS | ConfigResource.Type.CLUSTER_LINK =>
           authHelper.authorize(request.context, DESCRIBE_CONFIGS, CLUSTER, CLUSTER_NAME)
         case ConfigResource.Type.TOPIC =>
           authHelper.authorize(request.context, DESCRIBE_CONFIGS, TOPIC, resource.resourceName)
@@ -65,7 +66,7 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
     val authorizedConfigs = describeConfigs(authorizedResources.toList, describeConfigsRequest.data.includeSynonyms, describeConfigsRequest.data.includeDocumentation)
     val unauthorizedConfigs = unauthorizedResources.map { resource =>
       val error = ConfigResource.Type.forId(resource.resourceType) match {
-        case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER | ConfigResource.Type.CLIENT_METRICS => Errors.CLUSTER_AUTHORIZATION_FAILED
+        case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER | ConfigResource.Type.CLIENT_METRICS | ConfigResource.Type.CLUSTER_LINK => Errors.CLUSTER_AUTHORIZATION_FAILED
         case ConfigResource.Type.TOPIC => Errors.TOPIC_AUTHORIZATION_FAILED
         case ConfigResource.Type.GROUP => Errors.GROUP_AUTHORIZATION_FAILED
         case rt => throw new InvalidRequestException(s"Unexpected resource type $rt for resource ${resource.resourceName}")
@@ -135,6 +136,22 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
               val groupProps = configRepository.groupConfig(group)
               val groupConfig = GroupConfig.fromProps(config.groupCoordinatorConfig.extractGroupConfigMap(config.shareGroupConfig), groupProps)
               createResponseConfig(resource, groupConfig, createGroupConfigEntry(groupConfig, groupProps, includeSynonyms, includeDocumentation)(_, _))
+            }
+
+          case ConfigResource.Type.CLUSTER_LINK =>
+            val cluster = resource.resourceName
+            if (cluster == null || cluster.isEmpty) {
+              throw new InvalidRequestException("Cluster name must not be empty")
+            } else {
+              val clusterConfigProps = configRepository.config(new ConfigResource(ConfigResource.Type.CLUSTER_LINK, resource.resourceName))
+              val configEntries = new util.ArrayList[DescribeConfigsResponseData.DescribeConfigsResourceResult]()
+              clusterConfigProps.entrySet().forEach(entry =>
+                configEntries.add(new DescribeConfigsResponseData.DescribeConfigsResourceResult().setName(entry.getKey.toString).setValue(entry.getValue.toString).setConfigType(DescribeConfigsResponse.ConfigType.STRING.id()).setConfigSource(ConfigSource.DYNAMIC_BROKER_CONFIG.id))
+              )
+              // createBrokerConfigEntry(perBrokerConfig = true, includeSynonyms, includeDocumentation)(_, _))
+              new DescribeConfigsResponseData.DescribeConfigsResult()
+                .setErrorCode(Errors.NONE.code())
+                .setConfigs(configEntries)
             }
 
           case resourceType => throw new InvalidRequestException(s"Unsupported resource type: $resourceType")

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -133,6 +133,7 @@ class ControllerApis(
         case ApiKeys.ADD_RAFT_VOTER => handleAddRaftVoter(request)
         case ApiKeys.REMOVE_RAFT_VOTER => handleRemoveRaftVoter(request)
         case ApiKeys.UPDATE_RAFT_VOTER => handleUpdateRaftVoter(request)
+        case ApiKeys.CREATE_CLUSTER_LINK => handleCreateClusterLink(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -160,6 +161,42 @@ class ControllerApis(
       }
     }
   }
+
+  def handleCreateClusterLink(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    // test
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val createClusterLinkRequest = request.body[CreateClusterLinkRequest]
+    info("!!! create cluster link request: " + createClusterLinkRequest)
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
+    val altersByName = new util.HashMap[String, Entry[AlterConfigOp.OpType, String]]()
+    val configChanges = new util.HashMap[ConfigResource,
+      util.Map[String, Entry[AlterConfigOp.OpType, String]]]()
+    // set resource to cluster_link, and name as cluster_link name
+    val resource = new ConfigResource(ConfigResource.Type.forId(64), createClusterLinkRequest.data().clusterLinkName())
+    createClusterLinkRequest.data().configs.forEach { config =>
+      // TODO: currently assume always SET value
+      altersByName.put(config.name, new util.AbstractMap.SimpleEntry[AlterConfigOp.OpType, String](
+        AlterConfigOp.OpType.forId(0), config.value))
+    }
+    configChanges.put(resource, altersByName)
+
+    controller.createClusterLink(context, configChanges)
+      .handle[Unit] { (response, exception) =>
+        logger.info("!!! create cluster link response: " + response + " exception: " + exception)
+        if (exception != null) {
+          requestHelper.handleError(request, exception)
+        } else {
+
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new CreateClusterLinkResponse(response.setThrottleTimeMs(throttleMs)))
+        }
+      }
+
+    CompletableFuture.completedFuture[Unit](())
+
+  }
+
 
   def handleEnvelopeRequest(request: RequestChannel.Request, requestLocal: RequestLocal): CompletableFuture[Unit] = {
     if (!authHelper.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME)) {

--- a/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
+++ b/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
@@ -20,6 +20,7 @@ package kafka.server
 import java.util
 import java.util.Properties
 import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.config.ConfigResource.Type
 import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, CLIENT_METRICS, GROUP, TOPIC}
 import org.apache.kafka.controller.ConfigurationValidator
 import org.apache.kafka.common.errors.{InvalidConfigurationException, InvalidRequestException}
@@ -140,6 +141,7 @@ class ControllerConfigurationValidator(kafkaConfig: KafkaConfig) extends Configu
             nullGroupConfigs.mkString(","))
         }
         GroupConfigManager.validate(properties, kafkaConfig.groupCoordinatorConfig, kafkaConfig.shareGroupConfig)
+      case Type.CLUSTER_LINK =>
       case _ => throwExceptionForUnknownResourceType(resource)
     }
   }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -272,6 +272,9 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     val createClusterLinkRequest = request.body[CreateClusterLinkRequest]
     info("!!! create cluster link request: " + createClusterLinkRequest)
+    val clusterLinkData = new CreateClusterLinkResponseData()
+    clusterLinkData.setErrorCode(0)
+    requestHelper.sendMaybeThrottle(request, new CreateClusterLinkResponse(clusterLinkData))
   }
 
   def handleGetReplicaLogInfo(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -249,7 +249,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.STREAMS_GROUP_DESCRIBE => handleStreamsGroupDescribe(request).exceptionally(handleError)
         case ApiKeys.STREAMS_GROUP_HEARTBEAT => handleStreamsGroupHeartbeat(request).exceptionally(handleError)
         case ApiKeys.GET_REPLICA_LOG_INFO => handleGetReplicaLogInfo(request)
-        case ApiKeys.CREATE_CLUSTER_LINK => handleCreateClusterLink(request)
+        case ApiKeys.CREATE_CLUSTER_LINK => forwardToController(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -265,16 +265,6 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (request.apiLocalCompleteTimeNanos < 0)
         request.apiLocalCompleteTimeNanos = time.nanoseconds
     }
-  }
-
-  def handleCreateClusterLink(request: RequestChannel.Request): Unit = {
-    // test
-
-    val createClusterLinkRequest = request.body[CreateClusterLinkRequest]
-    info("!!! create cluster link request: " + createClusterLinkRequest)
-    val clusterLinkData = new CreateClusterLinkResponseData()
-    clusterLinkData.setErrorCode(0)
-    requestHelper.sendMaybeThrottle(request, new CreateClusterLinkResponse(clusterLinkData))
   }
 
   def handleGetReplicaLogInfo(request: RequestChannel.Request): Unit = {

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -25,10 +25,13 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.ConfigResource.Type;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.message.CreateClusterLinkRequestData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.metadata.ClearElrRecord;
 import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
+import org.apache.kafka.common.requests.CreateClusterLinkResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.metadata.KafkaConfigSchema;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
@@ -212,6 +215,31 @@ public class ConfigurationControlManager {
         }
         outputRecords.addAll(createClearElrRecordsAsNeeded(outputRecords));
         return ControllerResult.atomicOf(outputRecords, outputResults);
+    }
+
+    // luke
+    ControllerResult<CreateClusterLinkResponseData> addClusterLinkConfigs(
+            Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
+            boolean newlyCreatedResource
+    ) {
+        List<ApiMessageAndVersion> outputRecords =
+                BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+        CreateClusterLinkResponseData data = new CreateClusterLinkResponseData();
+
+        for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> resourceEntry :
+                configChanges.entrySet()) {
+            ApiError apiError = incrementalAlterConfigResource(resourceEntry.getKey(),
+                    resourceEntry.getValue(),
+                    newlyCreatedResource,
+                    outputRecords);
+            // TODO: Should handle the error here
+            log.info("!!! addClusterLinkConfigs apiError: {} for {}", apiError, resourceEntry);
+        }
+        outputRecords.addAll(outputRecords);
+
+        data.setErrorCode((short) 0);
+
+        return ControllerResult.atomicOf(outputRecords, data);
     }
 
     List<ApiMessageAndVersion> createClearElrRecordsAsNeeded(List<ApiMessageAndVersion> input) {

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
 import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
@@ -52,6 +53,7 @@ import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.requests.ApiError;
+import org.apache.kafka.common.requests.CreateClusterLinkRequest;
 import org.apache.kafka.metadata.BrokerHeartbeatReply;
 import org.apache.kafka.metadata.BrokerRegistrationReply;
 import org.apache.kafka.metadata.FinalizedControllerFeatures;
@@ -143,6 +145,11 @@ public interface Controller extends AclMutator, AutoCloseable {
         ControllerRequestContext context,
         CreateTopicsRequestData request,
         Set<String> describable
+    );
+
+    CompletableFuture<CreateClusterLinkResponseData> createClusterLink(
+            ControllerRequestContext context,
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.controller;
 
+import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.clients.admin.FeatureUpdate;
 import org.apache.kafka.common.Uuid;
@@ -41,6 +42,7 @@ import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
 import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
@@ -1762,6 +1764,18 @@ public final class QuorumController implements Controller {
         }
         return appendWriteEvent("createTopics", context.deadlineNs(),
             () -> replicationControl.createTopics(context, request, describable));
+    }
+
+    @Override
+    public CompletableFuture<CreateClusterLinkResponseData> createClusterLink(
+            ControllerRequestContext context,
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
+    ) {
+        return appendWriteEvent("createClusterLink", context.deadlineNs(), () -> {
+            ControllerResult<CreateClusterLinkResponseData> result =
+                    configurationControl.addClusterLinkConfigs(configChanges, false);
+            return result;
+        });
     }
 
     @Override

--- a/server-common/src/main/java/org/apache/kafka/server/config/ConfigType.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ConfigType.java
@@ -26,7 +26,8 @@ public enum ConfigType {
     BROKER("brokers"),
     IP("ips"),
     CLIENT_METRICS("client-metrics"),
-    GROUP("groups");
+    GROUP("groups"),
+    CLUSTER_LINK("cluster-link");
 
     private final String value;
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1270,7 +1270,6 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     public Optional<OffsetAndEpoch> endOffsetForEpoch(int leaderEpoch) {
-        System.out.println("endOffsetForEpoch: " + leaderEpoch + ";;" + latestEpoch());
         Map.Entry<Integer, Long> entry = leaderEpochCache.endOffsetFor(leaderEpoch, logEndOffset());
         int foundEpoch = entry.getKey();
         long foundOffset = entry.getValue();

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
 import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
@@ -93,6 +94,14 @@ public class MockController implements Controller {
     public CompletableFuture<List<AclCreateResult>> createAcls(
         ControllerRequestContext context,
         List<AclBinding> aclBindings
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<CreateClusterLinkResponseData> createClusterLink(
+            ControllerRequestContext context,
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
     ) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
1.  create cluster link configs to store in broker
```
> cat /tmp/test.properties 
security.protocol=SASL_PLAINTEXT
sasl.mechanism=PLAIN
sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
    username="admin" \
    password="secret";
```


2. create cluster link using CLI. After this step, the configs will be stored in metadata log with configType: Cluster_Link, and name as `testLink` (the `--topic` is required, but for PoC, let's keep it).
```
> bin/kafka-topics.sh --createLink --link testLink --bootstrap-server localhost:9092 --topic xx --cluster-link-config /tmp/test.properties  
```
3. dump the metadata log, the configRecord contains what we stored with type 64 (CLUSTER_LINK), name: testLink
```
> ./bin/kafka-dump-log.sh --files /tmp/kraft-controller-logs/__cluster_metadata-0/00000000000000000000.log  --cluster-metadata-decoder 
...
offset: 592 CreateTime: 1757647473437 keySize: -1 valueSize: 47 sequence: -1 headerKeys: [] payload: {"type":"CONFIG_RECORD","version":0,"data":{"resourceType":64,"resourceName":"testLink","name":"security.protocol","value":"SASL_PLAINTEXT"}}
| offset: 593 CreateTime: 1757647473437 keySize: -1 valueSize: 35 sequence: -1 headerKeys: [] payload: {"type":"CONFIG_RECORD","version":0,"data":{"resourceType":64,"resourceName":"testLink","name":"sasl.mechanism","value":"PLAIN"}}
| offset: 594 CreateTime: 1757647473437 keySize: -1 valueSize: 132 sequence: -1 headerKeys: [] payload: {"type":"CONFIG_RECORD","version":0,"data":{"resourceType":64,"resourceName":"testLink","name":"sasl.jaas.config","value":"org.apache.kafka.common.security.plain.PlainLoginModule required username=\"admin\" password=\"secret\";"}}

```

4. Describe the config for cluster-link testLink:
```
> ./bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type cluster-link --entity-name testLink
Dynamic configs for cluster-lin testLink are:
  sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="secret"; sensitive=false synonyms={}
  sasl.mechanism=PLAIN sensitive=false synonyms={}
  security.protocol=SASL_PLAINTEXT sensitive=false synonyms={}
```



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
