### PR TITLE
Mirror data to LSO for transaction data

### DIFF
--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -21,7 +21,7 @@ import java.util.{Collections, Optional}
 import kafka.utils.Logging
 import org.apache.kafka.clients.FetchSessionHandler
 import org.apache.kafka.common.errors.KafkaStorageException
-import org.apache.kafka.common.{Node, TopicPartition, Uuid}
+import org.apache.kafka.common.{IsolationLevel, Node, TopicPartition, Uuid}
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.{OffsetForLeaderTopic, OffsetForLeaderTopicCollection}
@@ -226,7 +226,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
       val requestBuilder = if (readOnlyTopics.isEmpty) {
         FetchRequest.Builder.forReplica(version, brokerConfig.brokerId, brokerEpochSupplier(), maxWait, minBytes, fetchData.toSend)
       } else {
-        FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend)
+        FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend).isolationLevel(IsolationLevel.READ_COMMITTED)
       }
       requestBuilder
         .setMaxBytes(maxBytes)


### PR DESCRIPTION
Mirror data to LSO for transaction data

After mirroring the topic from the source, check the logs in the destination cluster with `isolationLevel=read_committed`:
```
bin/kafka-topics.sh --createMirror --topic quickstart-events --bootstrap-server localhost:9094 --remote-bootstrap-server localhost:9092 --topic-id 4bF1V1ljTqGRbls7tHFduA
```
```
[2025-09-17 20:48:43,614] INFO [ReplicaFetcher replicaId=4, leaderId=2, fetcherId=0, readOnly=true] !!! Sending fetch request (type=FetchRequest, replicaId=-1, maxWait=1000, minBytes=1, maxBytes=10485760, fetchData={quickstart-events-0=PartitionData(topicId=4bF1V1ljTqGRbls7tHFduA, fetchOffset=0, logStartOffset=0, maxBytes=1048576, currentLeaderEpoch=Optional[0], lastFetchedEpoch=Optional[0])}, isolationLevel=read_committed, removed=, replaced=, metadata=(sessionId=INVALID, epoch=INITIAL), rackId=) (kafka.server.ReplicaFetcherThread)
```
