### PR TITLE
Add kafka-mirrors.sh tool

### DIFF
--- a/bin/kafka-mirrors.sh
+++ b/bin/kafka-mirrors.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.MirrorCommand "$@"

--- a/bin/windows/kafka-mirrors.bat
+++ b/bin/windows/kafka-mirrors.bat
@@ -1,0 +1,17 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+"%~dp0kafka-run-class.bat" org.apache.kafka.tools.MirrorCommand %*

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1168,13 +1168,7 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                if (isMirroredTopic) {
-                                    for (MutableRecordBatch batch : records.batches()) {
-                                        // reset producer id for mirrored topic
-                                        logger.info("!!! resetting batch producer id to {} for batch {}", -(batch.producerId() + 2), batch.baseOffset());
-                                        batch.setProducerId(-(batch.producerId() + 2));
-                                    }
-                                }
+                                maybeResetProducerIdForMirroredTopic(records, isMirroredTopic);
                                 // we are taking the offsets we are given
                                 if (appendInfo.firstOrLastOffsetOfFirstBatch() < localLog.logEndOffset()) {
                                     // we may still be able to recover if the log is empty
@@ -1273,6 +1267,16 @@ public class UnifiedLog implements AutoCloseable {
                             }
                             return appendInfo;
                         });
+            }
+        }
+    }
+
+    private void maybeResetProducerIdForMirroredTopic(MemoryRecords records, boolean isMirroredTopic) {
+        if (isMirroredTopic) {
+            for (MutableRecordBatch batch : records.batches()) {
+                // reset producer id for mirrored topic
+                logger.info("!!! resetting batch producer id to {} for batch {}", -(batch.producerId() + 2), batch.baseOffset());
+                batch.setProducerId(-(batch.producerId() + 2));
             }
         }
     }

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.CreateMirrorOptions;
+import org.apache.kafka.clients.admin.CreateMirrorResult;
+import org.apache.kafka.clients.admin.CreateTopicsOptions;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.FindCoordinatorResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.config.MirrorConfig;
+import org.apache.kafka.server.util.CommandDefaultOptions;
+import org.apache.kafka.server.util.CommandLineUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionSpec;
+import joptsimple.OptionSpecBuilder;
+
+/**
+ * Command-line tool for managing cluster mirrors.
+ */
+public abstract class MirrorCommand {
+    private static final Logger LOG = LoggerFactory.getLogger(MirrorCommand.class);
+
+    public static void main(String... args) {
+        Exit.exit(mainNoExit(args));
+    }
+
+    private static int mainNoExit(String... args) {
+        try {
+            execute(args);
+            return 0;
+        } catch (Throwable e) {
+            System.err.println(e.getMessage());
+            System.err.println(Utils.stackTrace(e));
+            return 1;
+        }
+    }
+
+    static void execute(String... args) throws Exception {
+        MirrorCommandOptions opts = new MirrorCommandOptions(args);
+        MirrorService mirrorService = new MirrorService(opts.bootstrapServer(), opts.commandConfig(), opts.mirrorConfig());
+        int exitCode = 0;
+        try {
+            if (opts.hasCreateOption()) {
+                mirrorService.createMirror(opts);
+            } else if (opts.hasAddOption()) {
+                mirrorService.addTopicToMirror(opts);
+            }
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            printException(cause != null ? cause : e);
+            exitCode = 1;
+        } catch (Throwable e) {
+            printException(e);
+            exitCode = 1;
+        } finally {
+            mirrorService.close();
+            Exit.exit(exitCode);
+        }
+    }
+
+    private static void printException(Throwable e) {
+        System.out.println("Error while executing mirror command : " + e.getMessage());
+        LOG.error(Utils.stackTrace(e));
+    }
+
+    /*
+     * Service class that handles the core mirror operations using Kafka Admin Client.
+     */
+    public static class MirrorService implements AutoCloseable {
+        private final Admin adminClient;
+        private final Map<String, String> mirrorConfigs;
+        private final Properties commandConfig;
+
+        public MirrorService(Optional<String> bootstrapServer, Properties commandConfig, Map<String, String> mirrorConfigs) {
+            this.adminClient = createAdminClient(bootstrapServer, commandConfig);
+            this.commandConfig = commandConfig;
+            this.mirrorConfigs = mirrorConfigs;
+        }
+
+        private static Admin createAdminClient(Optional<String> bootstrapServer, Properties commandConfig) {
+            bootstrapServer.ifPresent(s -> commandConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, s));
+            return Admin.create(commandConfig);
+        }
+
+        public void createMirror(MirrorCommandOptions opts) throws ExecutionException, InterruptedException {
+            System.out.println("Creating mirror " + opts.mirror().get());
+
+            // Use the remote bootstrap server from command line option if provided
+            Map<String, String> effectiveMirrorConfigs = new HashMap<>(mirrorConfigs);
+            opts.remoteBootstrapServer().ifPresent(server ->
+                effectiveMirrorConfigs.put(MirrorConfig.BOOTSTRAP_SERVERS_CONFIG, server));
+
+            CreateMirrorResult result = adminClient.createMirror(
+                opts.mirror().get(),
+                effectiveMirrorConfigs,
+                new CreateMirrorOptions()
+            );
+            result.all().get();
+            System.out.println("Successfully created mirror " + opts.mirror().get());
+        }
+
+        public void addTopicToMirror(MirrorCommandOptions opts) throws Exception {
+            String topicName = opts.topic().get();
+            String mirrorName = opts.mirror().get();
+
+            System.out.println("Adding topic " + topicName + " to mirror " + mirrorName);
+
+            // Find coordinator for the mirror
+            FindCoordinatorResult findCoordinatorResult = adminClient.findCoordinator(mirrorName);
+            Optional<Node> coordinator = Optional.ofNullable(findCoordinatorResult.node().get());
+
+            if (coordinator.isEmpty()) {
+                throw new RuntimeException("Could not find coordinator for mirror " + mirrorName);
+            }
+
+            System.out.println("Found coordinator " + coordinator.get().idString() + " for mirror " + mirrorName);
+
+            // Create the mirror topic with the provided topic ID
+            NewTopic newTopic = new NewTopic(topicName,
+                Optional.empty(), // partitions - will use source topic partitions
+                opts.replicationFactor(), // replicationFactor - use provided value or cluster default
+                Optional.of(opts.remoteBootstrapServer().get()),
+                Optional.of(opts.topicId().get()),
+                Optional.of(mirrorName));
+
+            Map<String, String> configsMap = new HashMap<>();
+            configsMap.put(TopicConfig.READ_ONLY_CONFIG, "true");
+            newTopic.configs(configsMap);
+
+            // Create topic using coordinator's bootstrap server
+            Node node = coordinator.get();
+            String bootstrapServer = node.host() + ":" + node.port();
+            System.out.println("Creating mirror topic " + topicName + " using bootstrap server " + bootstrapServer);
+
+            try (Admin admin = createAdminClient(Optional.of(bootstrapServer), commandConfig)) {
+                CreateTopicsResult createResult = admin.createTopics(Set.of(newTopic),
+                    new CreateTopicsOptions().retryOnQuotaViolation(false));
+                createResult.all().get();
+                System.out.println("Successfully added topic " + topicName + " to mirror " + mirrorName);
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            adminClient.close();
+        }
+    }
+
+    public static final class MirrorCommandOptions extends CommandDefaultOptions {
+        private final ArgumentAcceptingOptionSpec<String> bootstrapServerOpt;
+        private final ArgumentAcceptingOptionSpec<String> remoteBootstrapServerOpt;
+        private final ArgumentAcceptingOptionSpec<String> commandConfigOpt;
+        private final ArgumentAcceptingOptionSpec<String> mirrorConfigOpt;
+        private final OptionSpecBuilder createOpt;
+        private final OptionSpecBuilder addOpt;
+        private final ArgumentAcceptingOptionSpec<String> mirrorOpt;
+        private final ArgumentAcceptingOptionSpec<String> topicOpt;
+        private final ArgumentAcceptingOptionSpec<String> topicIdOpt;
+        private final ArgumentAcceptingOptionSpec<Short> replicationFactorOpt;
+
+        public MirrorCommandOptions(String[] args) {
+            super(args);
+
+            bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The destination Kafka server to connect to.")
+                .withRequiredArg()
+                .describedAs("server to connect to")
+                .ofType(String.class);
+
+            remoteBootstrapServerOpt = parser.accepts("remote-bootstrap-server", "The source Kafka server to connect to for mirroring.")
+                .withRequiredArg()
+                .describedAs("remote server to connect to")
+                .ofType(String.class);
+
+            commandConfigOpt = parser.accepts("command-config", "Property file containing configs to be passed to Admin Client.")
+                .withRequiredArg()
+                .describedAs("command config property file")
+                .ofType(String.class);
+
+            mirrorConfigOpt = parser.accepts("mirror-config", "Property file containing source cluster configs for mirroring.")
+                .withRequiredArg()
+                .describedAs("mirror config property file")
+                .ofType(String.class);
+
+            createOpt = parser.accepts("create", "Create a new cluster mirror from a source cluster.");
+            addOpt = parser.accepts("add", "Add a topic to an existing cluster mirror.");
+
+            mirrorOpt = parser.accepts("mirror", "The name of the cluster mirror.")
+                .withRequiredArg()
+                .describedAs("mirror")
+                .ofType(String.class);
+
+            topicOpt = parser.accepts("topic", "The topic name to add to the mirror.")
+                .withRequiredArg()
+                .describedAs("topic")
+                .ofType(String.class);
+
+            topicIdOpt = parser.accepts("topic-id", "The topic ID to use when adding the topic to the mirror.")
+                .withRequiredArg()
+                .describedAs("topic-id")
+                .ofType(String.class);
+
+            replicationFactorOpt = parser.accepts("replication-factor", "The replication factor to use for the mirror topic. If not specified, uses the destination cluster's default.")
+                .withRequiredArg()
+                .describedAs("replication-factor")
+                .ofType(Short.class);
+
+            options = parser.parse(args);
+            checkArgs();
+        }
+
+        public boolean has(OptionSpec<?> builder) {
+            return options.has(builder);
+        }
+
+        public <A> Optional<A> valueAsOption(OptionSpec<A> option) {
+            return options.has(option) ? Optional.of(options.valueOf(option)) : Optional.empty();
+        }
+
+        public boolean hasCreateOption() {
+            return has(createOpt);
+        }
+
+        public boolean hasAddOption() {
+            return has(addOpt);
+        }
+
+        public Optional<String> bootstrapServer() {
+            return valueAsOption(bootstrapServerOpt);
+        }
+
+        public Optional<String> remoteBootstrapServer() {
+            return valueAsOption(remoteBootstrapServerOpt);
+        }
+
+        public Properties commandConfig() throws IOException {
+            if (has(commandConfigOpt)) {
+                return Utils.loadProps(options.valueOf(commandConfigOpt));
+            } else {
+                return new Properties();
+            }
+        }
+
+        public Map<String, String> mirrorConfig() throws IOException {
+            Map<String, String> config = new HashMap<>();
+            if (has(mirrorConfigOpt)) {
+                Properties properties = Utils.loadProps(options.valueOf(mirrorConfigOpt));
+                properties.forEach((k, v) -> config.put(k.toString(), v.toString()));
+            }
+            return config;
+        }
+
+        public Optional<String> mirror() {
+            return valueAsOption(mirrorOpt);
+        }
+
+        public Optional<String> topic() {
+            return valueAsOption(topicOpt);
+        }
+
+        public Optional<String> topicId() {
+            return valueAsOption(topicIdOpt);
+        }
+
+        public Optional<Short> replicationFactor() {
+            return valueAsOption(replicationFactorOpt);
+        }
+
+        @SuppressWarnings("NPathComplexity")
+        private void checkArgs() {
+            if (args.length == 0)
+                CommandLineUtils.printUsageAndExit(parser, "Create cluster mirrors and add topics to them.");
+
+            CommandLineUtils.maybePrintHelpOrVersion(this, "This tool helps to create cluster mirrors and add topics to them.");
+
+            // should have exactly one action
+            long actions = (has(createOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0);
+            if (actions != 1)
+                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create or --add");
+
+            // check required args
+            if (!has(bootstrapServerOpt))
+                throw new IllegalArgumentException("--bootstrap-server must be specified");
+
+            if (!has(mirrorOpt))
+                throw new IllegalArgumentException("--mirror must be specified");
+
+            if (has(createOpt) && !has(mirrorConfigOpt) && !has(remoteBootstrapServerOpt))
+                throw new IllegalArgumentException("Either --mirror-config or --remote-bootstrap-server must be specified when creating a mirror");
+
+            if (has(addOpt) && !has(topicOpt))
+                throw new IllegalArgumentException("--topic must be specified when adding a topic to a mirror");
+
+            if (has(addOpt) && !has(remoteBootstrapServerOpt))
+                throw new IllegalArgumentException("--remote-bootstrap-server must be specified when adding a topic to a mirror");
+
+            if (has(addOpt) && !has(topicIdOpt))
+                throw new IllegalArgumentException("--topic-id must be specified when adding a topic to a mirror");
+        }
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -21,14 +21,11 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.clients.admin.CreateMirrorOptions;
-import org.apache.kafka.clients.admin.CreateMirrorResult;
 import org.apache.kafka.clients.admin.CreatePartitionsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsOptions;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
-import org.apache.kafka.clients.admin.FindCoordinatorResult;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
@@ -63,7 +60,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -101,7 +97,7 @@ public abstract class TopicCommand {
 
     static void execute(String... args) throws Exception {
         TopicCommandOptions opts = new TopicCommandOptions(args);
-        TopicService topicService = new TopicService(opts.commandConfig(), opts.bootstrapServer(), opts.clusterLinkConfig());
+        TopicService topicService = new TopicService(opts.commandConfig(), opts.bootstrapServer());
         int exitCode = 0;
         try {
             if (opts.hasCreateOption()) {
@@ -114,10 +110,6 @@ public abstract class TopicCommand {
                 topicService.describeTopic(opts);
             } else if (opts.hasDeleteOption()) {
                 topicService.deleteTopic(opts);
-            } else if (opts.hasCreateMirrorOption()) {
-                topicService.createMirrorTopic(opts);
-            } else if (opts.hasCreateLinkOption()) {
-                topicService.createLink(opts);
             }
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
@@ -253,8 +245,6 @@ public abstract class TopicCommand {
         private final Optional<Integer> replicationFactor;
         private final Map<Integer, List<Integer>> replicaAssignment;
         private final Properties configsToAdd;
-        private final Optional<String> remoteBootstrapServers;
-        private final Optional<String> topicId;
 
         private final TopicCommandOptions opts;
 
@@ -265,8 +255,6 @@ public abstract class TopicCommand {
             replicationFactor = options.replicationFactor();
             replicaAssignment = options.replicaAssignment().orElse(Map.of());
             configsToAdd = parseTopicConfigsToBeAdded(options);
-            remoteBootstrapServers = options.remoteBootstrapServer();
-            topicId = options.topicId();
         }
 
         public boolean hasReplicaAssignment() {
@@ -442,26 +430,13 @@ public abstract class TopicCommand {
 
     public static class TopicService implements AutoCloseable {
         private final Admin adminClient;
-        private final Map<String, String> linkConfigs;
-        // TODO: remove this once we remove find coordinator of mirror topic creation logic out of this class
-        private final Properties commandConfig;
 
         public TopicService(Properties commandConfig, Optional<String> bootstrapServer) {
             this.adminClient = createAdminClient(commandConfig, bootstrapServer);
-            this.commandConfig = commandConfig;
-            linkConfigs = new HashMap<>();
-        }
-
-        public TopicService(Properties commandConfig, Optional<String> bootstrapServer, Map<String, String> linkConfigs) {
-            this.adminClient = createAdminClient(commandConfig, bootstrapServer);
-            this.commandConfig = commandConfig;
-            this.linkConfigs = linkConfigs;
         }
 
         public TopicService(Admin admin) {
             this.adminClient = admin;
-            this.commandConfig = new Properties();
-            this.linkConfigs = new HashMap<>();
         }
 
         private static Admin createAdminClient(Properties commandConfig, Optional<String> bootstrapServer) {
@@ -478,15 +453,6 @@ public abstract class TopicCommand {
             createTopic(topic);
         }
 
-        public void createMirrorTopic(TopicCommandOptions opts) throws Exception {
-            CommandTopicPartition topic = new CommandTopicPartition(opts);
-            if (Topic.hasCollisionChars(topic.name)) {
-                System.out.println("WARNING: Due to limitations in metric names, topics with a period ('.') or underscore ('_') could " +
-                        "collide. To avoid issues it is best to use either, but not both.");
-            }
-            createTopic(topic);
-        }
-
         public void createTopic(CommandTopicPartition topic) throws Exception {
             if (topic.replicationFactor.filter(rf -> rf > Short.MAX_VALUE || rf < 1).isPresent()) {
                 throw new IllegalArgumentException("The replication factor must be between 1 and " + Short.MAX_VALUE + " inclusive");
@@ -497,13 +463,7 @@ public abstract class TopicCommand {
 
             try {
                 NewTopic newTopic;
-                Optional<Node> coordinator = Optional.empty();
-                if (topic.opts.hasCreateMirrorOption()) {
-                    FindCoordinatorResult findCoordinatorResult = adminClient.findCoordinator(topic.opts.linkName().get());
-                    coordinator = Optional.ofNullable(findCoordinatorResult.node().get());
-                    System.out.println("Found coordinator " + coordinator.map(Node::idString).orElse("none") + " for link " + topic.opts.linkName().get() + ".");
-                    newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue), topic.remoteBootstrapServers, topic.topicId, topic.opts.linkName());
-                } else if (topic.hasReplicaAssignment()) {
+                if (topic.hasReplicaAssignment()) {
                     newTopic = new NewTopic(topic.name, topic.replicaAssignment);
                 } else {
                     newTopic = new NewTopic(topic.name, topic.partitions, topic.replicationFactor.map(Integer::shortValue));
@@ -511,29 +471,12 @@ public abstract class TopicCommand {
 
                 Map<String, String> configsMap = topic.configsToAdd.stringPropertyNames().stream()
                     .collect(Collectors.toMap(name -> name, topic.configsToAdd::getProperty));
-                if (topic.opts.hasCreateMirrorOption()) {
-                    configsMap.put(TopicConfig.READ_ONLY_CONFIG, "true");
-                }
 
-                if (coordinator.isPresent()) {
-                    Node node = coordinator.get();
-                    System.out.println("Node info: " + node);
-                    String bootstrapServer = node.host() + ":" + node.port();
-                    System.out.println("Creating topic " + topic.name + " using bootstrap server " + bootstrapServer + ".");
-                    try (Admin admin = createAdminClient(commandConfig, Optional.of(bootstrapServer))) {
-                        newTopic.configs(configsMap);
-                        CreateTopicsResult createResult = admin.createTopics(Set.of(newTopic),
-                                new CreateTopicsOptions().retryOnQuotaViolation(false));
-                        createResult.all().get();
-                        System.out.println("Created topic " + topic.name + ".");
-                    }
-                } else {
-                    newTopic.configs(configsMap);
-                    CreateTopicsResult createResult = adminClient.createTopics(Set.of(newTopic),
-                            new CreateTopicsOptions().retryOnQuotaViolation(false));
-                    createResult.all().get();
-                    System.out.println("Created topic " + topic.name + ".");
-                }
+                newTopic.configs(configsMap);
+                CreateTopicsResult createResult = adminClient.createTopics(Set.of(newTopic),
+                    new CreateTopicsOptions().retryOnQuotaViolation(false));
+                createResult.all().get();
+                System.out.println("Created topic " + topic.name + ".");
             } catch (ExecutionException e) {
                 if (e.getCause() == null) {
                     throw e;
@@ -542,11 +485,6 @@ public abstract class TopicCommand {
                     throw (Exception) e.getCause();
                 }
             }
-        }
-
-        public void createLink(TopicCommandOptions opts) throws ExecutionException, InterruptedException {
-            CreateMirrorResult result = adminClient.createMirror(opts.linkName().orElse(""), linkConfigs, new CreateMirrorOptions());
-            result.all().get();
         }
 
         public void listTopics(TopicCommandOptions opts) throws ExecutionException, InterruptedException {
@@ -737,11 +675,8 @@ public abstract class TopicCommand {
 
     public static final class TopicCommandOptions extends CommandDefaultOptions {
         private final ArgumentAcceptingOptionSpec<String> bootstrapServerOpt;
-        private final ArgumentAcceptingOptionSpec<String> remoteBootstrapServerOpt;
 
         private final ArgumentAcceptingOptionSpec<String> commandConfigOpt;
-
-        private final ArgumentAcceptingOptionSpec<String> clusterLinkConfigOpt;
 
         private final OptionSpecBuilder listOpt;
 
@@ -753,13 +688,7 @@ public abstract class TopicCommand {
 
         private final OptionSpecBuilder describeOpt;
 
-        private final OptionSpecBuilder createMirrorOpt;
-
-        private final OptionSpecBuilder createLinkOpt;
-
         private final ArgumentAcceptingOptionSpec<String> topicOpt;
-
-        private final ArgumentAcceptingOptionSpec<String> linkNameOpt;
 
         private final ArgumentAcceptingOptionSpec<String> topicIdOpt;
 
@@ -810,19 +739,10 @@ public abstract class TopicCommand {
                 .withRequiredArg()
                 .describedAs("server to connect to")
                 .ofType(String.class);
-            remoteBootstrapServerOpt = parser.accepts("remote-bootstrap-server", "REQUIRED: The remote Kafka server to connect to.")
-                    .withRequiredArg()
-                    .describedAs("remote server to connect to")
-                    .ofType(String.class);
             commandConfigOpt = parser.accepts("command-config", "Property file containing configs to be passed to Admin Client.")
                 .withRequiredArg()
                 .describedAs("command config property file")
                 .ofType(String.class);
-
-            clusterLinkConfigOpt = parser.accepts("cluster-link-config", "Property file source cluster cluster configs")
-                    .withRequiredArg()
-                    .describedAs("cluster link config property file")
-                    .ofType(String.class);
 
             listOpt = parser.accepts("list", "List all available topics.");
             createOpt = parser.accepts("create", "Create a new topic.");
@@ -830,19 +750,12 @@ public abstract class TopicCommand {
             alterOpt = parser.accepts("alter", "Alter the number of partitions and replica assignment." +
                     KAFKA_CONFIGS_CLI_SUPPORTS_ALTERING_TOPIC_CONFIGS);
             describeOpt = parser.accepts("describe", "List details for the given topics.");
-            createMirrorOpt = parser.accepts("createMirror", "Create a new mirror topic.");
-            createLinkOpt = parser.accepts("createLink", "Create a new link for mirroring remote topics.");
             topicOpt = parser.accepts("topic", "The topic to create, alter, describe or delete. It also accepts a regular " +
                             "expression, except for --create option. Put topic name in double quotes and use the '\\' prefix " +
                             "to escape regular expression symbols; e.g. \"test\\.topic\".")
                 .withRequiredArg()
                 .describedAs("topic")
                 .ofType(String.class);
-
-            linkNameOpt = parser.accepts("link", "Name of the link for creating new mirror topics.")
-                    .withRequiredArg()
-                    .describedAs("link")
-                    .ofType(String.class);
             topicIdOpt = parser.accepts("topic-id", "The topic-id to describe.")
                 .withRequiredArg()
                 .describedAs("topic-id")
@@ -934,14 +847,6 @@ public abstract class TopicCommand {
             return has(createOpt);
         }
 
-        public boolean hasCreateMirrorOption() {
-            return has(createMirrorOpt);
-        }
-
-        public boolean hasCreateLinkOption() {
-            return has(createLinkOpt);
-        }
-
         public boolean hasAlterOption() {
             return has(alterOpt);
         }
@@ -970,17 +875,12 @@ public abstract class TopicCommand {
             }
         }
 
-        public Map<String, String> clusterLinkConfig() throws IOException {
-            Map<String, String> config = new HashMap<>();
-            if (has(clusterLinkConfigOpt)) {
-                Properties properties = Utils.loadProps(options.valueOf(clusterLinkConfigOpt));
-                properties.forEach((k, v) -> config.put(k.toString(), v.toString()));
-            }
-            return config;
-        }
-
         public Optional<String> topic() {
             return valueAsOption(topicOpt);
+        }
+
+        public Optional<String> topicId() {
+            return valueAsOption(topicIdOpt);
         }
 
         public Optional<Integer> partitions() {
@@ -989,18 +889,6 @@ public abstract class TopicCommand {
 
         public Optional<Integer> replicationFactor() {
             return valueAsOption(replicationFactorOpt);
-        }
-
-        public Optional<String> remoteBootstrapServer() {
-            return valueAsOption(remoteBootstrapServerOpt);
-        }
-
-        public Optional<String> linkName() {
-            return valueAsOption(linkNameOpt);
-        }
-
-        public Optional<String> topicId() {
-            return valueAsOption(topicIdOpt);
         }
 
         public Optional<Map<Integer, List<Integer>>> replicaAssignment() {
@@ -1058,7 +946,7 @@ public abstract class TopicCommand {
 
             // should have exactly one action
             long actions =
-                Stream.of(createOpt, listOpt, alterOpt, describeOpt, deleteOpt, createMirrorOpt, createLinkOpt).filter(options::has)
+                Stream.of(createOpt, listOpt, alterOpt, describeOpt, deleteOpt).filter(options::has)
                     .count();
             if (actions != 1)
                 CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --list, --describe, --create, --alter or --delete");
@@ -1088,9 +976,6 @@ public abstract class TopicCommand {
                 Set<OptionSpec<?>> invalidOptions = Set.of(alterOpt);
                 CommandLineUtils.checkInvalidArgsSet(parser, options, usedOptions, invalidOptions, Optional.of(KAFKA_CONFIGS_CLI_SUPPORTS_ALTERING_TOPIC_CONFIGS));
                 CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt);
-            }
-            if (has(createLinkOpt)) {
-                CommandLineUtils.checkRequiredArgs(parser, options, linkNameOpt, clusterLinkConfigOpt);
             }
         }
 


### PR DESCRIPTION
This patch introduces the `kafka-mirrors.sh` tool by moving out all Cluster Mirror operations from `TopicCommand`. This is covering current tests, but will be expanded in the future.

Example:

```sh
echo "bootstrap.servers=localhost:9092" >/tmp/mirror.properties
bin/kafka-mirror.sh --bootstrap-server :9094 --create --mirror my-mirror --mirror-config /tmp/mirror.properties

bin/kafka-mirror.sh --bootstrap-server :9094 --add --topic my-topic --mirror my-mirror --replication-factor 2 \
  --remote-bootstrap-server :9092 --topic-id gWrR6uDrSNSSfu_ubGndCg
```