### PR TITLE
Create cluster link internal topic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/internals/Topic.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/Topic.java
@@ -28,13 +28,19 @@ public class Topic {
     public static final String TRANSACTION_STATE_TOPIC_NAME = "__transaction_state";
     public static final String SHARE_GROUP_STATE_TOPIC_NAME = "__share_group_state";
     public static final String CLUSTER_METADATA_TOPIC_NAME = "__cluster_metadata";
+    public static final String CLUSTER_LINK_TOPIC_NAME = "__cluster_link";
     public static final TopicPartition CLUSTER_METADATA_TOPIC_PARTITION = new TopicPartition(
         CLUSTER_METADATA_TOPIC_NAME,
         0
     );
     public static final String LEGAL_CHARS = "[a-zA-Z0-9._-]";
 
-    private static final Set<String> INTERNAL_TOPICS = Set.of(GROUP_METADATA_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME, SHARE_GROUP_STATE_TOPIC_NAME);
+    private static final Set<String> INTERNAL_TOPICS = Set.of(
+        GROUP_METADATA_TOPIC_NAME,
+        TRANSACTION_STATE_TOPIC_NAME,
+        SHARE_GROUP_STATE_TOPIC_NAME,
+        CLUSTER_LINK_TOPIC_NAME
+    );
 
     private static final int MAX_NAME_LENGTH = 249;
 

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -22,9 +22,10 @@ import java.util.{Collections, Properties}
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.utils.Logging
 import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors.InvalidTopicException
 import org.apache.kafka.common.internals.Topic
-import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, SHARE_GROUP_STATE_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME}
+import org.apache.kafka.common.internals.Topic.{CLUSTER_LINK_TOPIC_NAME, GROUP_METADATA_TOPIC_NAME, SHARE_GROUP_STATE_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME}
 import org.apache.kafka.common.message.CreateTopicsRequestData
 import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, CreatableTopicConfig, CreatableTopicConfigCollection}
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic
@@ -35,6 +36,7 @@ import org.apache.kafka.coordinator.share.ShareCoordinator
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 import org.apache.kafka.server.quota.ControllerMutationQuota
+import org.apache.kafka.server.record.BrokerCompressionType
 
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.jdk.CollectionConverters._
@@ -204,6 +206,19 @@ class DefaultAutoTopicCreationManager(
           .setNumPartitions(config.shareCoordinatorConfig.shareCoordinatorStateTopicNumPartitions())
           .setReplicationFactor(config.shareCoordinatorConfig.shareCoordinatorStateTopicReplicationFactor())
           .setConfigs(convertToTopicConfigCollections(shareCoordinator.shareGroupStateTopicConfigs()))
+      case CLUSTER_LINK_TOPIC_NAME =>
+        // TODO
+        // these properties I think we should define in the CLusterLinkCoordinator but now, I will hardcode
+        // them here
+        val properties = new Properties
+        properties.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
+        properties.put(TopicConfig.COMPRESSION_TYPE_CONFIG, BrokerCompressionType.PRODUCER.name)
+        properties.put(TopicConfig.RETENTION_MS_CONFIG, -1)
+        new CreatableTopic()
+          .setName(topic)
+          .setNumPartitions(config.clusterLinksConfig.clusterLinkTopicNumPartitions())
+          .setReplicationFactor(config.clusterLinksConfig.clusterLinkTopicReplicationFactor())
+          .setConfigs(convertToTopicConfigCollections(properties))
       case topicName =>
         new CreatableTopic()
           .setName(topicName)

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -601,6 +601,12 @@ class BrokerServer(
         enableRequestProcessingFuture, startupDeadline, time)
 
       maybeChangeStatus(STARTING, STARTED)
+      // TODO this topic should created after cluster link, but now we automatically create it here to
+      autoTopicCreationManager.createTopics(
+        Seq("__cluster_link").toSet,
+        null,
+        None
+      )
     } catch {
       case e: Throwable =>
         maybeChangeStatus(STARTING, STARTED)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -45,7 +45,7 @@ import org.apache.kafka.server.ProcessRole
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.config.AbstractKafkaConfig.getMap
-import org.apache.kafka.server.config.{AbstractKafkaConfig, ClusterLinksConfig, KRaftConfigs, QuotaConfig, ReplicationConfigs, ServerConfigs, ServerLogConfigs}
+import org.apache.kafka.server.config.{AbstractKafkaConfig, ClusterLinkConfig, KRaftConfigs, QuotaConfig, ReplicationConfigs, ServerConfigs, ServerLogConfigs}
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.MetricConfigs
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig}
@@ -204,8 +204,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   private val _shareCoordinatorConfig = new ShareCoordinatorConfig(this)
   def shareCoordinatorConfig: ShareCoordinatorConfig = _shareCoordinatorConfig
 
-  private val _clusterLinksConfig = new ClusterLinksConfig(this)
-  def clusterLinksConfig: ClusterLinksConfig = _clusterLinksConfig
+  private val _clusterLinksConfig = new ClusterLinkConfig(this)
+  def clusterLinksConfig: ClusterLinkConfig = _clusterLinksConfig
 
   private val _quotaConfig = new QuotaConfig(this)
   def quotaConfig: QuotaConfig = _quotaConfig

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -45,7 +45,7 @@ import org.apache.kafka.server.ProcessRole
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.config.AbstractKafkaConfig.getMap
-import org.apache.kafka.server.config.{AbstractKafkaConfig, KRaftConfigs, QuotaConfig, ReplicationConfigs, ServerConfigs, ServerLogConfigs}
+import org.apache.kafka.server.config.{AbstractKafkaConfig, ClusterLinksConfig, KRaftConfigs, QuotaConfig, ReplicationConfigs, ServerConfigs, ServerLogConfigs}
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.MetricConfigs
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig}
@@ -203,6 +203,9 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
 
   private val _shareCoordinatorConfig = new ShareCoordinatorConfig(this)
   def shareCoordinatorConfig: ShareCoordinatorConfig = _shareCoordinatorConfig
+
+  private val _clusterLinksConfig = new ClusterLinksConfig(this)
+  def clusterLinksConfig: ClusterLinksConfig = _clusterLinksConfig
 
   private val _quotaConfig = new QuotaConfig(this)
   def quotaConfig: QuotaConfig = _quotaConfig

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -64,6 +64,7 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         LogConfig.SERVER_CONFIG_DEF,
         ShareGroupConfig.CONFIG_DEF,
         ShareCoordinatorConfig.CONFIG_DEF,
+        ClusterLinkConfig.CONFIG_DEF,
         TransactionLogConfig.CONFIG_DEF,
         TransactionStateManagerConfig.CONFIG_DEF,
         QuorumConfig.CONFIG_DEF,

--- a/server/src/main/java/org/apache/kafka/server/config/ClusterLinkConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/ClusterLinkConfig.java
@@ -24,7 +24,7 @@ import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.Type.INT;
 import static org.apache.kafka.common.config.ConfigDef.Type.SHORT;
 
-public class ClusterLinksConfig {
+public class ClusterLinkConfig {
 
     public static final String CLUSTER_LINK_TOPIC_NUM_PARTITIONS_CONFIG = "cluster.link.topic.num.partitions";
     public static final int CLUSTER_LINK_TOPIC_NUM_PARTITIONS_DEFAULT = 50;
@@ -42,7 +42,7 @@ public class ClusterLinksConfig {
     private final int clusterLinkTopicNumPartitions;
     private final short clusterLinkTopicReplicationFactor;
 
-    public ClusterLinksConfig(AbstractConfig config) {
+    public ClusterLinkConfig(AbstractConfig config) {
         clusterLinkTopicNumPartitions = config.getInt(CLUSTER_LINK_TOPIC_NUM_PARTITIONS_CONFIG);
         clusterLinkTopicReplicationFactor = config.getShort(CLUSTER_LINK_TOPIC_REPLICATION_FACTOR_CONFIG);
     }

--- a/server/src/main/java/org/apache/kafka/server/config/ClusterLinksConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/ClusterLinksConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.config;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
+import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+import static org.apache.kafka.common.config.ConfigDef.Type.INT;
+import static org.apache.kafka.common.config.ConfigDef.Type.SHORT;
+
+public class ClusterLinksConfig {
+
+    public static final String CLUSTER_LINK_TOPIC_NUM_PARTITIONS_CONFIG = "cluster.link.topic.num.partitions";
+    public static final int CLUSTER_LINK_TOPIC_NUM_PARTITIONS_DEFAULT = 50;
+    public static final String CLUSTER_LINK_TOPIC_NUM_PARTITIONS_DOC = "The number of partitions for the cluster link topic (should not change after deployment).";
+
+    public static final String CLUSTER_LINK_TOPIC_REPLICATION_FACTOR_CONFIG = "cluster.link.topic.replication.factor";
+    public static final short CLUSTER_LINK_TOPIC_REPLICATION_FACTOR_DEFAULT = 3;
+    public static final String CLUSTER_LINK_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor for the cluster link topic. " +
+            "Topic creation will fail until the cluster size meets this replication factor requirement.";
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(CLUSTER_LINK_TOPIC_NUM_PARTITIONS_CONFIG, INT, CLUSTER_LINK_TOPIC_NUM_PARTITIONS_DEFAULT, atLeast(1), HIGH, CLUSTER_LINK_TOPIC_NUM_PARTITIONS_DOC)
+            .define(CLUSTER_LINK_TOPIC_REPLICATION_FACTOR_CONFIG, SHORT, CLUSTER_LINK_TOPIC_REPLICATION_FACTOR_DEFAULT, atLeast(1), HIGH, CLUSTER_LINK_TOPIC_REPLICATION_FACTOR_DOC);
+
+    private final int clusterLinkTopicNumPartitions;
+    private final short clusterLinkTopicReplicationFactor;
+
+    public ClusterLinksConfig(AbstractConfig config) {
+        clusterLinkTopicNumPartitions = config.getInt(CLUSTER_LINK_TOPIC_NUM_PARTITIONS_CONFIG);
+        clusterLinkTopicReplicationFactor = config.getShort(CLUSTER_LINK_TOPIC_REPLICATION_FACTOR_CONFIG);
+    }
+
+    public int clusterLinkTopicNumPartitions() {
+        return clusterLinkTopicNumPartitions;
+    }
+
+    public short clusterLinkTopicReplicationFactor() {
+        return clusterLinkTopicReplicationFactor;
+    }
+}


### PR DESCRIPTION
Create an internal __cluster_link topic to store the source cluster metadata
a. By default it should be “compact” and retention.ms/bytes=-1” topic because we only need to store the latest record, and the key of one cluster-link should always be the same (i.e. the record key will be the cluster-link name (or UUID?)) 


New Config
- cluster.link.topic.num.partitions
- cluster.link.topic.replication.factor

```
./bin/kafka-configs.sh --bootstrap-server localhost:9092   --entity-type topics   --entity-name __cluster_link   --describe  --all | grep retention
  delete.retention.ms=86400000 sensitive=false synonyms={DEFAULT_CONFIG:log.cleaner.delete.retention.ms=86400000}
  local.retention.bytes=-2 sensitive=false synonyms={DEFAULT_CONFIG:log.local.retention.bytes=-2}
  local.retention.ms=-2 sensitive=false synonyms={DEFAULT_CONFIG:log.local.retention.ms=-2}
  retention.bytes=-1 sensitive=false synonyms={DEFAULT_CONFIG:log.retention.bytes=-1}
  retention.ms=-1 sensitive=false synonyms={DYNAMIC_TOPIC_CONFIG:retention.ms=-1}

```