### PR TITLE
Add find coordinator when create mirror

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -199,6 +199,7 @@ public interface Admin extends AutoCloseable {
      */
     CreateTopicsResult createTopics(Collection<NewTopic> newTopics, CreateTopicsOptions options);
 
+    FindCoordinatorResult findCoordinator(String key);
     /**
      * This is a convenience method for {@link #deleteTopics(TopicCollection, DeleteTopicsOptions)}
      * with default options. See the overload for more details.
@@ -2130,6 +2131,6 @@ public interface Admin extends AutoCloseable {
      * @param options               The options to use when terminating the transaction.
      * @return The TerminateTransactionResult.
      */
-    TerminateTransactionResult forceTerminateTransaction(String transactionalId, 
+    TerminateTransactionResult forceTerminateTransaction(String transactionalId,
                                                         TerminateTransactionOptions options);
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/FindCoordinatorResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/FindCoordinatorResult.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+
+public class FindCoordinatorResult {
+
+    private final KafkaFutureImpl<CoordinatorInfo> future;
+
+    public FindCoordinatorResult(KafkaFutureImpl<CoordinatorInfo> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Node> node() {
+        return future.thenApply(CoordinatorInfo::node);
+    }
+
+    public KafkaFuture<String> key() {
+        return future.thenApply(CoordinatorInfo::key);
+    }
+
+    public static class CoordinatorInfo {
+        private final Node node;
+        private final String key;
+
+        public CoordinatorInfo(Node node, String key) {
+            this.node = node;
+            this.key = key;
+        }
+
+        public Node node() {
+            return node;
+        }
+
+        public String key() {
+            return key;
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -64,6 +64,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public FindCoordinatorResult findCoordinator(String key) {
+        return null;
+    }
+
+    @Override
     public DeleteTopicsResult deleteTopics(TopicCollection topics, DeleteTopicsOptions options) {
         return delegate.deleteTopics(topics, options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -159,6 +159,7 @@ import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData.U
 import org.apache.kafka.common.message.DescribeUserScramCredentialsResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
+import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.ListConfigResourcesRequestData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
@@ -1810,7 +1811,10 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     private Call getFindCoordinatorCall(KafkaFutureImpl<FindCoordinatorResult.CoordinatorInfo> future, String key) {
-        return new Call("findCoordinator", 5000, new LeastLoadedNodeProvider()) {
+        final long now = time.milliseconds();
+        final long deadline = calcDeadlineMs(now, 10000);
+
+        return new Call("findCoordinator", deadline, new LeastLoadedNodeProvider()) {
             @Override
             AbstractRequest.Builder<?> createRequest(int timeoutMs) {
                 return new FindCoordinatorRequest.Builder(
@@ -1824,12 +1828,15 @@ public class KafkaAdminClient extends AdminClient {
             @Override
             void handleResponse(AbstractResponse abstractResponse) {
                 final FindCoordinatorResponse response = (FindCoordinatorResponse) abstractResponse;
+                System.out.println("The findCoordinator response is: " + response);
                 ApiError error = new ApiError(response.data().errorCode(), response.data().errorMessage());
                 if (error.isFailure()) {
                     future.completeExceptionally(error.exception());
                 } else {
-                    Node node = new Node(response.data().nodeId(), response.data().host(),
-                        response.data().port());
+                    FindCoordinatorResponseData.Coordinator coordinator = response.coordinators()
+                            .stream().findFirst().orElseThrow();
+                    Node node = new Node(coordinator.nodeId(), coordinator.host(),
+                            coordinator.port());
                     future.complete(new FindCoordinatorResult.CoordinatorInfo(node, key));
                 }
             }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -158,6 +158,7 @@ import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData.UserName;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
+import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.ListConfigResourcesRequestData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
@@ -232,6 +233,8 @@ import org.apache.kafka.common.requests.ElectLeadersRequest;
 import org.apache.kafka.common.requests.ElectLeadersResponse;
 import org.apache.kafka.common.requests.ExpireDelegationTokenRequest;
 import org.apache.kafka.common.requests.ExpireDelegationTokenResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsResponse;
 import org.apache.kafka.common.requests.JoinGroupRequest;
@@ -1791,6 +1794,52 @@ public class KafkaAdminClient extends AdminClient {
             runnable.call(call, now);
         }
         return new CreateTopicsResult(new HashMap<>(topicFutures));
+    }
+
+    @Override
+    public FindCoordinatorResult findCoordinator(String key) {
+        KafkaFutureImpl<FindCoordinatorResult.CoordinatorInfo> future = new KafkaFutureImpl<>();
+        if (key == null) {
+            future.completeExceptionally(new IllegalArgumentException("The given key cannot be null."));
+        } else {
+            final long now = time.milliseconds();
+            final Call call = getFindCoordinatorCall(future, key);
+            runnable.call(call, now);
+        }
+        return new FindCoordinatorResult(future);
+    }
+
+    private Call getFindCoordinatorCall(KafkaFutureImpl<FindCoordinatorResult.CoordinatorInfo> future, String key) {
+        return new Call("findCoordinator", 5000, new LeastLoadedNodeProvider()) {
+            @Override
+            AbstractRequest.Builder<?> createRequest(int timeoutMs) {
+                return new FindCoordinatorRequest.Builder(
+                    new FindCoordinatorRequestData()
+                        .setKeyType(FindCoordinatorRequest.CoordinatorType.CLUSTER_LINK.id())
+                        .setKey(key)
+                        .setCoordinatorKeys(List.of())
+                );
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                final FindCoordinatorResponse response = (FindCoordinatorResponse) abstractResponse;
+                ApiError error = new ApiError(response.data().errorCode(), response.data().errorMessage());
+                if (error.isFailure()) {
+                    future.completeExceptionally(error.exception());
+                } else {
+                    Node node = new Node(response.data().nodeId(), response.data().host(),
+                        response.data().port());
+                    future.complete(new FindCoordinatorResult.CoordinatorInfo(node, key));
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                // Fail all the other remaining futures
+                completeAllExceptionally(List.of(future), throwable);
+            }
+        };
     }
 
     private Call getCreateTopicsCall(final CreateTopicsOptions options,

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -423,6 +423,11 @@ public class MockAdminClient extends AdminClient {
         return new CreateTopicsResult(createTopicResult);
     }
 
+    @Override
+    public FindCoordinatorResult findCoordinator(String key) {
+        return null;
+    }
+
     private static Config config(NewTopic newTopic) {
         Collection<ConfigEntry> configEntries = new ArrayList<>();
         if (newTopic.configs() != null) {
@@ -1478,7 +1483,7 @@ public class MockAdminClient extends AdminClient {
     public synchronized DescribeStreamsGroupsResult describeStreamsGroups(Collection<String> groupIds, DescribeStreamsGroupsOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
-    
+
     @Override
     public synchronized DescribeClassicGroupsResult describeClassicGroups(Collection<String> groupIds, DescribeClassicGroupsOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");

--- a/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkRecordSerde.java
+++ b/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkRecordSerde.java
@@ -19,7 +19,7 @@ package kafka.server.coordinator;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecordSerde;
-import org.apache.kafka.coordinator.share.generated.CoordinatorRecordType;
+import org.apache.kafka.coordinator.clusterlink.generated.CoordinatorRecordType;
 
 public class TopicMirrorLinkRecordSerde extends CoordinatorRecordSerde {
     @Override

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1274,7 +1274,9 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleFindCoordinatorRequest(request: RequestChannel.Request): Unit = {
+    logger.info("================================handleFindCoordinatorRequest========================")
     val version = request.header.apiVersion
+    logger.info("the version of FindCoordinatorRequest is " + version)
     if (version < 4) {
       handleFindCoordinatorRequestLessThanV4(request)
     } else {
@@ -1287,6 +1289,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     val coordinators = findCoordinatorRequest.data.coordinatorKeys.asScala.map { key =>
       val (error, node) = getCoordinator(request, findCoordinatorRequest.data.keyType, key)
+      logger.info("the node is " + node + ", the error is " + error)
       new FindCoordinatorResponseData.Coordinator()
         .setKey(key)
         .setErrorCode(error.code)
@@ -1301,6 +1304,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                 .setThrottleTimeMs(requestThrottleMs))
       trace("Sending FindCoordinator response %s for correlation id %d to client %s."
               .format(response, request.header.correlationId, request.header.clientId))
+      logger.info("the response of FindCoordinatorRequest is " + response)
       response
     }
     requestHelper.sendResponseMaybeThrottle(request, createResponse)
@@ -1339,9 +1343,11 @@ class KafkaApis(val requestChannel: RequestChannel,
       (Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED, Node.noNode)
     else if (keyType == CoordinatorType.SHARE.id && request.context.apiVersion < 6)
       (Errors.INVALID_REQUEST, Node.noNode)
-    else if (keyType == CoordinatorType.CLUSTER_LINK.id && request.context.apiVersion < 7)
+    else if (keyType == CoordinatorType.CLUSTER_LINK.id && request.context.apiVersion < 7) {
+      logger.warn("Cluster link coordinator type is not supported for " +
+        s"FindCoordinatorRequest version ${request.context.apiVersion}")
       (Errors.INVALID_REQUEST, Node.noNode)
-    else {
+    } else {
       if (keyType == CoordinatorType.SHARE.id) {
         authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
         try {
@@ -1374,9 +1380,13 @@ class KafkaApis(val requestChannel: RequestChannel,
           (topicMirrorLinkCoordinator.partitionFor(ClusterLinkKey.getInstance(key)), CLUSTER_LINK_TOPIC_NAME)
       }
 
+      logger.info("The partition of coordinator key " + key + " is " + partition + ", the internal topic name is " + internalTopicName)
+
       val topicMetadata = metadataCache.getTopicMetadata(Set(internalTopicName).asJava, request.context.listenerName, false, false).asScala
 
       if (topicMetadata.headOption.isEmpty) {
+        logger.info("The internal topic " + internalTopicName + " does not exist when finding coordinator for key " + key +
+          ". Attempting to create the topic.")
         val controllerMutationQuota = quotas.controllerMutation.newPermissiveQuotaFor(request.session, request.header.clientId)
         autoTopicCreationManager.createTopics(Seq(internalTopicName).toSet, controllerMutationQuota, None)
         (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
@@ -1391,6 +1401,7 @@ class KafkaApis(val requestChannel: RequestChannel,
             .findFirst()
 
           if (coordinatorEndpoint.isPresent) {
+            logger.info("The coordinator for key " + key + " is " + coordinatorEndpoint.get())
             (Errors.NONE, coordinatorEndpoint.get)
           } else {
             (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -110,6 +110,7 @@ import org.apache.kafka.clients.admin.ExpireDelegationTokenResult;
 import org.apache.kafka.clients.admin.FeatureUpdate;
 import org.apache.kafka.clients.admin.FenceProducersOptions;
 import org.apache.kafka.clients.admin.FenceProducersResult;
+import org.apache.kafka.clients.admin.FindCoordinatorResult;
 import org.apache.kafka.clients.admin.ListClientMetricsResourcesOptions;
 import org.apache.kafka.clients.admin.ListClientMetricsResourcesResult;
 import org.apache.kafka.clients.admin.ListConfigResourcesOptions;
@@ -197,6 +198,11 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     @Override
     public CreateTopicsResult createTopics(final Collection<NewTopic> newTopics, final CreateTopicsOptions options) {
         return adminDelegate.createTopics(newTopics, options);
+    }
+
+    @Override
+    public FindCoordinatorResult findCoordinator(String key) {
+        return null;
     }
 
     @Override
@@ -475,7 +481,7 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     public DescribeShareGroupsResult describeShareGroups(final Collection<String> groupIds, final DescribeShareGroupsOptions options) {
         return adminDelegate.describeShareGroups(groupIds, options);
     }
-    
+
     @Override
     public DescribeStreamsGroupsResult describeStreamsGroups(final Collection<String> groupIds, final DescribeStreamsGroupsOptions options) {
         return adminDelegate.describeStreamsGroups(groupIds, options);

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -496,6 +496,7 @@ public abstract class TopicCommand {
                 if (topic.opts.hasCreateMirrorOption()) {
                     FindCoordinatorResult findCoordinatorResult = adminClient.findCoordinator(topic.opts.linkName().get());
                     coordinator = Optional.ofNullable(findCoordinatorResult.node().get());
+                    System.out.println("Found coordinator " + coordinator.map(Node::idString).orElse("none") + " for link " + topic.opts.linkName().get() + ".");
                     newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue), topic.remoteBootstrapServers, topic.topicId, topic.opts.linkName());
                 } else if (topic.hasReplicaAssignment()) {
                     newTopic = new NewTopic(topic.name, topic.replicaAssignment);
@@ -511,7 +512,9 @@ public abstract class TopicCommand {
 
                 if (coordinator.isPresent()) {
                     Node node = coordinator.get();
+                    System.out.println("Node info: " + node);
                     String bootstrapServer = node.host() + ":" + node.port();
+                    System.out.println("Creating topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
                     try (Admin admin = createAdminClient(new Properties(), Optional.of(bootstrapServer))) {
                         newTopic.configs(configsMap);
                         CreateTopicsResult createResult = admin.createTopics(Set.of(newTopic),

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsOptions;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
+import org.apache.kafka.clients.admin.FindCoordinatorResult;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
@@ -491,7 +492,10 @@ public abstract class TopicCommand {
 
             try {
                 NewTopic newTopic;
+                Optional<Node> coordinator = Optional.empty();
                 if (topic.opts.hasCreateMirrorOption()) {
+                    FindCoordinatorResult findCoordinatorResult = adminClient.findCoordinator(topic.opts.linkName().get());
+                    coordinator = Optional.ofNullable(findCoordinatorResult.node().get());
                     newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue), topic.remoteBootstrapServers, topic.topicId, topic.opts.linkName());
                 } else if (topic.hasReplicaAssignment()) {
                     newTopic = new NewTopic(topic.name, topic.replicaAssignment);
@@ -505,11 +509,23 @@ public abstract class TopicCommand {
                     configsMap.put(TopicConfig.READ_ONLY_CONFIG, "true");
                 }
 
-                newTopic.configs(configsMap);
-                CreateTopicsResult createResult = adminClient.createTopics(Set.of(newTopic),
-                    new CreateTopicsOptions().retryOnQuotaViolation(false));
-                createResult.all().get();
-                System.out.println("Created topic " + topic.name + ".");
+                if (coordinator.isPresent()) {
+                    Node node = coordinator.get();
+                    String bootstrapServer = node.host() + ":" + node.port();
+                    try (Admin admin = createAdminClient(new Properties(), Optional.of(bootstrapServer))) {
+                        newTopic.configs(configsMap);
+                        CreateTopicsResult createResult = admin.createTopics(Set.of(newTopic),
+                                new CreateTopicsOptions().retryOnQuotaViolation(false));
+                        createResult.all().get();
+                        System.out.println("Created topic " + topic.name + ".");
+                    }
+                } else {
+                    newTopic.configs(configsMap);
+                    CreateTopicsResult createResult = adminClient.createTopics(Set.of(newTopic),
+                            new CreateTopicsOptions().retryOnQuotaViolation(false));
+                    createResult.all().get();
+                    System.out.println("Created topic " + topic.name + ".");
+                }
             } catch (ExecutionException e) {
                 if (e.getCause() == null) {
                     throw e;


### PR DESCRIPTION
- Add new admin api findCoordinator
- When create mirror topic it should find the coordinator first then send the create topic request

```
./bin/kafka-topics.sh --createMirror --topic test --bootstrap-server localhost:9094 --remote-bootstrap-server localhost:9092 --topic-id  RI3uACW1QM2Exahq-CATrA --link my-link
The findCoordinator response is: FindCoordinatorResponseData(throttleTimeMs=0, errorCode=0, errorMessage='', nodeId=0, host='', port=0, coordinators=[Coordinator(key='my-link', nodeId=1, host='localhost', port=9094, errorCode=0, errorMessage='')])
Found coordinator 1 for link my-link.
Node info: localhost:9094 (id: 1 rack: null isFenced: false)
Creating topic test using bootstrap server localhost:9094.
Created topic test.
```