### PR TITLE
add cluster link name to createTopicRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
@@ -43,6 +43,7 @@ public class NewTopic {
     private Map<String, String> configs = null;
     private Optional<String> remoteBootstrapServer = Optional.empty();
     private Optional<String> topicId = Optional.empty();
+    private Optional<String> linkName = Optional.empty();
 
     /**
      * A new topic with the specified replication factor and number of partitions.
@@ -63,13 +64,14 @@ public class NewTopic {
         this.replicasAssignments = null;
     }
 
-    public NewTopic(String name, Optional<Integer> numPartitions, Optional<Short> replicationFactor, Optional<String> remoteBootstrapServer, Optional<String> topicId) {
+    public NewTopic(String name, Optional<Integer> numPartitions, Optional<Short> replicationFactor, Optional<String> remoteBootstrapServer, Optional<String> topicId, Optional<String> linkName) {
         this.name = name;
         this.numPartitions = numPartitions;
         this.replicationFactor = replicationFactor;
         this.replicasAssignments = null;
         this.remoteBootstrapServer = remoteBootstrapServer;
         this.topicId = topicId;
+        this.linkName = linkName;
     }
 
     /**
@@ -148,6 +150,10 @@ public class NewTopic {
         }
         if (topicId.isPresent()) {
             creatableTopic.setTopicId(Uuid.fromString(topicId.get()));
+        }
+
+        if (linkName.isPresent()) {
+            creatableTopic.setClusterLink(linkName.get());
         }
         if (replicasAssignments != null) {
             for (Entry<Integer, List<Integer>> entry : replicasAssignments.entrySet()) {

--- a/clients/src/main/resources/common/message/CreateTopicsRequest.json
+++ b/clients/src/main/resources/common/message/CreateTopicsRequest.json
@@ -58,6 +58,8 @@
       ]},
       { "name": "remoteBootstrapServer", "type": "string", "versions": "7+", "ignorable": true,
         "about": "If true, check that the topics can be created as specified, but don't create anything." },
+      { "name": "clusterLink", "type": "string", "versions": "7+", "ignorable": true,
+        "about": "If true, check that the topics can be created as specified, but don't create anything." },
       { "name": "TopicId", "type": "uuid", "versions": "7+", "ignorable": true, "about": "The unique topic ID."}
     ]},
     { "name": "timeoutMs", "type": "int32", "versions": "0+", "default": "60000",

--- a/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
+++ b/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
@@ -98,6 +98,10 @@ public class TopicMirrorLinkCoordinator {
         numPartitions = config.clusterLinksConfig().clusterLinkTopicNumPartitions();
     }
 
+    public void addTopicsInCoordinator(String clusterLinkName, String topics) {
+        // TODO: update this clusterLink(key) with the new topics in the internal topics
+    }
+
     // periodically query source cluster to get the metadata
     void querySourceCluster() {
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -185,7 +185,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.LIST_GROUPS => handleListGroupsRequest(request).exceptionally(handleError)
         case ApiKeys.SASL_HANDSHAKE => handleSaslHandshakeRequest(request)
         case ApiKeys.API_VERSIONS => handleApiVersionsRequest(request)
-        case ApiKeys.CREATE_TOPICS => forwardToController(request)
+        case ApiKeys.CREATE_TOPICS => handleCreateTopics(request)
         case ApiKeys.DELETE_TOPICS => forwardToController(request)
         case ApiKeys.DELETE_RECORDS => handleDeleteRecordsRequest(request)
         case ApiKeys.INIT_PRODUCER_ID => handleInitProducerIdRequest(request, requestLocal)
@@ -266,6 +266,16 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (request.apiLocalCompleteTimeNanos < 0)
         request.apiLocalCompleteTimeNanos = time.nanoseconds
     }
+  }
+
+  def handleCreateTopics(request: RequestChannel.Request): Unit = {
+    val createTopicsRequest = request.body[CreateTopicsRequest]
+    // TODO: might need to have a better way to pass the cluster link and bootstrap server info
+    val clusterLinkTopic = createTopicsRequest.data.topics.stream().filter(t => t.clusterLink() != null && !t.clusterLink().isEmpty).findFirst()
+    if (clusterLinkTopic.isPresent) {
+      topicMirrorLinkCoordinator.addTopicsInCoordinator(clusterLinkTopic.get().clusterLink(), clusterLinkTopic.get().name());
+    }
+    forwardToController(request)
   }
 
   def handleGetReplicaLogInfo(request: RequestChannel.Request): Unit = {

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -492,7 +492,7 @@ public abstract class TopicCommand {
             try {
                 NewTopic newTopic;
                 if (topic.opts.hasCreateMirrorOption()) {
-                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue), topic.remoteBootstrapServers, topic.topicId);
+                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue), topic.remoteBootstrapServers, topic.topicId, topic.opts.linkName());
                 } else if (topic.hasReplicaAssignment()) {
                     newTopic = new NewTopic(topic.name, topic.replicaAssignment);
                 } else {


### PR DESCRIPTION
createMirror option 可以加上 --link 給上cluster link name，我還沒測就是了XD
```
bin/kafka-topics.sh --createMirror --topic quickstart-events --bootstrap-server localhost:9094 --remote-bootstrap-server localhost:9092 --topic-id i6NzoatRSCOiV1tWM4zVQQ --link testLink
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
