### PR TITLE
Bump partition leader epoch when delete mirror topic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1668,6 +1668,8 @@ public interface Admin extends AutoCloseable {
 
     CreateClusterLinkResult createClusterLink(String clusterLinkName, Map<String, String> configs, CreateClusterLinkOptions options);
 
+    DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options);
+
     /**
      * Describe producer state on a set of topic partitions. See
      * {@link #describeProducers(Collection, DescribeProducersOptions)} for more details.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorTopicOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorTopicOptions.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Map;
+
+/**
+ * Options for {@link Admin#createClusterLink(String, Map)}.
+ */
+public class DeleteMirrorTopicOptions extends AbstractOptions<DeleteMirrorTopicOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorTopicResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorTopicResult.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+
+/**
+ * The result of the {@link Admin#unregisterBroker(int, UnregisterBrokerOptions)} call.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+public class DeleteMirrorTopicResult {
+    private final KafkaFuture<Void> future;
+
+    DeleteMirrorTopicResult(final KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    /**
+     * Return a future which succeeds if the operation is successful.
+     */
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -281,6 +281,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
+        return delegate.deleteMirrorTopic(clusterLinkName, topics, options);
+    }
+
+    @Override
     public DescribeProducersResult describeProducers(Collection<TopicPartition> partitions, DescribeProducersOptions options) {
         return delegate.describeProducers(partitions, options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -209,6 +209,8 @@ import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
 import org.apache.kafka.common.requests.DeleteAclsResponse;
+import org.apache.kafka.common.requests.DeleteMirrorTopicRequest;
+import org.apache.kafka.common.requests.DeleteMirrorTopicResponse;
 import org.apache.kafka.common.requests.DeleteTopicsRequest;
 import org.apache.kafka.common.requests.DeleteTopicsResponse;
 import org.apache.kafka.common.requests.DescribeAclsRequest;
@@ -4861,6 +4863,46 @@ public class KafkaAdminClient extends AdminClient {
         };
         runnable.call(call, now);
         return new CreateClusterLinkResult(future);
+    }
+
+    @Override
+    public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+        final Call call = new Call("createClusterLink", calcDeadlineMs(now, options.timeoutMs()),
+                new LeastLoadedBrokerOrActiveKController()) {
+
+            @Override
+            DeleteMirrorTopicRequest.Builder createRequest(int timeoutMs) {
+                return new DeleteMirrorTopicRequest.Builder(clusterLinkName, topics);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                final DeleteMirrorTopicResponse response =
+                        (DeleteMirrorTopicResponse) abstractResponse;
+                Errors error = Errors.forCode(response.data().errorCode());
+                switch (error) {
+                    case NONE:
+                        future.complete(null);
+                        break;
+                    case REQUEST_TIMED_OUT:
+                        throw error.exception(response.data().errorMessage());
+                    default:
+                        log.error("delete mirror topic {} failed: {}",
+                                clusterLinkName, response.data().errorMessage());
+                        future.completeExceptionally(error.exception(response.data().errorMessage()));
+                        break;
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        };
+        runnable.call(call, now);
+        return new DeleteMirrorTopicResult(future);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4882,7 +4882,6 @@ public class KafkaAdminClient extends AdminClient {
             void handleResponse(AbstractResponse abstractResponse) {
                 final DeleteMirrorTopicResponse response =
                         (DeleteMirrorTopicResponse) abstractResponse;
-                log.error("delete mirror topic:" + response);
                 Errors error = Errors.forCode(response.data().errorCode());
                 switch (error) {
                     case NONE:

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4867,9 +4867,10 @@ public class KafkaAdminClient extends AdminClient {
 
     @Override
     public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
+        log.info("!!! deleteMirrorTopic");
         final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
-        final Call call = new Call("createClusterLink", calcDeadlineMs(now, options.timeoutMs()),
+        final Call call = new Call("deleteMirrorTopic", calcDeadlineMs(now, options.timeoutMs()),
                 new LeastLoadedBrokerOrActiveKController()) {
 
             @Override
@@ -4881,6 +4882,7 @@ public class KafkaAdminClient extends AdminClient {
             void handleResponse(AbstractResponse abstractResponse) {
                 final DeleteMirrorTopicResponse response =
                         (DeleteMirrorTopicResponse) abstractResponse;
+                log.error("delete mirror topic:" + response);
                 Errors error = Errors.forCode(response.data().errorCode());
                 switch (error) {
                     case NONE:

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4867,7 +4867,6 @@ public class KafkaAdminClient extends AdminClient {
 
     @Override
     public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
-        log.info("!!! deleteMirrorTopic");
         final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
         final Call call = new Call("deleteMirrorTopic", calcDeadlineMs(now, options.timeoutMs()),

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -136,7 +136,10 @@ public enum ApiKeys {
     ALTER_SHARE_GROUP_OFFSETS(ApiMessageType.ALTER_SHARE_GROUP_OFFSETS),
     DELETE_SHARE_GROUP_OFFSETS(ApiMessageType.DELETE_SHARE_GROUP_OFFSETS),
     GET_REPLICA_LOG_INFO(ApiMessageType.GET_REPLICA_LOG_INFO),
-    CREATE_CLUSTER_LINK(ApiMessageType.CREATE_CLUSTER_LINK, false, true);
+    CREATE_CLUSTER_LINK(ApiMessageType.CREATE_CLUSTER_LINK, false, true),
+    CREATE_MIRROR_TOPIC(ApiMessageType.CREATE_MIRROR_TOPIC, false, true),
+    DELETE_MIRROR_TOPIC(ApiMessageType.DELETE_MIRROR_TOPIC, false, true),
+    BUMP_LEADER_EPOCH(ApiMessageType.BUMP_LEADER_EPOCH, false, true);
 
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.CreateMirrorTopicRequestData;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
@@ -357,6 +358,12 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
             case GET_REPLICA_LOG_INFO:
                 return GetReplicaLogInfoRequest.parse(readable, apiVersion);
             case CREATE_CLUSTER_LINK:
+                return CreateClusterLinkRequest.parse(readable, apiVersion);
+            case CREATE_MIRROR_TOPIC:
+                return CreateClusterLinkRequest.parse(readable, apiVersion);
+            case DELETE_MIRROR_TOPIC:
+                return CreateClusterLinkRequest.parse(readable, apiVersion);
+            case BUMP_LEADER_EPOCH:
                 return CreateClusterLinkRequest.parse(readable, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -362,7 +362,7 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
             case CREATE_MIRROR_TOPIC:
                 return CreateClusterLinkRequest.parse(readable, apiVersion);
             case DELETE_MIRROR_TOPIC:
-                return CreateClusterLinkRequest.parse(readable, apiVersion);
+                return DeleteMirrorTopicRequest.parse(readable, apiVersion);
             case BUMP_LEADER_EPOCH:
                 return CreateClusterLinkRequest.parse(readable, apiVersion);
             default:

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -364,7 +364,7 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
             case DELETE_MIRROR_TOPIC:
                 return DeleteMirrorTopicRequest.parse(readable, apiVersion);
             case BUMP_LEADER_EPOCH:
-                return CreateClusterLinkRequest.parse(readable, apiVersion);
+                return BumpLeaderEpochRequest.parse(readable, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -298,7 +298,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
             case CREATE_MIRROR_TOPIC:
                 return CreateClusterLinkResponse.parse(readable, version);
             case DELETE_MIRROR_TOPIC:
-                return CreateClusterLinkResponse.parse(readable, version);
+                return DeleteMirrorTopicResponse.parse(readable, version);
             case BUMP_LEADER_EPOCH:
                 return CreateClusterLinkResponse.parse(readable, version);
             default:

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -295,6 +295,12 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return GetReplicaLogInfoResponse.parse(readable, version);
             case CREATE_CLUSTER_LINK:
                 return CreateClusterLinkResponse.parse(readable, version);
+            case CREATE_MIRROR_TOPIC:
+                return CreateClusterLinkResponse.parse(readable, version);
+            case DELETE_MIRROR_TOPIC:
+                return CreateClusterLinkResponse.parse(readable, version);
+            case BUMP_LEADER_EPOCH:
+                return CreateClusterLinkResponse.parse(readable, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -300,7 +300,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
             case DELETE_MIRROR_TOPIC:
                 return DeleteMirrorTopicResponse.parse(readable, version);
             case BUMP_LEADER_EPOCH:
-                return CreateClusterLinkResponse.parse(readable, version);
+                return BumpLeaderEpochResponse.parse(readable, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/BumpLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BumpLeaderEpochRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.BumpLeaderEpochRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicRequestData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Map;
+
+public class BumpLeaderEpochRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<BumpLeaderEpochRequest> {
+
+        private final BumpLeaderEpochRequestData data;
+
+        public Builder(BumpLeaderEpochRequestData data) {
+            super(ApiKeys.BUMP_LEADER_EPOCH);
+            this.data = data;
+        }
+
+        public Builder(String name, Map<String, String> configs) {
+            super(ApiKeys.BUMP_LEADER_EPOCH, ApiKeys.BUMP_LEADER_EPOCH.oldestVersion(),
+                  ApiKeys.BUMP_LEADER_EPOCH.latestVersion());
+            BumpLeaderEpochRequestData data = new BumpLeaderEpochRequestData();
+            this.data = data;
+        }
+
+        @Override
+        public BumpLeaderEpochRequest build(short version) {
+            return new BumpLeaderEpochRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final BumpLeaderEpochRequestData data;
+
+    public BumpLeaderEpochRequest(BumpLeaderEpochRequestData data, short version) {
+        super(ApiKeys.BUMP_LEADER_EPOCH, version);
+        this.data = data;
+    }
+
+    @Override
+    public BumpLeaderEpochRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        BumpLeaderEpochResponseData responseData = new BumpLeaderEpochResponseData();
+        responseData.setErrorCode(error.code());
+
+        return new BumpLeaderEpochResponse(responseData);
+    }
+
+    public static BumpLeaderEpochRequest parse(Readable readable, short version) {
+        return new BumpLeaderEpochRequest(
+                new BumpLeaderEpochRequestData(readable, version),
+                version
+        );
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/BumpLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BumpLeaderEpochResponse.java
@@ -17,7 +17,8 @@
 
 package org.apache.kafka.common.requests;
 
-import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
@@ -25,16 +26,16 @@ import org.apache.kafka.common.protocol.Readable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CreateClusterLinkResponse extends AbstractResponse {
-    private final CreateClusterLinkResponseData data;
+public class BumpLeaderEpochResponse extends AbstractResponse {
+    private final BumpLeaderEpochResponseData data;
 
-    public CreateClusterLinkResponse(CreateClusterLinkResponseData data) {
-        super(ApiKeys.CREATE_CLUSTER_LINK);
+    public BumpLeaderEpochResponse(BumpLeaderEpochResponseData data) {
+        super(ApiKeys.DELETE_MIRROR_TOPIC);
         this.data = data;
     }
 
     @Override
-    public CreateClusterLinkResponseData data() {
+    public BumpLeaderEpochResponseData data() {
         return data;
     }
 
@@ -55,7 +56,7 @@ public class CreateClusterLinkResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static CreateClusterLinkResponse parse(Readable readable, short version) {
-        return new CreateClusterLinkResponse(new CreateClusterLinkResponseData(readable, version));
+    public static BumpLeaderEpochResponse parse(Readable readable, short version) {
+        return new BumpLeaderEpochResponse(new BumpLeaderEpochResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateMirrorTopicRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateMirrorTopicRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.CreateClusterLinkRequestData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.CreateMirrorTopicRequestData;
+import org.apache.kafka.common.message.CreateMirrorTopicResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Map;
+
+public class CreateMirrorTopicRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<CreateMirrorTopicRequest> {
+
+        private final CreateMirrorTopicRequestData data;
+
+        public Builder(CreateMirrorTopicRequestData data) {
+            super(ApiKeys.CREATE_MIRROR_TOPIC);
+            this.data = data;
+        }
+
+        public Builder(String name, Map<String, String> configs) {
+            super(ApiKeys.CREATE_MIRROR_TOPIC, ApiKeys.CREATE_MIRROR_TOPIC.oldestVersion(),
+                  ApiKeys.CREATE_MIRROR_TOPIC.latestVersion());
+            CreateMirrorTopicRequestData data = new CreateMirrorTopicRequestData();
+            this.data = data;
+        }
+
+        @Override
+        public CreateMirrorTopicRequest build(short version) {
+            return new CreateMirrorTopicRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final CreateMirrorTopicRequestData data;
+
+    public CreateMirrorTopicRequest(CreateMirrorTopicRequestData data, short version) {
+        super(ApiKeys.CREATE_MIRROR_TOPIC, version);
+        this.data = data;
+    }
+
+    @Override
+    public CreateMirrorTopicRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        CreateMirrorTopicResponseData responseData = new CreateMirrorTopicResponseData();
+        responseData.setErrorCode(error.code());
+
+        return new CreateMirrorTopicResponse(responseData);
+    }
+
+    public static CreateMirrorTopicRequest parse(Readable readable, short version) {
+        return new CreateMirrorTopicRequest(
+                new CreateMirrorTopicRequestData(readable, version),
+                version
+        );
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateMirrorTopicResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateMirrorTopicResponse.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.CreateMirrorTopicResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
@@ -25,16 +26,16 @@ import org.apache.kafka.common.protocol.Readable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CreateClusterLinkResponse extends AbstractResponse {
-    private final CreateClusterLinkResponseData data;
+public class CreateMirrorTopicResponse extends AbstractResponse {
+    private final CreateMirrorTopicResponseData data;
 
-    public CreateClusterLinkResponse(CreateClusterLinkResponseData data) {
-        super(ApiKeys.CREATE_CLUSTER_LINK);
+    public CreateMirrorTopicResponse(CreateMirrorTopicResponseData data) {
+        super(ApiKeys.DELETE_MIRROR_TOPIC);
         this.data = data;
     }
 
     @Override
-    public CreateClusterLinkResponseData data() {
+    public CreateMirrorTopicResponseData data() {
         return data;
     }
 
@@ -55,7 +56,7 @@ public class CreateClusterLinkResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static CreateClusterLinkResponse parse(Readable readable, short version) {
-        return new CreateClusterLinkResponse(new CreateClusterLinkResponseData(readable, version));
+    public static CreateMirrorTopicResponse parse(Readable readable, short version) {
+        return new CreateMirrorTopicResponse(new CreateMirrorTopicResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicRequest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateMirrorTopicRequestData;
 import org.apache.kafka.common.message.DeleteMirrorTopicRequestData;
@@ -26,6 +27,7 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.Map;
+import java.util.Set;
 
 public class DeleteMirrorTopicRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<DeleteMirrorTopicRequest> {
@@ -37,10 +39,12 @@ public class DeleteMirrorTopicRequest extends AbstractRequest {
             this.data = data;
         }
 
-        public Builder(String name, Map<String, String> configs) {
+        public Builder(String name, Set<String> topics) {
             super(ApiKeys.DELETE_MIRROR_TOPIC, ApiKeys.DELETE_MIRROR_TOPIC.oldestVersion(),
                   ApiKeys.DELETE_MIRROR_TOPIC.latestVersion());
             DeleteMirrorTopicRequestData data = new DeleteMirrorTopicRequestData();
+            data.setClusterLink(name);
+            topics.forEach(topic -> data.topics().add(new DeleteMirrorTopicRequestData.TopicState().setName(topic)));
             this.data = data;
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.CreateMirrorTopicRequestData;
+import org.apache.kafka.common.message.DeleteMirrorTopicRequestData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Map;
+
+public class DeleteMirrorTopicRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<DeleteMirrorTopicRequest> {
+
+        private final DeleteMirrorTopicRequestData data;
+
+        public Builder(DeleteMirrorTopicRequestData data) {
+            super(ApiKeys.DELETE_MIRROR_TOPIC);
+            this.data = data;
+        }
+
+        public Builder(String name, Map<String, String> configs) {
+            super(ApiKeys.DELETE_MIRROR_TOPIC, ApiKeys.DELETE_MIRROR_TOPIC.oldestVersion(),
+                  ApiKeys.DELETE_MIRROR_TOPIC.latestVersion());
+            DeleteMirrorTopicRequestData data = new DeleteMirrorTopicRequestData();
+            this.data = data;
+        }
+
+        @Override
+        public DeleteMirrorTopicRequest build(short version) {
+            return new DeleteMirrorTopicRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final DeleteMirrorTopicRequestData data;
+
+    public DeleteMirrorTopicRequest(DeleteMirrorTopicRequestData data, short version) {
+        super(ApiKeys.DELETE_MIRROR_TOPIC, version);
+        this.data = data;
+    }
+
+    @Override
+    public DeleteMirrorTopicRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        DeleteMirrorTopicResponseData responseData = new DeleteMirrorTopicResponseData();
+        responseData.setErrorCode(error.code());
+
+        return new DeleteMirrorTopicResponse(responseData);
+    }
+
+    public static DeleteMirrorTopicRequest parse(Readable readable, short version) {
+        return new DeleteMirrorTopicRequest(
+                new DeleteMirrorTopicRequestData(readable, version),
+                version
+        );
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorTopicResponse.java
@@ -17,7 +17,9 @@
 
 package org.apache.kafka.common.requests;
 
-import org.apache.kafka.common.message.CreateClusterLinkResponseData;
+import org.apache.kafka.common.message.CreateMirrorTopicResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicRequestData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
@@ -25,16 +27,16 @@ import org.apache.kafka.common.protocol.Readable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CreateClusterLinkResponse extends AbstractResponse {
-    private final CreateClusterLinkResponseData data;
+public class DeleteMirrorTopicResponse extends AbstractResponse {
+    private final DeleteMirrorTopicResponseData data;
 
-    public CreateClusterLinkResponse(CreateClusterLinkResponseData data) {
-        super(ApiKeys.CREATE_CLUSTER_LINK);
+    public DeleteMirrorTopicResponse(DeleteMirrorTopicResponseData data) {
+        super(ApiKeys.DELETE_MIRROR_TOPIC);
         this.data = data;
     }
 
     @Override
-    public CreateClusterLinkResponseData data() {
+    public DeleteMirrorTopicResponseData data() {
         return data;
     }
 
@@ -55,7 +57,7 @@ public class CreateClusterLinkResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static CreateClusterLinkResponse parse(Readable readable, short version) {
-        return new CreateClusterLinkResponse(new CreateClusterLinkResponseData(readable, version));
+    public static DeleteMirrorTopicResponse parse(Readable readable, short version) {
+        return new DeleteMirrorTopicResponse(new DeleteMirrorTopicResponseData(readable, version));
     }
 }

--- a/clients/src/main/resources/common/message/BumpLeaderEpochRequest.json
+++ b/clients/src/main/resources/common/message/BumpLeaderEpochRequest.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":97,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "BumpLeaderEpochRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The cluster link name."},
+    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
+      "about": "The configurations.",  "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+        "about": "The configuration key name." },
+      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
+        "about": "The value to set for the configuration key."}
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/BumpLeaderEpochRequest.json
+++ b/clients/src/main/resources/common/message/BumpLeaderEpochRequest.json
@@ -21,14 +21,14 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
-      "about": "The cluster link name."},
-    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
-      "about": "The configurations.",  "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
-        "about": "The configuration key name." },
-      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
-        "about": "The value to set for the configuration key."}
-    ]}
+    { "name": "Topics", "type": "[]TopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
+      "fields": [
+        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "Partitions", "type": "[]LeaderEpochState", "versions": "0+", "about": "The name or topic ID of the topic.",
+          "fields": [
+            {"name": "partitionIndex", "type": "int32", "versions": "0+", "about": "The topic name."},
+            {"name": "leaderEpoch", "type": "int32", "versions": "0+", "default": -1, "about": "The topic name."}
+            ]}
+      ]}
   ]
 }

--- a/clients/src/main/resources/common/message/BumpLeaderEpochResponse.json
+++ b/clients/src/main/resources/common/message/BumpLeaderEpochResponse.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":97,
+  "type": "response",
+  "name": "BumpLeaderEpochResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+      "about": "The error message, or null if there was no error." }
+  ]
+}

--- a/clients/src/main/resources/common/message/CreateMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/CreateMirrorTopicRequest.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":95,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "CreateMirrorTopicRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The cluster link name."},
+    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
+      "about": "The configurations.",  "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+        "about": "The configuration key name." },
+      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
+        "about": "The value to set for the configuration key."}
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/CreateMirrorTopicResponse.json
+++ b/clients/src/main/resources/common/message/CreateMirrorTopicResponse.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":95,
+  "type": "response",
+  "name": "CreateMirrorTopicResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+      "about": "The error message, or null if there was no error." }
+  ]
+}

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -25,14 +25,9 @@
       "about": "If true, check that the topics can be created as specified, but don't create anything." },
     { "name": "Topics", "type": "[]TopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
       "fields": [
-        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
         { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
-          "about": "The topic name." },
-        { "name": "Partitions", "type": "[]LeaderEpochState", "versions": "0+", "ignorable": true ,"about": "The name or topic ID of the topic.",
-          "fields": [
-            {"name": "partitionIndex", "type": "int32", "versions": "0+", "about": "The topic name."},
-            {"name": "leaderEpoch", "type": "int32", "versions": "0+", "default": -1, "about": "The topic name."}
-          ]}
+          "about": "The topic name." }
       ]}
   ]
 }

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":96,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "DeleteMirrorTopicRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The cluster link name."},
+    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
+      "about": "The configurations.",  "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+        "about": "The configuration key name." },
+      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
+        "about": "The value to set for the configuration key."}
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -21,12 +21,14 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "Topics", "type": "[]DeleteMirrorTopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
+    { "name": "Topics", "type": "[]TopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
       "fields": [
-        {"name": "name", "type": "string", "versions": "0+", "about": "The unique topic ID."},
-        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."}
-      ]},
-    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
-      "about": "The length of time in milliseconds to wait for the deletions to complete." }
+        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "Partitions", "type": "[]LeaderEpochState", "versions": "0+", "ignorable": true ,"about": "The name or topic ID of the topic.",
+          "fields": [
+            {"name": "partitionIndex", "type": "int32", "versions": "0+", "about": "The topic name."},
+            {"name": "leaderEpoch", "type": "int32", "versions": "0+", "default": -1, "about": "The topic name."}
+          ]}
+      ]}
   ]
 }

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -21,9 +21,13 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
+    { "name": "clusterLink", "type": "string", "versions": "7+", "ignorable": true,
+      "about": "If true, check that the topics can be created as specified, but don't create anything." },
     { "name": "Topics", "type": "[]TopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
       "fields": [
         {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
+          "about": "The topic name." },
         { "name": "Partitions", "type": "[]LeaderEpochState", "versions": "0+", "ignorable": true ,"about": "The name or topic ID of the topic.",
           "fields": [
             {"name": "partitionIndex", "type": "int32", "versions": "0+", "about": "The topic name."},

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicRequest.json
@@ -21,14 +21,12 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "ClusterLinkName", "type": "string", "versions": "0+", "nullableVersions": "0+",
-      "about": "The cluster link name."},
-    { "name": "Configs", "type": "[]ClusterLinkConfigs", "versions": "0+",
-      "about": "The configurations.",  "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
-        "about": "The configuration key name." },
-      { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
-        "about": "The value to set for the configuration key."}
-    ]}
+    { "name": "Topics", "type": "[]DeleteMirrorTopicState", "versions": "0+", "about": "The name or topic ID of the topic.",
+      "fields": [
+        {"name": "name", "type": "string", "versions": "0+", "about": "The unique topic ID."},
+        {"name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."}
+      ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+      "about": "The length of time in milliseconds to wait for the deletions to complete." }
   ]
 }

--- a/clients/src/main/resources/common/message/DeleteMirrorTopicResponse.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorTopicResponse.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":96,
+  "type": "response",
+  "name": "DeleteMirrorTopicResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+      "about": "The error message, or null if there was no error." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1376,6 +1376,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public DeleteMirrorTopicResult deleteMirrorTopic(String clusterLinkName, Set<String> topics, DeleteMirrorTopicOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     public DescribeProducersResult describeProducers(Collection<TopicPartition> partitions, DescribeProducersOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }

--- a/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
+++ b/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
@@ -16,6 +16,8 @@
  */
 package kafka.server;
 
+import kafka.log.LogManager;
+import kafka.server.metadata.KRaftMetadataCache;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -23,11 +25,13 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.message.BumpLeaderEpochRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
 import org.apache.kafka.common.message.DescribeConfigsRequestData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.requests.BumpLeaderEpochRequest;
 import org.apache.kafka.common.requests.CreatePartitionsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
@@ -46,6 +50,7 @@ import org.apache.kafka.metadata.MetadataCache;
 import org.apache.kafka.server.common.ControllerRequestCompletionHandler;
 import org.apache.kafka.server.common.NodeToControllerChannelManager;
 import org.apache.kafka.server.network.BrokerEndPoint;
+import org.apache.kafka.server.util.KafkaScheduler;
 import org.apache.kafka.server.util.Scheduler;
 
 import org.slf4j.Logger;
@@ -88,12 +93,16 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
     private MetadataImage metadataImage;
     private MetadataCache metadataCache;
     private NodeToControllerChannelManager channelManager;
+    private LogManager logManager;
+    private Scheduler scheduler;
 
     public RemoteClusterMetadataManager(
         KafkaConfig config,
         Metrics metrics,
         Time time,
         MetadataCache metadataCache,
+        LogManager logManager,
+        Scheduler scheduler,
         NodeToControllerChannelManager channelManager
     ) {
         this.brokerConfig = config;
@@ -108,6 +117,16 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
         this.random = new Random();
         this.metadataCache = metadataCache;
         this.channelManager = channelManager;
+        this.logManager = logManager;
+        this.scheduler = scheduler;
+
+        scheduler.startup();
+        // periodically query source cluster to get the metadata
+        scheduler.schedule("query",
+                this::refreshRemoteMetadata,
+                300000,
+                300000
+        );
     }
 
     @Override
@@ -132,6 +151,29 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
 
     public void updateMirroredTopics(String clusterName, Set<String> topics) {
         this.topics.put(clusterName, topics);
+    }
+
+    public void maybeUpdateLeaderEpoch(List<String> topics) {
+        // sent in another thread to avoid to block the api handling thread
+        scheduler.scheduleOnce("bump-leader-epoch", () -> sendBumpLeaderEpoch(topics));
+    }
+
+    private void sendBumpLeaderEpoch(List<String> topics) {
+        List<BumpLeaderEpochRequestData.TopicState> topicStates = new ArrayList<>();
+        topics.forEach(topic -> {
+            BumpLeaderEpochRequestData.TopicState topicState = new BumpLeaderEpochRequestData.TopicState();
+            List<BumpLeaderEpochRequestData.LeaderEpochState> topicLeaderEpoch = new ArrayList<>();
+            ((KRaftMetadataCache) metadataCache).getImage().topics().getTopic(topic).partitions().keySet().forEach(partitionId -> {
+                int epoch = logManager.getLog(new TopicPartition(topic, partitionId), false).get().latestEpochFromLog().orElse(-1);
+                topicLeaderEpoch.add(new BumpLeaderEpochRequestData.LeaderEpochState().setLeaderEpoch(epoch).setPartitionIndex(partitionId));
+            });
+            topicState.setTopicId(metadataCache.getTopicId(topic)).setPartitions(topicLeaderEpoch);
+            topicStates.add(topicState);
+        });
+
+        channelManager.sendRequest(new BumpLeaderEpochRequest.Builder(
+                new BumpLeaderEpochRequestData().setTopics(topicStates)
+        ), new TimeoutHandler());
     }
 
     // TODO: When mirror deleted, we should write a record in internal topic and remove topics from the list

--- a/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
+++ b/core/src/main/java/kafka/server/coordinator/TopicMirrorLinkCoordinator.java
@@ -39,10 +39,8 @@ import org.apache.kafka.coordinator.clusterlink.generated.CoordinatorRecordType;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.metadata.MetadataCache;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
-import org.apache.kafka.server.common.NodeToControllerChannelManager;
 import org.apache.kafka.server.common.RequestLocal;
 import org.apache.kafka.server.storage.log.FetchIsolation;
-import org.apache.kafka.server.util.Scheduler;
 import org.apache.kafka.storage.internals.log.AppendOrigin;
 import org.apache.kafka.storage.internals.log.FetchDataInfo;
 
@@ -71,7 +69,6 @@ public class TopicMirrorLinkCoordinator {
     private final AtomicBoolean isActive = new AtomicBoolean(false);
     private final KafkaConfig config;
     private final ReplicaManager replicaManager;
-    private final Scheduler scheduler;
     private final Metrics metrics;
     private final MetadataCache metadataCache;
     private final Time time;
@@ -83,7 +80,6 @@ public class TopicMirrorLinkCoordinator {
     public TopicMirrorLinkCoordinator(
             KafkaConfig config,
             ReplicaManager replicaManager,
-            Scheduler scheduler,
             Metrics metrics,
             MetadataCache metadataCache,
             Time time,
@@ -91,7 +87,6 @@ public class TopicMirrorLinkCoordinator {
     ) {
         this.config = config;
         this.replicaManager = replicaManager;
-        this.scheduler = scheduler;
         this.metrics = metrics;
         this.metadataCache = metadataCache;
         this.time = time;
@@ -105,13 +100,6 @@ public class TopicMirrorLinkCoordinator {
         }
 
         logger.info("Starting up.");
-        scheduler.startup();
-        // periodically query source cluster to get the metadata
-        scheduler.schedule("topic-mirror-link-query",
-                remoteClusterMetadataManager::refreshRemoteMetadata,
-                300000,
-                300000
-        );
         numPartitions = config.clusterLinksConfig().clusterLinkTopicNumPartitions();
     }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -344,6 +344,8 @@ class BrokerServer(
         metrics,
         time,
         metadataCache,
+        logManager,
+        new KafkaScheduler(1, true, "remote-cluster-metadata-manager-"),
         clientToControllerChannelManager
       )
 
@@ -398,7 +400,7 @@ class BrokerServer(
         producerIdManagerSupplier, metrics, metadataCache, Time.SYSTEM)
 
       topicMirrorLinkCoordinator = new TopicMirrorLinkCoordinator(config, replicaManager,
-        new KafkaScheduler(1, true, "topic-mirror-link-manager-"), metrics, metadataCache, Time.SYSTEM, remoteClusterMetadataManager)
+        metrics, metadataCache, Time.SYSTEM, remoteClusterMetadataManager)
 
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
         config, clientToControllerChannelManager, groupCoordinator,

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -138,8 +138,8 @@ class ControllerApis(
         case ApiKeys.UPDATE_RAFT_VOTER => handleUpdateRaftVoter(request)
         case ApiKeys.CREATE_CLUSTER_LINK => handleCreateClusterLink(request)
         case ApiKeys.CREATE_MIRROR_TOPIC => handleCreateClusterLink(request)
-        case ApiKeys.DELETE_MIRROR_TOPIC => handleCreateClusterLink(request)
-        case ApiKeys.BUMP_LEADER_EPOCH => handleBumpLeaderEpoch(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => handleDeleteMirrorTopic(request)
+        case ApiKeys.BUMP_LEADER_EPOCH => handleDeleteMirrorTopic(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -231,21 +231,29 @@ class ControllerApis(
 
   }
 
-  def handleBumpLeaderEpoch(request: RequestChannel.Request): CompletableFuture[Unit] = {
+  def handleDeleteMirrorTopic(request: RequestChannel.Request): CompletableFuture[Unit] = {
     // luke
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
-    val bumpLeaderEpochRequest = request.body[BumpLeaderEpochRequest]
+    val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    controller.bumpLeaderEpoch(context, bumpLeaderEpochRequest.data().apiKey().toInt)
+    val partitionLeaderEpochs: util.Map[Uuid, util.Map[Integer, Integer]] = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+    deleteMirrorTopicRequest.data().topics().forEach( topic => {
+      val map = new util.HashMap[Integer, Integer]()
+      topic.partitions().forEach(par => {
+        map.put(par.partitionIndex(), par.leaderEpoch())
+      })
+      partitionLeaderEpochs.put(topic.topicId(), map)
+    })
+    controller.deleteMirrorTopic(context, partitionLeaderEpochs)
       .handle[Unit] { (response, exception) =>
-        logger.info("!!! bump leader epoch response: " + response + " exception: " + exception)
+        logger.info("!!! delete mirror topic response: " + response + " exception: " + exception)
         if (exception != null) {
           requestHelper.handleError(request, exception)
         } else {
 
           requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
-            new BumpLeaderEpochResponse(response.setThrottleTimeMs(throttleMs)))
+            new DeleteMirrorTopicResponse(response.setThrottleTimeMs(throttleMs)))
         }
       }
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -137,6 +137,9 @@ class ControllerApis(
         case ApiKeys.REMOVE_RAFT_VOTER => handleRemoveRaftVoter(request)
         case ApiKeys.UPDATE_RAFT_VOTER => handleUpdateRaftVoter(request)
         case ApiKeys.CREATE_CLUSTER_LINK => handleCreateClusterLink(request)
+        case ApiKeys.CREATE_MIRROR_TOPIC => handleCreateClusterLink(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => handleCreateClusterLink(request)
+        case ApiKeys.BUMP_LEADER_EPOCH => handleBumpLeaderEpoch(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -166,7 +169,6 @@ class ControllerApis(
   }
 
   def handleCreateClusterLink(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    // test
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     val createClusterLinkRequest = request.body[CreateClusterLinkRequest]
     info("!!! create cluster link request: " + createClusterLinkRequest)
@@ -224,6 +226,28 @@ class ControllerApis(
         names => authHelper.filterByAuthorized(request.context, CREATE, TOPIC, names)(identity),
         names => authHelper.filterByAuthorized(request.context, DESCRIBE_CONFIGS, TOPIC, names, logIfDenied = false)(identity))
     }
+
+    CompletableFuture.completedFuture[Unit](())
+
+  }
+
+  def handleBumpLeaderEpoch(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    // luke
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val bumpLeaderEpochRequest = request.body[BumpLeaderEpochRequest]
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
+    controller.bumpLeaderEpoch(context, bumpLeaderEpochRequest.data().apiKey().toInt)
+      .handle[Unit] { (response, exception) =>
+        logger.info("!!! bump leader epoch response: " + response + " exception: " + exception)
+        if (exception != null) {
+          requestHelper.handleError(request, exception)
+        } else {
+
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new BumpLeaderEpochResponse(response.setThrottleTimeMs(throttleMs)))
+        }
+      }
 
     CompletableFuture.completedFuture[Unit](())
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -235,6 +235,7 @@ class ControllerApis(
     // luke
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
+    info("!!! delete mirror topic request: " + deleteMirrorTopicRequest)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
     val partitionLeaderEpochs: util.Map[Uuid, util.Map[Integer, Integer]] = new util.HashMap[Uuid, util.Map[Integer, Integer]]()

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -139,7 +139,7 @@ class ControllerApis(
         case ApiKeys.CREATE_CLUSTER_LINK => handleCreateClusterLink(request)
         case ApiKeys.CREATE_MIRROR_TOPIC => handleCreateClusterLink(request)
         case ApiKeys.DELETE_MIRROR_TOPIC => handleDeleteMirrorTopic(request)
-        case ApiKeys.BUMP_LEADER_EPOCH => handleDeleteMirrorTopic(request)
+        case ApiKeys.BUMP_LEADER_EPOCH => handleBumpLeaderEpoch(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -238,15 +238,15 @@ class ControllerApis(
     info("!!! delete mirror topic request: " + deleteMirrorTopicRequest)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    val partitionLeaderEpochs: util.Map[Uuid, util.Map[Integer, Integer]] = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+    val topicIds: util.Set[Uuid] = new util.HashSet[Uuid]()
     deleteMirrorTopicRequest.data().topics().forEach( topic => {
-      val map = new util.HashMap[Integer, Integer]()
-      topic.partitions().forEach(par => {
-        map.put(par.partitionIndex(), par.leaderEpoch())
-      })
-      partitionLeaderEpochs.put(topic.topicId(), map)
+      if (!topic.topicId().equals(Uuid.ZERO_UUID)) {
+        topicIds.add(topic.topicId())
+      } else {
+        topicIds.add(metadataCache.getTopicId(topic.name()))
+      }
     })
-    controller.deleteMirrorTopic(context, partitionLeaderEpochs)
+    controller.deleteMirrorTopic(context, topicIds)
       .handle[Unit] { (response, exception) =>
         logger.info("!!! delete mirror topic response: " + response + " exception: " + exception)
         if (exception != null) {
@@ -255,6 +255,37 @@ class ControllerApis(
 
           requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
             new DeleteMirrorTopicResponse(response.setThrottleTimeMs(throttleMs)))
+        }
+      }
+
+    CompletableFuture.completedFuture[Unit](())
+
+  }
+
+  def handleBumpLeaderEpoch(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    // luke
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val bumpLeaderEpochRequest = request.body[BumpLeaderEpochRequest]
+    info("!!! bump leader epoch request: " + bumpLeaderEpochRequest)
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
+    val partitionLeaderEpochs: util.Map[Uuid, util.Map[Integer, Integer]] = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+    bumpLeaderEpochRequest.data().topics().forEach( topic => {
+      val map = new util.HashMap[Integer, Integer]()
+      topic.partitions().forEach(par => {
+        map.put(par.partitionIndex(), par.leaderEpoch())
+      })
+      partitionLeaderEpochs.put(topic.topicId(), map)
+    })
+    controller.bumpLeaderEpoch(context, partitionLeaderEpochs)
+      .handle[Unit] { (response, exception) =>
+        logger.info("!!! bump leader epoch response: " + response + " exception: " + exception)
+        if (exception != null) {
+          requestHelper.handleError(request, exception)
+        } else {
+
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new BumpLeaderEpochResponse(response.setThrottleTimeMs(throttleMs)))
         }
       }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -253,7 +253,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.GET_REPLICA_LOG_INFO => handleGetReplicaLogInfo(request)
         case ApiKeys.CREATE_CLUSTER_LINK => forwardToController(request)
         case ApiKeys.CREATE_MIRROR_TOPIC => forwardToController(request)
-        case ApiKeys.DELETE_MIRROR_TOPIC => handleDeleteMirrorTopic(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => forwardToController(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -269,17 +269,6 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (request.apiLocalCompleteTimeNanos < 0)
         request.apiLocalCompleteTimeNanos = time.nanoseconds
     }
-  }
-
-  def handleDeleteMirrorTopic(request: RequestChannel.Request): Unit = {
-    val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
-    logger.info(s"!!! Handling delete mirror topics request:" + request.sizeInBytes + ";;" + deleteMirrorTopicRequest)
-    val topicNames = deleteMirrorTopicRequest.data().topics().stream().map(t => t.name()).toList
-
-    // TODO: need to find a way to bump the leader epoch AFTER deleteMirrorTopic completed and the broker has stopped fetch,
-    // otherwise, the new appended records after leader epoch bump might be larger
-    replicaManager.remoteClusterMetadataManager.get.maybeUpdateLeaderEpoch(topicNames)
-    forwardToController(request)
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic.{CLUSTER_LINK_TOPIC_NAME, GROUP_METADATA_TOPIC_NAME, SHARE_GROUP_STATE_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME, isInternal}
 import org.apache.kafka.common.internals.{FatalExitError, Plugin, Topic}
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.{AddPartitionsToTxnResult, AddPartitionsToTxnResultCollection}
+import org.apache.kafka.common.message.BumpLeaderEpochRequestData.LeaderEpochState
 import org.apache.kafka.common.message.DeleteRecordsResponseData.{DeleteRecordsPartitionResult, DeleteRecordsTopicResult}
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData.DeleteShareGroupOffsetsRequestTopic
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic
@@ -269,6 +270,32 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (request.apiLocalCompleteTimeNanos < 0)
         request.apiLocalCompleteTimeNanos = time.nanoseconds
     }
+  }
+
+  def handleDeleteMirrorTopic(request: RequestChannel.Request): Unit = {
+    val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
+    logger.info(s"!!! Handling delete mirror topics request")
+    // get the leader epoch to bump from each partition
+
+    val topicIds = deleteMirrorTopicRequest.data().topics().stream().map(t => t.topicId()).toList
+    val bumpLeaderEpochs = new BumpLeaderEpochRequestData()
+    topicIds.forEach( tid => {
+      val leaderEpochStates = new util.ArrayList[LeaderEpochState]()
+      metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(tid).partitions().keySet().forEach(par => {
+        val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(metadataCache.getTopicName(tid).get(), par)).map(log => log.latestEpochFromLog().orElse(-1)).get
+        leaderEpochStates.add(new LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
+      })
+      bumpLeaderEpochs.topics().add(new BumpLeaderEpochRequestData.TopicState().setTopicId(tid).setPartitions(leaderEpochStates))
+    })
+
+
+
+//    val clusterLinkTopic = createTopicsRequest.data.topics.stream().filter(t => t.clusterLink() != null && !t.clusterLink().isEmpty).findFirst()
+//    if (clusterLinkTopic.isPresent) {
+//      logger.info(s"!!! Handling create mirror topics request: ${clusterLinkTopic.get().clusterLink()}")
+//      topicMirrorLinkCoordinator.addTopicsInCoordinator(clusterLinkTopic.get().clusterLink(), util.Set.of(clusterLinkTopic.get().name()));
+//    }
+    forwardToController(request)
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -252,6 +252,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.STREAMS_GROUP_HEARTBEAT => handleStreamsGroupHeartbeat(request).exceptionally(handleError)
         case ApiKeys.GET_REPLICA_LOG_INFO => handleGetReplicaLogInfo(request)
         case ApiKeys.CREATE_CLUSTER_LINK => forwardToController(request)
+        case ApiKeys.CREATE_MIRROR_TOPIC => forwardToController(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => forwardToController(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -34,7 +34,6 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic.{CLUSTER_LINK_TOPIC_NAME, GROUP_METADATA_TOPIC_NAME, SHARE_GROUP_STATE_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME, isInternal}
 import org.apache.kafka.common.internals.{FatalExitError, Plugin, Topic}
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.{AddPartitionsToTxnResult, AddPartitionsToTxnResultCollection}
-import org.apache.kafka.common.message.BumpLeaderEpochRequestData.LeaderEpochState
 import org.apache.kafka.common.message.DeleteRecordsResponseData.{DeleteRecordsPartitionResult, DeleteRecordsTopicResult}
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData.DeleteShareGroupOffsetsRequestTopic
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic
@@ -277,25 +276,20 @@ class KafkaApis(val requestChannel: RequestChannel,
     logger.info(s"!!! Handling delete mirror topics request")
     // get the leader epoch to bump from each partition
 
+    val updatedDeleteMirrorTopicRequestData = new DeleteMirrorTopicRequestData()
     val topicIds = deleteMirrorTopicRequest.data().topics().stream().map(t => t.topicId()).toList
-    val bumpLeaderEpochs = new BumpLeaderEpochRequestData()
     topicIds.forEach( tid => {
-      val leaderEpochStates = new util.ArrayList[LeaderEpochState]()
+      val leaderEpochStates = new util.ArrayList[DeleteMirrorTopicRequestData.LeaderEpochState]()
       metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(tid).partitions().keySet().forEach(par => {
         val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(metadataCache.getTopicName(tid).get(), par)).map(log => log.latestEpochFromLog().orElse(-1)).get
-        leaderEpochStates.add(new LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
+        leaderEpochStates.add(new DeleteMirrorTopicRequestData.LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
       })
-      bumpLeaderEpochs.topics().add(new BumpLeaderEpochRequestData.TopicState().setTopicId(tid).setPartitions(leaderEpochStates))
+      updatedDeleteMirrorTopicRequestData.topics().add(new DeleteMirrorTopicRequestData.TopicState().setTopicId(tid).setPartitions(leaderEpochStates))
     })
 
+    val updatedDeleteMirrorTopicRequest = new DeleteMirrorTopicRequest(updatedDeleteMirrorTopicRequestData, deleteMirrorTopicRequest.version())
 
-
-//    val clusterLinkTopic = createTopicsRequest.data.topics.stream().filter(t => t.clusterLink() != null && !t.clusterLink().isEmpty).findFirst()
-//    if (clusterLinkTopic.isPresent) {
-//      logger.info(s"!!! Handling create mirror topics request: ${clusterLinkTopic.get().clusterLink()}")
-//      topicMirrorLinkCoordinator.addTopicsInCoordinator(clusterLinkTopic.get().clusterLink(), util.Set.of(clusterLinkTopic.get().name()));
-//    }
-    forwardToController(request)
+    forwardToController(updatedDeleteMirrorTopicRequest.asInstanceOf[RequestChannel.Request])
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -277,14 +277,14 @@ class KafkaApis(val requestChannel: RequestChannel,
     // get the leader epoch to bump from each partition
 
     val updatedDeleteMirrorTopicRequestData = new DeleteMirrorTopicRequestData()
-    val topicIds = deleteMirrorTopicRequest.data().topics().stream().map(t => t.topicId()).toList
-    topicIds.forEach( tid => {
+    val topicNames = deleteMirrorTopicRequest.data().topics().stream().map(t => t.name()).toList
+    topicNames.forEach( name => {
       val leaderEpochStates = new util.ArrayList[DeleteMirrorTopicRequestData.LeaderEpochState]()
-      metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(tid).partitions().keySet().forEach(par => {
-        val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(metadataCache.getTopicName(tid).get(), par)).map(log => log.latestEpochFromLog().orElse(-1)).get
+      metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(name).partitions().keySet().forEach(par => {
+        val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(name, par)).map(log => log.latestEpochFromLog().orElse(-1)).get
         leaderEpochStates.add(new DeleteMirrorTopicRequestData.LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
       })
-      updatedDeleteMirrorTopicRequestData.topics().add(new DeleteMirrorTopicRequestData.TopicState().setTopicId(tid).setPartitions(leaderEpochStates))
+      updatedDeleteMirrorTopicRequestData.topics().add(new DeleteMirrorTopicRequestData.TopicState().setTopicId(metadataCache.getTopicId(name)).setPartitions(leaderEpochStates))
     })
 
     val updatedDeleteMirrorTopicRequest = new DeleteMirrorTopicRequest(updatedDeleteMirrorTopicRequestData, deleteMirrorTopicRequest.version())

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -253,7 +253,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.GET_REPLICA_LOG_INFO => handleGetReplicaLogInfo(request)
         case ApiKeys.CREATE_CLUSTER_LINK => forwardToController(request)
         case ApiKeys.CREATE_MIRROR_TOPIC => forwardToController(request)
-        case ApiKeys.DELETE_MIRROR_TOPIC => forwardToController(request)
+        case ApiKeys.DELETE_MIRROR_TOPIC => handleDeleteMirrorTopic(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -289,7 +289,9 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     val updatedDeleteMirrorTopicRequest = new DeleteMirrorTopicRequest(updatedDeleteMirrorTopicRequestData, deleteMirrorTopicRequest.version())
 
-    forwardToController(updatedDeleteMirrorTopicRequest.asInstanceOf[RequestChannel.Request])
+//    request.body
+
+//    requestChannel
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -273,25 +273,13 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleDeleteMirrorTopic(request: RequestChannel.Request): Unit = {
     val deleteMirrorTopicRequest = request.body[DeleteMirrorTopicRequest]
-    logger.info(s"!!! Handling delete mirror topics request")
-    // get the leader epoch to bump from each partition
-
-    val updatedDeleteMirrorTopicRequestData = new DeleteMirrorTopicRequestData()
+    logger.info(s"!!! Handling delete mirror topics request:" + request.sizeInBytes + ";;" + deleteMirrorTopicRequest)
     val topicNames = deleteMirrorTopicRequest.data().topics().stream().map(t => t.name()).toList
-    topicNames.forEach( name => {
-      val leaderEpochStates = new util.ArrayList[DeleteMirrorTopicRequestData.LeaderEpochState]()
-      metadataCache.asInstanceOf[KRaftMetadataCache].getImage().topics().getTopic(name).partitions().keySet().forEach(par => {
-        val leaderEpoch: Int = replicaManager.getLog(new TopicPartition(name, par)).map(log => log.latestEpochFromLog().orElse(-1)).get
-        leaderEpochStates.add(new DeleteMirrorTopicRequestData.LeaderEpochState().setPartitionIndex(par).setLeaderEpoch(leaderEpoch))
-      })
-      updatedDeleteMirrorTopicRequestData.topics().add(new DeleteMirrorTopicRequestData.TopicState().setTopicId(metadataCache.getTopicId(name)).setPartitions(leaderEpochStates))
-    })
 
-    val updatedDeleteMirrorTopicRequest = new DeleteMirrorTopicRequest(updatedDeleteMirrorTopicRequestData, deleteMirrorTopicRequest.version())
-
-//    request.body
-
-//    requestChannel
+    // TODO: need to find a way to bump the leader epoch AFTER deleteMirrorTopic completed and the broker has stopped fetch,
+    // otherwise, the new appended records after leader epoch bump might be larger
+    replicaManager.remoteClusterMetadataManager.get.maybeUpdateLeaderEpoch(topicNames)
+    forwardToController(request)
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {
@@ -686,8 +674,6 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     val fetchData = fetchRequest.fetchData(topicNames)
     val forgottenTopics = fetchRequest.forgottenTopics(topicNames)
-
-    info("!!! fetchData:" + fetchData)
 
     val fetchContext = fetchManager.newContext(
       fetchRequest.version,

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2307,6 +2307,7 @@ class ReplicaManager(val config: KafkaConfig,
     } else {
       ""
     }
+
     getPartition(tp) match {
       case HostedPartition.Offline(offlinePartition) =>
         if (offlinePartition.flatMap(p => p.topicId).contains(topicId)) {
@@ -2332,7 +2333,7 @@ class ReplicaManager(val config: KafkaConfig,
           throw new IllegalStateException(s"Topic $tp exists, but its ID is " +
             s"${partition.topicId.get}, not $topicId as expected")
         }
-        logger.info("!!! update partition: " + tp + " " + topicId + " " + clusterLinkName + ";;" + partition.clusterLinkName)
+        // TODO: We should update the partition state in makeLeader/MakeFollower, not when getting it
         partition.setClusterLinkName(clusterLinkName)
         Some(partition, false)
 
@@ -2393,8 +2394,13 @@ class ReplicaManager(val config: KafkaConfig,
         val lazyOffsetCheckpoints = new LazyOffsetCheckpoints(this.highWatermarkCheckpoints.asJava)
         val leaderChangedPartitions = new mutable.HashSet[Partition]
         val followerChangedPartitions = new mutable.HashSet[Partition]
+        val deleteMirrorTopics = new mutable.HashSet[String]
         if (!localChanges.leaders.isEmpty) {
-          applyLocalLeadersDelta(leaderChangedPartitions, delta, lazyOffsetCheckpoints, localChanges.leaders.asScala, localChanges.directoryIds.asScala)
+          applyLocalLeadersDelta(leaderChangedPartitions, delta, lazyOffsetCheckpoints, localChanges.leaders.asScala, localChanges.directoryIds.asScala, deleteMirrorTopics)
+          if (deleteMirrorTopics.nonEmpty) {
+            info("!!! sent bumpLeaderEpoch:" + deleteMirrorTopics)
+            remoteClusterMetadataManager.get.maybeUpdateLeaderEpoch(deleteMirrorTopics.toList.asJava)
+          }
         }
         if (!localChanges.followers.isEmpty) {
           applyLocalFollowersDelta(followerChangedPartitions, newImage, delta, lazyOffsetCheckpoints, localChanges.followers.asScala, localChanges.directoryIds.asScala)
@@ -2423,16 +2429,24 @@ class ReplicaManager(val config: KafkaConfig,
     delta: TopicsDelta,
     offsetCheckpoints: OffsetCheckpoints,
     localLeaders: mutable.Map[TopicPartition, LocalReplicaChanges.PartitionInfo],
-    directoryIds: mutable.Map[TopicIdPartition, Uuid]
+    directoryIds: mutable.Map[TopicIdPartition, Uuid],
+    deleteMirrorTopics: mutable.Set[String]
   ): Unit = {
     stateChangeLogger.info(s"Transitioning ${localLeaders.size} partition(s) to " +
       "local leaders.")
     replicaFetcherManager.removeFetcherForPartitions(localLeaders.keySet)
+    var isDeleteMirrorTopic = false
     localLeaders.foreachEntry { (tp, info) =>
       getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
         try {
           val state = info.partition.toLeaderAndIsrPartitionState(tp, isNew)
           val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
+
+          val newClusterName = delta.changedTopics().get(info.topicId()).partitionChanges().get(tp.partition()).clusterLinkName
+          if (partition.clusterLinkName.nonEmpty && newClusterName.isEmpty && !isDeleteMirrorTopic) {
+            isDeleteMirrorTopic = true
+          }
+
           partition.makeLeader(state, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
           changedPartitions.add(partition)
@@ -2446,6 +2460,9 @@ class ReplicaManager(val config: KafkaConfig,
             // to an empty Partition object. We need to map this topic-partition to OfflinePartition instead.
             markPartitionOffline(tp)
         }
+      }
+      if (isDeleteMirrorTopic) {
+        deleteMirrorTopics.add(tp.topic())
       }
     }
   }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1768,7 +1768,6 @@ class ReplicaManager(val config: KafkaConfig,
     }
 
     def read(tp: TopicIdPartition, fetchInfo: PartitionData, limitBytes: Int, minOneMessage: Boolean): LogReadResult = {
-      info("!!! readFromLog:" + tp + " " + fetchInfo)
       val offset = fetchInfo.fetchOffset
       val partitionFetchSize = fetchInfo.maxBytes
       val followerLogStartOffset = fetchInfo.logStartOffset

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
@@ -148,6 +149,11 @@ public interface Controller extends AclMutator, AutoCloseable {
     CompletableFuture<CreateClusterLinkResponseData> createClusterLink(
             ControllerRequestContext context,
             Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
+    );
+
+    CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
+            int leaderEpoch
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -154,6 +154,11 @@ public interface Controller extends AclMutator, AutoCloseable {
 
     CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
+            Set<Uuid> topicIds
+    );
+
+    CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
             Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
     );
 

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
@@ -151,9 +152,9 @@ public interface Controller extends AclMutator, AutoCloseable {
             Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
     );
 
-    CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+    CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
-            int leaderEpoch
+            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -100,7 +100,7 @@ public class PartitionChangeBuilder {
     private boolean eligibleLeaderReplicasEnabled;
     private DefaultDirProvider defaultDirProvider;
     private String clusterLink;
-    private int minLeaderEpoch;
+    private int minLeaderEpoch = -1;
 
     // Whether allow electing last known leader in a Balanced recovery. Note, the last known leader will be stored in the
     // lastKnownElr field if enabled.

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -100,6 +100,7 @@ public class PartitionChangeBuilder {
     private boolean eligibleLeaderReplicasEnabled;
     private DefaultDirProvider defaultDirProvider;
     private String clusterLink;
+    private int minLeaderEpoch;
 
     // Whether allow electing last known leader in a Balanced recovery. Note, the last known leader will be stored in the
     // lastKnownElr field if enabled.
@@ -200,6 +201,11 @@ public class PartitionChangeBuilder {
 
     public PartitionChangeBuilder setClusterLink(String clusterLink) {
         this.clusterLink = clusterLink;
+        return this;
+    }
+
+    public PartitionChangeBuilder setMinLeaderEpoch(int leaderEpoch) {
+        this.minLeaderEpoch = leaderEpoch;
         return this;
     }
 
@@ -438,7 +444,8 @@ public class PartitionChangeBuilder {
         PartitionChangeRecord record = new PartitionChangeRecord().
             setTopicId(topicId).
             setPartitionId(partitionId).
-            setClusterLinkName(clusterLink);
+            setClusterLinkName(clusterLink).
+            setLeaderEpoch(minLeaderEpoch);
 
         completeReassignmentIfNeeded();
 

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
@@ -1777,6 +1778,17 @@ public final class QuorumController implements Controller {
             return result;
         });
     }
+
+    @Override
+    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
+            int leaderEpoch
+    ) {
+        return appendWriteEvent("bumpLeaderEpoch", context.deadlineNs(),
+                () -> replicationControl.bumpLeaderEpoch(leaderEpoch));
+    }
+
+
 
     @Override
     public CompletableFuture<Void> unregisterBroker(

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1783,12 +1783,20 @@ public final class QuorumController implements Controller {
     @Override
     public CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
-            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
+            Set<Uuid> topicIds
     ) {
         return appendWriteEvent("deleteMirrorTopic", context.deadlineNs(),
-                () -> replicationControl.deleteMirrorTopic(partitionLeaderEpochs));
+                () -> replicationControl.deleteMirrorTopic(topicIds));
     }
 
+    @Override
+    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
+            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
+    ) {
+        return appendWriteEvent("bumpLeaderEpochs", context.deadlineNs(),
+                () -> replicationControl.bumpLeaderEpochs(partitionLeaderEpochs));
+    }
 
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -50,6 +50,7 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
@@ -1780,12 +1781,12 @@ public final class QuorumController implements Controller {
     }
 
     @Override
-    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+    public CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
-            int leaderEpoch
+            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs
     ) {
-        return appendWriteEvent("bumpLeaderEpoch", context.deadlineNs(),
-                () -> replicationControl.bumpLeaderEpoch(leaderEpoch));
+        return appendWriteEvent("deleteMirrorTopic", context.deadlineNs(),
+                () -> replicationControl.deleteMirrorTopic(partitionLeaderEpochs));
     }
 
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -50,6 +50,8 @@ import org.apache.kafka.common.message.AlterPartitionResponseData;
 import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
+import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
@@ -1715,6 +1717,16 @@ public class ReplicationControlManager {
                 request.currentMetadataOffset());
         log.error("processExpiredBrokerHeartbeat: controller event queue overloaded. Timed out " +
                 "heartbeat from broker {}.", brokerId);
+    }
+
+    public ControllerResult<BumpLeaderEpochResponseData> bumpLeaderEpoch(int leaderEpoch) {
+//        BrokerRegistration registration = clusterControl.brokerRegistrations().get(brokerId);
+//        if (registration == null) {
+//            throw new BrokerIdNotRegisteredException("Broker ID " + brokerId +
+//                    " is not currently registered");
+//        }
+        List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+        return ControllerResult.of(records, null);
     }
 
     public ControllerResult<Void> unregisterBroker(int brokerId) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -61,6 +61,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicCol
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicConfigCollection;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersRequestData.TopicPartitions;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
@@ -1719,14 +1720,34 @@ public class ReplicationControlManager {
                 "heartbeat from broker {}.", brokerId);
     }
 
-    public ControllerResult<BumpLeaderEpochResponseData> bumpLeaderEpoch(int leaderEpoch) {
-//        BrokerRegistration registration = clusterControl.brokerRegistrations().get(brokerId);
-//        if (registration == null) {
-//            throw new BrokerIdNotRegisteredException("Broker ID " + brokerId +
-//                    " is not currently registered");
-//        }
+    public ControllerResult<DeleteMirrorTopicResponseData> deleteMirrorTopic(Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
-        return ControllerResult.of(records, null);
+        for (Entry<Uuid, Map<Integer, Integer>> partitionLeaderEpoch : partitionLeaderEpochs.entrySet()) {
+            Uuid topicId = partitionLeaderEpoch.getKey();
+            Map<Integer, Integer> leaderEpochs = partitionLeaderEpoch.getValue();
+            TopicControlInfo info = topics.get(topicId);
+            String topicName = info.name;
+            for (int partitionId : info.parts.keySet()) {
+                PartitionRegistration partition = info.parts.get(partitionId);
+                PartitionChangeBuilder builder = new PartitionChangeBuilder(
+                        partition,
+                        info.topicId(),
+                        partitionId,
+                        new LeaderAcceptor(clusterControl, partition),
+                        featureControl.metadataVersionOrThrow(),
+                        getTopicEffectiveMinIsr(topicName)
+                )
+                        .setClusterLink("")
+                        .setMinLeaderEpoch(leaderEpochs.getOrDefault(partitionId, -1))
+                        .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
+                        .setDefaultDirProvider(clusterDescriber);
+
+                builder.build().ifPresent(records::add);
+                log.info("!!! update partition {} for topic {} with empty cluster link: {}", partitionId, topicName, records);
+            }
+        }
+
+        return ControllerResult.of(records, new DeleteMirrorTopicResponseData().setErrorCode((short) 0));
     }
 
     public ControllerResult<Void> unregisterBroker(int brokerId) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -139,6 +139,7 @@ import static org.apache.kafka.common.protocol.Errors.NO_REASSIGNMENT_IN_PROGRES
 import static org.apache.kafka.common.protocol.Errors.TOPIC_AUTHORIZATION_FAILED;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_ID;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_OR_PARTITION;
+import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
 import static org.apache.kafka.controller.PartitionReassignmentReplicas.isReassignmentInProgress;
 import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_OP;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
@@ -1720,7 +1721,35 @@ public class ReplicationControlManager {
                 "heartbeat from broker {}.", brokerId);
     }
 
-    public ControllerResult<DeleteMirrorTopicResponseData> deleteMirrorTopic(Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
+    public ControllerResult<DeleteMirrorTopicResponseData> deleteMirrorTopic(Set<Uuid> topicIds) {
+        List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+        for (Uuid topicId : topicIds) {
+            TopicControlInfo info = topics.get(topicId);
+            String topicName = info.name;
+            for (int partitionId : info.parts.keySet()) {
+                PartitionRegistration partition = info.parts.get(partitionId);
+                PartitionChangeBuilder builder = new PartitionChangeBuilder(
+                        partition,
+                        info.topicId(),
+                        partitionId,
+                        new LeaderAcceptor(clusterControl, partition),
+                        featureControl.metadataVersionOrThrow(),
+                        getTopicEffectiveMinIsr(topicName)
+                )
+                        // clear the cluster link name
+                        .setClusterLink("")
+                        .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
+                        .setDefaultDirProvider(clusterDescriber);
+
+                builder.build().ifPresent(records::add);
+                log.info("!!! update partition {} for topic {} with empty cluster link: {}", partitionId, topicName, records);
+            }
+        }
+
+        return ControllerResult.of(records, new DeleteMirrorTopicResponseData().setErrorCode((short) 0));
+    }
+
+    public ControllerResult<BumpLeaderEpochResponseData> bumpLeaderEpochs(Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         for (Entry<Uuid, Map<Integer, Integer>> partitionLeaderEpoch : partitionLeaderEpochs.entrySet()) {
             Uuid topicId = partitionLeaderEpoch.getKey();
@@ -1737,17 +1766,18 @@ public class ReplicationControlManager {
                         featureControl.metadataVersionOrThrow(),
                         getTopicEffectiveMinIsr(topicName)
                 )
-                        .setClusterLink("")
-                        .setMinLeaderEpoch(leaderEpochs.getOrDefault(partitionId, -1))
+                        // set the min leader epoch for each partition
+                        .setMinLeaderEpoch(leaderEpochs.getOrDefault(partitionId, NO_PARTITION_LEADER_EPOCH))
+                        .setClusterLink(partition.clusterLinkName)
                         .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled())
                         .setDefaultDirProvider(clusterDescriber);
 
                 builder.build().ifPresent(records::add);
-                log.info("!!! update partition {} for topic {} with empty cluster link: {}", partitionId, topicName, records);
+                log.info("!!! update partition {} for topic {} with cluster link: {}", partitionId, topicName, records);
             }
         }
 
-        return ControllerResult.of(records, new DeleteMirrorTopicResponseData().setErrorCode((short) 0));
+        return ControllerResult.of(records, new BumpLeaderEpochResponseData().setErrorCode((short) 0));
     }
 
     public ControllerResult<Void> unregisterBroker(int brokerId) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
 
 
@@ -263,13 +264,18 @@ public class PartitionRegistration {
 
         int newLeader;
         int newLeaderEpoch;
-        if (record.leader() == NO_LEADER_CHANGE) {
+        // we should bump the leader epoch when leaderEpoch is assiged (bump_leader_epoch request), even if no_leader_change
+        if (record.leader() == NO_LEADER_CHANGE && record.leaderEpoch() == NO_PARTITION_LEADER_EPOCH) {
             newLeader = leader;
             newLeaderEpoch = leaderEpoch;
         } else {
             newLeader = record.leader();
             newLeaderEpoch = leaderEpoch + 1;
         }
+        if (record.leaderEpoch() != NO_PARTITION_LEADER_EPOCH && record.leaderEpoch() < newLeaderEpoch ) {
+            newLeaderEpoch = record.leaderEpoch();
+        }
+
 
         LeaderRecoveryState newLeaderRecoveryState = leaderRecoveryState.changeTo(record.leaderRecoveryState());
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -272,6 +272,7 @@ public class PartitionRegistration {
             newLeader = record.leader();
             newLeaderEpoch = leaderEpoch + 1;
         }
+        System.out.println("!!! newLeaderEpoch:" + newLeaderEpoch + ";;" + leaderEpoch + ";;" + record.leaderEpoch() + ";;" + record.leader());
         if (record.leaderEpoch() != NO_PARTITION_LEADER_EPOCH && record.leaderEpoch() < newLeaderEpoch ) {
             newLeaderEpoch = record.leaderEpoch();
         }

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -265,18 +265,21 @@ public class PartitionRegistration {
         int newLeader;
         int newLeaderEpoch;
         // we should bump the leader epoch when leaderEpoch is assiged (bump_leader_epoch request), even if no_leader_change
-        if (record.leader() == NO_LEADER_CHANGE && record.leaderEpoch() == NO_PARTITION_LEADER_EPOCH) {
+        if (record.leader() == NO_LEADER_CHANGE) {
             newLeader = leader;
-            newLeaderEpoch = leaderEpoch;
+            if (record.leaderEpoch() == NO_PARTITION_LEADER_EPOCH) {
+                newLeaderEpoch = leaderEpoch;
+            } else {
+                newLeaderEpoch = leaderEpoch + 1;
+            }
         } else {
             newLeader = record.leader();
             newLeaderEpoch = leaderEpoch + 1;
         }
         System.out.println("!!! newLeaderEpoch:" + newLeaderEpoch + ";;" + leaderEpoch + ";;" + record.leaderEpoch() + ";;" + record.leader());
-        if (record.leaderEpoch() != NO_PARTITION_LEADER_EPOCH && record.leaderEpoch() < newLeaderEpoch ) {
-            newLeaderEpoch = record.leaderEpoch();
+        if (record.leaderEpoch() != NO_PARTITION_LEADER_EPOCH && record.leaderEpoch() >= newLeaderEpoch) {
+            newLeaderEpoch = record.leaderEpoch() + 1;
         }
-
 
         LeaderRecoveryState newLeaderRecoveryState = leaderRecoveryState.changeTo(record.leaderRecoveryState());
 

--- a/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
@@ -53,6 +53,8 @@
       "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 7,
       "about": "null if the LastKnownElr didn't change; the last known eligible leader replicas otherwise." },
     { "name": "clusterLinkName", "type": "string", "versions": "2+", "default": "",
-      "about": "clusterLinkName." }
+      "about": "clusterLinkName." },
+    { "name": "LeaderEpoch", "type": "int32", "versions": "2+", "default": "-1",
+      "about": "The epoch of the partition leader." }
   ]
 }

--- a/server/src/main/java/org/apache/kafka/network/RequestConvertToJson.java
+++ b/server/src/main/java/org/apache/kafka/network/RequestConvertToJson.java
@@ -583,6 +583,12 @@ public class RequestConvertToJson {
                 return GetReplicaLogInfoRequestDataJsonConverter.write(((GetReplicaLogInfoRequest) request).data(), request.version());
             case CREATE_CLUSTER_LINK:
                 return CreateClusterLinkRequestDataJsonConverter.write(((CreateClusterLinkRequest) request).data(), request.version());
+            case CREATE_MIRROR_TOPIC:
+                return CreateClusterLinkRequestDataJsonConverter.write(((CreateClusterLinkRequest) request).data(), request.version());
+            case DELETE_MIRROR_TOPIC:
+                return CreateClusterLinkRequestDataJsonConverter.write(((CreateClusterLinkRequest) request).data(), request.version());
+            case BUMP_LEADER_EPOCH:
+                return CreateClusterLinkRequestDataJsonConverter.write(((CreateClusterLinkRequest) request).data(), request.version());
             default:
                 throw new IllegalStateException("ApiKey " + request.apiKey() + " is not currently handled in `request`, the " +
                     "code should be updated to do so.");
@@ -772,6 +778,12 @@ public class RequestConvertToJson {
             case GET_REPLICA_LOG_INFO:
                 return GetReplicaLogInfoResponseDataJsonConverter.write(((GetReplicaLogInfoResponse) response).data(), version);
             case CREATE_CLUSTER_LINK:
+                return CreateClusterLinkResponseDataJsonConverter.write(((CreateClusterLinkResponse) response).data(), version);
+            case CREATE_MIRROR_TOPIC:
+                return CreateClusterLinkResponseDataJsonConverter.write(((CreateClusterLinkResponse) response).data(), version);
+            case DELETE_MIRROR_TOPIC:
+                return CreateClusterLinkResponseDataJsonConverter.write(((CreateClusterLinkResponse) response).data(), version);
+            case BUMP_LEADER_EPOCH:
                 return CreateClusterLinkResponseDataJsonConverter.write(((CreateClusterLinkResponse) response).data(), version);
             default:
                 throw new IllegalStateException("ApiKey " + response.apiKey() + " is not currently handled in `response`, the " +

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1467,6 +1467,11 @@ public class UnifiedLog implements AutoCloseable {
                         "be 0, but it is " + batch.baseOffset());
             }
 
+            // validate if the new appended leader epoch is lower than the leader epoch in previous message
+            if (hasLowerPartitionLeaderEpochThanBefore(leaderEpoch)) {
+                throw new InvalidRecordException("leader epoch " + leaderEpoch + " is lower than previous one:" + leaderEpochCache.latestEpoch());
+            }
+
             /* During replication of uncommitted data it is possible for the remote replica to send record batches after it lost
              * leadership. This can happen if sending FETCH responses is slow. There is a race between sending the FETCH
              * response and the replica truncating and appending to the log. The replicating replica resolves this issue by only
@@ -1558,6 +1563,12 @@ public class UnifiedLog implements AutoCloseable {
         return origin == AppendOrigin.REPLICATION
                 && batch.partitionLeaderEpoch() != RecordBatch.NO_PARTITION_LEADER_EPOCH
                 && batch.partitionLeaderEpoch() > leaderEpoch;
+    }
+
+    private boolean hasLowerPartitionLeaderEpochThanBefore(int leaderEpoch) {
+        return leaderEpochCache.latestEpoch().isPresent()
+                && leaderEpochCache.latestEpoch().get() != RecordBatch.NO_PARTITION_LEADER_EPOCH
+                && leaderEpochCache.latestEpoch().get() > leaderEpoch;
     }
 
     /**

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.BumpLeaderEpochResponseData;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.message.CreateClusterLinkResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
@@ -103,6 +104,11 @@ public class MockController implements Controller {
             ControllerRequestContext context,
             Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
     ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(ControllerRequestContext context, int leaderEpoch) {
         throw new UnsupportedOperationException();
     }
 

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -111,6 +111,12 @@ public class MockController implements Controller {
     @Override
     public CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
             ControllerRequestContext context,
+            Set<Uuid> topicIds) {
+        throw new UnsupportedOperationException();
+    }
+
+    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(
+            ControllerRequestContext context,
             Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
         throw new UnsupportedOperationException();
     }

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -47,6 +47,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
+import org.apache.kafka.common.message.DeleteMirrorTopicResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
@@ -108,7 +109,9 @@ public class MockController implements Controller {
     }
 
     @Override
-    public CompletableFuture<BumpLeaderEpochResponseData> bumpLeaderEpoch(ControllerRequestContext context, int leaderEpoch) {
+    public CompletableFuture<DeleteMirrorTopicResponseData> deleteMirrorTopic(
+            ControllerRequestContext context,
+            Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
         throw new UnsupportedOperationException();
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -117,8 +117,10 @@ public abstract class TopicCommand {
                 topicService.describeTopic(opts);
             } else if (opts.hasDeleteOption()) {
                 topicService.deleteTopic(opts);
-            } else if (opts.hasCreateMirrorOption() || opts.hasDeleteMirrorOption()) {
+            } else if (opts.hasCreateMirrorOption()) {
                 topicService.createMirrorTopic(opts);
+            } else if (opts.hasDeleteMirrorOption()) {
+                topicService.deleteMirrorTopic(opts);
             } else if (opts.hasCreateLinkOption()) {
                 topicService.createLink(opts);
             }
@@ -493,23 +495,11 @@ public abstract class TopicCommand {
             }
 
             try {
-                NewTopic newTopic;
                 Optional<Node> coordinator = Optional.empty();
-                if (topic.opts.hasCreateMirrorOption()) {
+                if (topic.opts.hasDeleteMirrorOption()) {
                     FindCoordinatorResult findCoordinatorResult = adminClient.findCoordinator(topic.opts.linkName().get());
                     coordinator = Optional.ofNullable(findCoordinatorResult.node().get());
                     System.out.println("Found coordinator " + coordinator.map(Node::idString).orElse("none") + " for link " + topic.opts.linkName().get() + ".");
-                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue), topic.remoteBootstrapServers, topic.topicId, topic.opts.linkName());
-                } else if (topic.hasReplicaAssignment()) {
-                    newTopic = new NewTopic(topic.name, topic.replicaAssignment);
-                } else {
-                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue));
-                }
-
-                Map<String, String> configsMap = topic.configsToAdd.stringPropertyNames().stream()
-                        .collect(Collectors.toMap(name -> name, topic.configsToAdd::getProperty));
-                if (topic.opts.hasCreateMirrorOption()) {
-                    configsMap.put(TopicConfig.READ_ONLY_CONFIG, "true");
                 }
 
                 if (coordinator.isPresent()) {
@@ -518,7 +508,6 @@ public abstract class TopicCommand {
                     String bootstrapServer = node.host() + ":" + node.port();
                     System.out.println("Creating topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
                     try (Admin admin = createAdminClient(new Properties(), Optional.of(bootstrapServer))) {
-                        newTopic.configs(configsMap);
                         DeleteMirrorTopicResult deleteMirrorTopicResult = admin.deleteMirrorTopic(topic.opts.linkName().orElse(""), Set.of(topic.name), new DeleteMirrorTopicOptions());
                         deleteMirrorTopicResult.all().get();
                         System.out.println("Delete mirror topic topic " + topic.name + ".");

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -27,6 +27,8 @@ import org.apache.kafka.clients.admin.CreateClusterLinkResult;
 import org.apache.kafka.clients.admin.CreatePartitionsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteMirrorTopicOptions;
+import org.apache.kafka.clients.admin.DeleteMirrorTopicResult;
 import org.apache.kafka.clients.admin.DeleteTopicsOptions;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
 import org.apache.kafka.clients.admin.FindCoordinatorResult;
@@ -481,6 +483,57 @@ public abstract class TopicCommand {
                         "collide. To avoid issues it is best to use either, but not both.");
             }
             createTopic(topic);
+        }
+
+        public void deleteMirrorTopic(TopicCommandOptions opts) throws Exception {
+            CommandTopicPartition topic = new CommandTopicPartition(opts);
+            if (Topic.hasCollisionChars(topic.name)) {
+                System.out.println("WARNING: Due to limitations in metric names, topics with a period ('.') or underscore ('_') could " +
+                        "collide. To avoid issues it is best to use either, but not both.");
+            }
+
+            try {
+                NewTopic newTopic;
+                Optional<Node> coordinator = Optional.empty();
+                if (topic.opts.hasCreateMirrorOption()) {
+                    FindCoordinatorResult findCoordinatorResult = adminClient.findCoordinator(topic.opts.linkName().get());
+                    coordinator = Optional.ofNullable(findCoordinatorResult.node().get());
+                    System.out.println("Found coordinator " + coordinator.map(Node::idString).orElse("none") + " for link " + topic.opts.linkName().get() + ".");
+                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue), topic.remoteBootstrapServers, topic.topicId, topic.opts.linkName());
+                } else if (topic.hasReplicaAssignment()) {
+                    newTopic = new NewTopic(topic.name, topic.replicaAssignment);
+                } else {
+                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue));
+                }
+
+                Map<String, String> configsMap = topic.configsToAdd.stringPropertyNames().stream()
+                        .collect(Collectors.toMap(name -> name, topic.configsToAdd::getProperty));
+                if (topic.opts.hasCreateMirrorOption()) {
+                    configsMap.put(TopicConfig.READ_ONLY_CONFIG, "true");
+                }
+
+                if (coordinator.isPresent()) {
+                    Node node = coordinator.get();
+                    System.out.println("Node info: " + node);
+                    String bootstrapServer = node.host() + ":" + node.port();
+                    System.out.println("Creating topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
+                    try (Admin admin = createAdminClient(new Properties(), Optional.of(bootstrapServer))) {
+                        newTopic.configs(configsMap);
+                        DeleteMirrorTopicResult deleteMirrorTopicResult = admin.deleteMirrorTopic(topic.opts.linkName().orElse(""), Set.of(topic.name), new DeleteMirrorTopicOptions());
+                        deleteMirrorTopicResult.all().get();
+                        System.out.println("Delete mirror topic topic " + topic.name + ".");
+                    }
+                } else {
+                    System.out.println("error when delete mirror topic " + topic.name + ".");
+                }
+            } catch (ExecutionException e) {
+                if (e.getCause() == null) {
+                    throw e;
+                }
+                if (!(e.getCause() instanceof TopicExistsException && topic.ifTopicDoesntExist())) {
+                    throw (Exception) e.getCause();
+                }
+            }
         }
 
         public void createTopic(CommandTopicPartition topic) throws Exception {

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -506,7 +506,7 @@ public abstract class TopicCommand {
                     Node node = coordinator.get();
                     System.out.println("Node info: " + node);
                     String bootstrapServer = node.host() + ":" + node.port();
-                    System.out.println("Creating topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
+                    System.out.println("Deleting mirror topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
                     try (Admin admin = createAdminClient(new Properties(), Optional.of(bootstrapServer))) {
                         DeleteMirrorTopicResult deleteMirrorTopicResult = admin.deleteMirrorTopic(topic.opts.linkName().orElse(""), Set.of(topic.name), new DeleteMirrorTopicOptions());
                         deleteMirrorTopicResult.all().get();


### PR DESCRIPTION
1. Added 3 more APIs: `CREATE_MIRROR_TOPIC`, `DELETE_MIRROR_TOPIC`, `BUMP_LEADER_EPOCH`. Currently, `CREATE_MIRROR_TOPIC` is to be implemented.
2. Implement `DELETE_MIRROR_TOPIC`, this will clear the cluster link name for each partition
3. Implement `BUMP_LEADER_EPOCH` in controller side, to bump the leader epoch for each partition
4. Sent `BUMP_LEADER_EPOCH` after remote fetcher thread is stopped, in another thread to avoid blocking the makeLeader/makeFollower process

Tests:

Tests:
1. prepare 2 properties files for cluster-link
```
> cat /tmp/test.properties 
bootstrap.servers=localhost:9092
```

2. create a topic in the cluster 9092, and write some data to it
```
bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092
bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9092
```

3. stop the source cluster 9092, and start it, to force the leader epoch bump



3. create a cluster-link in the cluster 9094
```
 bin/kafka-topics.sh --createLink --link my-link --bootstrap-server localhost:9094  --topic foo --cluster-link-config /tmp/test.properties
```

5. mirror the topic from cluster 9092 to 9094
```
bin/kafka-topics.sh --createMirror --topic quickstart-events --bootstrap-server localhost:9094 --link my-link --topic-id r55jCra2QluFc_r0oxDVhQ
```

6. stop the mirroring in 9094
```
bin/kafka-topics.sh --deleteMirror --topic quickstart-events --bootstrap-server localhost:9094 --link my-link 
```

7. write some data to 9094
```
bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9094
```




~~Note: Currently, the leader epoch bump happened during deleteMirrorTopic. There might be race condition that after delete mirror topic, there are more data appended with higher leader epoch, so the leader epoch bump doesn't work.~~
Ex:
1. user sends deleteMirrorTopic
2. broker collect the leader epochs in the partitions, and send the bumpLeaderEpoch to the controller in another thread
3. deleteMirrorTopic is handling
6. new records appended with higher leader epoch than step (2)
8. deleteMirrorTopic done
9. bumpLeaderEpoch done
10. User appends the data to the node, but the leader epoch is lower than previous data

~~We can send the bumpLeaderEpoch by each partition, so that we can make sure no more fetch from source node and then bump leader epoch, but that will cause many bumpLeaderEpoch requests when deleteMirrorTopic, ex: a topic has 1000 partitions, there will be 1000 bumpLeaderEpoch requests in flight. Any thought?~~

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
