### PR TITLE
Add ACL synchronization for cluster linking

### DIFF
--- a/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
+++ b/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
@@ -24,8 +24,13 @@ import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.acl.AccessControlEntryFilter;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.message.CreateAclsRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
+import org.apache.kafka.common.message.DeleteAclsRequestData;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;
 import org.apache.kafka.common.message.DescribeConfigsRequestData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
@@ -37,8 +42,12 @@ import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.CreateAclsRequest;
 import org.apache.kafka.common.requests.CreatePartitionsRequest;
+import org.apache.kafka.common.requests.DeleteAclsRequest;
 import org.apache.kafka.common.requests.DeleteTopicsRequest;
+import org.apache.kafka.common.requests.DescribeAclsRequest;
+import org.apache.kafka.common.requests.DescribeAclsResponse;
 import org.apache.kafka.common.requests.DescribeConfigsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
@@ -50,13 +59,20 @@ import org.apache.kafka.common.requests.OffsetFetchRequest;
 import org.apache.kafka.common.requests.OffsetFetchResponse;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePatternFilter;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.GroupCoordinator;
+import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
+import org.apache.kafka.image.loader.LoaderManifest;
+import org.apache.kafka.image.publisher.MetadataPublisher;
 import org.apache.kafka.metadata.MetadataCache;
+import org.apache.kafka.metadata.authorizer.StandardAcl;
 import org.apache.kafka.server.common.ControllerRequestCompletionHandler;
 import org.apache.kafka.server.common.NodeToControllerChannelManager;
 import org.apache.kafka.server.common.RequestLocal;
@@ -72,6 +88,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
@@ -85,8 +102,11 @@ import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CON
  * topic partitions changes, and topic configuration changes in remote clusters and updates
  * the local metadata accordingly.
  */
-public class RemoteClusterMetadataManager implements AutoCloseable {
+public class RemoteClusterMetadataManager implements MetadataPublisher, AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(RemoteClusterMetadataManager.class);
+    private static final ResourcePatternFilter ANY_RESOURCE = new ResourcePatternFilter(ResourceType.ANY, null, PatternType.ANY);
+    private static final AclBindingFilter ANY_RESOURCE_ACL = new AclBindingFilter(ANY_RESOURCE, AccessControlEntryFilter.ANY);
+
     private final KafkaConfig brokerConfig;
     private final int nodeId;
     // Mapping from remote bootstrap servers to its corresponding broker sender and topics.
@@ -127,6 +147,16 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
     }
 
     @Override
+    public String name() {
+        return "RemoteClusterMetadataManager(id=" + brokerConfig.nodeId() + ")";
+    }
+
+    @Override
+    public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage, LoaderManifest manifest) {
+        this.metadataImage = newImage;
+    }
+
+    @Override
     public void close() throws Exception {
 
     }
@@ -138,7 +168,9 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
         }
         // return a random node if no leader info
         Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_LINK, clusterLinkName));
-        String bootstrapServers = props.get(BOOTSTRAP_SERVERS_CONFIG).toString();
+        String bootstrapServers = Optional.ofNullable(props.get(BOOTSTRAP_SERVERS_CONFIG))
+                .map(Object::toString)
+                .orElseThrow(() -> new IllegalArgumentException("remote bootstrap server not found in cluster link config: " + clusterLinkName));
         // get the 1st one bootstrap server
         var addresses = ClientUtils.parseAndValidateAddresses(Arrays.stream(bootstrapServers.split(",")).toList(), "use_all_dns_ips");
         int rand = random.nextInt(addresses.size());
@@ -159,7 +191,9 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
             if (!remoteBrokers.containsKey(clusterLinkName)) {
                 // should get the cluster name from records
                 Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_LINK, clusterLinkName));
-                String bootstrapServers = props.get(BOOTSTRAP_SERVERS_CONFIG).toString();
+                String bootstrapServers = Optional.ofNullable(props.get(BOOTSTRAP_SERVERS_CONFIG))
+                        .map(Object::toString)
+                        .orElseThrow(() -> new IllegalArgumentException("remote bootstrap server not found in cluster link config: " + clusterLinkName));
                 // get the 1st one bootstrap server
                 var addresses = ClientUtils.parseAndValidateAddresses(Arrays.stream(bootstrapServers.split(",")).toList(), "use_all_dns_ips");
                 int rand = random.nextInt(addresses.size());
@@ -204,7 +238,6 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
                             .setCount(partitionLeaders.size())
                             .setAssignments(null)
                         );
-
                     }
                 });
 
@@ -286,6 +319,7 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
 
         });
         updateConsumerGroupOffsets();
+        updateACLs();
     }
 
     private void maybeDeleteTopic(String clusterLinkName, Collection<MetadataResponse.TopicMetadata> topicMetadataResp) {
@@ -328,8 +362,8 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
                         new OffsetFetchRequestData()
                                 .setRequireStable(false)
                                 .setGroups(listGroupsRes.data().groups().stream().map(group -> new OffsetFetchRequestData.OffsetFetchRequestGroup()
-                                                .setGroupId(group.groupId())
-                                                .setTopics(null)).toList())
+                                        .setGroupId(group.groupId())
+                                        .setTopics(null)).toList())
                                 , false);
                 var offsetFetchResponse = senders.get(random.nextInt(senders.size())).sendRequest(offsetFetchBuilder);
                 if (offsetFetchResponse.responseBody() instanceof OffsetFetchResponse offsetFetchRes) {
@@ -339,19 +373,19 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
                     // TODO: need to find the current group coordinator for each group
                     offsetFetchRes.data().groups().forEach(group -> {
                         List<OffsetCommitRequestData.OffsetCommitRequestTopic> topicList = new ArrayList<>();
-                        group.topics().stream().forEach(t -> {
-                                List<OffsetCommitRequestData.OffsetCommitRequestPartition> parList = new ArrayList<>();
-                                t.partitions().forEach(par -> {
-                                    parList.add(new OffsetCommitRequestData.OffsetCommitRequestPartition()
-                                            .setPartitionIndex(par.partitionIndex())
-                                            .setCommittedOffset(par.committedOffset())
-                                            .setCommittedLeaderEpoch(par.committedLeaderEpoch())
-                                            .setCommittedMetadata(par.metadata()));
-                                });
-                                topicList.add(new OffsetCommitRequestData.OffsetCommitRequestTopic()
-                                        .setTopicId(t.topicId())
-                                        .setName(t.name())
-                                        .setPartitions(parList));
+                        group.topics().forEach(t -> {
+                            List<OffsetCommitRequestData.OffsetCommitRequestPartition> parList = new ArrayList<>();
+                            t.partitions().forEach(par -> {
+                                parList.add(new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                                        .setPartitionIndex(par.partitionIndex())
+                                        .setCommittedOffset(par.committedOffset())
+                                        .setCommittedLeaderEpoch(par.committedLeaderEpoch())
+                                        .setCommittedMetadata(par.metadata()));
+                            });
+                            topicList.add(new OffsetCommitRequestData.OffsetCommitRequestTopic()
+                                    .setTopicId(t.topicId())
+                                    .setName(t.name())
+                                    .setPartitions(parList));
 
                         });
                         groupCoordinatorSupplier.get().commitOffsets(
@@ -384,6 +418,83 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
                         });
                     });
                 }
+            }
+        });
+    }
+
+    private void updateACLs() {
+        remoteBrokers.forEach((clusterLinkName, senders) -> {
+            // TODO: We currently mirror all ACLs from the source to the target.
+            //       Any ACLs added/removed directly on the target will be overwritten
+            //       on the next sync to match the source.
+            //
+            // TODO: How do we disambiguate ACLs that reference the same resource name
+            //       when multiple ClusterLinks exist?
+            // list remote acls
+            var describeAclsRequest = new DescribeAclsRequest.Builder(ANY_RESOURCE_ACL);
+            var describeAclsResponse = senders.get(random.nextInt(senders.size())).sendRequest(describeAclsRequest);
+            if (!(describeAclsResponse.responseBody() instanceof DescribeAclsResponse aclsResponse)) {
+                log.warn("!!! describeAclsResponse is not DescribeAclsResponse: {}", describeAclsResponse);
+                return;
+            }
+
+            log.info("!!! describeAclsResponse from remote cluster {}: {}", clusterLinkName, aclsResponse);
+
+            // check delta
+            var allRemoteAcls = DescribeAclsResponse.aclBindings(aclsResponse.acls());
+            var addACLsList = new ArrayList<AclBinding>();
+            var deleteACLsList = new ArrayList<AclBinding>();
+            var current = metadataImage.acls().acls().values();
+
+            // collect missing acls list
+            allRemoteAcls.forEach(acl -> {
+                if (current.stream().map(StandardAcl::toBinding).noneMatch(a -> a.equals(acl))) {
+                    log.info("!!! Add ACL from remote cluster {}: {}", clusterLinkName, acl);
+                    addACLsList.add(acl);
+                }
+            });
+
+            // collect remove acls list
+            metadataImage.acls().acls().values().forEach(acl -> {
+                if (!allRemoteAcls.contains(acl.toBinding())) {
+                    log.info("!!! Remove ACL from remote cluster {}: {}", clusterLinkName, acl);
+                    deleteACLsList.add(acl.toBinding());
+                }
+            });
+
+            // send createAcls request
+            if (!addACLsList.isEmpty())  {
+                var requestData = addACLsList.stream().map(
+                        aclBinding -> new CreateAclsRequestData.AclCreation()
+                                .setResourceType(aclBinding.pattern().resourceType().code())
+                                .setResourceName(aclBinding.pattern().name())
+                                .setResourcePatternType(aclBinding.pattern().patternType().code())
+                                .setPrincipal(aclBinding.entry().principal())
+                                .setHost(aclBinding.entry().host())
+                                .setOperation(aclBinding.entry().operation().code())
+                                .setPermissionType(aclBinding.entry().permissionType().code()))
+                        .toList();
+                channelManager.sendRequest(
+                        new CreateAclsRequest.Builder(new CreateAclsRequestData().setCreations(requestData)),
+                        new TimeoutHandler()
+                );
+            }
+            // send deleteAcls request
+            if (!deleteACLsList.isEmpty()) {
+                var requestData = deleteACLsList.stream().map(
+                        aclBinding -> new DeleteAclsRequestData.DeleteAclsFilter()
+                                .setResourceTypeFilter(aclBinding.pattern().resourceType().code())
+                                .setResourceNameFilter(aclBinding.pattern().name())
+                                .setPatternTypeFilter(aclBinding.pattern().patternType().code())
+                                .setPrincipalFilter(aclBinding.entry().principal())
+                                .setHostFilter(aclBinding.entry().host())
+                                .setOperation(aclBinding.entry().operation().code())
+                                .setPermissionType(aclBinding.entry().permissionType().code()))
+                        .toList();
+                channelManager.sendRequest(
+                        new DeleteAclsRequest.Builder(new DeleteAclsRequestData().setFilters(requestData)),
+                        new TimeoutHandler()
+                );
             }
         });
     }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -247,6 +247,8 @@ class BrokerMetadataPublisher(
       // Apply ACL delta.
       aclPublisher.onMetadataUpdate(delta, newImage, manifest)
 
+      remoteClusterMetadataManager.onMetadataUpdate(delta, newImage, manifest)
+
       try {
         // Propagate the new image to the group coordinator.
         groupCoordinator.onNewMetadataImage(new KRaftCoordinatorMetadataImage(newImage), new KRaftCoordinatorMetadataDelta(delta))

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -443,19 +443,24 @@ public abstract class TopicCommand {
     public static class TopicService implements AutoCloseable {
         private final Admin adminClient;
         private final Map<String, String> linkConfigs;
+        // TODO: remove this once we remove find coordinator of mirror topic creation logic out of this class
+        private final Properties commandConfig;
 
         public TopicService(Properties commandConfig, Optional<String> bootstrapServer) {
             this.adminClient = createAdminClient(commandConfig, bootstrapServer);
+            this.commandConfig = commandConfig;
             linkConfigs = new HashMap<>();
         }
 
         public TopicService(Properties commandConfig, Optional<String> bootstrapServer, Map<String, String> linkConfigs) {
             this.adminClient = createAdminClient(commandConfig, bootstrapServer);
+            this.commandConfig = commandConfig;
             this.linkConfigs = linkConfigs;
         }
 
         public TopicService(Admin admin) {
             this.adminClient = admin;
+            this.commandConfig = new Properties();
             this.linkConfigs = new HashMap<>();
         }
 
@@ -515,7 +520,7 @@ public abstract class TopicCommand {
                     System.out.println("Node info: " + node);
                     String bootstrapServer = node.host() + ":" + node.port();
                     System.out.println("Creating topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
-                    try (Admin admin = createAdminClient(new Properties(), Optional.of(bootstrapServer))) {
+                    try (Admin admin = createAdminClient(commandConfig, Optional.of(bootstrapServer))) {
                         newTopic.configs(configsMap);
                         CreateTopicsResult createResult = admin.createTopics(Set.of(newTopic),
                                 new CreateTopicsOptions().retryOnQuotaViolation(false));
@@ -815,7 +820,7 @@ public abstract class TopicCommand {
                 .describedAs("command config property file")
                 .ofType(String.class);
 
-            clusterLinkConfigOpt = parser.accepts("cluster-link-config", "Property file containing configs to be passed to Admin Client.")
+            clusterLinkConfigOpt = parser.accepts("cluster-link-config", "Property file source cluster cluster configs")
                     .withRequiredArg()
                     .describedAs("cluster link config property file")
                     .ofType(String.class);
@@ -1084,6 +1089,9 @@ public abstract class TopicCommand {
                 Set<OptionSpec<?>> invalidOptions = Set.of(alterOpt);
                 CommandLineUtils.checkInvalidArgsSet(parser, options, usedOptions, invalidOptions, Optional.of(KAFKA_CONFIGS_CLI_SUPPORTS_ALTERING_TOPIC_CONFIGS));
                 CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt);
+            }
+            if (has(createLinkOpt)) {
+                CommandLineUtils.checkRequiredArgs(parser, options, linkNameOpt, clusterLinkConfigOpt);
             }
         }
 


### PR DESCRIPTION
The idea in this PR is quite simple:
- Fetches all ACLs from remote cluster using DescribeAclsRequest
- Compares with local ACLs to identify additions and deletions
- Sends CreateAclsRequest for missing ACLs
- Sends DeleteAclsRequest for extra ACLs to maintain consistency

### Prerequisites:
- Source and target clusters share the same JAAS configuration.

### TODOs:
- We currently mirror all ACLs from the source to the target. Any ACLs added or removed directly on the target will be overwritten on the next sync to match the source.
- Figure out how to distinguish ACLs that reference the same resource name when multiple ClusterLinks exist.

### Test Steps:
- setup source cluster 
  <details>
  <summary>broker.properties with 2 users, admin(super user), alice.</summary>
  <pre>
  
  ```
  # Licensed to the Apache Software Foundation (ASF) under one or more
  # contributor license agreements.  See the NOTICE file distributed with
  # this work for additional information regarding copyright ownership.
  # The ASF licenses this file to You under the Apache License, Version 2.0
  # (the "License"); you may not use this file except in compliance with
  # the License.  You may obtain a copy of the License at
  #
  #    http://www.apache.org/licenses/LICENSE-2.0
  #
  # Unless required by applicable law or agreed to in writing, software
  # distributed under the License is distributed on an "AS IS" BASIS,
  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  # See the License for the specific language governing permissions and
  # limitations under the License.
  
  ############################# Server Basics #############################
  
  # The role of this server. Setting this puts us in KRaft mode
  process.roles=broker,controller
  
  # The node id associated with this instance's roles
  node.id=1
  
  # List of controller endpoints used connect to the controller cluster
  controller.quorum.bootstrap.servers=localhost:9093
  
  ############################# Socket Server Settings #############################
  
  # The address the socket server listens on.
  # Combined nodes (i.e. those with `process.roles=broker,controller`) must list the controller listener here at a minimum.
  # If the broker listener is not defined, the default listener will use a host name that is equal to the value of java.net.InetAddress.getCanonicalHostName(),
  # with PLAINTEXT listener name, and port 9092.
  #   FORMAT:
  #     listeners = listener_name://host_name:port
  #   EXAMPLE:
  #     listeners = PLAINTEXT://your.host.name:9092
  listeners=BROKER://:9092,CONTROLLER://:9093
  
  # Name of listener used for communication between brokers.
  inter.broker.listener.name=BROKER
  
  # Listener name, hostname and port the broker or the controller will advertise to clients.
  # If not set, it uses the value for "listeners".
  advertised.listeners=BROKER://localhost:9092,CONTROLLER://localhost:9093
  
  # A comma-separated list of the names of the listeners used by the controller.
  # If no explicit mapping set in `listener.security.protocol.map`, default will be using PLAINTEXT protocol
  # This is required if running in KRaft mode.
  controller.listener.names=CONTROLLER
  
  #authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
  sasl.enabled.mechanisms=PLAIN
  sasl.mechanism.inter.broker.protocol=PLAIN
  sasl.mechanism.controller.protocol=PLAIN
  
  super.users=User:admin
  listener.name.broker.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
      username="admin" \
      password="secret" \
      user_admin="secret" \
      user_alice="alice-secret";
  
  listener.name.controller.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
      username="admin" \
      password="secret" \
      user_admin="secret";
  
  
  # Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
  listener.security.protocol.map=CONTROLLER:SASL_PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,BROKER:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
  
  # The number of threads that the server uses for receiving requests from the network and sending responses to the network
  num.network.threads=3
  
  # The number of threads that the server uses for processing requests, which may include disk I/O
  num.io.threads=8
  
  # The send buffer (SO_SNDBUF) used by the socket server
  socket.send.buffer.bytes=102400
  
  # The receive buffer (SO_RCVBUF) used by the socket server
  socket.receive.buffer.bytes=102400
  
  # The maximum size of a request that the socket server will accept (protection against OOM)
  socket.request.max.bytes=104857600
  
  
  ############################# Log Basics #############################
  
  # A comma separated list of directories under which to store log files
  log.dirs=/tmp/kraft-combined-logs
  
  # The default number of log partitions per topic. More partitions allow greater
  # parallelism for consumption, but this will also result in more files across
  # the brokers.
  num.partitions=1
  
  # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
  # This value is recommended to be increased for installations with data dirs located in RAID array.
  num.recovery.threads.per.data.dir=1
  
  ############################# Internal Topic Settings  #############################
  # The replication factor for the group metadata internal topics "__consumer_offsets", "__share_group_state" and "__transaction_state"
  # For anything other than development testing, a value greater than 1 is recommended to ensure availability such as 3.
  offsets.topic.replication.factor=1
  share.coordinator.state.topic.replication.factor=1
  share.coordinator.state.topic.min.isr=1
  transaction.state.log.replication.factor=1
  transaction.state.log.min.isr=1
  
  ############################# Log Flush Policy #############################
  
  # Messages are immediately written to the filesystem but by default we only fsync() to sync
  # the OS cache lazily. The following configurations control the flush of data to disk.
  # There are a few important trade-offs here:
  #    1. Durability: Unflushed data may be lost if you are not using replication.
  #    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
  #    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to excessive seeks.
  # The settings below allow one to configure the flush policy to flush data after a period of time or
  # every N messages (or both). This can be done globally and overridden on a per-topic basis.
  
  # The number of messages to accept before forcing a flush of data to disk
  #log.flush.interval.messages=10000
  
  # The maximum amount of time a message can sit in a log before we force a flush
  #log.flush.interval.ms=1000
  
  ############################# Log Retention Policy #############################
  
  # The following configurations control the disposal of log segments. The policy can
  # be set to delete segments after a period of time, or after a given size has accumulated.
  # A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
  # from the end of the log.
  
  # The minimum age of a log file to be eligible for deletion due to age
  log.retention.hours=168
  
  # A size-based retention policy for logs. Segments are pruned from the log unless the remaining
  # segments drop below log.retention.bytes. Functions independently of log.retention.hours.
  #log.retention.bytes=1073741824
  
  # The maximum size of a log segment file. When this size is reached a new log segment will be created.
  log.segment.bytes=1073741824
  
  # The interval at which log segments are checked to see if they can be deleted according
  # to the retention policies
  log.retention.check.interval.ms=300000
  
  authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
  allow.everyone.if.no.acl.found=false
  ```
  
  </pre>
  </details>
- create ACL binding to source cluster
  - admin.conf
    ```
    sasl.mechanism=PLAIN
    security.protocol=SASL_PLAINTEXT
    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
      username="admin" \
      password="secret";
    ```
  - add producer privilege
    ```
    bin/kafka-acls.sh --bootstrap-server localhost:9092 \
      --add --allow-principal User:alice \
      --producer --topic my-topic --command-config ./config/admin.conf
    ```
  - add consumer privilege
    ```
    bin/kafka-acls.sh --bootstrap-server localhost:9092 \
      --add --allow-principal User:alice \
      --resource-pattern-type prefixed \
      --consumer \
      --topic my-topic \
      --group console-consumer- \
      --command-config ./config/admin.conf
    ```
  - list all acls
    ```
    bin/kafka-acls.sh --bootstrap-server localhost:9092  \
      --list --command-config ./config/admin.conf
    ```
    
    ```
    Current ACLs for resource `ResourcePattern(resourceType=GROUP, name=console-consumer-, patternType=PREFIXED)`:
	    (principal=User:alice, host=*, operation=READ, permissionType=ALLOW)
    
    Current ACLs for resource `ResourcePattern(resourceType=TOPIC, name=my-topic, patternType=PREFIXED)`:
	    (principal=User:alice, host=*, operation=READ, permissionType=ALLOW)
	    (principal=User:alice, host=*, operation=DESCRIBE, permissionType=ALLOW)
    
    Current ACLs for resource `ResourcePattern(resourceType=TOPIC, name=my-topic, patternType=LITERAL)`:
	    (principal=User:alice, host=*, operation=CREATE, permissionType=ALLOW)
	    (principal=User:alice, host=*, operation=WRITE, permissionType=ALLOW)
	    (principal=User:alice, host=*, operation=DESCRIBE, permissionType=ALLOW)
    ```
- Test ACL binding works in source cluster
  - alice.conf
    ```
    sasl.mechanism=PLAIN
    security.protocol=SASL_PLAINTEXT
    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
      username="alice" \
      password="alice-secret";
    ```
  - test producer
    ```
    bin/kafka-console-producer.sh \
      --producer.config ./config/alice.conf \
      --topic my-topic \
      --bootstrap-server localhost:9092
    ```
  - input
    ```
    >a
    >b
    >c
    ```
  - test consumer
    ```
    bin/kafka-console-consumer.sh \
      --topic my-topic \
      --from-beginning \
      --bootstrap-server localhost:9092 \
      --consumer.config ./config/alice.conf
    ```
    
    ```
    a
    b
    c
    ```
- setup target cluster
    <details>
    <summary>broker.properties</summary>
    <pre>
    
    ```
    # Licensed to the Apache Software Foundation (ASF) under one or more
    # contributor license agreements.  See the NOTICE file distributed with
    # this work for additional information regarding copyright ownership.
    # The ASF licenses this file to You under the Apache License, Version 2.0
    # (the "License"); you may not use this file except in compliance with
    # the License.  You may obtain a copy of the License at
    #
    #    http://www.apache.org/licenses/LICENSE-2.0
    #
    # Unless required by applicable law or agreed to in writing, software
    # distributed under the License is distributed on an "AS IS" BASIS,
    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    # See the License for the specific language governing permissions and
    # limitations under the License.
    
    ############################# Server Basics #############################
    
    # The role of this server. Setting this puts us in KRaft mode
    process.roles=broker,controller
    
    # The node id associated with this instance's roles
    node.id=10
    
    # List of controller endpoints used connect to the controller cluster
    controller.quorum.bootstrap.servers=localhost:19093
    
    ############################# Socket Server Settings #############################
    
    # The address the socket server listens on.
    # Combined nodes (i.e. those with `process.roles=broker,controller`) must list the controller listener here at a minimum.
    # If the broker listener is not defined, the default listener will use a host name that is equal to the value of java.net.InetAddress.getCanonicalHostName(),
    # with PLAINTEXT listener name, and port 9092.
    #   FORMAT:
    #     listeners = listener_name://host_name:port
    #   EXAMPLE:
    #     listeners = PLAINTEXT://your.host.name:9092
    listeners=BROKER://:19092,CONTROLLER://:19093
    
    # Name of listener used for communication between brokers.
    inter.broker.listener.name=BROKER
    
    # Listener name, hostname and port the broker or the controller will advertise to clients.
    # If not set, it uses the value for "listeners".
    advertised.listeners=BROKER://localhost:19092,CONTROLLER://localhost:19093
    
    # A comma-separated list of the names of the listeners used by the controller.
    # If no explicit mapping set in `listener.security.protocol.map`, default will be using PLAINTEXT protocol
    # This is required if running in KRaft mode.
    controller.listener.names=CONTROLLER
    
    #authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
    sasl.enabled.mechanisms=PLAIN
    sasl.mechanism.inter.broker.protocol=PLAIN
    sasl.mechanism.controller.protocol=PLAIN
    
    super.users=User:admin
    listener.name.broker.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
        username="admin" \
        password="secret" \
        user_admin="secret" \
        user_alice="alice-secret";
    
    listener.name.controller.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
        username="admin" \
        password="secret" \
        user_admin="secret";
    
    
    # Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
    listener.security.protocol.map=CONTROLLER:SASL_PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,BROKER:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
    
    # The number of threads that the server uses for receiving requests from the network and sending responses to the network
    num.network.threads=3
    
    # The number of threads that the server uses for processing requests, which may include disk I/O
    num.io.threads=8
    
    # The send buffer (SO_SNDBUF) used by the socket server
    socket.send.buffer.bytes=102400
    
    # The receive buffer (SO_RCVBUF) used by the socket server
    socket.receive.buffer.bytes=102400
    
    # The maximum size of a request that the socket server will accept (protection against OOM)
    socket.request.max.bytes=104857600
    
    
    ############################# Log Basics #############################
    
    # A comma separated list of directories under which to store log files
    log.dirs=/tmp/kraft-combined-logs-10
    
    # The default number of log partitions per topic. More partitions allow greater
    # parallelism for consumption, but this will also result in more files across
    # the brokers.
    num.partitions=1
    
    # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
    # This value is recommended to be increased for installations with data dirs located in RAID array.
    num.recovery.threads.per.data.dir=1
    
    ############################# Internal Topic Settings  #############################
    # The replication factor for the group metadata internal topics "__consumer_offsets", "__share_group_state" and "__transaction_state"
    # For anything other than development testing, a value greater than 1 is recommended to ensure availability such as 3.
    offsets.topic.replication.factor=1
    share.coordinator.state.topic.replication.factor=1
    share.coordinator.state.topic.min.isr=1
    transaction.state.log.replication.factor=1
    transaction.state.log.min.isr=1
    
    ############################# Log Flush Policy #############################
    
    # Messages are immediately written to the filesystem but by default we only fsync() to sync
    # the OS cache lazily. The following configurations control the flush of data to disk.
    # There are a few important trade-offs here:
    #    1. Durability: Unflushed data may be lost if you are not using replication.
    #    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
    #    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to excessive seeks.
    # The settings below allow one to configure the flush policy to flush data after a period of time or
    # every N messages (or both). This can be done globally and overridden on a per-topic basis.
    
    # The number of messages to accept before forcing a flush of data to disk
    #log.flush.interval.messages=10000
    
    # The maximum amount of time a message can sit in a log before we force a flush
    #log.flush.interval.ms=1000
    
    ############################# Log Retention Policy #############################
    
    # The following configurations control the disposal of log segments. The policy can
    # be set to delete segments after a period of time, or after a given size has accumulated.
    # A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
    # from the end of the log.
    
    # The minimum age of a log file to be eligible for deletion due to age
    log.retention.hours=168
    
    # A size-based retention policy for logs. Segments are pruned from the log unless the remaining
    # segments drop below log.retention.bytes. Functions independently of log.retention.hours.
    #log.retention.bytes=1073741824
    
    # The maximum size of a log segment file. When this size is reached a new log segment will be created.
    log.segment.bytes=1073741824
    
    # The interval at which log segments are checked to see if they can be deleted according
    # to the retention policies
    log.retention.check.interval.ms=300000
    
    authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
    allow.everyone.if.no.acl.found=false
    
    security.protocol=SASL_PLAINTEXT
    sasl.mechanism=PLAIN
    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
        username="admin" \
        password="secret";
    ```
    
    </pre>
    </details>
- The key difference from the source cluster is that we establish a SASL_PLAINTEXT channel in order to send fetch requests to the source.
  ```
  security.protocol=SASL_PLAINTEXT
  sasl.mechanism=PLAIN
  sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
      username="admin" \
      password="secret"; 
  ```
- create cluster link
  - remote.config
    ```
    bootstrap.servers=localhost:9092
    ```

  ```
  ./bin/kafka-topics.sh --createLink \
    --link my-link \
    --bootstrap-server localhost:19092 \
    --topic my-topic \
    --command-config ./config/admin.conf \
    --cluster-link-config ./remote.config
  ```
- create mirror topic
  ```
  ./bin/kafka-topics.sh --createMirror \
    --topic my-topic \
    --bootstrap-server localhost:19092 \
    --topic-id r_nBkvFSSBuznNmF9auJpQ \
    --link my-link \
    --command-config ./config/admin.conf
  ```
- list acl bindings in target cluster
  ```
  bin/kafka-acls.sh --bootstrap-server localhost:19092  \
    --list --command-config ./config/admin.conf
  ```

  ```
  Current ACLs for resource `ResourcePattern(resourceType=TOPIC, name=my-topic, patternType=PREFIXED)`:
	  (principal=User:alice, host=*, operation=READ, permissionType=ALLOW)
	  (principal=User:alice, host=*, operation=DESCRIBE, permissionType=ALLOW)
  
  Current ACLs for resource `ResourcePattern(resourceType=TOPIC, name=my-topic, patternType=LITERAL)`:
	  (principal=User:alice, host=*, operation=CREATE, permissionType=ALLOW)
	  (principal=User:alice, host=*, operation=WRITE, permissionType=ALLOW)
	  (principal=User:alice, host=*, operation=DESCRIBE, permissionType=ALLOW)
  
  Current ACLs for resource `ResourcePattern(resourceType=GROUP, name=console-consumer-, patternType=PREFIXED)`:
	  (principal=User:alice, host=*, operation=READ, permissionType=ALLOW)
  ```
- test consumer in target clsuter
  ```
  bin/kafka-console-consumer.sh \
    --topic my-topic \
    --from-beginning \
    --bootstrap-server localhost:19092 \
    --consumer.config ./config/alice.conf
  ```
  output
  ```
  !!! committing
  a
  b
  c
  ```
- remove consumer ACL from source cluster
  ```
  bin/kafka-acls.sh --bootstrap-server localhost:9092 \
    --remove \
    --allow-principal User:alice \
    --operation READ \
    --group console-consumer- \
    --resource-pattern-type prefixed \
    --command-config ./config/admin.conf
  ```
- test consumer again
  ```
  bin/kafka-console-consumer.sh \
    --topic my-topic \
    --from-beginning \
    --bootstrap-server localhost:19092 \
    --consumer.config ./config/alice.conf
  ```
  ```
  [2025-10-03 15:26:08,932] ERROR Error processing message, terminating consumer process:  (org.apache.kafka.tools.consumer.ConsoleConsumer)
  org.apache.kafka.common.errors.GroupAuthorizationException: Not authorized to access group: console-consumer-20113
  Processed a total of 0 messages
  ```
[Note]: we can’t send data to target cluster mirror topic as mirror topic is read-only.