### PR TITLE
allow delete mirror and attach a new cluster-link

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1668,6 +1668,8 @@ public interface Admin extends AutoCloseable {
 
     CreateClusterLinkResult createClusterLink(String clusterLinkName, Map<String, String> configs, CreateClusterLinkOptions options);
 
+    DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options);
+
     /**
      * Describe producer state on a set of topic partitions. See
      * {@link #describeProducers(Collection, DescribeProducersOptions)} for more details.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorTopicOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorTopicOptions.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Map;
+
+/**
+ * Options for {@link Admin#createClusterLink(String, Map)}.
+ */
+public class DeleteMirrorTopicOptions extends AbstractOptions<DeleteMirrorTopicOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorTopicResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorTopicResult.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+
+/**
+ * The result of the {@link Admin#unregisterBroker(int, UnregisterBrokerOptions)} call.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+public class DeleteMirrorTopicResult {
+    private final KafkaFuture<Void> future;
+
+    DeleteMirrorTopicResult(final KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    /**
+     * Return a future which succeeds if the operation is successful.
+     */
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -281,6 +281,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
+        return delegate.deleteMirrorTopic(clusterLinkName, topics, options);
+    }
+
+    @Override
     public DescribeProducersResult describeProducers(Collection<TopicPartition> partitions, DescribeProducersOptions options) {
         return delegate.describeProducers(partitions, options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -209,6 +209,8 @@ import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
 import org.apache.kafka.common.requests.DeleteAclsResponse;
+import org.apache.kafka.common.requests.DeleteMirrorTopicRequest;
+import org.apache.kafka.common.requests.DeleteMirrorTopicResponse;
 import org.apache.kafka.common.requests.DeleteTopicsRequest;
 import org.apache.kafka.common.requests.DeleteTopicsResponse;
 import org.apache.kafka.common.requests.DescribeAclsRequest;
@@ -4861,6 +4863,46 @@ public class KafkaAdminClient extends AdminClient {
         };
         runnable.call(call, now);
         return new CreateClusterLinkResult(future);
+    }
+
+    @Override
+    public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+        final Call call = new Call("createClusterLink", calcDeadlineMs(now, options.timeoutMs()),
+                new LeastLoadedBrokerOrActiveKController()) {
+
+            @Override
+            DeleteMirrorTopicRequest.Builder createRequest(int timeoutMs) {
+                return new DeleteMirrorTopicRequest.Builder(clusterLinkName, topics);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                final DeleteMirrorTopicResponse response =
+                        (DeleteMirrorTopicResponse) abstractResponse;
+                Errors error = Errors.forCode(response.data().errorCode());
+                switch (error) {
+                    case NONE:
+                        future.complete(null);
+                        break;
+                    case REQUEST_TIMED_OUT:
+                        throw error.exception(response.data().errorMessage());
+                    default:
+                        log.error("delete mirror topic {} failed: {}",
+                                clusterLinkName, response.data().errorMessage());
+                        future.completeExceptionally(error.exception(response.data().errorMessage()));
+                        break;
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        };
+        runnable.call(call, now);
+        return new DeleteMirrorTopicResult(future);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4882,7 +4882,6 @@ public class KafkaAdminClient extends AdminClient {
             void handleResponse(AbstractResponse abstractResponse) {
                 final DeleteMirrorTopicResponse response =
                         (DeleteMirrorTopicResponse) abstractResponse;
-                log.error("delete mirror topic:" + response);
                 Errors error = Errors.forCode(response.data().errorCode());
                 switch (error) {
                     case NONE:

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4867,9 +4867,10 @@ public class KafkaAdminClient extends AdminClient {
 
     @Override
     public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
+        log.info("!!! deleteMirrorTopic");
         final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
-        final Call call = new Call("createClusterLink", calcDeadlineMs(now, options.timeoutMs()),
+        final Call call = new Call("deleteMirrorTopic", calcDeadlineMs(now, options.timeoutMs()),
                 new LeastLoadedBrokerOrActiveKController()) {
 
             @Override
@@ -4881,6 +4882,7 @@ public class KafkaAdminClient extends AdminClient {
             void handleResponse(AbstractResponse abstractResponse) {
                 final DeleteMirrorTopicResponse response =
                         (DeleteMirrorTopicResponse) abstractResponse;
+                log.error("delete mirror topic:" + response);
                 Errors error = Errors.forCode(response.data().errorCode());
                 switch (error) {
                     case NONE:

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4867,7 +4867,6 @@ public class KafkaAdminClient extends AdminClient {
 
     @Override
     public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
-        log.info("!!! deleteMirrorTopic");
         final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
         final Call call = new Call("deleteMirrorTopic", calcDeadlineMs(now, options.timeoutMs()),

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -136,7 +136,10 @@ public enum ApiKeys {
     ALTER_SHARE_GROUP_OFFSETS(ApiMessageType.ALTER_SHARE_GROUP_OFFSETS),
     DELETE_SHARE_GROUP_OFFSETS(ApiMessageType.DELETE_SHARE_GROUP_OFFSETS),
     GET_REPLICA_LOG_INFO(ApiMessageType.GET_REPLICA_LOG_INFO),
-    CREATE_CLUSTER_LINK(ApiMessageType.CREATE_CLUSTER_LINK, false, true);
+    CREATE_CLUSTER_LINK(ApiMessageType.CREATE_CLUSTER_LINK, false, true),
+    CREATE_MIRROR_TOPIC(ApiMessageType.CREATE_MIRROR_TOPIC, false, true),
+    DELETE_MIRROR_TOPIC(ApiMessageType.DELETE_MIRROR_TOPIC, false, true),
+    BUMP_LEADER_EPOCH(ApiMessageType.BUMP_LEADER_EPOCH, false, true);
 
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =

--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
@@ -18,9 +18,13 @@ package org.apache.kafka.common.record;
 
 
 abstract class AbstractRecordBatch implements RecordBatch {
+
+    /*
+     * As long as the producer id is not NO_PRODUCER_ID, it is seen as a valid producer id
+     */
     @Override
     public boolean hasProducerId() {
-        return RecordBatch.NO_PRODUCER_ID == producerId();
+        return RecordBatch.NO_PRODUCER_ID != producerId();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
@@ -20,7 +20,7 @@ package org.apache.kafka.common.record;
 abstract class AbstractRecordBatch implements RecordBatch {
     @Override
     public boolean hasProducerId() {
-        return RecordBatch.NO_PRODUCER_ID < producerId();
+        return RecordBatch.NO_PRODUCER_ID == producerId();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -386,6 +386,10 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
         buffer.putInt(PARTITION_LEADER_EPOCH_OFFSET, epoch);
     }
 
+    public void setProducerId(long producerId) {
+        buffer.putLong(PRODUCER_ID_OFFSET, producerId);
+    }
+
     @Override
     public long checksum() {
         return ByteUtils.readUnsignedInt(buffer, CRC_OFFSET);

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -388,6 +388,9 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
 
     public void setProducerId(long producerId) {
         buffer.putLong(PRODUCER_ID_OFFSET, producerId);
+        // update crc
+        long crc = computeChecksum();
+        ByteUtils.writeUnsignedInt(buffer, CRC_OFFSET, crc);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/MutableRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MutableRecordBatch.java
@@ -51,6 +51,10 @@ public interface MutableRecordBatch extends RecordBatch {
      */
     void setPartitionLeaderEpoch(int epoch);
 
+    /**
+     * Set the producer id for this batch of records.
+     * @param producerId The producer id to use
+     */
     default void setProducerId(long producerId) { }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/record/MutableRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MutableRecordBatch.java
@@ -51,6 +51,8 @@ public interface MutableRecordBatch extends RecordBatch {
      */
     void setPartitionLeaderEpoch(int epoch);
 
+    default void setProducerId(long producerId) { }
+
     /**
      * Write this record batch into an output stream.
      * @param outputStream The buffer to write the batch to

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.CreateMirrorTopicRequestData;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
@@ -357,6 +358,12 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
             case GET_REPLICA_LOG_INFO:
                 return GetReplicaLogInfoRequest.parse(readable, apiVersion);
             case CREATE_CLUSTER_LINK:
+                return CreateClusterLinkRequest.parse(readable, apiVersion);
+            case CREATE_MIRROR_TOPIC:
+                return CreateClusterLinkRequest.parse(readable, apiVersion);
+            case DELETE_MIRROR_TOPIC:
+                return CreateClusterLinkRequest.parse(readable, apiVersion);
+            case BUMP_LEADER_EPOCH:
                 return CreateClusterLinkRequest.parse(readable, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -362,7 +362,7 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
             case CREATE_MIRROR_TOPIC:
                 return CreateClusterLinkRequest.parse(readable, apiVersion);
             case DELETE_MIRROR_TOPIC:
-                return CreateClusterLinkRequest.parse(readable, apiVersion);
+                return DeleteMirrorTopicRequest.parse(readable, apiVersion);
             case BUMP_LEADER_EPOCH:
                 return CreateClusterLinkRequest.parse(readable, apiVersion);
             default:

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -364,7 +364,7 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
             case DELETE_MIRROR_TOPIC:
                 return DeleteMirrorTopicRequest.parse(readable, apiVersion);
             case BUMP_LEADER_EPOCH:
-                return CreateClusterLinkRequest.parse(readable, apiVersion);
+                return BumpLeaderEpochRequest.parse(readable, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -298,7 +298,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
             case CREATE_MIRROR_TOPIC:
                 return CreateClusterLinkResponse.parse(readable, version);
             case DELETE_MIRROR_TOPIC:
-                return CreateClusterLinkResponse.parse(readable, version);
+                return DeleteMirrorTopicResponse.parse(readable, version);
             case BUMP_LEADER_EPOCH:
                 return CreateClusterLinkResponse.parse(readable, version);
             default:

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -295,6 +295,12 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return GetReplicaLogInfoResponse.parse(readable, version);
             case CREATE_CLUSTER_LINK:
                 return CreateClusterLinkResponse.parse(readable, version);
+            case CREATE_MIRROR_TOPIC:
+                return CreateClusterLinkResponse.parse(readable, version);
+            case DELETE_MIRROR_TOPIC:
+                return CreateClusterLinkResponse.parse(readable, version);
+            case BUMP_LEADER_EPOCH:
+                return CreateClusterLinkResponse.parse(readable, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -300,7 +300,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
             case DELETE_MIRROR_TOPIC:
                 return DeleteMirrorTopicResponse.parse(readable, version);
             case BUMP_LEADER_EPOCH:
-                return CreateClusterLinkResponse.parse(readable, version);
+                return BumpLeaderEpochResponse.parse(readable, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/BumpLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BumpLeaderEpochRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.BumpLeaderEpochRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicRequestData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Map;
+
+public class BumpLeaderEpochRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<BumpLeaderEpochRequest> {
+
+        private final BumpLeaderEpochRequestData data;
+
+        public Builder(BumpLeaderEpochRequestData data) {
+            super(ApiKeys.BUMP_LEADER_EPOCH);
+            this.data = data;
+        }
+
+        public Builder(String name, Map<String, String> configs) {
+            super(ApiKeys.BUMP_LEADER_EPOCH, ApiKeys.BUMP_LEADER_EPOCH.oldestVersion(),
+                  ApiKeys.BUMP_LEADER_EPOCH.latestVersion());
+            BumpLeaderEpochRequestData data = new BumpLeaderEpochRequestData();
+            this.data = data;
+        }
+
+        @Override
+        public BumpLeaderEpochRequest build(short version) {
+            return new BumpLeaderEpochRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final BumpLeaderEpochRequestData data;
+
+    public BumpLeaderEpochRequest(BumpLeaderEpochRequestData data, short version) {
+        super(ApiKeys.BUMP_LEADER_EPOCH, version);
+        this.data = data;
+    }
+
+    @Override
+    public BumpLeaderEpochRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        BumpLeaderEpochResponseData responseData = new BumpLeaderEpochResponseData();
+        responseData.setErrorCode(error.code());
+
+        return new BumpLeaderEpochResponse(responseData);
+    }
+
+    public static BumpLeaderEpochRequest parse(Readable readable, short version) {
+        return new BumpLeaderEpochRequest(
+                new BumpLeaderEpochRequestData(readable, version),
+                version
+        );
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/BumpLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BumpLeaderEpochResponse.java
@@ -17,7 +17,8 @@
 
 package org.apache.kafka.common.requests;
 
-import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
@@ -25,16 +26,16 @@ import org.apache.kafka.common.protocol.Readable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CreateClusterLinkResponse extends AbstractResponse {
-    private final CreateClusterLinkResponseData data;
+public class BumpLeaderEpochResponse extends AbstractResponse {
+    private final BumpLeaderEpochResponseData data;
 
-    public CreateClusterLinkResponse(CreateClusterLinkResponseData data) {
-        super(ApiKeys.CREATE_CLUSTER_LINK);
+    public BumpLeaderEpochResponse(BumpLeaderEpochResponseData data) {
+        super(ApiKeys.DELETE_MIRROR_TOPIC);
         this.data = data;
     }
 
     @Override
-    public CreateClusterLinkResponseData data() {
+    public BumpLeaderEpochResponseData data() {
         return data;
     }
 
@@ -55,7 +56,7 @@ public class CreateClusterLinkResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static CreateClusterLinkResponse parse(Readable readable, short version) {
-        return new CreateClusterLinkResponse(new CreateClusterLinkResponseData(readable, version));
+    public static BumpLeaderEpochResponse parse(Readable readable, short version) {
+        return new BumpLeaderEpochResponse(new BumpLeaderEpochResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateMirrorTopicRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateMirrorTopicRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.CreateClusterLinkRequestData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.CreateMirrorTopicRequestData;
+import org.apache.kafka.common.message.CreateMirrorTopicResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Map;
+
+public class CreateMirrorTopicRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<CreateMirrorTopicRequest> {
+
+        private final CreateMirrorTopicRequestData data;
+
+        public Builder(CreateMirrorTopicRequestData data) {
+            super(ApiKeys.CREATE_MIRROR_TOPIC);
+            this.data = data;
+        }
+
+        public Builder(String name, Map<String, String> configs) {
+            super(ApiKeys.CREATE_MIRROR_TOPIC, ApiKeys.CREATE_MIRROR_TOPIC.oldestVersion(),
+                  ApiKeys.CREATE_MIRROR_TOPIC.latestVersion());
+            CreateMirrorTopicRequestData data = new CreateMirrorTopicRequestData();
+            this.data = data;
+        }
+
+        @Override
+        public CreateMirrorTopicRequest build(short version) {
+            return new CreateMirrorTopicRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final CreateMirrorTopicRequestData data;
+
+    public CreateMirrorTopicRequest(CreateMirrorTopicRequestData data, short version) {
+        super(ApiKeys.CREATE_MIRROR_TOPIC, version);
+        this.data = data;
+    }
+
+    @Override
+    public CreateMirrorTopicRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        CreateMirrorTopicResponseData responseData = new CreateMirrorTopicResponseData();
+        responseData.setErrorCode(error.code());
+
+        return new CreateMirrorTopicResponse(responseData);
+    }
+
+    public static CreateMirrorTopicRequest parse(Readable readable, short version) {
+        return new CreateMirrorTopicRequest(
+                new CreateMirrorTopicRequestData(readable, version),
+                version
+        );
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateMirrorTopicResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateMirrorTopicResponse.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.CreateMirrorTopicResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
@@ -25,16 +26,16 @@ import org.apache.kafka.common.protocol.Readable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CreateClusterLinkResponse extends AbstractResponse {
-    private final CreateClusterLinkResponseData data;
+public class CreateMirrorTopicResponse extends AbstractResponse {
+    private final CreateMirrorTopicResponseData data;
 
-    public CreateClusterLinkResponse(CreateClusterLinkResponseData data) {
-        super(ApiKeys.CREATE_CLUSTER_LINK);
+    public CreateMirrorTopicResponse(CreateMirrorTopicResponseData data) {
+        super(ApiKeys.DELETE_MIRROR_TOPIC);
         this.data = data;
     }
 
     @Override
-    public CreateClusterLinkResponseData data() {
+    public CreateMirrorTopicResponseData data() {
         return data;
     }
 
@@ -55,7 +56,7 @@ public class CreateClusterLinkResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static CreateClusterLinkResponse parse(Readable readable, short version) {
-        return new CreateClusterLinkResponse(new CreateClusterLinkResponseData(readable, version));
+    public static CreateMirrorTopicResponse parse(Readable readable, short version) {
+        return new CreateMirrorTopicResponse(new CreateMirrorTopicResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicRequest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateMirrorTopicRequestData;
 import org.apache.kafka.common.message.DeleteMirrorTopicRequestData;
@@ -26,6 +27,7 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.Map;
+import java.util.Set;
 
 public class DeleteMirrorTopicRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<DeleteMirrorTopicRequest> {
@@ -37,10 +39,12 @@ public class DeleteMirrorTopicRequest extends AbstractRequest {
             this.data = data;
         }
 
-        public Builder(String name, Map<String, String> configs) {
+        public Builder(String name, Set<String> topics) {
             super(ApiKeys.DELETE_MIRROR_TOPIC, ApiKeys.DELETE_MIRROR_TOPIC.oldestVersion(),
                   ApiKeys.DELETE_MIRROR_TOPIC.latestVersion());
             DeleteMirrorTopicRequestData data = new DeleteMirrorTopicRequestData();
+            data.setClusterLink(name);
+            topics.forEach(topic -> data.topics().add(new DeleteMirrorTopicRequestData.TopicState().setName(topic)));
             this.data = data;
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.CreateMirrorTopicRequestData;
+import org.apache.kafka.common.message.DeleteMirrorTopicRequestData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Map;
+
+public class DeleteMirrorTopicRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<DeleteMirrorTopicRequest> {
+
+        private final DeleteMirrorTopicRequestData data;
+
+        public Builder(DeleteMirrorTopicRequestData data) {
+            super(ApiKeys.DELETE_MIRROR_TOPIC);
+            this.data = data;
+        }
+
+        public Builder(String name, Map<String, String> configs) {
+            super(ApiKeys.DELETE_MIRROR_TOPIC, ApiKeys.DELETE_MIRROR_TOPIC.oldestVersion(),
+                  ApiKeys.DELETE_MIRROR_TOPIC.latestVersion());
+            DeleteMirrorTopicRequestData data = new DeleteMirrorTopicRequestData();
+            this.data = data;
+        }
+
+        @Override
+        public DeleteMirrorTopicRequest build(short version) {
+            return new DeleteMirrorTopicRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final DeleteMirrorTopicRequestData data;
+
+    public DeleteMirrorTopicRequest(DeleteMirrorTopicRequestData data, short version) {
+        super(ApiKeys.DELETE_MIRROR_TOPIC, version);
+        this.data = data;
+    }
+
+    @Override
+    public DeleteMirrorTopicRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        DeleteMirrorTopicResponseData responseData = new DeleteMirrorTopicResponseData();
+        responseData.setErrorCode(error.code());
+
+        return new DeleteMirrorTopicResponse(responseData);
+    }
+
+    public static DeleteMirrorTopicRequest parse(Readable readable, short version) {
+        return new DeleteMirrorTopicRequest(
+                new DeleteMirrorTopicRequestData(readable, version),
+                version
+        );
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicResponse.java
@@ -17,7 +17,9 @@
 
 package org.apache.kafka.common.requests;
 
-import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.CreateMirrorTopicResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicRequestData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
@@ -25,16 +27,16 @@ import org.apache.kafka.common.protocol.Readable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CreateClusterLinkResponse extends AbstractResponse {
-    private final CreateClusterLinkResponseData data;
+public class DeleteMirrorTopicResponse extends AbstractResponse {
+    private final DeleteMirrorTopicResponseData data;
 
-    public CreateClusterLinkResponse(CreateClusterLinkResponseData data) {
-        super(ApiKeys.CREATE_CLUSTER_LINK);
+    public DeleteMirrorTopicResponse(DeleteMirrorTopicResponseData data) {
+        super(ApiKeys.DELETE_MIRROR_TOPIC);
         this.data = data;
     }
 
     @Override
-    public CreateClusterLinkResponseData data() {
+    public DeleteMirrorTopicResponseData data() {
         return data;
     }
 
@@ -55,7 +57,7 @@ public class CreateClusterLinkResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static CreateClusterLinkResponse parse(Readable readable, short version) {
-        return new CreateClusterLinkResponse(new CreateClusterLinkResponseData(readable, version));
+    public static DeleteMirrorTopicResponse parse(Readable readable, short version) {
+        return new DeleteMirrorTopicResponse(new DeleteMirrorTopicResponseData(readable, version));
     }
 }

--- a/clients/src/main/resources/common/message/BumpLeaderEpochRequest.json
+++ b/clients/src/main/resources/common/message/BumpLeaderEpochRequest.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":97,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "BumpLeaderEpochRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The cluster link name."},
+    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
+      "about": "The configurations.",  "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+        "about": "The configuration key name." },
+      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
+        "about": "The value to set for the configuration key."}
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/BumpLeaderEpochRequest.json
+++ b/clients/src/main/resources/common/message/BumpLeaderEpochRequest.json
@@ -21,14 +21,14 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
-      "about": "The cluster link name."},
-    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
-      "about": "The configurations.",  "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
-        "about": "The configuration key name." },
-      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
-        "about": "The value to set for the configuration key."}
-    ]}
+    { "name": "Topics", "type": "[]TopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
+      "fields": [
+        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "Partitions", "type": "[]LeaderEpochState", "versions": "0+", "about": "The name or topic ID of the topic.",
+          "fields": [
+            {"name": "partitionIndex", "type": "int32", "versions": "0+", "about": "The topic name."},
+            {"name": "leaderEpoch", "type": "int32", "versions": "0+", "default": -1, "about": "The topic name."}
+            ]}
+      ]}
   ]
 }

--- a/clients/src/main/resources/common/message/BumpLeaderEpochResponse.json
+++ b/clients/src/main/resources/common/message/BumpLeaderEpochResponse.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":97,
+  "type": "response",
+  "name": "BumpLeaderEpochResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+      "about": "The error message, or null if there was no error." }
+  ]
+}

--- a/clients/src/main/resources/common/message/CreateMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/CreateMirrorTopicRequest.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":95,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "CreateMirrorTopicRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The cluster link name."},
+    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
+      "about": "The configurations.",  "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+        "about": "The configuration key name." },
+      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
+        "about": "The value to set for the configuration key."}
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/CreateMirrorTopicResponse.json
+++ b/clients/src/main/resources/common/message/CreateMirrorTopicResponse.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":95,
+  "type": "response",
+  "name": "CreateMirrorTopicResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+      "about": "The error message, or null if there was no error." }
+  ]
+}

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -25,14 +25,9 @@
       "about": "If true, check that the topics can be created as specified, but don't create anything." },
     { "name": "Topics", "type": "[]TopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
       "fields": [
-        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
         { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
-          "about": "The topic name." },
-        { "name": "Partitions", "type": "[]LeaderEpochState", "versions": "0+", "ignorable": true ,"about": "The name or topic ID of the topic.",
-          "fields": [
-            {"name": "partitionIndex", "type": "int32", "versions": "0+", "about": "The topic name."},
-            {"name": "leaderEpoch", "type": "int32", "versions": "0+", "default": -1, "about": "The topic name."}
-          ]}
+          "about": "The topic name." }
       ]}
   ]
 }

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":96,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "DeleteMirrorTopicRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The cluster link name."},
+    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
+      "about": "The configurations.",  "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+        "about": "The configuration key name." },
+      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
+        "about": "The value to set for the configuration key."}
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -21,12 +21,14 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "Topics", "type": "[]DeleteMirrorTopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
+    { "name": "Topics", "type": "[]TopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
       "fields": [
-        {"name": "name", "type": "string", "versions": "0+", "about": "The unique topic ID."},
-        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."}
-      ]},
-    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
-      "about": "The length of time in milliseconds to wait for the deletions to complete." }
+        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "Partitions", "type": "[]LeaderEpochState", "versions": "0+", "ignorable": true ,"about": "The name or topic ID of the topic.",
+          "fields": [
+            {"name": "partitionIndex", "type": "int32", "versions": "0+", "about": "The topic name."},
+            {"name": "leaderEpoch", "type": "int32", "versions": "0+", "default": -1, "about": "The topic name."}
+          ]}
+      ]}
   ]
 }

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -21,9 +21,13 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
+    { "name": "clusterLink", "type": "string", "versions": "7+", "ignorable": true,
+      "about": "If true, check that the topics can be created as specified, but don't create anything." },
     { "name": "Topics", "type": "[]TopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
       "fields": [
         {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
+          "about": "The topic name." },
         { "name": "Partitions", "type": "[]LeaderEpochState", "versions": "0+", "ignorable": true ,"about": "The name or topic ID of the topic.",
           "fields": [
             {"name": "partitionIndex", "type": "int32", "versions": "0+", "about": "The topic name."},

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -21,14 +21,12 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
-      "about": "The cluster link name."},
-    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
-      "about": "The configurations.",  "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
-        "about": "The configuration key name." },
-      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
-        "about": "The value to set for the configuration key."}
-    ]}
+    { "name": "Topics", "type": "[]DeleteMirrorTopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
+      "fields": [
+        {"name": "name", "type": "string", "versions": "0+", "about": "The unique topic ID."},
+        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."}
+      ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+      "about": "The length of time in milliseconds to wait for the deletions to complete." }
   ]
 }

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicResponse.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicResponse.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":96,
+  "type": "response",
+  "name": "DeleteMirrorTopicResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+      "about": "The error message, or null if there was no error." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1376,6 +1376,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     public DescribeProducersResult describeProducers(Collection<TopicPartition> partitions, DescribeProducersOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }

--- a/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
+++ b/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
@@ -16,6 +16,8 @@
  */
 package kafka.server;
 
+import kafka.log.LogManager;
+import kafka.server.metadata.KRaftMetadataCache;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -29,6 +31,7 @@ import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.CreateAclsRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
 import org.apache.kafka.common.message.DeleteAclsRequestData;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;
@@ -43,6 +46,7 @@ import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.CreateAclsRequest;
+import org.apache.kafka.common.requests.BumpLeaderEpochRequest;
 import org.apache.kafka.common.requests.CreatePartitionsRequest;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
 import org.apache.kafka.common.requests.DeleteTopicsRequest;
@@ -77,6 +81,8 @@ import org.apache.kafka.server.common.ControllerRequestCompletionHandler;
 import org.apache.kafka.server.common.NodeToControllerChannelManager;
 import org.apache.kafka.server.common.RequestLocal;
 import org.apache.kafka.server.network.BrokerEndPoint;
+import org.apache.kafka.server.util.KafkaScheduler;
+import org.apache.kafka.server.util.Scheduler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,14 +128,18 @@ public class RemoteClusterMetadataManager implements MetadataPublisher, AutoClos
     private MetadataCache metadataCache;
     private NodeToControllerChannelManager channelManager;
     private final Supplier<GroupCoordinator> groupCoordinatorSupplier;
+    private LogManager logManager;
+    private Scheduler scheduler;
 
     public RemoteClusterMetadataManager(
         KafkaConfig config,
         Metrics metrics,
         Time time,
         MetadataCache metadataCache,
-        NodeToControllerChannelManager channelManager,
-        Supplier<GroupCoordinator> groupCoordinatorSupplier
+        Supplier<GroupCoordinator> groupCoordinatorSupplier,
+        LogManager logManager,
+        Scheduler scheduler,
+        NodeToControllerChannelManager channelManager
     ) {
         this.brokerConfig = config;
         this.nodeId = config.nodeId();
@@ -144,6 +154,16 @@ public class RemoteClusterMetadataManager implements MetadataPublisher, AutoClos
         this.metadataCache = metadataCache;
         this.channelManager = channelManager;
         this.groupCoordinatorSupplier = groupCoordinatorSupplier;
+        this.logManager = logManager;
+        this.scheduler = scheduler;
+
+        scheduler.startup();
+        // periodically query source cluster to get the metadata
+        scheduler.schedule("query",
+                this::refreshRemoteMetadata,
+                300000,
+                300000
+        );
     }
 
     @Override
@@ -180,6 +200,29 @@ public class RemoteClusterMetadataManager implements MetadataPublisher, AutoClos
 
     public void updateMirroredTopics(String clusterName, Set<String> topics) {
         this.topics.put(clusterName, topics);
+    }
+
+    public void maybeUpdateLeaderEpoch(List<String> topics) {
+        // sent in another thread to avoid to block the api handling thread
+        scheduler.scheduleOnce("bump-leader-epoch", () -> sendBumpLeaderEpoch(topics));
+    }
+
+    private void sendBumpLeaderEpoch(List<String> topics) {
+        List<BumpLeaderEpochRequestData.TopicState> topicStates = new ArrayList<>();
+        topics.forEach(topic -> {
+            BumpLeaderEpochRequestData.TopicState topicState = new BumpLeaderEpochRequestData.TopicState();
+            List<BumpLeaderEpochRequestData.LeaderEpochState> topicLeaderEpoch = new ArrayList<>();
+            ((KRaftMetadataCache) metadataCache).getImage().topics().getTopic(topic).partitions().keySet().forEach(partitionId -> {
+                int epoch = logManager.getLog(new TopicPartition(topic, partitionId), false).get().latestEpochFromLog().orElse(-1);
+                topicLeaderEpoch.add(new BumpLeaderEpochRequestData.LeaderEpochState().setLeaderEpoch(epoch).setPartitionIndex(partitionId));
+            });
+            topicState.setTopicId(metadataCache.getTopicId(topic)).setPartitions(topicLeaderEpoch);
+            topicStates.add(topicState);
+        });
+
+        channelManager.sendRequest(new BumpLeaderEpochRequest.Builder(
+                new BumpLeaderEpochRequestData().setTopics(topicStates)
+        ), new TimeoutHandler());
     }
 
     // TODO: When mirror deleted, we should write a record in internal topic and remove topics from the list

--- a/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
+++ b/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
@@ -182,6 +182,7 @@ public class RemoteClusterMetadataManager implements MetadataPublisher, AutoClos
         this.topics.put(clusterName, topics);
     }
 
+    // TODO: When mirror deleted, we should write a record in internal topic and remove topics from the list
     public void refreshRemoteMetadata() {
         log.info("!!! Refreshing remote cluster metadata:" + topics);
         // make sure all clusterLinkNames has at least one connections ready

--- a/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
+++ b/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
@@ -41,7 +41,6 @@ import org.apache.kafka.metadata.MetadataCache;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.RequestLocal;
 import org.apache.kafka.server.storage.log.FetchIsolation;
-import org.apache.kafka.server.util.Scheduler;
 import org.apache.kafka.storage.internals.log.AppendOrigin;
 import org.apache.kafka.storage.internals.log.FetchDataInfo;
 
@@ -70,7 +69,6 @@ public class TopicMirrorLinkCoordinator {
     private final AtomicBoolean isActive = new AtomicBoolean(false);
     private final KafkaConfig config;
     private final ReplicaManager replicaManager;
-    private final Scheduler scheduler;
     private final Metrics metrics;
     private final MetadataCache metadataCache;
     private final Time time;
@@ -82,7 +80,6 @@ public class TopicMirrorLinkCoordinator {
     public TopicMirrorLinkCoordinator(
             KafkaConfig config,
             ReplicaManager replicaManager,
-            Scheduler scheduler,
             Metrics metrics,
             MetadataCache metadataCache,
             Time time,
@@ -90,7 +87,6 @@ public class TopicMirrorLinkCoordinator {
     ) {
         this.config = config;
         this.replicaManager = replicaManager;
-        this.scheduler = scheduler;
         this.metrics = metrics;
         this.metadataCache = metadataCache;
         this.time = time;
@@ -104,13 +100,6 @@ public class TopicMirrorLinkCoordinator {
         }
 
         logger.info("Starting up.");
-        scheduler.startup();
-        // periodically query source cluster to get the metadata
-        scheduler.schedule("topic-mirror-link-query",
-                remoteClusterMetadataManager::refreshRemoteMetadata,
-                300000,
-                300000
-        );
         numPartitions = config.clusterLinksConfig().clusterLinkTopicNumPartitions();
     }
 

--- a/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
+++ b/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
@@ -106,11 +106,11 @@ public class TopicMirrorLinkCoordinator {
         logger.info("Starting up.");
         scheduler.startup();
         // periodically query source cluster to get the metadata
-//        scheduler.schedule("topic-mirror-link-query",
-//                remoteClusterMetadataManager::refreshRemoteMetadata,
-//                10000,
-//                10000
-//        );
+        scheduler.schedule("topic-mirror-link-query",
+                remoteClusterMetadataManager::refreshRemoteMetadata,
+                300000,
+                300000
+        );
         numPartitions = config.clusterLinksConfig().clusterLinkTopicNumPartitions();
     }
 

--- a/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
+++ b/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
@@ -106,11 +106,11 @@ public class TopicMirrorLinkCoordinator {
         logger.info("Starting up.");
         scheduler.startup();
         // periodically query source cluster to get the metadata
-        scheduler.schedule("topic-mirror-link-query",
-                remoteClusterMetadataManager::refreshRemoteMetadata,
-                10000,
-                10000
-        );
+//        scheduler.schedule("topic-mirror-link-query",
+//                remoteClusterMetadataManager::refreshRemoteMetadata,
+//                10000,
+//                10000
+//        );
         numPartitions = config.clusterLinksConfig().clusterLinkTopicNumPartitions();
     }
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -26,7 +26,6 @@ import kafka.server._
 import kafka.server.share.DelayedShareFetch
 import kafka.utils.CoreUtils.{inReadLock, inWriteLock}
 import kafka.utils._
-import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.{DirectoryId, IsolationLevel, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState
@@ -1374,10 +1373,6 @@ class Partition(val topicPartition: TopicPartition,
     val (info, leaderHWIncremented) = inReadLock(leaderIsrUpdateLock) {
       leaderLogIfLocal match {
         case Some(leaderLog) =>
-          if (leaderLog.config().getBoolean(TopicConfig.READ_ONLY_CONFIG)) {
-            throw new InvalidTopicException("Cannot append to read-only partition %s on broker %d"
-              .format(topicPartition, localBrokerId))
-          }
           val minIsr = effectiveMinIsr(leaderLog)
           val inSyncSize = partitionState.isr.size
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1327,13 +1327,13 @@ class Partition(val topicPartition: TopicPartition,
       inReadLock(leaderIsrUpdateLock) {
         // Note the replica may be undefined if it is removed by a non-ReplicaAlterLogDirsThread before
         // this method is called
-        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch) }
+        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, !clusterLinkName.isEmpty) }
       }
     } else {
       // The lock is needed to prevent the follower replica from being updated while ReplicaAlterDirThread
       // is executing maybeReplaceCurrentWithFutureReplica() to replace follower replica with the future replica.
       futureLogLock.synchronized {
-        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch))
+        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, !clusterLinkName.isEmpty))
       }
     }
   }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -347,7 +347,6 @@ class BrokerServer(
         clientToControllerChannelManager,
         () => groupCoordinator
       )
-      kafkaScheduler.schedule("remote-cluster-metadata-refresh", () => remoteClusterMetadataManager.refreshRemoteMetadata(), 5000L, 30000L)
 
       this._replicaManager = new ReplicaManager(
         config = config,

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -344,8 +344,10 @@ class BrokerServer(
         metrics,
         time,
         metadataCache,
-        clientToControllerChannelManager,
-        () => groupCoordinator
+        () => groupCoordinator,
+        logManager,
+        new KafkaScheduler(1, true, "remote-cluster-metadata-manager-"),
+        clientToControllerChannelManager
       )
 
       this._replicaManager = new ReplicaManager(
@@ -399,7 +401,7 @@ class BrokerServer(
         producerIdManagerSupplier, metrics, metadataCache, Time.SYSTEM)
 
       topicMirrorLinkCoordinator = new TopicMirrorLinkCoordinator(config, replicaManager,
-        new KafkaScheduler(1, true, "topic-mirror-link-manager-"), metrics, metadataCache, Time.SYSTEM, remoteClusterMetadataManager)
+        metrics, metadataCache, Time.SYSTEM, remoteClusterMetadataManager)
 
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
         config, clientToControllerChannelManager, groupCoordinator,

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -138,8 +138,8 @@ class ControllerApis(
         case ApiKeys.UPDATE_RAFT_VOTER => handleUpdateRaftVoter(request)
         case ApiKeys.CREATE_CLUSTER_LINK => handleCreateClusterLink(request)
         case ApiKeys.CREATE_MIRROR_TOPIC => handleCreateClusterLink(request)
-        case ApiKeys.DELETE_MIRROR_TOPIC => handleCreateClusterLink(request)
-        case ApiKeys.BUMP_LEADER_EPOCH => handleBumpLeaderEpoch(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => handleDeleteMirrorTopic(request)
+        case ApiKeys.BUMP_LEADER_EPOCH => handleDeleteMirrorTopic(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -231,21 +231,29 @@ class ControllerApis(
 
   }
 
-  def handleBumpLeaderEpoch(request: RequestChannel.Request): CompletableFuture[Unit] = {
+  def handleDeleteMirrorTopic(request: RequestChannel.Request): CompletableFuture[Unit] = {
     // luke
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
-    val bumpLeaderEpochRequest = request.body[BumpLeaderEpochRequest]
+    val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    controller.bumpLeaderEpoch(context, bumpLeaderEpochRequest.data().apiKey().toInt)
+    val partitionLeaderEpochs: util.Map[Uuid, util.Map[Integer, Integer]] = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+    deleteMirrorTopicRequest.data().topics().forEach( topic => {
+      val map = new util.HashMap[Integer, Integer]()
+      topic.partitions().forEach(par => {
+        map.put(par.partitionIndex(), par.leaderEpoch())
+      })
+      partitionLeaderEpochs.put(topic.topicId(), map)
+    })
+    controller.deleteMirrorTopic(context, partitionLeaderEpochs)
       .handle[Unit] { (response, exception) =>
-        logger.info("!!! bump leader epoch response: " + response + " exception: " + exception)
+        logger.info("!!! delete mirror topic response: " + response + " exception: " + exception)
         if (exception != null) {
           requestHelper.handleError(request, exception)
         } else {
 
           requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
-            new BumpLeaderEpochResponse(response.setThrottleTimeMs(throttleMs)))
+            new DeleteMirrorTopicResponse(response.setThrottleTimeMs(throttleMs)))
         }
       }
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -137,6 +137,9 @@ class ControllerApis(
         case ApiKeys.REMOVE_RAFT_VOTER => handleRemoveRaftVoter(request)
         case ApiKeys.UPDATE_RAFT_VOTER => handleUpdateRaftVoter(request)
         case ApiKeys.CREATE_CLUSTER_LINK => handleCreateClusterLink(request)
+        case ApiKeys.CREATE_MIRROR_TOPIC => handleCreateClusterLink(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => handleCreateClusterLink(request)
+        case ApiKeys.BUMP_LEADER_EPOCH => handleBumpLeaderEpoch(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -166,7 +169,6 @@ class ControllerApis(
   }
 
   def handleCreateClusterLink(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    // test
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     val createClusterLinkRequest = request.body[CreateClusterLinkRequest]
     info("!!! create cluster link request: " + createClusterLinkRequest)
@@ -224,6 +226,28 @@ class ControllerApis(
         names => authHelper.filterByAuthorized(request.context, CREATE, TOPIC, names)(identity),
         names => authHelper.filterByAuthorized(request.context, DESCRIBE_CONFIGS, TOPIC, names, logIfDenied = false)(identity))
     }
+
+    CompletableFuture.completedFuture[Unit](())
+
+  }
+
+  def handleBumpLeaderEpoch(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    // luke
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val bumpLeaderEpochRequest = request.body[BumpLeaderEpochRequest]
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
+    controller.bumpLeaderEpoch(context, bumpLeaderEpochRequest.data().apiKey().toInt)
+      .handle[Unit] { (response, exception) =>
+        logger.info("!!! bump leader epoch response: " + response + " exception: " + exception)
+        if (exception != null) {
+          requestHelper.handleError(request, exception)
+        } else {
+
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new BumpLeaderEpochResponse(response.setThrottleTimeMs(throttleMs)))
+        }
+      }
 
     CompletableFuture.completedFuture[Unit](())
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -235,6 +235,7 @@ class ControllerApis(
     // luke
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
+    info("!!! delete mirror topic request: " + deleteMirrorTopicRequest)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
     val partitionLeaderEpochs: util.Map[Uuid, util.Map[Integer, Integer]] = new util.HashMap[Uuid, util.Map[Integer, Integer]]()

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -139,7 +139,7 @@ class ControllerApis(
         case ApiKeys.CREATE_CLUSTER_LINK => handleCreateClusterLink(request)
         case ApiKeys.CREATE_MIRROR_TOPIC => handleCreateClusterLink(request)
         case ApiKeys.DELETE_MIRROR_TOPIC => handleDeleteMirrorTopic(request)
-        case ApiKeys.BUMP_LEADER_EPOCH => handleDeleteMirrorTopic(request)
+        case ApiKeys.BUMP_LEADER_EPOCH => handleBumpLeaderEpoch(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -238,15 +238,15 @@ class ControllerApis(
     info("!!! delete mirror topic request: " + deleteMirrorTopicRequest)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    val partitionLeaderEpochs: util.Map[Uuid, util.Map[Integer, Integer]] = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+    val topicIds: util.Set[Uuid] = new util.HashSet[Uuid]()
     deleteMirrorTopicRequest.data().topics().forEach( topic => {
-      val map = new util.HashMap[Integer, Integer]()
-      topic.partitions().forEach(par => {
-        map.put(par.partitionIndex(), par.leaderEpoch())
-      })
-      partitionLeaderEpochs.put(topic.topicId(), map)
+      if (!topic.topicId().equals(Uuid.ZERO_UUID)) {
+        topicIds.add(topic.topicId())
+      } else {
+        topicIds.add(metadataCache.getTopicId(topic.name()))
+      }
     })
-    controller.deleteMirrorTopic(context, partitionLeaderEpochs)
+    controller.deleteMirrorTopic(context, topicIds)
       .handle[Unit] { (response, exception) =>
         logger.info("!!! delete mirror topic response: " + response + " exception: " + exception)
         if (exception != null) {
@@ -255,6 +255,37 @@ class ControllerApis(
 
           requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
             new DeleteMirrorTopicResponse(response.setThrottleTimeMs(throttleMs)))
+        }
+      }
+
+    CompletableFuture.completedFuture[Unit](())
+
+  }
+
+  def handleBumpLeaderEpoch(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    // luke
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val bumpLeaderEpochRequest = request.body[BumpLeaderEpochRequest]
+    info("!!! bump leader epoch request: " + bumpLeaderEpochRequest)
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
+    val partitionLeaderEpochs: util.Map[Uuid, util.Map[Integer, Integer]] = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+    bumpLeaderEpochRequest.data().topics().forEach( topic => {
+      val map = new util.HashMap[Integer, Integer]()
+      topic.partitions().forEach(par => {
+        map.put(par.partitionIndex(), par.leaderEpoch())
+      })
+      partitionLeaderEpochs.put(topic.topicId(), map)
+    })
+    controller.bumpLeaderEpoch(context, partitionLeaderEpochs)
+      .handle[Unit] { (response, exception) =>
+        logger.info("!!! bump leader epoch response: " + response + " exception: " + exception)
+        if (exception != null) {
+          requestHelper.handleError(request, exception)
+        } else {
+
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new BumpLeaderEpochResponse(response.setThrottleTimeMs(throttleMs)))
         }
       }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -253,7 +253,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.GET_REPLICA_LOG_INFO => handleGetReplicaLogInfo(request)
         case ApiKeys.CREATE_CLUSTER_LINK => forwardToController(request)
         case ApiKeys.CREATE_MIRROR_TOPIC => forwardToController(request)
-        case ApiKeys.DELETE_MIRROR_TOPIC => handleDeleteMirrorTopic(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => forwardToController(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -269,17 +269,6 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (request.apiLocalCompleteTimeNanos < 0)
         request.apiLocalCompleteTimeNanos = time.nanoseconds
     }
-  }
-
-  def handleDeleteMirrorTopic(request: RequestChannel.Request): Unit = {
-    val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
-    logger.info(s"!!! Handling delete mirror topics request:" + request.sizeInBytes + ";;" + deleteMirrorTopicRequest)
-    val topicNames = deleteMirrorTopicRequest.data().topics().stream().map(t => t.name()).toList
-
-    // TODO: need to find a way to bump the leader epoch AFTER deleteMirrorTopic completed and the broker has stopped fetch,
-    // otherwise, the new appended records after leader epoch bump might be larger
-    replicaManager.remoteClusterMetadataManager.get.maybeUpdateLeaderEpoch(topicNames)
-    forwardToController(request)
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -273,25 +273,13 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleDeleteMirrorTopic(request: RequestChannel.Request): Unit = {
     val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
-    logger.info(s"!!! Handling delete mirror topics request")
-    // get the leader epoch to bump from each partition
-
-    val updatedDeleteMirrorTopicRequestData = new DeleteMirrorTopicRequestData()
+    logger.info(s"!!! Handling delete mirror topics request:" + request.sizeInBytes + ";;" + deleteMirrorTopicRequest)
     val topicNames = deleteMirrorTopicRequest.data().topics().stream().map(t => t.name()).toList
-    topicNames.forEach( name => {
-      val leaderEpochStates = new util.ArrayList[DeleteMirrorTopicRequestData.LeaderEpochState]()
-      metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(name).partitions().keySet().forEach(par => {
-        val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(name, par)).map(log => log.latestEpochFromLog().orElse(-1)).get
-        leaderEpochStates.add(new DeleteMirrorTopicRequestData.LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
-      })
-      updatedDeleteMirrorTopicRequestData.topics().add(new DeleteMirrorTopicRequestData.TopicState().setTopicId(metadataCache.getTopicId(name)).setPartitions(leaderEpochStates))
-    })
 
-    val updatedDeleteMirrorTopicRequest = new DeleteMirrorTopicRequest(updatedDeleteMirrorTopicRequestData, deleteMirrorTopicRequest.version())
-
-//    request.body
-
-//    requestChannel
+    // TODO: need to find a way to bump the leader epoch AFTER deleteMirrorTopic completed and the broker has stopped fetch,
+    // otherwise, the new appended records after leader epoch bump might be larger
+    replicaManager.remoteClusterMetadataManager.get.maybeUpdateLeaderEpoch(topicNames)
+    forwardToController(request)
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic.{CLUSTER_LINK_TOPIC_NAME, GROUP_METADATA_TOPIC_NAME, SHARE_GROUP_STATE_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME, isInternal}
 import org.apache.kafka.common.internals.{FatalExitError, Plugin, Topic}
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.{AddPartitionsToTxnResult, AddPartitionsToTxnResultCollection}
+import org.apache.kafka.common.message.BumpLeaderEpochRequestData.LeaderEpochState
 import org.apache.kafka.common.message.DeleteRecordsResponseData.{DeleteRecordsPartitionResult, DeleteRecordsTopicResult}
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData.DeleteShareGroupOffsetsRequestTopic
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic
@@ -269,6 +270,32 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (request.apiLocalCompleteTimeNanos < 0)
         request.apiLocalCompleteTimeNanos = time.nanoseconds
     }
+  }
+
+  def handleDeleteMirrorTopic(request: RequestChannel.Request): Unit = {
+    val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
+    logger.info(s"!!! Handling delete mirror topics request")
+    // get the leader epoch to bump from each partition
+
+    val topicIds = deleteMirrorTopicRequest.data().topics().stream().map(t => t.topicId()).toList
+    val bumpLeaderEpochs = new BumpLeaderEpochRequestData()
+    topicIds.forEach( tid => {
+      val leaderEpochStates = new util.ArrayList[LeaderEpochState]()
+      metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(tid).partitions().keySet().forEach(par => {
+        val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(metadataCache.getTopicName(tid).get(), par)).map(log => log.latestEpochFromLog().orElse(-1)).get
+        leaderEpochStates.add(new LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
+      })
+      bumpLeaderEpochs.topics().add(new BumpLeaderEpochRequestData.TopicState().setTopicId(tid).setPartitions(leaderEpochStates))
+    })
+
+
+
+//    val clusterLinkTopic = createTopicsRequest.data.topics.stream().filter(t => t.clusterLink() != null && !t.clusterLink().isEmpty).findFirst()
+//    if (clusterLinkTopic.isPresent) {
+//      logger.info(s"!!! Handling create mirror topics request: ${clusterLinkTopic.get().clusterLink()}")
+//      topicMirrorLinkCoordinator.addTopicsInCoordinator(clusterLinkTopic.get().clusterLink(), util.Set.of(clusterLinkTopic.get().name()));
+//    }
+    forwardToController(request)
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -252,6 +252,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.STREAMS_GROUP_HEARTBEAT => handleStreamsGroupHeartbeat(request).exceptionally(handleError)
         case ApiKeys.GET_REPLICA_LOG_INFO => handleGetReplicaLogInfo(request)
         case ApiKeys.CREATE_CLUSTER_LINK => forwardToController(request)
+        case ApiKeys.CREATE_MIRROR_TOPIC => forwardToController(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => forwardToController(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -34,7 +34,6 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic.{CLUSTER_LINK_TOPIC_NAME, GROUP_METADATA_TOPIC_NAME, SHARE_GROUP_STATE_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME, isInternal}
 import org.apache.kafka.common.internals.{FatalExitError, Plugin, Topic}
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.{AddPartitionsToTxnResult, AddPartitionsToTxnResultCollection}
-import org.apache.kafka.common.message.BumpLeaderEpochRequestData.LeaderEpochState
 import org.apache.kafka.common.message.DeleteRecordsResponseData.{DeleteRecordsPartitionResult, DeleteRecordsTopicResult}
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData.DeleteShareGroupOffsetsRequestTopic
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic
@@ -277,25 +276,20 @@ class KafkaApis(val requestChannel: RequestChannel,
     logger.info(s"!!! Handling delete mirror topics request")
     // get the leader epoch to bump from each partition
 
+    val updatedDeleteMirrorTopicRequestData = new DeleteMirrorTopicRequestData()
     val topicIds = deleteMirrorTopicRequest.data().topics().stream().map(t => t.topicId()).toList
-    val bumpLeaderEpochs = new BumpLeaderEpochRequestData()
     topicIds.forEach( tid => {
-      val leaderEpochStates = new util.ArrayList[LeaderEpochState]()
+      val leaderEpochStates = new util.ArrayList[DeleteMirrorTopicRequestData.LeaderEpochState]()
       metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(tid).partitions().keySet().forEach(par => {
         val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(metadataCache.getTopicName(tid).get(), par)).map(log => log.latestEpochFromLog().orElse(-1)).get
-        leaderEpochStates.add(new LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
+        leaderEpochStates.add(new DeleteMirrorTopicRequestData.LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
       })
-      bumpLeaderEpochs.topics().add(new BumpLeaderEpochRequestData.TopicState().setTopicId(tid).setPartitions(leaderEpochStates))
+      updatedDeleteMirrorTopicRequestData.topics().add(new DeleteMirrorTopicRequestData.TopicState().setTopicId(tid).setPartitions(leaderEpochStates))
     })
 
+    val updatedDeleteMirrorTopicRequest = new DeleteMirrorTopicRequest(updatedDeleteMirrorTopicRequestData, deleteMirrorTopicRequest.version())
 
-
-//    val clusterLinkTopic = createTopicsRequest.data.topics.stream().filter(t => t.clusterLink() != null && !t.clusterLink().isEmpty).findFirst()
-//    if (clusterLinkTopic.isPresent) {
-//      logger.info(s"!!! Handling create mirror topics request: ${clusterLinkTopic.get().clusterLink()}")
-//      topicMirrorLinkCoordinator.addTopicsInCoordinator(clusterLinkTopic.get().clusterLink(), util.Set.of(clusterLinkTopic.get().name()));
-//    }
-    forwardToController(request)
+    forwardToController(updatedDeleteMirrorTopicRequest.asInstanceOf[RequestChannel.Request])
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -277,14 +277,14 @@ class KafkaApis(val requestChannel: RequestChannel,
     // get the leader epoch to bump from each partition
 
     val updatedDeleteMirrorTopicRequestData = new DeleteMirrorTopicRequestData()
-    val topicIds = deleteMirrorTopicRequest.data().topics().stream().map(t => t.topicId()).toList
-    topicIds.forEach( tid => {
+    val topicNames = deleteMirrorTopicRequest.data().topics().stream().map(t => t.name()).toList
+    topicNames.forEach( name => {
       val leaderEpochStates = new util.ArrayList[DeleteMirrorTopicRequestData.LeaderEpochState]()
-      metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(tid).partitions().keySet().forEach(par => {
-        val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(metadataCache.getTopicName(tid).get(), par)).map(log => log.latestEpochFromLog().orElse(-1)).get
+      metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(name).partitions().keySet().forEach(par => {
+        val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(name, par)).map(log => log.latestEpochFromLog().orElse(-1)).get
         leaderEpochStates.add(new DeleteMirrorTopicRequestData.LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
       })
-      updatedDeleteMirrorTopicRequestData.topics().add(new DeleteMirrorTopicRequestData.TopicState().setTopicId(tid).setPartitions(leaderEpochStates))
+      updatedDeleteMirrorTopicRequestData.topics().add(new DeleteMirrorTopicRequestData.TopicState().setTopicId(metadataCache.getTopicId(name)).setPartitions(leaderEpochStates))
     })
 
     val updatedDeleteMirrorTopicRequest = new DeleteMirrorTopicRequest(updatedDeleteMirrorTopicRequestData, deleteMirrorTopicRequest.version())

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -22,6 +22,7 @@ import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.{QuotaManagers, UNBOUNDED_QUOTA}
 import kafka.server.coordinator.{ClusterLinkKey, TopicMirrorLinkCoordinator}
 import kafka.server.handlers.DescribeTopicPartitionsRequestHandler
+import kafka.server.metadata.KRaftMetadataCache
 import kafka.server.share.{ShareFetchUtils, SharePartitionManager}
 import kafka.utils.Logging
 import org.apache.kafka.clients.CommonClientConfigs
@@ -491,6 +492,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val unauthorizedTopicResponses = mutable.Map[TopicIdPartition, PartitionResponse]()
     val nonExistingTopicResponses = mutable.Map[TopicIdPartition, PartitionResponse]()
     val invalidRequestResponses = mutable.Map[TopicIdPartition, PartitionResponse]()
+    val readOnlyTopicResponses = mutable.Map[TopicIdPartition, PartitionResponse]()
     val authorizedRequestInfo = mutable.Map[TopicIdPartition, MemoryRecords]()
     val topicIdToPartitionData = new mutable.ArrayBuffer[(TopicIdPartition, ProduceRequestData.PartitionProduceData)]
 
@@ -501,11 +503,13 @@ class KafkaApis(val requestChannel: RequestChannel,
         } else {
           (metadataCache.getTopicName(topic.topicId).orElse(topic.name), topic.topicId())
         }
-
         val topicPartition = new TopicPartition(topicName, partition.index())
+
         // To be compatible with the old version, only return UNKNOWN_TOPIC_ID if request version uses topicId, but the corresponding topic name can't be found.
         if (topicName.isEmpty && request.header.apiVersion > 12)
           nonExistingTopicResponses += new TopicIdPartition(topicId, topicPartition) -> new PartitionResponse(Errors.UNKNOWN_TOPIC_ID)
+        else if (!metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(topic.topicId()).partitions().get(partition.index()).clusterLinkName.isEmpty())
+          readOnlyTopicResponses += new TopicIdPartition(topicId, topicPartition) -> new PartitionResponse(Errors.INVALID_REQUEST)
         else
           topicIdToPartitionData += new TopicIdPartition(topicId, topicPartition) -> partition
       }
@@ -538,7 +542,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     // https://issues.apache.org/jira/browse/KAFKA-10730
     @nowarn("cat=deprecation")
     def sendResponseCallback(responseStatus: Map[TopicIdPartition, PartitionResponse]): Unit = {
-      val mergedResponseStatus = responseStatus ++ unauthorizedTopicResponses ++ nonExistingTopicResponses ++ invalidRequestResponses
+      val mergedResponseStatus = responseStatus ++ unauthorizedTopicResponses ++ nonExistingTopicResponses ++ invalidRequestResponses ++ readOnlyTopicResponses
       var errorInResponse = false
 
       val nodeEndpoints = new mutable.HashMap[Int, Node]

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -253,7 +253,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.GET_REPLICA_LOG_INFO => handleGetReplicaLogInfo(request)
         case ApiKeys.CREATE_CLUSTER_LINK => forwardToController(request)
         case ApiKeys.CREATE_MIRROR_TOPIC => forwardToController(request)
-        case ApiKeys.DELETE_MIRROR_TOPIC => forwardToController(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => handleDeleteMirrorTopic(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -289,7 +289,9 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     val updatedDeleteMirrorTopicRequest = new DeleteMirrorTopicRequest(updatedDeleteMirrorTopicRequestData, deleteMirrorTopicRequest.version())
 
-    forwardToController(updatedDeleteMirrorTopicRequest.asInstanceOf[RequestChannel.Request])
+//    request.body
+
+//    requestChannel
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2300,6 +2300,11 @@ class ReplicaManager(val config: KafkaConfig,
                                           delta: TopicsDelta,
                                           topicId: Uuid): Option[(Partition, Boolean)] = {
     val localChanges = delta.localChanges(config.nodeId)
+    val clusterLinkName = if (localChanges.readOnlyLeaders().containsKey(tp)) {
+      delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).clusterLinkName
+    } else {
+      ""
+    }
     getPartition(tp) match {
       case HostedPartition.Offline(offlinePartition) =>
         if (offlinePartition.flatMap(p => p.topicId).contains(topicId)) {
@@ -2311,11 +2316,7 @@ class ReplicaManager(val config: KafkaConfig,
           stateChangeLogger.info(s"Creating new partition $tp with topic id " + s"$topicId." +
             s"A topic with the same name but different id exists but it resides in an offline log " +
             s"directory.")
-          val clusterLinkName = if (localChanges.readOnlyLeaders().containsKey(tp)) {
-            delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).clusterLinkName
-          } else {
-            ""
-          }
+
           logger.info("!!! create new partition: " + tp + " " + topicId + " " + clusterLinkName)
           val partition = Partition(new TopicIdPartition(topicId, tp), time, this, clusterLinkName)
           allPartitions.put(tp, HostedPartition.Online(partition))
@@ -2329,6 +2330,8 @@ class ReplicaManager(val config: KafkaConfig,
           throw new IllegalStateException(s"Topic $tp exists, but its ID is " +
             s"${partition.topicId.get}, not $topicId as expected")
         }
+        logger.info("!!! update partition: " + tp + " " + topicId + " " + clusterLinkName + ";;" + partition.clusterLinkName)
+        partition.setClusterLinkName(clusterLinkName)
         Some(partition, false)
 
       case HostedPartition.None =>
@@ -2340,11 +2343,6 @@ class ReplicaManager(val config: KafkaConfig,
             s"$topicId.")
         }
         // it's a partition that we don't know about yet, so create it and mark it online
-        val clusterLinkName = if (localChanges.readOnlyLeaders().containsKey(tp)) {
-          delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).clusterLinkName
-        } else {
-          ""
-        }
         logger.info("!!! create new partition: " + tp + " " + topicId + " " + clusterLinkName)
         val partition = Partition(new TopicIdPartition(topicId, tp), time, this, clusterLinkName)
         allPartitions.put(tp, HostedPartition.Online(partition))
@@ -2468,17 +2466,7 @@ class ReplicaManager(val config: KafkaConfig,
       getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
         try {
           val readonly: Boolean = newImage.configs().configProperties(new ConfigResource(ConfigResource.Type.TOPIC, tp.topic)).getOrDefault(TopicConfig.READ_ONLY_CONFIG, "false").asInstanceOf[String].toBoolean
-          logger.info("!!! tp = " + tp + ", remoteLeader = " + remoteLeader + ", readonly = " + readonly)
-          if (remoteLeader) {
-            if (!readonly) {
-              // skip remote leader with read.only=false topic
-              return
-            }
-            // When a broker restarts, it brings up partition as follower first.
-            // We don't set remote bootstrap server when a partition is follower.
-            // If it becomes remote leader later, we need to set remote bootstrap server here.
-            partition.setClusterLinkName(info.partition.clusterLinkName)
-          }
+          logger.info("!!! tp = " + tp + ", remoteLeader = " + remoteLeader + ", readonly = " + readonly + ";;" + partition.clusterLinkName)
           followerTopicSet.add(tp.topic)
 
           // We always update the follower state.

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2305,6 +2305,7 @@ class ReplicaManager(val config: KafkaConfig,
     } else {
       ""
     }
+
     getPartition(tp) match {
       case HostedPartition.Offline(offlinePartition) =>
         if (offlinePartition.flatMap(p => p.topicId).contains(topicId)) {
@@ -2330,7 +2331,7 @@ class ReplicaManager(val config: KafkaConfig,
           throw new IllegalStateException(s"Topic $tp exists, but its ID is " +
             s"${partition.topicId.get}, not $topicId as expected")
         }
-        logger.info("!!! update partition: " + tp + " " + topicId + " " + clusterLinkName + ";;" + partition.clusterLinkName)
+        // TODO: We should update the partition state in makeLeader/MakeFollower, not when getting it
         partition.setClusterLinkName(clusterLinkName)
         Some(partition, false)
 
@@ -2391,8 +2392,13 @@ class ReplicaManager(val config: KafkaConfig,
         val lazyOffsetCheckpoints = new LazyOffsetCheckpoints(this.highWatermarkCheckpoints.asJava)
         val leaderChangedPartitions = new mutable.HashSet[Partition]
         val followerChangedPartitions = new mutable.HashSet[Partition]
+        val deleteMirrorTopics = new mutable.HashSet[String]
         if (!localChanges.leaders.isEmpty) {
-          applyLocalLeadersDelta(leaderChangedPartitions, delta, lazyOffsetCheckpoints, localChanges.leaders.asScala, localChanges.directoryIds.asScala)
+          applyLocalLeadersDelta(leaderChangedPartitions, delta, lazyOffsetCheckpoints, localChanges.leaders.asScala, localChanges.directoryIds.asScala, deleteMirrorTopics)
+          if (deleteMirrorTopics.nonEmpty) {
+            info("!!! sent bumpLeaderEpoch:" + deleteMirrorTopics)
+            remoteClusterMetadataManager.get.maybeUpdateLeaderEpoch(deleteMirrorTopics.toList.asJava)
+          }
         }
         if (!localChanges.followers.isEmpty) {
           applyLocalFollowersDelta(followerChangedPartitions, newImage, delta, lazyOffsetCheckpoints, localChanges.followers.asScala, localChanges.directoryIds.asScala)
@@ -2421,16 +2427,24 @@ class ReplicaManager(val config: KafkaConfig,
     delta: TopicsDelta,
     offsetCheckpoints: OffsetCheckpoints,
     localLeaders: mutable.Map[TopicPartition, LocalReplicaChanges.PartitionInfo],
-    directoryIds: mutable.Map[TopicIdPartition, Uuid]
+    directoryIds: mutable.Map[TopicIdPartition, Uuid],
+    deleteMirrorTopics: mutable.Set[String]
   ): Unit = {
     stateChangeLogger.info(s"Transitioning ${localLeaders.size} partition(s) to " +
       "local leaders.")
     replicaFetcherManager.removeFetcherForPartitions(localLeaders.keySet)
+    var isDeleteMirrorTopic = false
     localLeaders.foreachEntry { (tp, info) =>
       getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
         try {
           val state = info.partition.toLeaderAndIsrPartitionState(tp, isNew)
           val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
+
+          val newClusterName = delta.changedTopics().get(info.topicId()).partitionChanges().get(tp.partition()).clusterLinkName
+          if (partition.clusterLinkName.nonEmpty && newClusterName.isEmpty && !isDeleteMirrorTopic) {
+            isDeleteMirrorTopic = true
+          }
+
           partition.makeLeader(state, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
           changedPartitions.add(partition)
@@ -2444,6 +2458,9 @@ class ReplicaManager(val config: KafkaConfig,
             // to an empty Partition object. We need to map this topic-partition to OfflinePartition instead.
             markPartitionOffline(tp)
         }
+      }
+      if (isDeleteMirrorTopic) {
+        deleteMirrorTopics.add(tp.topic())
       }
     }
   }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -60,7 +60,6 @@ object BrokerMetadataPublisher extends Logging {
   def getTopicDelta(topicName: String,
                     newImage: MetadataImage,
                     delta: MetadataDelta): Option[TopicDelta] = {
-    logger.info(s"!!! Looking for topic delta for topic ${newImage.topics().getTopic(topicName)} ;; ${delta.topicsDelta()}")
     Option(newImage.topics().getTopic(topicName)).flatMap {
       topicImage => Option(delta.topicsDelta()).flatMap {
         topicDelta => Option(topicDelta.changedTopic(topicImage.id()))

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
@@ -148,6 +149,11 @@ public interface Controller extends AclMutator, AutoCloseable {
     CompletableFuture<CreateClusterLinkResponseData> createClusterLink(
             ControllerRequestContext context,
             Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
+    );
+
+    CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
+            int leaderEpoch
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -154,6 +154,11 @@ public interface Controller extends AclMutator, AutoCloseable {
 
     CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
+            Set<Uuid> topicIds
+    );
+
+    CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
             Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
     );
 

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
@@ -151,9 +152,9 @@ public interface Controller extends AclMutator, AutoCloseable {
             Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
     );
 
-    CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+    CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
-            int leaderEpoch
+            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -100,7 +100,7 @@ public class PartitionChangeBuilder {
     private boolean eligibleLeaderReplicasEnabled;
     private DefaultDirProvider defaultDirProvider;
     private String clusterLink;
-    private int minLeaderEpoch;
+    private int minLeaderEpoch = -1;
 
     // Whether allow electing last known leader in a Balanced recovery. Note, the last known leader will be stored in the
     // lastKnownElr field if enabled.

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -59,6 +59,7 @@ public class PartitionChangeBuilder {
         if (record.removingReplicas() != null) return false;
         if (record.addingReplicas() != null) return false;
         if (record.leaderRecoveryState() != LeaderRecoveryState.NO_CHANGE) return false;
+        if (record.clusterLinkName() != null) return false;
         return record.directories() == null;
     }
 
@@ -98,6 +99,7 @@ public class PartitionChangeBuilder {
     private LeaderRecoveryState targetLeaderRecoveryState;
     private boolean eligibleLeaderReplicasEnabled;
     private DefaultDirProvider defaultDirProvider;
+    private String clusterLink;
 
     // Whether allow electing last known leader in a Balanced recovery. Note, the last known leader will be stored in the
     // lastKnownElr field if enabled.
@@ -193,6 +195,11 @@ public class PartitionChangeBuilder {
 
     public PartitionChangeBuilder setDefaultDirProvider(DefaultDirProvider defaultDirProvider) {
         this.defaultDirProvider = defaultDirProvider;
+        return this;
+    }
+
+    public PartitionChangeBuilder setClusterLink(String clusterLink) {
+        this.clusterLink = clusterLink;
         return this;
     }
 
@@ -431,7 +438,7 @@ public class PartitionChangeBuilder {
         PartitionChangeRecord record = new PartitionChangeRecord().
             setTopicId(topicId).
             setPartitionId(partitionId).
-            setClusterLinkName(partition.clusterLinkName);
+            setClusterLinkName(clusterLink);
 
         completeReassignmentIfNeeded();
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -100,6 +100,7 @@ public class PartitionChangeBuilder {
     private boolean eligibleLeaderReplicasEnabled;
     private DefaultDirProvider defaultDirProvider;
     private String clusterLink;
+    private int minLeaderEpoch;
 
     // Whether allow electing last known leader in a Balanced recovery. Note, the last known leader will be stored in the
     // lastKnownElr field if enabled.
@@ -200,6 +201,11 @@ public class PartitionChangeBuilder {
 
     public PartitionChangeBuilder setClusterLink(String clusterLink) {
         this.clusterLink = clusterLink;
+        return this;
+    }
+
+    public PartitionChangeBuilder setMinLeaderEpoch(int leaderEpoch) {
+        this.minLeaderEpoch = leaderEpoch;
         return this;
     }
 
@@ -438,7 +444,8 @@ public class PartitionChangeBuilder {
         PartitionChangeRecord record = new PartitionChangeRecord().
             setTopicId(topicId).
             setPartitionId(partitionId).
-            setClusterLinkName(clusterLink);
+            setClusterLinkName(clusterLink).
+            setLeaderEpoch(minLeaderEpoch);
 
         completeReassignmentIfNeeded();
 

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
@@ -1777,6 +1778,17 @@ public final class QuorumController implements Controller {
             return result;
         });
     }
+
+    @Override
+    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
+            int leaderEpoch
+    ) {
+        return appendWriteEvent("bumpLeaderEpoch", context.deadlineNs(),
+                () -> replicationControl.bumpLeaderEpoch(leaderEpoch));
+    }
+
+
 
     @Override
     public CompletableFuture<Void> unregisterBroker(

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1783,12 +1783,20 @@ public final class QuorumController implements Controller {
     @Override
     public CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
-            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
+            Set<Uuid> topicIds
     ) {
         return appendWriteEvent("deleteMirrorTopic", context.deadlineNs(),
-                () -> replicationControl.deleteMirrorTopic(partitionLeaderEpochs));
+                () -> replicationControl.deleteMirrorTopic(topicIds));
     }
 
+    @Override
+    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
+            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
+    ) {
+        return appendWriteEvent("bumpLeaderEpochs", context.deadlineNs(),
+                () -> replicationControl.bumpLeaderEpochs(partitionLeaderEpochs));
+    }
 
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -50,6 +50,7 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
@@ -1780,12 +1781,12 @@ public final class QuorumController implements Controller {
     }
 
     @Override
-    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+    public CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
-            int leaderEpoch
+            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
     ) {
-        return appendWriteEvent("bumpLeaderEpoch", context.deadlineNs(),
-                () -> replicationControl.bumpLeaderEpoch(leaderEpoch));
+        return appendWriteEvent("deleteMirrorTopic", context.deadlineNs(),
+                () -> replicationControl.deleteMirrorTopic(partitionLeaderEpochs));
     }
 
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -50,6 +50,8 @@ import org.apache.kafka.common.message.AlterPartitionResponseData;
 import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
@@ -1715,6 +1717,16 @@ public class ReplicationControlManager {
                 request.currentMetadataOffset());
         log.error("processExpiredBrokerHeartbeat: controller event queue overloaded. Timed out " +
                 "heartbeat from broker {}.", brokerId);
+    }
+
+    public ControllerResult<BumpLeaderEpochResponseData> bumpLeaderEpoch(int leaderEpoch) {
+//        BrokerRegistration registration = clusterControl.brokerRegistrations().get(brokerId);
+//        if (registration == null) {
+//            throw new BrokerIdNotRegisteredException("Broker ID " + brokerId +
+//                    " is not currently registered");
+//        }
+        List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+        return ControllerResult.of(records, null);
     }
 
     public ControllerResult<Void> unregisterBroker(int brokerId) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -618,12 +618,18 @@ public class ReplicationControlManager {
         return numRemoved;
     }
 
+    private boolean hasDifferentClusterLink(String topicName, String clusterLink) {
+        return !topics.get(topicsByName.get(topicName)).parts.get(0).clusterLinkName.equals(clusterLink);
+    }
+
     ControllerResult<CreateTopicsResponseData> createTopics(
         ControllerRequestContext context,
         CreateTopicsRequestData request,
         Set<String> describable
     ) {
+        log.info("!!! createTopics:" + request);
         Map<String, ApiError> topicErrors = new HashMap<>();
+        Map<String, String> attachedTopicsClusterLink = new HashMap<>();
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
 
         validateTotalNumberOfPartitions(request, defaultNumPartitions);
@@ -633,8 +639,14 @@ public class ReplicationControlManager {
 
         // Identify topics that already exist and mark them with the appropriate error
         request.topics().stream().filter(creatableTopic -> topicsByName.containsKey(creatableTopic.name()))
-                .forEach(t -> topicErrors.put(t.name(), new ApiError(Errors.TOPIC_ALREADY_EXISTS,
-                    "Topic '" + t.name() + "' already exists.")));
+                .forEach(t -> {
+                    if (!hasDifferentClusterLink(t.name(), t.clusterLink())) {
+                        topicErrors.put(t.name(), new ApiError(Errors.TOPIC_ALREADY_EXISTS,
+                                "Topic '" + t.name() + "' already exists."));
+                    } else {
+                        attachedTopicsClusterLink.put(t.name(), t.clusterLink());
+                    }
+                });
 
         // Verify that the configurations for the new topics are OK, and figure out what
         // configurations should be created.
@@ -644,7 +656,7 @@ public class ReplicationControlManager {
         // Try to create whatever topics are needed.
         Map<String, CreatableTopicResult> successes = new HashMap<>();
         for (CreatableTopic topic : request.topics()) {
-            if (topicErrors.containsKey(topic.name())) continue;
+            if (topicErrors.containsKey(topic.name()) || attachedTopicsClusterLink.containsKey(topic.name())) continue;
             // Figure out what ConfigRecords should be created, if any.
             ConfigResource configResource = new ConfigResource(TOPIC, topic.name());
             Map<String, Entry<OpType, String>> keyToOps = configChanges.get(configResource);
@@ -670,6 +682,41 @@ public class ReplicationControlManager {
             if (error.isFailure()) {
                 topicErrors.put(topic.name(), error);
             }
+        }
+
+        // luke
+        // handle attached mirror topics
+        log.info("!!! attachedTopic:" + attachedTopicsClusterLink + ";;" + topicErrors);
+        for (Entry<String, String> attachedTopic : attachedTopicsClusterLink.entrySet()) {
+            String topicName = attachedTopic.getKey();
+            String clusterLink = attachedTopic.getValue();
+            TopicControlInfo info = topics.get(topicsByName.get(topicName));
+            for (int partitionId : info.parts.keySet()) {
+                PartitionRegistration partition = info.parts.get(partitionId);
+                PartitionChangeBuilder builder = new PartitionChangeBuilder(
+                        partition,
+                        info.topicId(),
+                        partitionId,
+                        new LeaderAcceptor(clusterControl, partition),
+                        featureControl.metadataVersionOrThrow(),
+                        getTopicEffectiveMinIsr(topicName)
+                )
+                        .setClusterLink(clusterLink)
+                        .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
+                        .setDefaultDirProvider(clusterDescriber);
+                builder.build().ifPresent(records::add);
+                log.info("!!! update partition {} for topic {} with cluster link {}: {}", partitionId, topicName, clusterLink, records);
+
+            }
+            CreatableTopicResult result = new CreatableTopicResult().
+                    setName(topicName).
+                    setTopicId(topicsByName.get(topicName)).
+                    setErrorCode(NONE.code()).
+                    setErrorMessage(null);
+            result.setNumPartitions(info.parts.size());
+            result.setReplicationFactor((short) info.parts.values().iterator().next().replicas.length);
+            result.setTopicConfigErrorCode(NONE.code());
+            successes.put(topicName, result);
         }
 
         // Create responses for all topics.
@@ -1136,7 +1183,8 @@ public class ReplicationControlManager {
                     featureControl.metadataVersionOrThrow(),
                     getTopicEffectiveMinIsr(topic.name)
                 )
-                    .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
+                    .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
+                    .setClusterLink(partition.clusterLinkName);
                 if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name())) {
                     builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
                 }
@@ -1600,6 +1648,7 @@ public class ReplicationControlManager {
             .setElection(election)
             .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
             .setDefaultDirProvider(clusterDescriber)
+            .setClusterLink(partition.clusterLinkName)
             .build();
         if (record.isEmpty()) {
             if (electionType == ElectionType.PREFERRED) {
@@ -1764,6 +1813,7 @@ public class ReplicationControlManager {
                 .setElection(PartitionChangeBuilder.Election.PREFERRED)
                 .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
                 .setDefaultDirProvider(clusterDescriber)
+                .setClusterLink(partition.clusterLinkName)
                 .build().ifPresent(records::add);
         }
     }
@@ -2032,6 +2082,7 @@ public class ReplicationControlManager {
                 getTopicEffectiveMinIsr(topic.name)
             );
             builder.setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
+            builder.setClusterLink(partition.clusterLinkName);
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
             }
@@ -2161,6 +2212,7 @@ public class ReplicationControlManager {
             setTargetRemoving(List.of()).
             setTargetAdding(List.of()).
             setDefaultDirProvider(clusterDescriber).
+            setClusterLink(part.clusterLinkName).
             build();
     }
 
@@ -2218,6 +2270,7 @@ public class ReplicationControlManager {
             getTopicEffectiveMinIsr(topics.get(tp.topicId()).name)
         );
         builder.setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
+        builder.setClusterLink(part.clusterLinkName);
         if (!reassignment.replicas().equals(currentReplicas)) {
             builder.setTargetReplicas(reassignment.replicas());
         }
@@ -2302,6 +2355,7 @@ public class ReplicationControlManager {
                             )
                                     .setDirectory(brokerId, dirId)
                                     .setDefaultDirProvider(clusterDescriber)
+                                    .setClusterLink(partitionRegistration.clusterLinkName)
                                     .build();
                             partitionChangeRecord.ifPresent(records::add);
                             if (directoryIsOffline) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -61,6 +61,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicCol
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfigCollection;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersRequestData.TopicPartitions;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
@@ -1719,14 +1720,34 @@ public class ReplicationControlManager {
                 "heartbeat from broker {}.", brokerId);
     }
 
-    public ControllerResult<BumpLeaderEpochResponseData> bumpLeaderEpoch(int leaderEpoch) {
-//        BrokerRegistration registration = clusterControl.brokerRegistrations().get(brokerId);
-//        if (registration == null) {
-//            throw new BrokerIdNotRegisteredException("Broker ID " + brokerId +
-//                    " is not currently registered");
-//        }
+    public ControllerResult<DeleteMirrorTopicResponseData> deleteMirrorTopic(Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
-        return ControllerResult.of(records, null);
+        for (Entry<Uuid, Map<Integer, Integer>> partitionLeaderEpoch : partitionLeaderEpochs.entrySet()) {
+            Uuid topicId = partitionLeaderEpoch.getKey();
+            Map<Integer, Integer> leaderEpochs = partitionLeaderEpoch.getValue();
+            TopicControlInfo info = topics.get(topicId);
+            String topicName = info.name;
+            for (int partitionId : info.parts.keySet()) {
+                PartitionRegistration partition = info.parts.get(partitionId);
+                PartitionChangeBuilder builder = new PartitionChangeBuilder(
+                        partition,
+                        info.topicId(),
+                        partitionId,
+                        new LeaderAcceptor(clusterControl, partition),
+                        featureControl.metadataVersionOrThrow(),
+                        getTopicEffectiveMinIsr(topicName)
+                )
+                        .setClusterLink("")
+                        .setMinLeaderEpoch(leaderEpochs.getOrDefault(partitionId, -1))
+                        .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
+                        .setDefaultDirProvider(clusterDescriber);
+
+                builder.build().ifPresent(records::add);
+                log.info("!!! update partition {} for topic {} with empty cluster link: {}", partitionId, topicName, records);
+            }
+        }
+
+        return ControllerResult.of(records, new DeleteMirrorTopicResponseData().setErrorCode((short) 0));
     }
 
     public ControllerResult<Void> unregisterBroker(int brokerId) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -139,6 +139,7 @@ import static org.apache.kafka.common.protocol.Errors.NO_REASSIGNMENT_IN_PROGRES
 import static org.apache.kafka.common.protocol.Errors.TOPIC_AUTHORIZATION_FAILED;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_ID;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_OR_PARTITION;
+import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
 import static org.apache.kafka.controller.PartitionReassignmentReplicas.isReassignmentInProgress;
 import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_OP;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
@@ -1720,7 +1721,35 @@ public class ReplicationControlManager {
                 "heartbeat from broker {}.", brokerId);
     }
 
-    public ControllerResult<DeleteMirrorTopicResponseData> deleteMirrorTopic(Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
+    public ControllerResult<DeleteMirrorTopicResponseData> deleteMirrorTopic(Set<Uuid> topicIds) {
+        List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+        for (Uuid topicId : topicIds) {
+            TopicControlInfo info = topics.get(topicId);
+            String topicName = info.name;
+            for (int partitionId : info.parts.keySet()) {
+                PartitionRegistration partition = info.parts.get(partitionId);
+                PartitionChangeBuilder builder = new PartitionChangeBuilder(
+                        partition,
+                        info.topicId(),
+                        partitionId,
+                        new LeaderAcceptor(clusterControl, partition),
+                        featureControl.metadataVersionOrThrow(),
+                        getTopicEffectiveMinIsr(topicName)
+                )
+                        // clear the cluster link name
+                        .setClusterLink("")
+                        .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
+                        .setDefaultDirProvider(clusterDescriber);
+
+                builder.build().ifPresent(records::add);
+                log.info("!!! update partition {} for topic {} with empty cluster link: {}", partitionId, topicName, records);
+            }
+        }
+
+        return ControllerResult.of(records, new DeleteMirrorTopicResponseData().setErrorCode((short) 0));
+    }
+
+    public ControllerResult<BumpLeaderEpochResponseData> bumpLeaderEpochs(Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         for (Entry<Uuid, Map<Integer, Integer>> partitionLeaderEpoch : partitionLeaderEpochs.entrySet()) {
             Uuid topicId = partitionLeaderEpoch.getKey();
@@ -1737,17 +1766,18 @@ public class ReplicationControlManager {
                         featureControl.metadataVersionOrThrow(),
                         getTopicEffectiveMinIsr(topicName)
                 )
-                        .setClusterLink("")
-                        .setMinLeaderEpoch(leaderEpochs.getOrDefault(partitionId, -1))
+                        // set the min leader epoch for each partition
+                        .setMinLeaderEpoch(leaderEpochs.getOrDefault(partitionId, NO_PARTITION_LEADER_EPOCH))
+                        .setClusterLink(partition.clusterLinkName)
                         .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
                         .setDefaultDirProvider(clusterDescriber);
 
                 builder.build().ifPresent(records::add);
-                log.info("!!! update partition {} for topic {} with empty cluster link: {}", partitionId, topicName, records);
+                log.info("!!! update partition {} for topic {} with cluster link: {}", partitionId, topicName, records);
             }
         }
 
-        return ControllerResult.of(records, new DeleteMirrorTopicResponseData().setErrorCode((short) 0));
+        return ControllerResult.of(records, new BumpLeaderEpochResponseData().setErrorCode((short) 0));
     }
 
     public ControllerResult<Void> unregisterBroker(int brokerId) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
 
 
@@ -263,13 +264,18 @@ public class PartitionRegistration {
 
         int newLeader;
         int newLeaderEpoch;
-        if (record.leader() == NO_LEADER_CHANGE) {
+        // we should bump the leader epoch when leaderEpoch is assiged (bump_leader_epoch request), even if no_leader_change
+        if (record.leader() == NO_LEADER_CHANGE && record.leaderEpoch() == NO_PARTITION_LEADER_EPOCH) {
             newLeader = leader;
             newLeaderEpoch = leaderEpoch;
         } else {
             newLeader = record.leader();
             newLeaderEpoch = leaderEpoch + 1;
         }
+        if (record.leaderEpoch() != NO_PARTITION_LEADER_EPOCH && record.leaderEpoch() < newLeaderEpoch ) {
+            newLeaderEpoch = record.leaderEpoch();
+        }
+
 
         LeaderRecoveryState newLeaderRecoveryState = leaderRecoveryState.changeTo(record.leaderRecoveryState());
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -286,7 +286,7 @@ public class PartitionRegistration {
             partitionEpoch + 1,
             newElr,
             newLastKnownElr,
-            record.clusterLinkName().isBlank() ? clusterLinkName : record.clusterLinkName());
+            record.clusterLinkName());
     }
 
     public String diff(PartitionRegistration prev) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -272,6 +272,7 @@ public class PartitionRegistration {
             newLeader = record.leader();
             newLeaderEpoch = leaderEpoch + 1;
         }
+        System.out.println("!!! newLeaderEpoch:" + newLeaderEpoch + ";;" + leaderEpoch + ";;" + record.leaderEpoch() + ";;" + record.leader());
         if (record.leaderEpoch() != NO_PARTITION_LEADER_EPOCH && record.leaderEpoch() < newLeaderEpoch ) {
             newLeaderEpoch = record.leaderEpoch();
         }

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -265,18 +265,21 @@ public class PartitionRegistration {
         int newLeader;
         int newLeaderEpoch;
         // we should bump the leader epoch when leaderEpoch is assiged (bump_leader_epoch request), even if no_leader_change
-        if (record.leader() == NO_LEADER_CHANGE && record.leaderEpoch() == NO_PARTITION_LEADER_EPOCH) {
+        if (record.leader() == NO_LEADER_CHANGE) {
             newLeader = leader;
-            newLeaderEpoch = leaderEpoch;
+            if (record.leaderEpoch() == NO_PARTITION_LEADER_EPOCH) {
+                newLeaderEpoch = leaderEpoch;
+            } else {
+                newLeaderEpoch = leaderEpoch + 1;
+            }
         } else {
             newLeader = record.leader();
             newLeaderEpoch = leaderEpoch + 1;
         }
         System.out.println("!!! newLeaderEpoch:" + newLeaderEpoch + ";;" + leaderEpoch + ";;" + record.leaderEpoch() + ";;" + record.leader());
-        if (record.leaderEpoch() != NO_PARTITION_LEADER_EPOCH && record.leaderEpoch() < newLeaderEpoch ) {
-            newLeaderEpoch = record.leaderEpoch();
+        if (record.leaderEpoch() != NO_PARTITION_LEADER_EPOCH && record.leaderEpoch() >= newLeaderEpoch) {
+            newLeaderEpoch = record.leaderEpoch() + 1;
         }
-
 
         LeaderRecoveryState newLeaderRecoveryState = leaderRecoveryState.changeTo(record.leaderRecoveryState());
 

--- a/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
@@ -53,6 +53,8 @@
       "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 7,
       "about": "null if the LastKnownElr didn't change; the last known eligible leader replicas otherwise." },
     { "name": "clusterLinkName", "type": "string", "versions": "2+", "default": "",
-      "about": "clusterLinkName." }
+      "about": "clusterLinkName." },
+    { "name": "LeaderEpoch", "type": "int32", "versions": "2+", "default": "-1",
+      "about": "The epoch of the partition leader." }
   ]
 }

--- a/server/src/main/java/org/apache/kafka/network/RequestConvertToJson.java
+++ b/server/src/main/java/org/apache/kafka/network/RequestConvertToJson.java
@@ -583,6 +583,12 @@ public class RequestConvertToJson {
                 return GetReplicaLogInfoRequestDataJsonConverter.write(((GetReplicaLogInfoRequest) request).data(), request.version());
             case CREATE_CLUSTER_LINK:
                 return CreateClusterLinkRequestDataJsonConverter.write(((CreateClusterLinkRequest) request).data(), request.version());
+            case CREATE_MIRROR_TOPIC:
+                return CreateClusterLinkRequestDataJsonConverter.write(((CreateClusterLinkRequest) request).data(), request.version());
+            case DELETE_MIRROR_TOPIC:
+                return CreateClusterLinkRequestDataJsonConverter.write(((CreateClusterLinkRequest) request).data(), request.version());
+            case BUMP_LEADER_EPOCH:
+                return CreateClusterLinkRequestDataJsonConverter.write(((CreateClusterLinkRequest) request).data(), request.version());
             default:
                 throw new IllegalStateException("ApiKey " + request.apiKey() + " is not currently handled in `request`, the " +
                     "code should be updated to do so.");
@@ -772,6 +778,12 @@ public class RequestConvertToJson {
             case GET_REPLICA_LOG_INFO:
                 return GetReplicaLogInfoResponseDataJsonConverter.write(((GetReplicaLogInfoResponse) response).data(), version);
             case CREATE_CLUSTER_LINK:
+                return CreateClusterLinkResponseDataJsonConverter.write(((CreateClusterLinkResponse) response).data(), version);
+            case CREATE_MIRROR_TOPIC:
+                return CreateClusterLinkResponseDataJsonConverter.write(((CreateClusterLinkResponse) response).data(), version);
+            case DELETE_MIRROR_TOPIC:
+                return CreateClusterLinkResponseDataJsonConverter.write(((CreateClusterLinkResponse) response).data(), version);
+            case BUMP_LEADER_EPOCH:
                 return CreateClusterLinkResponseDataJsonConverter.write(((CreateClusterLinkResponse) response).data(), version);
             default:
                 throw new IllegalStateException("ApiKey " + response.apiKey() + " is not currently handled in `response`, the " +

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1173,7 +1173,7 @@ public class UnifiedLog implements AutoCloseable {
                                     for (MutableRecordBatch batch : records.batches()) {
                                         // reset to -1
                                         logger.info("!!! resetting batch producer id to -1 for batch {}", batch.baseOffset());
-                                        batch.setProducerId(-1L);
+                                        batch.setProducerId(-(batch.producerId() + 2));
                                     }
                                 }
                                 // we are taking the offsets we are given

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1042,6 +1042,10 @@ public class UnifiedLog implements AutoCloseable {
                 VerificationGuard.SENTINEL, false, recordVersion.value);
     }
 
+    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch) {
+        return appendAsFollower(records, leaderEpoch, false);
+    }
+
     /**
      * Append this message set to the active segment of the local log without assigning offsets or Partition Leader Epochs
      *
@@ -1050,7 +1054,7 @@ public class UnifiedLog implements AutoCloseable {
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @return Information about the appended messages including the first and last offset.
      */
-    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch) {
+    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, boolean mirroredTopic) {
         return append(records,
                       AppendOrigin.REPLICATION,
                       false,
@@ -1058,7 +1062,19 @@ public class UnifiedLog implements AutoCloseable {
                       Optional.empty(),
                       VerificationGuard.SENTINEL,
                       true,
-                      RecordBatch.CURRENT_MAGIC_VALUE);
+                      RecordBatch.CURRENT_MAGIC_VALUE,
+                mirroredTopic);
+    }
+
+    private LogAppendInfo append(MemoryRecords records,
+                                 AppendOrigin origin,
+                                 boolean validateAndAssignOffsets,
+                                 int leaderEpoch,
+                                 Optional<RequestLocal> requestLocal,
+                                 VerificationGuard verificationGuard,
+                                 boolean ignoreRecordSize,
+                                 byte toMagic) {
+        return append(records, origin, validateAndAssignOffsets, leaderEpoch, requestLocal, verificationGuard, ignoreRecordSize, toMagic, false);
     }
 
     /**
@@ -1085,7 +1101,8 @@ public class UnifiedLog implements AutoCloseable {
                                  Optional<RequestLocal> requestLocal,
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
-                                 byte toMagic) {
+                                 byte toMagic,
+                                 boolean mirroredTopic) {
         // We want to ensure the partition metadata file is written to the log dir before any log data is written to disk.
         // This will ensure that any log data can be recovered with the correct topic ID in the case of failure.
         maybeFlushMetadataFile();
@@ -1151,6 +1168,14 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
+                                // luke
+                                if (mirroredTopic) {
+                                    for (MutableRecordBatch batch : records.batches()) {
+                                        // reset to -1
+                                        logger.info("!!! resetting batch producer id to -1 for batch {}", batch.baseOffset());
+                                        batch.setProducerId(-1L);
+                                    }
+                                }
                                 // we are taking the offsets we are given
                                 if (appendInfo.firstOrLastOffsetOfFirstBatch() < localLog.logEndOffset()) {
                                     // we may still be able to recover if the log is empty

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1467,6 +1467,11 @@ public class UnifiedLog implements AutoCloseable {
                         "be 0, but it is " + batch.baseOffset());
             }
 
+            // validate if the new appended leader epoch is lower than the leader epoch in previous message
+            if (hasLowerPartitionLeaderEpochThanBefore(leaderEpoch)) {
+                throw new InvalidRecordException("leader epoch " + leaderEpoch + " is lower than previous one:" + leaderEpochCache.latestEpoch());
+            }
+
             /* During replication of uncommitted data it is possible for the remote replica to send record batches after it lost
              * leadership. This can happen if sending FETCH responses is slow. There is a race between sending the FETCH
              * response and the replica truncating and appending to the log. The replicating replica resolves this issue by only
@@ -1558,6 +1563,12 @@ public class UnifiedLog implements AutoCloseable {
         return origin == AppendOrigin.REPLICATION
                 && batch.partitionLeaderEpoch() != RecordBatch.NO_PARTITION_LEADER_EPOCH
                 && batch.partitionLeaderEpoch() > leaderEpoch;
+    }
+
+    private boolean hasLowerPartitionLeaderEpochThanBefore(int leaderEpoch) {
+        return leaderEpochCache.latestEpoch().isPresent()
+                && leaderEpochCache.latestEpoch().get() != RecordBatch.NO_PARTITION_LEADER_EPOCH
+                && leaderEpochCache.latestEpoch().get() > leaderEpoch;
     }
 
     /**

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1063,7 +1063,7 @@ public class UnifiedLog implements AutoCloseable {
                       VerificationGuard.SENTINEL,
                       true,
                       RecordBatch.CURRENT_MAGIC_VALUE,
-                mirroredTopic);
+                      mirroredTopic);
     }
 
     private LogAppendInfo append(MemoryRecords records,
@@ -1168,11 +1168,10 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                // luke
                                 if (mirroredTopic) {
                                     for (MutableRecordBatch batch : records.batches()) {
-                                        // reset to -1
-                                        logger.info("!!! resetting batch producer id to -1 for batch {}", batch.baseOffset());
+                                        // reset producer id for mirrored topic
+                                        logger.info("!!! resetting batch producer id to {} for batch {}", -(batch.producerId() + 2), batch.baseOffset());
                                         batch.setProducerId(-(batch.producerId() + 2));
                                     }
                                 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1054,7 +1054,7 @@ public class UnifiedLog implements AutoCloseable {
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @return Information about the appended messages including the first and last offset.
      */
-    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, boolean mirroredTopic) {
+    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, boolean isMirroredTopic) {
         return append(records,
                       AppendOrigin.REPLICATION,
                       false,
@@ -1063,7 +1063,7 @@ public class UnifiedLog implements AutoCloseable {
                       VerificationGuard.SENTINEL,
                       true,
                       RecordBatch.CURRENT_MAGIC_VALUE,
-                      mirroredTopic);
+                      isMirroredTopic);
     }
 
     private LogAppendInfo append(MemoryRecords records,
@@ -1102,7 +1102,7 @@ public class UnifiedLog implements AutoCloseable {
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
                                  byte toMagic,
-                                 boolean mirroredTopic) {
+                                 boolean isMirroredTopic) {
         // We want to ensure the partition metadata file is written to the log dir before any log data is written to disk.
         // This will ensure that any log data can be recovered with the correct topic ID in the case of failure.
         maybeFlushMetadataFile();
@@ -1168,7 +1168,7 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                if (mirroredTopic) {
+                                if (isMirroredTopic) {
                                     for (MutableRecordBatch batch : records.batches()) {
                                         // reset producer id for mirrored topic
                                         logger.info("!!! resetting batch producer id to {} for batch {}", -(batch.producerId() + 2), batch.baseOffset());

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
@@ -103,6 +104,11 @@ public class MockController implements Controller {
             ControllerRequestContext context,
             Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
     ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(ControllerRequestContext context, int leaderEpoch) {
         throw new UnsupportedOperationException();
     }
 

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -111,6 +111,12 @@ public class MockController implements Controller {
     @Override
     public CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
+            Set<Uuid> topicIds) {
+        throw new UnsupportedOperationException();
+    }
+
+    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
             Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
         throw new UnsupportedOperationException();
     }

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -47,6 +47,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
@@ -108,7 +109,9 @@ public class MockController implements Controller {
     }
 
     @Override
-    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(ControllerRequestContext context, int leaderEpoch) {
+    public CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
+            ControllerRequestContext context,
+            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
         throw new UnsupportedOperationException();
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -511,7 +511,7 @@ public abstract class TopicCommand {
                     Node node = coordinator.get();
                     System.out.println("Node info: " + node);
                     String bootstrapServer = node.host() + ":" + node.port();
-                    System.out.println("Creating topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
+                    System.out.println("Deleting mirror topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
                     try (Admin admin = createAdminClient(new Properties(), Optional.of(bootstrapServer))) {
                         DeleteMirrorTopicResult deleteMirrorTopicResult = admin.deleteMirrorTopic(topic.opts.linkName().orElse(""), Set.of(topic.name), new DeleteMirrorTopicOptions());
                         deleteMirrorTopicResult.all().get();

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -27,6 +27,8 @@ import org.apache.kafka.clients.admin.CreateClusterLinkResult;
 import org.apache.kafka.clients.admin.CreatePartitionsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteMirrorTopicOptions;
+import org.apache.kafka.clients.admin.DeleteMirrorTopicResult;
 import org.apache.kafka.clients.admin.DeleteTopicsOptions;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
 import org.apache.kafka.clients.admin.FindCoordinatorResult;
@@ -486,6 +488,57 @@ public abstract class TopicCommand {
                         "collide. To avoid issues it is best to use either, but not both.");
             }
             createTopic(topic);
+        }
+
+        public void deleteMirrorTopic(TopicCommandOptions opts) throws Exception {
+            CommandTopicPartition topic = new CommandTopicPartition(opts);
+            if (Topic.hasCollisionChars(topic.name)) {
+                System.out.println("WARNING: Due to limitations in metric names, topics with a period ('.') or underscore ('_') could " +
+                        "collide. To avoid issues it is best to use either, but not both.");
+            }
+
+            try {
+                NewTopic newTopic;
+                Optional<Node> coordinator = Optional.empty();
+                if (topic.opts.hasCreateMirrorOption()) {
+                    FindCoordinatorResult findCoordinatorResult = adminClient.findCoordinator(topic.opts.linkName().get());
+                    coordinator = Optional.ofNullable(findCoordinatorResult.node().get());
+                    System.out.println("Found coordinator " + coordinator.map(Node::idString).orElse("none") + " for link " + topic.opts.linkName().get() + ".");
+                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue), topic.remoteBootstrapServers, topic.topicId, topic.opts.linkName());
+                } else if (topic.hasReplicaAssignment()) {
+                    newTopic = new NewTopic(topic.name, topic.replicaAssignment);
+                } else {
+                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue));
+                }
+
+                Map<String, String> configsMap = topic.configsToAdd.stringPropertyNames().stream()
+                        .collect(Collectors.toMap(name -> name, topic.configsToAdd::getProperty));
+                if (topic.opts.hasCreateMirrorOption()) {
+                    configsMap.put(TopicConfig.READ_ONLY_CONFIG, "true");
+                }
+
+                if (coordinator.isPresent()) {
+                    Node node = coordinator.get();
+                    System.out.println("Node info: " + node);
+                    String bootstrapServer = node.host() + ":" + node.port();
+                    System.out.println("Creating topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
+                    try (Admin admin = createAdminClient(new Properties(), Optional.of(bootstrapServer))) {
+                        newTopic.configs(configsMap);
+                        DeleteMirrorTopicResult deleteMirrorTopicResult = admin.deleteMirrorTopic(topic.opts.linkName().orElse(""), Set.of(topic.name), new DeleteMirrorTopicOptions());
+                        deleteMirrorTopicResult.all().get();
+                        System.out.println("Delete mirror topic topic " + topic.name + ".");
+                    }
+                } else {
+                    System.out.println("error when delete mirror topic " + topic.name + ".");
+                }
+            } catch (ExecutionException e) {
+                if (e.getCause() == null) {
+                    throw e;
+                }
+                if (!(e.getCause() instanceof TopicExistsException && topic.ifTopicDoesntExist())) {
+                    throw (Exception) e.getCause();
+                }
+            }
         }
 
         public void createTopic(CommandTopicPartition topic) throws Exception {

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.tools;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
@@ -114,7 +115,7 @@ public abstract class TopicCommand {
                 topicService.describeTopic(opts);
             } else if (opts.hasDeleteOption()) {
                 topicService.deleteTopic(opts);
-            } else if (opts.hasCreateMirrorOption()) {
+            } else if (opts.hasCreateMirrorOption() || opts.hasDeleteMirrorOption()) {
                 topicService.createMirrorTopic(opts);
             } else if (opts.hasCreateLinkOption()) {
                 topicService.createLink(opts);
@@ -546,6 +547,12 @@ public abstract class TopicCommand {
 
         // luke
         public void createLink(TopicCommandOptions opts) throws ExecutionException, InterruptedException {
+            // add "bootstrap.server" config if it is provided via CLI
+            if (!linkConfigs.containsKey(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG)) {
+                if (opts.remoteBootstrapServer().isPresent()) {
+                    linkConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.remoteBootstrapServer().get());
+                }
+            }
             CreateClusterLinkResult result = adminClient.createClusterLink(opts.linkName().orElse(""), linkConfigs, new CreateClusterLinkOptions());
             result.all().get();
         }
@@ -758,6 +765,8 @@ public abstract class TopicCommand {
 
         private final OptionSpecBuilder createLinkOpt;
 
+        private final OptionSpecBuilder deleteMirrorOpt;
+
         private final ArgumentAcceptingOptionSpec<String> topicOpt;
 
         private final ArgumentAcceptingOptionSpec<String> linkNameOpt;
@@ -833,6 +842,7 @@ public abstract class TopicCommand {
             describeOpt = parser.accepts("describe", "List details for the given topics.");
             createMirrorOpt = parser.accepts("createMirror", "Create a new mirror topic.");
             createLinkOpt = parser.accepts("createLink", "Create a new link for mirroring remote topics.");
+            deleteMirrorOpt = parser.accepts("deleteMirror", "Delete a new link for mirroring remote topics.");
             topicOpt = parser.accepts("topic", "The topic to create, alter, describe or delete. It also accepts a regular " +
                             "expression, except for --create option. Put topic name in double quotes and use the '\\' prefix " +
                             "to escape regular expression symbols; e.g. \"test\\.topic\".")
@@ -937,6 +947,10 @@ public abstract class TopicCommand {
 
         public boolean hasCreateMirrorOption() {
             return has(createMirrorOpt);
+        }
+
+        public boolean hasDeleteMirrorOption() {
+            return has(deleteMirrorOpt);
         }
 
         public boolean hasCreateLinkOption() {
@@ -1059,7 +1073,7 @@ public abstract class TopicCommand {
 
             // should have exactly one action
             long actions =
-                Stream.of(createOpt, listOpt, alterOpt, describeOpt, deleteOpt, createMirrorOpt, createLinkOpt).filter(options::has)
+                Stream.of(createOpt, listOpt, alterOpt, describeOpt, deleteOpt, createMirrorOpt, createLinkOpt, deleteMirrorOpt).filter(options::has)
                     .count();
             if (actions != 1)
                 CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --list, --describe, --create, --alter or --delete");

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -117,8 +117,10 @@ public abstract class TopicCommand {
                 topicService.describeTopic(opts);
             } else if (opts.hasDeleteOption()) {
                 topicService.deleteTopic(opts);
-            } else if (opts.hasCreateMirrorOption() || opts.hasDeleteMirrorOption()) {
+            } else if (opts.hasCreateMirrorOption()) {
                 topicService.createMirrorTopic(opts);
+            } else if (opts.hasDeleteMirrorOption()) {
+                topicService.deleteMirrorTopic(opts);
             } else if (opts.hasCreateLinkOption()) {
                 topicService.createLink(opts);
             }
@@ -498,23 +500,11 @@ public abstract class TopicCommand {
             }
 
             try {
-                NewTopic newTopic;
                 Optional<Node> coordinator = Optional.empty();
-                if (topic.opts.hasCreateMirrorOption()) {
+                if (topic.opts.hasDeleteMirrorOption()) {
                     FindCoordinatorResult findCoordinatorResult = adminClient.findCoordinator(topic.opts.linkName().get());
                     coordinator = Optional.ofNullable(findCoordinatorResult.node().get());
                     System.out.println("Found coordinator " + coordinator.map(Node::idString).orElse("none") + " for link " + topic.opts.linkName().get() + ".");
-                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue), topic.remoteBootstrapServers, topic.topicId, topic.opts.linkName());
-                } else if (topic.hasReplicaAssignment()) {
-                    newTopic = new NewTopic(topic.name, topic.replicaAssignment);
-                } else {
-                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue));
-                }
-
-                Map<String, String> configsMap = topic.configsToAdd.stringPropertyNames().stream()
-                        .collect(Collectors.toMap(name -> name, topic.configsToAdd::getProperty));
-                if (topic.opts.hasCreateMirrorOption()) {
-                    configsMap.put(TopicConfig.READ_ONLY_CONFIG, "true");
                 }
 
                 if (coordinator.isPresent()) {
@@ -523,7 +513,6 @@ public abstract class TopicCommand {
                     String bootstrapServer = node.host() + ":" + node.port();
                     System.out.println("Creating topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
                     try (Admin admin = createAdminClient(new Properties(), Optional.of(bootstrapServer))) {
-                        newTopic.configs(configsMap);
                         DeleteMirrorTopicResult deleteMirrorTopicResult = admin.deleteMirrorTopic(topic.opts.linkName().orElse(""), Set.of(topic.name), new DeleteMirrorTopicOptions());
                         deleteMirrorTopicResult.all().get();
                         System.out.println("Delete mirror topic topic " + topic.name + ".");


### PR DESCRIPTION
1. Add `--deleteMirror` option to stop a mirrored topic, and make the topic in the destination cluster writable.
2. Allow `--createMirror` option to attach an existing topic and continue to fetch from the other cluster node.

Tests:
1. prepare 2 properties files for cluster-link
```
> cat /tmp/test.properties 
bootstrap.servers=localhost:9092

> cat /tmp/test2.properties 
bootstrap.servers=localhost:9094
```

2. create a topic in the cluster 9092, and write some data to it
```
bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092
bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9092
```

3. create a cluster-link in the cluster 9094
```
 bin/kafka-topics.sh --createLink --link my-link --bootstrap-server localhost:9094  --topic foo --cluster-link-config /tmp/test.properties
```

4. mirror the topic from cluster 9092 to 9094
```
bin/kafka-topics.sh --createMirror --topic quickstart-events --bootstrap-server localhost:9094 --link my-link --topic-id r55jCra2QluFc_r0oxDVhQ
```

5. stop the mirroring in 9094
```
bin/kafka-topics.sh --deleteMirror --topic quickstart-events --bootstrap-server localhost:9094 --link my-link 
```

6. write some data to 9094
```
bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9094
```

7. create a cluster-link in cluster 9092
```
bin/kafka-topics.sh --createLink --link my-link2 --bootstrap-server localhost:9092  --topic foo --cluster-link-config /tmp/test2.properties
```

8. mirror topics from cluster 9094 to 9092
```
bin/kafka-topics.sh --createMirror --topic quickstart-events --bootstrap-server localhost:9092 --link my-link2 --topic-id r55jCra2QluFc_r0oxDVhQ
```
 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
