### PR TITLE
Fix stuck mirroring after source leader election

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerBlockingSender.scala
+++ b/core/src/main/scala/kafka/server/BrokerBlockingSender.scala
@@ -148,8 +148,15 @@ class RemoteBrokerBlockingSender(sourceBroker: BrokerEndPoint,
 
     val channelBuilder = ClientUtils.createChannelBuilder(brokerConfig, time, logContext)
     val selector = new Selector(
+      NetworkReceive.UNLIMITED,
       brokerConfig.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-      metrics, time, "remote-readonly-" + clientId, channelBuilder, logContext)
+      metrics,
+      time,
+      "remote-readonly-" + clientId,
+      Map("broker-id" -> sourceBroker.id.toString, "fetcher-id" -> fetcherId.toString).asJava,
+      false,
+      channelBuilder,
+      logContext)
     val networkClient = new NetworkClient(
       selector,
       new ManualMetadataUpdater(),


### PR DESCRIPTION
After a source cluster leader election, the remote fetcher thread is recreated. At this point, there is a metric collision that stops the remote fetcher thread creation and mirroring. 

```bash
[2025-09-24 10:22:26,539] ERROR [ReplicaFetcherThread-0-2]: Error due to (kafka.server.ReplicaFetcherThread)
java.lang.IllegalArgumentException: A metric named 'MetricName [name=connection-count, group=remote-readonly-broker-6-remote-fetcher-0-metrics, description=The current number of active connections., tags={}]' already exists, can't register another one.
	at org.apache.kafka.common.metrics.Metrics.addMetric(Metrics.java:506) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.metrics.Metrics.addMetric(Metrics.java:486) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.metrics.Metrics.addMetric(Metrics.java:471) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector$SelectorMetrics.<init>(Selector.java:1262) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector.<init>(Selector.java:178) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector.<init>(Selector.java:213) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector.<init>(Selector.java:225) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector.<init>(Selector.java:229) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.RemoteBrokerBlockingSender.<init>(BrokerBlockingSender.scala:152) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
```

This happens because `RemoteBrokerBlockingSender` tries to create a Selector instance without unique tags to differentiate metrics between instances.
