### PR TITLE
Sync commit offset

### DIFF
--- a/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
+++ b/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
@@ -20,37 +20,57 @@ import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.ListGroupsOptions;
+import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
 import org.apache.kafka.common.message.DescribeConfigsRequestData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
+import org.apache.kafka.common.message.ListGroupsRequestData;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
+import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.CreatePartitionsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsResponse;
+import org.apache.kafka.common.requests.ListGroupsRequest;
+import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.OffsetFetchRequest;
+import org.apache.kafka.common.requests.OffsetFetchResponse;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.coordinator.group.GroupCoordinator;
 import org.apache.kafka.image.LocalReplicaChanges;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.metadata.MetadataCache;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.apache.kafka.server.common.ControllerRequestCompletionHandler;
 import org.apache.kafka.server.common.NodeToControllerChannelManager;
+import org.apache.kafka.server.common.RequestLocal;
 import org.apache.kafka.server.network.BrokerEndPoint;
 import org.apache.kafka.server.util.Scheduler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -64,7 +84,9 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
+import static java.util.Collections.singletonList;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
 /**
@@ -88,13 +110,15 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
     private MetadataImage metadataImage;
     private MetadataCache metadataCache;
     private NodeToControllerChannelManager channelManager;
+    private final Supplier<GroupCoordinator> groupCoordinatorSupplier;
 
     public RemoteClusterMetadataManager(
         KafkaConfig config,
         Metrics metrics,
         Time time,
         MetadataCache metadataCache,
-        NodeToControllerChannelManager channelManager
+        NodeToControllerChannelManager channelManager,
+        Supplier<GroupCoordinator> groupCoordinatorSupplier
     ) {
         this.brokerConfig = config;
         this.nodeId = config.nodeId();
@@ -108,6 +132,7 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
         this.random = new Random();
         this.metadataCache = metadataCache;
         this.channelManager = channelManager;
+        this.groupCoordinatorSupplier = groupCoordinatorSupplier;
     }
 
     @Override
@@ -265,7 +290,83 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
             }
 
         });
+        updateConsumerGroupOffsets();
+    }
 
+    private void updateConsumerGroupOffsets() {
+        remoteBrokers.forEach((clusterLinkName, senders) -> {
+
+            // 1. list group
+            ListGroupsRequest.Builder builder = new ListGroupsRequest.Builder(new ListGroupsRequestData()
+                    .setTypesFilter(List.of(GroupType.CLASSIC.name(), GroupType.CONSUMER.name()))
+                    .setStatesFilter(singletonList(GroupState.STABLE.name())));
+            var listGroupResponse = senders.get(random.nextInt(senders.size())).sendRequest(builder);
+            if (listGroupResponse.responseBody() instanceof ListGroupsResponse listGroupsRes) {
+                log.info("!!! periodic list group: {}", listGroupsRes);
+
+                // 2. get committed offsets for each group
+                OffsetFetchRequest.Builder offsetFetchBuilder = OffsetFetchRequest.Builder.forTopicNames(
+                        new OffsetFetchRequestData()
+                                .setRequireStable(false)
+                                .setGroups(listGroupsRes.data().groups().stream().map(group -> new OffsetFetchRequestData.OffsetFetchRequestGroup()
+                                                .setGroupId(group.groupId())
+                                                .setTopics(null)).toList())
+                                , false);
+                var offsetFetchResponse = senders.get(random.nextInt(senders.size())).sendRequest(offsetFetchBuilder);
+                if (offsetFetchResponse.responseBody() instanceof OffsetFetchResponse offsetFetchRes) {
+                    log.info("!!! periodic offset fetch: {}", offsetFetchRes);
+
+                    // 3. commit offsets to consumer group coordinator
+                    // TODO: need to find the current group coordinator for each group
+                    offsetFetchRes.data().groups().forEach(group -> {
+                        List<OffsetCommitRequestData.OffsetCommitRequestTopic> topicList = new ArrayList<>();
+                        group.topics().stream().forEach(t -> {
+                                List<OffsetCommitRequestData.OffsetCommitRequestPartition> parList = new ArrayList<>();
+                                t.partitions().forEach(par -> {
+                                    parList.add(new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                                            .setPartitionIndex(par.partitionIndex())
+                                            .setCommittedOffset(par.committedOffset())
+                                            .setCommittedLeaderEpoch(par.committedLeaderEpoch())
+                                            .setCommittedMetadata(par.metadata()));
+                                });
+                                topicList.add(new OffsetCommitRequestData.OffsetCommitRequestTopic()
+                                        .setTopicId(t.topicId())
+                                        .setName(t.name())
+                                        .setPartitions(parList));
+
+                        });
+                        groupCoordinatorSupplier.get().commitOffsets(
+                                new RequestContext(
+                                        new RequestHeader(
+                                                ApiKeys.OFFSET_COMMIT,
+                                                ApiKeys.OFFSET_COMMIT.latestVersion(),
+                                                "client",
+                                                0
+                                        ),
+                                        "1",
+                                        InetAddress.getLoopbackAddress(),
+                                        KafkaPrincipal.ANONYMOUS,
+                                        ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+                                        SecurityProtocol.PLAINTEXT,
+                                        ClientInformation.EMPTY,
+                                        true
+                                ),
+                                new OffsetCommitRequestData()
+                                        .setGroupId(group.groupId())
+                                        .setMemberId("")
+                                        .setGenerationIdOrMemberEpoch(-1)
+                                        .setRetentionTimeMs(-1)
+                                        .setGroupInstanceId("")
+                                        .setTopics(topicList),
+                                RequestLocal.noCaching().bufferSupplier()
+                        ).handle((data, exception) -> {
+                            log.info("!!! periodic offset commit: {} ;; {}", data, exception);
+                            return null;
+                        });
+                    });
+                }
+            }
+        });
     }
 
     public void clear() {

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -344,7 +344,8 @@ class BrokerServer(
         metrics,
         time,
         metadataCache,
-        clientToControllerChannelManager
+        clientToControllerChannelManager,
+        () => groupCoordinator
       )
       kafkaScheduler.schedule("remote-cluster-metadata-refresh", () => remoteClusterMetadataManager.refreshRemoteMetadata(), 5000L, 30000L)
 

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -857,7 +857,7 @@ class FetchManager(private val time: Time,
       } else {
         new FullFetchContext(time, cache, reqMetadata, fetchData, reqVersion >= 13, isFollower)
       }
-      info(s"!!! Created a new full FetchContext with ${partitionsToLogString(fetchData.keySet)}."+
+      debug(s"!!! Created a new full FetchContext with ${partitionsToLogString(fetchData.keySet)}."+
         s"$removedFetchSessionStr$suffix")
       context
     } else {
@@ -865,23 +865,23 @@ class FetchManager(private val time: Time,
       cacheShard.synchronized {
         cacheShard.get(reqMetadata.sessionId) match {
           case None => {
-            info(s"Session error for ${reqMetadata.sessionId}: no such session ID found.")
+            debug(s"Session error for ${reqMetadata.sessionId}: no such session ID found.")
             new SessionErrorContext(Errors.FETCH_SESSION_ID_NOT_FOUND, reqMetadata)
           }
           case Some(session) => session.synchronized {
             if (session.epoch != reqMetadata.epoch) {
-              info(s"Session error for ${reqMetadata.sessionId}: expected epoch " +
+              debug(s"Session error for ${reqMetadata.sessionId}: expected epoch " +
                 s"${session.epoch}, but got ${reqMetadata.epoch} instead.")
               new SessionErrorContext(Errors.INVALID_FETCH_SESSION_EPOCH, reqMetadata)
             } else if (session.usesTopicIds && reqVersion < 13 || !session.usesTopicIds && reqVersion >= 13)  {
-              info(s"Session error for ${reqMetadata.sessionId}: expected  " +
+              debug(s"Session error for ${reqMetadata.sessionId}: expected  " +
                 s"${if (session.usesTopicIds) "to use topic IDs" else "to not use topic IDs"}" +
                 s", but request version $reqVersion means that we can not.")
               new SessionErrorContext(Errors.FETCH_SESSION_TOPIC_ID_ERROR, reqMetadata)
             } else {
               val (added, updated, removed) = session.update(fetchData, toForget)
               if (session.isEmpty) {
-                info(s"Created a new sessionless FetchContext and closing session id ${session.id}, " +
+                debug(s"Created a new sessionless FetchContext and closing session id ${session.id}, " +
                   s"epoch ${session.epoch}: after removing ${partitionsToLogString(removed)}, " +
                   s"there are no more partitions left.")
                 cacheShard.remove(session)
@@ -889,7 +889,7 @@ class FetchManager(private val time: Time,
               } else {
                 cacheShard.touch(session, time.milliseconds())
                 session.epoch = JFetchMetadata.nextEpoch(session.epoch)
-                info(s"Created a new incremental FetchContext for session id ${session.id}, " +
+                debug(s"Created a new incremental FetchContext for session id ${session.id}, " +
                   s"epoch ${session.epoch}: added ${partitionsToLogString(added)}, " +
                   s"updated ${partitionsToLogString(updated)}, " +
                   s"removed ${partitionsToLogString(removed)}")

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -658,8 +658,6 @@ class KafkaApis(val requestChannel: RequestChannel,
     val fetchData = fetchRequest.fetchData(topicNames)
     val forgottenTopics = fetchRequest.forgottenTopics(topicNames)
 
-    info("!!! fetchData:" + fetchData)
-
     val fetchContext = fetchManager.newContext(
       fetchRequest.version,
       fetchRequest.metadata,
@@ -1152,6 +1150,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       groupFetchRequest,
       requireStable
     ).handle[OffsetFetchResponseData.OffsetFetchResponseGroup] { (groupFetchResponse, exception) =>
+
       if (exception != null) {
         OffsetFetchResponse.groupError(
           groupFetchRequest,

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1666,8 +1666,6 @@ class ReplicaManager(val config: KafkaConfig,
                     fetchInfos: Seq[(TopicIdPartition, PartitionData)],
                     quota: ReplicaQuota,
                     responseCallback: Seq[(TopicIdPartition, FetchPartitionData)] => Unit): Unit = {
-    info("!!! fetchMessages:" + fetchInfos)
-
     // check if this fetch request can be satisfied right away
     val logReadResults = readFromLog(params, fetchInfos, quota, readFromPurgatory = false)
     var bytesReadable: Long = 0
@@ -1768,7 +1766,6 @@ class ReplicaManager(val config: KafkaConfig,
     }
 
     def read(tp: TopicIdPartition, fetchInfo: PartitionData, limitBytes: Int, minOneMessage: Boolean): LogReadResult = {
-      info("!!! readFromLog:" + tp + " " + fetchInfo)
       val offset = fetchInfo.fetchOffset
       val partitionFetchSize = fetchInfo.maxBytes
       val followerLogStartOffset = fetchInfo.logStartOffset

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -91,7 +91,7 @@ public class GroupCoordinatorConfig {
         "or this timeout is reached. This is similar to the producer request timeout. This is applied to all the writes made by the coordinator.";
 
     public static final String OFFSETS_TOPIC_PARTITIONS_CONFIG = "offsets.topic.num.partitions";
-    public static final int OFFSETS_TOPIC_PARTITIONS_DEFAULT = 50;
+    public static final int OFFSETS_TOPIC_PARTITIONS_DEFAULT = 3;
     public static final String OFFSETS_TOPIC_PARTITIONS_DOC = "The number of partitions for the offset commit topic (should not change after deployment).";
 
     public static final String OFFSETS_TOPIC_SEGMENT_BYTES_CONFIG = "offsets.topic.segment.bytes";

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -632,7 +632,7 @@ public class OffsetMetadataManager {
                         .setPartitionIndex(partition.partitionIndex())
                         .setErrorCode(Errors.OFFSET_METADATA_TOO_LARGE.code()));
                 } else {
-                    log.debug("[GroupId {}] Committing offsets {} for partition {}-{}-{} from member {} with leader epoch {}.",
+                    log.info("!!! [GroupId {}] Committing offsets {} for partition {}-{}-{} from member {} with leader epoch {}.",
                         request.groupId(), partition.committedOffset(), topic.topicId(), topic.name(), partition.partitionIndex(),
                         request.memberId(), partition.committedLeaderEpoch());
 

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumer.java
@@ -198,6 +198,8 @@ public class ConsoleConsumer {
                 if (!recordIter.hasNext() && (time.milliseconds() - startTimeMs > timeoutMs)) {
                     throw new TimeoutException();
                 }
+                System.out.println("!!! committing");
+                consumer.commitSync();
             }
             return recordIter.next();
         }


### PR DESCRIPTION
Sync up the consumer group offsets. Currently I sync up all consumer group offsets in the source cluster. We can have a configurable filter to filter out unwanted groups.

Tests:
1. prepare properties files for cluster-link
```
> cat /tmp/test.properties 
bootstrap.servers=localhost:9092
```

2. create a topic in the cluster 9092
```
bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092
```

3. create a cluster-link in the cluster 9094
```
 bin/kafka-topics.sh --createLink --link my-link --bootstrap-server localhost:9094  --topic foo --cluster-link-config /tmp/test.properties
```

4. mirror the topic from cluster 9092 to 9094
```
bin/kafka-topics.sh --createMirror --topic quickstart-events --bootstrap-server localhost:9094 --link my-link --topic-id r55jCra2QluFc_r0oxDVhQ
```

5. activate the group coordinator in destination cluster, stop it after initialized (TODO: the group coordinator is only initialized after the first consumer consumes data, might need to auto activate it when mirroring?)
```
bin/kafka-console-consumer.sh --topic quickstart-events  --bootstrap-server localhost:9094
```

6. create a consumer group "test" to read from the source cluster and don't stop it to make the group active.
```
bin/kafka-console-consumer.sh --topic quickstart-events --group test --bootstrap-server localhost:9092
```

7. Write some data to topic in the source cluster, this will make the consumer in step (6) commit the offset to the latest offset (2)
```
bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9092
>aaa
>bbb
```

9. Make sure the offset is committed
```
bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --describe --all-groups

GROUP                  TOPIC             PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG             CONSUMER-ID                                           HOST            CLIENT-ID
console-consumer-54017 quickstart-events 0          2               2               0               console-consumer-4331fa6d-8dd8-43f4-b710-c63dafc47b03 /127.0.0.1      console-consumer
``` 

10. Check the log in the destination cluster, make sure the offset is synced up
```
[2025-09-29 17:54:32,060] INFO !!! periodic list group: ListGroupsResponseData(throttleTimeMs=0, errorCode=0, groups=[ListedGroup(groupId='console-consumer-54017', protocolType='consumer', groupState='Stable', groupType='classic')]) (kafka.server.RemoteClusterMetadataManager)
[2025-09-29 17:54:32,065] INFO !!! periodic offset fetch: OffsetFetchResponseData(throttleTimeMs=0, topics=[], errorCode=0, groups=[OffsetFetchResponseGroup(groupId='console-consumer-54017', topics=[OffsetFetchResponseTopics(name='quickstart-events', topicId=AAAAAAAAAAAAAAAAAAAAAA, partitions=[OffsetFetchResponsePartitions(partitionIndex=0, committedOffset=2, committedLeaderEpoch=0, metadata='', errorCode=0)])], errorCode=0)]) (kafka.server.RemoteClusterMetadataManager)
[2025-09-29 17:54:32,075] INFO [GroupCoordinator id=4] !!! commitOffsets:OffsetCommitRequestData(groupId='console-consumer-54017', generationIdOrMemberEpoch=-1, memberId='', groupInstanceId='', retentionTimeMs=-1, topics=[OffsetCommitRequestTopic(name='quickstart-events', topicId=AAAAAAAAAAAAAAAAAAAAAA, partitions=[OffsetCommitRequestPartition(partitionIndex=0, committedOffset=2, committedLeaderEpoch=0, committedMetadata='')])]);;true (org.apache.kafka.coordinator.group.GroupCoordinatorService)
[2025-09-29 17:54:32,075] INFO [GroupCoordinator id=4 topic=__consumer_offsets partition=2] [GroupId console-consumer-54017] Creating a simple consumer group via manual offset commit. (org.apache.kafka.coordinator.group.OffsetMetadataManager)
[2025-09-29 17:54:32,076] INFO [GroupCoordinator id=4 topic=__consumer_offsets partition=2] !!! [GroupId console-consumer-54017] Committing offsets 2 for partition AAAAAAAAAAAAAAAAAAAAAA-quickstart-events-0 from member  with leader epoch 0. (org.apache.kafka.coordinator.group.OffsetMetadataManager)
[2025-09-29 17:54:32,085] INFO !!! periodic offset commit: OffsetCommitResponseData(throttleTimeMs=0, topics=[OffsetCommitResponseTopic(name='quickstart-events', topicId=AAAAAAAAAAAAAAAAAAAAAA, partitions=[OffsetCommitResponsePartition(partitionIndex=0, errorCode=0)])]) ;; null (kafka.server.RemoteClusterMetadataManager)
```

11. stop the consumer group in step (6), so no more offset commit to source cluster, the latest committed offset should be 2
12. Write some more data to topic in the source cluster after offset 2
```
bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9092
>ccc
>ddd
```

13. create a consumer group "test" in the destination cluster to read the topic, it should start from the offset 2 (because the latest committed offset sync up), with the output "ccc ddd".
```
bin/kafka-console-consumer.sh --topic quickstart-events --group test --bootstrap-server localhost:9094

ccc
ddd
```

This confirms the offset in consumer group "test" is successfully sync up to the destination cluster and can allow the consumer to continue to read from latest committed offsets.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
