### PR TITLE
Create cl coordinator skeleton

### DIFF
--- a/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
+++ b/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
@@ -26,6 +26,7 @@ import kafka.server.KafkaApis;
 import kafka.server.KafkaConfig;
 import kafka.server.QuotaFactory.QuotaManagers;
 import kafka.server.ReplicaManager;
+import kafka.server.coordinator.TopicMirrorLinkCoordinator;
 import kafka.server.share.SharePartitionManager;
 
 import org.apache.kafka.common.internals.Plugin;
@@ -71,6 +72,7 @@ public class KafkaApisBuilder {
     private ApiVersionManager apiVersionManager = null;
     private ClientMetricsManager clientMetricsManager = null;
     private ShareCoordinator shareCoordinator = null;
+    private TopicMirrorLinkCoordinator topicMirrorLinkCoordinator = null;
     private GroupConfigManager groupConfigManager = null;
     private Supplier<Long> brokerEpochSupplier = () -> -1L;
 
@@ -194,6 +196,11 @@ public class KafkaApisBuilder {
         return this;
     }
 
+    public KafkaApisBuilder setTopicMirrorCoordinator(TopicMirrorLinkCoordinator topicMirrorLinkCoordinator) {
+        this.topicMirrorLinkCoordinator = topicMirrorLinkCoordinator;
+        return this;
+    }
+
     @SuppressWarnings({"CyclomaticComplexity"})
     public KafkaApis build() {
         if (requestChannel == null) throw new RuntimeException("you must set requestChannel");
@@ -214,6 +221,7 @@ public class KafkaApisBuilder {
         if (brokerTopicStats == null) brokerTopicStats = new BrokerTopicStats(config.remoteLogManagerConfig().isRemoteStorageSystemEnabled());
         if (apiVersionManager == null) throw new RuntimeException("You must set apiVersionManager");
         if (groupConfigManager == null) throw new RuntimeException("You must set groupConfigManager");
+        if (topicMirrorLinkCoordinator == null) throw new RuntimeException("You must set topicMirrorLinkCoordinator");
 
         return new KafkaApis(requestChannel,
                              forwardingManager,
@@ -221,6 +229,7 @@ public class KafkaApisBuilder {
                              groupCoordinator,
                              txnCoordinator,
                              shareCoordinator,
+                             topicMirrorLinkCoordinator,
                              autoTopicCreationManager,
                              brokerId,
                              config,

--- a/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
+++ b/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
@@ -1,0 +1,57 @@
+package kafka.server.coordinator;
+
+import kafka.server.KafkaConfig;
+import kafka.server.ReplicaManager;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.metadata.MetadataCache;
+import org.apache.kafka.server.util.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.OptionalInt;
+
+public record TopicMirrorLinkCoordinator(KafkaConfig config,
+                                         ReplicaManager replicaManager,
+                                         Scheduler scheduler,
+                                         Metrics metrics,
+                                         MetadataCache metadataCache,
+                                         Time time) {
+
+    private static final Logger log = LoggerFactory.getLogger(TopicMirrorLinkCoordinator.class);
+
+    public void startup() {
+        log.info("Starting up.");
+        scheduler.startup();
+        scheduler.schedule("topic-mirror-link-query",
+                this::querySourceCluster,
+                5000,
+                5000
+        );
+    }
+
+    // periodically query source cluster to get the metadata
+    void querySourceCluster() {
+
+    }
+
+    // called when onMetadataUpdate, needs to handle new leader elected
+    public void onElection(
+            int partitionIndex,
+            int partitionLeaderEpoch
+    ) {
+
+    }
+
+    // called when onMetadataUpdate, needs to handle old leader resigned
+    public void onResignation(
+            int partitionIndex,
+            OptionalInt partitionLeaderEpoch
+    ) {
+
+    }
+
+    public void shutdown() {
+
+    }
+}

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -399,7 +399,7 @@ class BrokerServer(
         producerIdManagerSupplier, metrics, metadataCache, Time.SYSTEM)
 
       topicMirrorLinkCoordinator = new TopicMirrorLinkCoordinator(config, replicaManager,
-        new KafkaScheduler(1, true, "transaction-log-manager-"), metrics, metadataCache, Time.SYSTEM)
+        new KafkaScheduler(1, true, "topic-mirror-link-manager-"), metrics, metadataCache, Time.SYSTEM, clientToControllerChannelManager)
 
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
         config, clientToControllerChannelManager, groupCoordinator,

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -22,6 +22,7 @@ import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.log.LogManager
 import kafka.network.SocketServer
 import kafka.raft.KafkaRaftManager
+import kafka.server.coordinator.TopicMirrorLinkCoordinator
 import kafka.server.metadata._
 import kafka.server.share.{ShareCoordinatorMetadataCacheHelperImpl, SharePartitionManager}
 import kafka.utils.CoreUtils
@@ -123,6 +124,8 @@ class BrokerServer(
   var groupConfigManager: GroupConfigManager = _
 
   var transactionCoordinator: TransactionCoordinator = _
+
+  var topicMirrorLinkCoordinator: TopicMirrorLinkCoordinator = _
 
   var shareCoordinator: ShareCoordinator = _
 
@@ -395,6 +398,9 @@ class BrokerServer(
         new KafkaScheduler(1, true, "transaction-log-manager-"),
         producerIdManagerSupplier, metrics, metadataCache, Time.SYSTEM)
 
+      topicMirrorLinkCoordinator = new TopicMirrorLinkCoordinator(config, replicaManager,
+        new KafkaScheduler(1, true, "transaction-log-manager-"), metrics, metadataCache, Time.SYSTEM)
+
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
         config, clientToControllerChannelManager, groupCoordinator,
         transactionCoordinator, shareCoordinator)
@@ -457,6 +463,7 @@ class BrokerServer(
         groupCoordinator = groupCoordinator,
         txnCoordinator = transactionCoordinator,
         shareCoordinator = shareCoordinator,
+        topicMirrorLinkCoordinator = topicMirrorLinkCoordinator,
         autoTopicCreationManager = autoTopicCreationManager,
         brokerId = config.nodeId,
         config = config,
@@ -488,6 +495,7 @@ class BrokerServer(
         groupCoordinator,
         transactionCoordinator,
         shareCoordinator,
+        topicMirrorLinkCoordinator,
         sharePartitionManager,
         new DynamicConfigPublisher(
           config,
@@ -791,6 +799,9 @@ class BrokerServer(
         CoreUtils.swallow(groupCoordinator.shutdown(), this)
       if (shareCoordinator != null)
         CoreUtils.swallow(shareCoordinator.shutdown(), this)
+
+      if (topicMirrorLinkCoordinator != null)
+        CoreUtils.swallow(topicMirrorLinkCoordinator.shutdown(), this)
 
       if (assignmentsManager != null)
         CoreUtils.swallow(assignmentsManager.close(), this)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -20,6 +20,7 @@ package kafka.server
 import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinator}
 import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.{QuotaManagers, UNBOUNDED_QUOTA}
+import kafka.server.coordinator.TopicMirrorLinkCoordinator
 import kafka.server.handlers.DescribeTopicPartitionsRequestHandler
 import kafka.server.share.{ShareFetchUtils, SharePartitionManager}
 import kafka.utils.Logging
@@ -95,6 +96,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                 val groupCoordinator: GroupCoordinator,
                 val txnCoordinator: TransactionCoordinator,
                 val shareCoordinator: ShareCoordinator,
+                val topicMirrorLinkCoordinator: TopicMirrorLinkCoordinator,
                 val autoTopicCreationManager: AutoTopicCreationManager,
                 val brokerId: Int,
                 val config: KafkaConfig,

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -20,8 +20,9 @@ package kafka.server.metadata
 import java.util.OptionalInt
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.log.LogManager
+import kafka.server.coordinator.TopicMirrorLinkCoordinator
 import kafka.server.share.SharePartitionManager
-import kafka.server.{KafkaConfig, ReplicaManager, RemoteClusterMetadataManager}
+import kafka.server.{KafkaConfig, RemoteClusterMetadataManager, ReplicaManager}
 import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
@@ -75,6 +76,7 @@ class BrokerMetadataPublisher(
   groupCoordinator: GroupCoordinator,
   txnCoordinator: TransactionCoordinator,
   shareCoordinator: ShareCoordinator,
+  topicMirrorLinkCoordinator: TopicMirrorLinkCoordinator,
   sharePartitionManager: SharePartitionManager,
   var dynamicConfigPublisher: DynamicConfigPublisher,
   dynamicClientQuotaPublisher: DynamicClientQuotaPublisher,
@@ -214,6 +216,17 @@ class BrokerMetadataPublisher(
         } catch {
           case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating share " +
             s"coordinator with deleted partitions in $deltaName", t)
+        }
+        try {
+          // Update the transaction coordinator of local changes
+          updateCoordinator(newImage,
+            delta,
+            Topic.CLUSTER_LINK_TOPIC_NAME,
+            topicMirrorLinkCoordinator.onElection,
+            (partitionIndex, leaderEpochOpt) => topicMirrorLinkCoordinator.onResignation(partitionIndex, toOptionalInt(leaderEpochOpt)))
+        } catch {
+          case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating txn " +
+            s"coordinator with local changes in $deltaName", t)
         }
       }
 
@@ -389,6 +402,12 @@ class BrokerMetadataPublisher(
         .orElse(config.shareCoordinatorConfig.shareCoordinatorStateTopicNumPartitions()))
     } catch {
       case t: Throwable => fatalFaultHandler.handleFault("Error starting Share coordinator", t)
+    }
+    try {
+      // Start the topic mirror coordinator.
+      topicMirrorLinkCoordinator.startup()
+    } catch {
+      case t: Throwable => fatalFaultHandler.handleFault("Error starting topic link coordinator", t)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -21,6 +21,7 @@ import kafka.cluster.Partition
 import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinator}
 import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.QuotaManagers
+import kafka.server.coordinator.TopicMirrorLinkCoordinator
 import kafka.server.metadata.KRaftMetadataCache
 import kafka.server.share.SharePartitionManager
 import kafka.utils.{CoreUtils, Logging, TestUtils}
@@ -128,6 +129,7 @@ class KafkaApisTest extends Logging {
   private val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
   private val groupCoordinator: GroupCoordinator = mock(classOf[GroupCoordinator])
   private val shareCoordinator: ShareCoordinator = mock(classOf[ShareCoordinator])
+  private val topicMirrorLinkCoordinator: TopicMirrorLinkCoordinator = mock(classOf[TopicMirrorLinkCoordinator])
   private val txnCoordinator: TransactionCoordinator = mock(classOf[TransactionCoordinator])
   private val forwardingManager: ForwardingManager = mock(classOf[ForwardingManager])
   private val autoTopicCreationManager: AutoTopicCreationManager = mock(classOf[AutoTopicCreationManager])
@@ -195,6 +197,7 @@ class KafkaApisTest extends Logging {
       groupCoordinator = groupCoordinator,
       txnCoordinator = txnCoordinator,
       shareCoordinator = shareCoordinator,
+      topicMirrorLinkCoordinator = topicMirrorLinkCoordinator,
       autoTopicCreationManager = autoTopicCreationManager,
       brokerId = brokerId,
       config = config,

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -23,6 +23,7 @@ import java.util.Collections.{singleton, singletonList, singletonMap}
 import java.util.{OptionalInt, Properties}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import kafka.log.LogManager
+import kafka.server.coordinator.TopicMirrorLinkCoordinator
 import kafka.server.share.SharePartitionManager
 import kafka.server.{BrokerServer, KafkaConfig, RemoteClusterMetadataManager, ReplicaManager}
 import kafka.utils.TestUtils
@@ -203,6 +204,7 @@ class BrokerMetadataPublisherTest {
       groupCoordinator,
       mock(classOf[TransactionCoordinator]),
       mock(classOf[ShareCoordinator]),
+      mock(classOf[TopicMirrorLinkCoordinator]),
       mock(classOf[SharePartitionManager]),
       mock(classOf[DynamicConfigPublisher]),
       mock(classOf[DynamicClientQuotaPublisher]),
@@ -268,6 +270,7 @@ class BrokerMetadataPublisherTest {
       groupCoordinator,
       mock(classOf[TransactionCoordinator]),
       mock(classOf[ShareCoordinator]),
+      mock(classOf[TopicMirrorLinkCoordinator]),
       mock(classOf[SharePartitionManager]),
       mock(classOf[DynamicConfigPublisher]),
       mock(classOf[DynamicClientQuotaPublisher]),
@@ -310,6 +313,7 @@ class BrokerMetadataPublisherTest {
       mock(classOf[GroupCoordinator]),
       mock(classOf[TransactionCoordinator]),
       mock(classOf[ShareCoordinator]),
+      mock(classOf[TopicMirrorLinkCoordinator]),
       sharePartitionManager,
       mock(classOf[DynamicConfigPublisher]),
       mock(classOf[DynamicClientQuotaPublisher]),


### PR DESCRIPTION
Create cl coordinator skeleton:
1. Created when brokerServer startup
2. Started when publisher initialized
3. Shutdown when broker shutdown
4. onMetadataUpdate will invoke onElection/onResignation for new/old leader handling.
5. Periodically invoke a method to query the source cluster