### PR TITLE
Fix diverging epochs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -61,6 +61,7 @@ public class FetchRequest extends AbstractRequest {
         public final int maxBytes;
         public final Optional<Integer> currentLeaderEpoch;
         public final Optional<Integer> lastFetchedEpoch;
+        public final Optional<Integer> mirrorLeaderEpoch;
 
         public PartitionData(
             Uuid topicId,
@@ -69,7 +70,7 @@ public class FetchRequest extends AbstractRequest {
             int maxBytes,
             Optional<Integer> currentLeaderEpoch
         ) {
-            this(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, Optional.empty());
+            this(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, Optional.empty(), Optional.empty());
         }
 
         public PartitionData(
@@ -80,12 +81,25 @@ public class FetchRequest extends AbstractRequest {
                 Optional<Integer> currentLeaderEpoch,
                 Optional<Integer> lastFetchedEpoch
         ) {
+            this(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, lastFetchedEpoch, Optional.empty());
+        }
+
+        public PartitionData(
+                Uuid topicId,
+                long fetchOffset,
+                long logStartOffset,
+                int maxBytes,
+                Optional<Integer> currentLeaderEpoch,
+                Optional<Integer> lastFetchedEpoch,
+                Optional<Integer> mirrorLeaderEpoch
+        ) {
             this.topicId = topicId;
             this.fetchOffset = fetchOffset;
             this.logStartOffset = logStartOffset;
             this.maxBytes = maxBytes;
             this.currentLeaderEpoch = currentLeaderEpoch;
             this.lastFetchedEpoch = lastFetchedEpoch;
+            this.mirrorLeaderEpoch = mirrorLeaderEpoch;
         }
 
         @Override
@@ -98,12 +112,13 @@ public class FetchRequest extends AbstractRequest {
                 logStartOffset == that.logStartOffset &&
                 maxBytes == that.maxBytes &&
                 Objects.equals(currentLeaderEpoch, that.currentLeaderEpoch) &&
-                Objects.equals(lastFetchedEpoch, that.lastFetchedEpoch);
+                Objects.equals(lastFetchedEpoch, that.lastFetchedEpoch) &&
+                Objects.equals(mirrorLeaderEpoch, that.mirrorLeaderEpoch);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, lastFetchedEpoch);
+            return Objects.hash(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, lastFetchedEpoch, mirrorLeaderEpoch);
         }
 
         @Override
@@ -115,6 +130,7 @@ public class FetchRequest extends AbstractRequest {
                 ", maxBytes=" + maxBytes +
                 ", currentLeaderEpoch=" + currentLeaderEpoch +
                 ", lastFetchedEpoch=" + lastFetchedEpoch +
+                ", mirrorLeaderEpoch=" + mirrorLeaderEpoch +
                 ')';
         }
     }
@@ -295,6 +311,7 @@ public class FetchRequest extends AbstractRequest {
                     .setPartition(topicPartition.partition())
                     .setCurrentLeaderEpoch(partitionData.currentLeaderEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
                     .setLastFetchedEpoch(partitionData.lastFetchedEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
+                    .setMirrorLeaderEpoch(partitionData.mirrorLeaderEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
                     .setFetchOffset(partitionData.fetchOffset)
                     .setLogStartOffset(partitionData.logStartOffset)
                     .setPartitionMaxBytes(partitionData.maxBytes);
@@ -411,7 +428,8 @@ public class FetchRequest extends AbstractRequest {
                         fetchPartition.logStartOffset(),
                         fetchPartition.partitionMaxBytes(),
                         optionalEpoch(fetchPartition.currentLeaderEpoch()),
-                        optionalEpoch(fetchPartition.lastFetchedEpoch())
+                        optionalEpoch(fetchPartition.lastFetchedEpoch()),
+                        optionalEpoch(fetchPartition.mirrorLeaderEpoch())
                     )
                 )
             );

--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -113,7 +113,7 @@
           "about": "The high-watermark known by the replica. -1 if the high-watermark is not known and 9223372036854775807 if the feature is not supported." },
         { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "taggedVersions": "19+",
           "tag": 2, "ignorable": true,
-          "about": "The leader epoch from the source cluster for mirrored partitions. Set to -1 for non-mirrored partitions." }
+          "about": "The mirrored leader epoch of the partition." }
       ]}
     ]},
     { "name": "ForgottenTopicsData", "type": "[]ForgottenTopic", "versions": "7+", "ignorable": false,

--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -58,7 +58,9 @@
   // Version 17 adds directory id support from KIP-853
   //
   // Version 18 adds high-watermark from KIP-1166
-  "validVersions": "4-18",
+  //
+  // Version 19 adds MirrorLeaderEpoch for cluster mirroring support
+  "validVersions": "4-19",
   "flexibleVersions": "12+",
   "fields": [
     { "name": "ClusterId", "type": "string", "versions": "12+", "nullableVersions": "12+", "default": "null",
@@ -108,7 +110,10 @@
           "about": "The directory id of the follower fetching." },
         { "name": "HighWatermark", "type": "int64", "versions": "18+", "default": "9223372036854775807", "taggedVersions": "18+",
           "tag": 1, "ignorable": true,
-          "about": "The high-watermark known by the replica. -1 if the high-watermark is not known and 9223372036854775807 if the feature is not supported." }
+          "about": "The high-watermark known by the replica. -1 if the high-watermark is not known and 9223372036854775807 if the feature is not supported." },
+        { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "taggedVersions": "19+",
+          "tag": 2, "ignorable": true,
+          "about": "The leader epoch from the source cluster for mirrored partitions. Set to -1 for non-mirrored partitions." }
       ]}
     ]},
     { "name": "ForgottenTopicsData", "type": "[]ForgottenTopic", "versions": "7+", "ignorable": false,

--- a/clients/src/main/resources/common/message/FetchResponse.json
+++ b/clients/src/main/resources/common/message/FetchResponse.json
@@ -50,7 +50,9 @@
   // Version 17 no changes to the response (KIP-853).
   //
   // Version 18 no changes to the response (KIP-1166)
-  "validVersions": "4-18",
+  //
+  // Version 19 adds MirrorLeaderEpoch to CurrentLeader for cluster mirroring support
+  "validVersions": "4-19",
   "flexibleVersions": "12+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
@@ -89,7 +91,10 @@
           { "name": "LeaderId", "type": "int32", "versions": "12+", "default": "-1", "entityType": "brokerId",
             "about": "The ID of the current leader or -1 if the leader is unknown."},
           { "name": "LeaderEpoch", "type": "int32", "versions": "12+", "default": "-1",
-            "about": "The latest known leader epoch." }
+            "about": "The latest known leader epoch." },
+          { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "taggedVersions": "19+",
+            "tag": 0, "ignorable": true,
+            "about": "The leader epoch from the source cluster for mirrored partitions. Set to -1 for non-mirrored partitions." }
         ]},
         { "name": "SnapshotId", "type": "SnapshotId",
           "versions": "12+", "taggedVersions": "12+", "tag": 2,

--- a/clients/src/main/resources/common/message/FetchResponse.json
+++ b/clients/src/main/resources/common/message/FetchResponse.json
@@ -51,7 +51,7 @@
   //
   // Version 18 no changes to the response (KIP-1166)
   //
-  // Version 19 adds MirrorLeaderEpoch to CurrentLeader for cluster mirroring support
+  // Version 19 adds MirrorLeaderEpoch for cluster mirroring support
   "validVersions": "4-19",
   "flexibleVersions": "12+",
   "fields": [
@@ -85,16 +85,16 @@
           { "name": "EndOffset", "type": "int64", "versions": "12+", "default": "-1",
             "about": "The end offset of the epoch." }
         ]},
+        { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "taggedVersions": "19+",
+          "tag": 3, "ignorable": true,
+          "about": "The latest known mirrored leader epoch." },
         { "name": "CurrentLeader", "type": "LeaderIdAndEpoch",
           "versions": "12+", "taggedVersions": "12+", "tag": 1,
           "about": "The current leader of the partition.", "fields": [
           { "name": "LeaderId", "type": "int32", "versions": "12+", "default": "-1", "entityType": "brokerId",
             "about": "The ID of the current leader or -1 if the leader is unknown."},
           { "name": "LeaderEpoch", "type": "int32", "versions": "12+", "default": "-1",
-            "about": "The latest known leader epoch." },
-          { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "taggedVersions": "19+",
-            "tag": 0, "ignorable": true,
-            "about": "The leader epoch from the source cluster for mirrored partitions. Set to -1 for non-mirrored partitions." }
+            "about": "The latest known leader epoch." }
         ]},
         { "name": "SnapshotId", "type": "SnapshotId",
           "versions": "12+", "taggedVersions": "12+", "tag": 2,

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -123,19 +123,19 @@ object Partition {
   def apply(topicIdPartition: TopicIdPartition,
             time: Time,
             replicaManager: ReplicaManager,
-            clusterLinkName: String): Partition = {
+            mirrorName: String): Partition = {
     Partition(
       topicPartition = topicIdPartition.topicPartition,
       topicId = Some(topicIdPartition.topicId),
       time = time,
       replicaManager = replicaManager,
-      clusterLinkName = clusterLinkName)
+      mirrorName = mirrorName)
   }
   def apply(topicPartition: TopicPartition,
             time: Time,
             replicaManager: ReplicaManager,
             topicId: Option[Uuid] = None,
-            clusterLinkName: String = ""): Partition = {
+            mirrorName: String = ""): Partition = {
 
     val isrChangeListener = new AlterPartitionListener {
       override def markIsrExpand(): Unit = {
@@ -168,7 +168,7 @@ object Partition {
       metadataCache = replicaManager.metadataCache,
       logManager = replicaManager.logManager,
       alterIsrManager = replicaManager.alterPartitionManager,
-      mirrorName = clusterLinkName)
+      mirrorName = mirrorName)
   }
 
   def removeMetrics(topicPartition: TopicPartition): Unit = {
@@ -1457,7 +1457,6 @@ class Partition(val topicPartition: TopicPartition,
           fetchParams.replicaId,
           fetchPartitionData
         )
-
         val logReadInfo = readFromLocalLog(localLog)
         (replica, logReadInfo)
       }
@@ -1490,13 +1489,12 @@ class Partition(val topicPartition: TopicPartition,
     fetchPartitionData: FetchRequest.PartitionData
   ): Replica = {
     getReplica(replicaId).getOrElse {
-      info(s"Leader $localBrokerId failed to record follower $replicaId's position " +
+      debug(s"Leader $localBrokerId failed to record follower $replicaId's position " +
         s"${fetchPartitionData.fetchOffset}, and last sent high watermark since the replica is " +
         s"not recognized to be one of the assigned replicas ${assignmentState.replicas.mkString(",")} " +
-        s"for leader epoch $leaderEpoch with partition epoch $partitionEpoch and ${fetchPartitionData.currentLeaderEpoch.isPresent}")
+        s"for leader epoch $leaderEpoch with partition epoch $partitionEpoch")
 
       val error = if (fetchPartitionData.currentLeaderEpoch.isPresent) {
-
         // The leader epoch is present in the request and matches the local epoch, but
         // the replica is not in the replica set. This case is possible in KRaft,
         // for example, when new replicas are added as part of a reassignment.
@@ -1534,9 +1532,7 @@ class Partition(val topicPartition: TopicPartition,
     val initialLastStableOffset = localLog.lastStableOffset
 
     lastFetchedEpoch.ifPresent { fetchEpoch =>
-      // get leader node's epoch and offset
       val epochEndOffset = lastOffsetForLeaderEpoch(currentLeaderEpoch, fetchEpoch, fetchOnlyFromLeader = false)
-      info(s"!!! Fetching  $epochEndOffset, $currentLeaderEpoch, $fetchEpoch")
       val error = Errors.forCode(epochEndOffset.errorCode)
       if (error != Errors.NONE) {
         throw error.exception()

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1449,6 +1449,20 @@ class Partition(val topicPartition: TopicPartition,
     if (fetchParams.isFromFollower) {
       // Check that the request is from a valid replica before doing the read
       val (replica, logReadInfo) = inReadLock(leaderIsrUpdateLock) {
+        // For mirrored partitions, validate the follower's mirrorLeaderEpoch against the log's highest epoch
+        if (mirrorName.nonEmpty && fetchPartitionData.mirrorLeaderEpoch.isPresent) {
+          val followerMirrorEpoch = fetchPartitionData.mirrorLeaderEpoch.get()
+          val logHighestEpoch = localLogOrException.latestEpoch.orElse(0)
+
+          if (followerMirrorEpoch < logHighestEpoch) {
+            info(s"==== Fencing follower: partition=$topicPartition, followerMirrorEpoch=$followerMirrorEpoch, logHighestEpoch=$logHighestEpoch")
+            // Follower's mirrorLeaderEpoch is outdated
+            throw new FencedLeaderEpochException(
+              s"Follower's mirrorLeaderEpoch $followerMirrorEpoch is lower than leader's highest epoch $logHighestEpoch for mirrored partition $topicPartition"
+            )
+          }
+        }
+
         val localLog = localLogWithEpochOrThrow(
           fetchPartitionData.currentLeaderEpoch,
           fetchParams.fetchOnlyLeader

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1449,14 +1449,13 @@ class Partition(val topicPartition: TopicPartition,
     if (fetchParams.isFromFollower) {
       // Check that the request is from a valid replica before doing the read
       val (replica, logReadInfo) = inReadLock(leaderIsrUpdateLock) {
-        // For mirrored partitions, validate the follower's mirrorLeaderEpoch against the log's highest epoch
+        // For mirrored partitions, validate the follower's mirrorLeaderEpoch against the log's highest epoch.
+        // This leader-side fencing guarantees liveness as it triggers mirrorLeaderEpoch update on the follower side.
         if (mirrorName.nonEmpty && fetchPartitionData.mirrorLeaderEpoch.isPresent) {
           val followerMirrorEpoch = fetchPartitionData.mirrorLeaderEpoch.get()
           val logHighestEpoch = localLogOrException.latestEpoch.orElse(0)
-
           if (followerMirrorEpoch < logHighestEpoch) {
             info(s"==== Fencing follower: partition=$topicPartition, followerMirrorEpoch=$followerMirrorEpoch, logHighestEpoch=$logHighestEpoch")
-            // Follower's mirrorLeaderEpoch is outdated
             throw new FencedLeaderEpochException(
               s"Follower's mirrorLeaderEpoch $followerMirrorEpoch is lower than leader's highest epoch $logHighestEpoch for mirrored partition $topicPartition"
             )

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1449,19 +1449,6 @@ class Partition(val topicPartition: TopicPartition,
     if (fetchParams.isFromFollower) {
       // Check that the request is from a valid replica before doing the read
       val (replica, logReadInfo) = inReadLock(leaderIsrUpdateLock) {
-        // For mirrored partitions, validate the follower's mirrorLeaderEpoch against the log's highest epoch.
-        // This leader-side fencing guarantees liveness as it triggers mirrorLeaderEpoch update on the follower side.
-        if (mirrorName.nonEmpty && fetchPartitionData.mirrorLeaderEpoch.isPresent) {
-          val followerMirrorEpoch = fetchPartitionData.mirrorLeaderEpoch.get()
-          val logHighestEpoch = localLogOrException.latestEpoch.orElse(0)
-          if (followerMirrorEpoch < logHighestEpoch) {
-            info(s"==== Fencing follower: partition=$topicPartition, followerMirrorEpoch=$followerMirrorEpoch, logHighestEpoch=$logHighestEpoch")
-            throw new FencedLeaderEpochException(
-              s"Follower's mirrorLeaderEpoch $followerMirrorEpoch is lower than leader's highest epoch $logHighestEpoch for mirrored partition $topicPartition"
-            )
-          }
-        }
-
         val localLog = localLogWithEpochOrThrow(
           fetchPartitionData.currentLeaderEpoch,
           fetchParams.fetchOnlyLeader

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -68,6 +68,7 @@ abstract class AbstractFetcherThread(name: String,
   extends ShutdownableThread(name, isInterruptible) with Logging {
 
   this.logIdent = this.logPrefix
+  private val defaultMirrorLeaderEpoch = -1 // mirrorLeaderEpoch not used
 
   type FetchData = FetchResponseData.PartitionData
   type EpochData = OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
@@ -284,20 +285,13 @@ abstract class AbstractFetcherThread(name: String,
           case Some(partitionData) =>
             // if we can't get the epoch from the log, assume it's starting from the beginning
             val latestEpochInLog = latestEpochFromLog(topicPartition).orElse(0)
+            // Update currentLeaderEpoch (for fetch validation) from the source cluster's leader epochs
             val sourceLeaderEpoch = partitionData.currentLeader().leaderEpoch()
-            // Get mirrorLeaderEpoch from response if present, otherwise use sourceLeaderEpoch
-            val sourceMirrorLeaderEpoch = if (partitionData.mirrorLeaderEpoch() >= 0)
-              partitionData.mirrorLeaderEpoch()
-            else
-              sourceLeaderEpoch
             info(s"==== Discovered epoch: partition=$topicPartition, " +
-              s"currentLeaderEpoch: ${currentFetchState.currentLeaderEpoch} -> $sourceLeaderEpoch, " +
-              s"mirrorLeaderEpoch: ${currentFetchState.mirrorLeaderEpoch} -> $sourceMirrorLeaderEpoch")
-            // Update both currentLeaderEpoch (for fetch validation) and mirrorLeaderEpoch (for batch validation)
-            // from the source cluster's leader epochs
+              s"currentLeaderEpoch: ${currentFetchState.currentLeaderEpoch} -> $sourceLeaderEpoch")
             new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
               sourceLeaderEpoch, currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog),
-              currentFetchState.dueMs(), currentFetchState.remoteFetch(), sourceMirrorLeaderEpoch)
+              currentFetchState.dueMs(), currentFetchState.remoteFetch(), defaultMirrorLeaderEpoch)
           case None => currentFetchState
         }
         (topicPartition, updatedFetchState)
@@ -474,17 +468,17 @@ abstract class AbstractFetcherThread(name: String,
                         .setLeaderEpoch(partitionData.divergingEpoch.epoch)
                         .setEndOffset(partitionData.divergingEpoch.endOffset)
                     } else {
-                      /* Once we hand off the partition data to the subclass, we can't mess with it any more in this thread
+                      /*
+                       * Once we hand off the partition data to the subclass, we can't mess with it any more in this thread
                        *
                        * When appending batches to the log only append record batches up to the leader epoch when the FETCH
                        * request was handled. This is done to make sure that logs are not inconsistent because of log
                        * truncation and append after the FETCH request was handled. See KAFKA-18723 for more details.
+                       *
+                       * For mirrored partition followers, use mirrorLeaderEpoch for validation against source cluster epochs.
                        */
-                      val epochForValidation = if (currentFetchState.remoteFetch()) {
-                        currentFetchState.mirrorLeaderEpoch
-                      } else {
-                        currentFetchState.currentLeaderEpoch
-                      }
+                      val epochForValidation = if (currentFetchState.mirrorLeaderEpoch != defaultMirrorLeaderEpoch)
+                        currentFetchState.mirrorLeaderEpoch else currentFetchState.currentLeaderEpoch
                       val logAppendInfoOpt = processPartitionData(
                         topicPartition,
                         currentFetchState.fetchOffset,
@@ -498,19 +492,18 @@ abstract class AbstractFetcherThread(name: String,
                         val lag = Math.max(0L, partitionData.highWatermark - nextOffset)
                         fetcherLagStats.getAndMaybePut(topicPartition).lag = lag
 
+                        val shouldUpdateState = (validBytes == 0 && partitionData.mirrorLeaderEpoch > currentFetchState.mirrorLeaderEpoch) ||
+                          (validBytes > 0 || currentFetchState.lag.isEmpty)
+
                         // ReplicaDirAlterThread may have removed topicPartition from the partitionStates after processing the partition data
-                        if ((validBytes > 0 || currentFetchState.lag.isEmpty) && partitionStates.contains(topicPartition)) {
+                        if (partitionStates.contains(topicPartition) && shouldUpdateState) {
                           val lastFetchedEpoch =
                             if (logAppendInfo.lastLeaderEpoch.isPresent) logAppendInfo.lastLeaderEpoch else currentFetchState.lastFetchedEpoch
-                          // For mirrored partitions, update fetch epoch to the source epoch from the fetch response
-                          val updatedMirrorLeaderEpoch = if (shouldUpdateMirrorLeaderEpoch(topicPartition)) {
-                            fetchPartitionData.mirrorLeaderEpoch.get().intValue()
-                          } else {
-                            currentFetchState.currentLeaderEpoch
-                          }
+                          // For mirrored partitions, update mirror leader epoch from the fetch response
+                          val mirrorLeaderEpoch = if (shouldUpdateMirrorLeaderEpoch(topicPartition)) partitionData.mirrorLeaderEpoch else defaultMirrorLeaderEpoch
                           // Update partitionStates only if there is no exception during processPartitionData
                           val newFetchState = new PartitionFetchState(currentFetchState.topicId, nextOffset, Optional.of(lag),
-                            currentFetchState.currentLeaderEpoch, ReplicaState.FETCHING, lastFetchedEpoch, currentFetchState.remoteFetch(), 0, updatedMirrorLeaderEpoch)
+                            currentFetchState.currentLeaderEpoch, ReplicaState.FETCHING, lastFetchedEpoch, currentFetchState.remoteFetch, 0, mirrorLeaderEpoch)
                           log.info(s"==== Updating $newFetchState")
                           partitionStates.updateAndMoveToEnd(topicPartition, newFetchState)
                           if (validBytes > 0) fetcherStats.byteRate.mark(validBytes)
@@ -646,7 +639,7 @@ abstract class AbstractFetcherThread(name: String,
    * From IBP 2.7 onwards, we can rely on truncation based on diverging data returned in fetch responses.
    * For older versions, we can skip the truncation step iff the leader epoch matches the existing epoch.
    */
-  protected def partitionFetchState(tp: TopicPartition, initialFetchState: InitialFetchState, currentState: PartitionFetchState): PartitionFetchState = {
+  private def partitionFetchState(tp: TopicPartition, initialFetchState: InitialFetchState, currentState: PartitionFetchState): PartitionFetchState = {
     if (currentState != null && currentState.currentLeaderEpoch == initialFetchState.currentLeaderEpoch) {
       currentState
     } else if (initialFetchState.initOffset < 0) {
@@ -661,14 +654,11 @@ abstract class AbstractFetcherThread(name: String,
         else Optional.of(0) // this should only happen when no data in local log
       } else latestEpoch(tp)
       val state = if (lastFetchedEpoch.isPresent) ReplicaState.FETCHING else ReplicaState.TRUNCATING
-
-      // Default: mirrorLeaderEpoch = -1 (not used)
-      // Subclasses can override partitionFetchState to set different values
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
-        state, lastFetchedEpoch, initialFetchState.mirrorName.nonEmpty, 0, -1)
+        state, lastFetchedEpoch, initialFetchState.mirrorName.nonEmpty, 0, defaultMirrorLeaderEpoch)
     } else {
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
-        ReplicaState.TRUNCATING, Optional.empty(), initialFetchState.mirrorName.nonEmpty, 0, -1)
+        ReplicaState.TRUNCATING, Optional.empty(), initialFetchState.mirrorName.nonEmpty, 0, defaultMirrorLeaderEpoch)
     }
   }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -492,6 +492,9 @@ abstract class AbstractFetcherThread(name: String,
                         val lag = Math.max(0L, partitionData.highWatermark - nextOffset)
                         fetcherLagStats.getAndMaybePut(topicPartition).lag = lag
 
+                        // Update fetch state when:
+                        // 1. No data fetched but mirror leader epoch advanced (mirrored partitions only)
+                        // 2. Data was fetched OR this is the first fetch (lag was unknown)
                         val shouldUpdateState = (validBytes == 0 && partitionData.mirrorLeaderEpoch > currentFetchState.mirrorLeaderEpoch) ||
                           (validBytes > 0 || currentFetchState.lag.isEmpty)
 
@@ -648,6 +651,8 @@ abstract class AbstractFetcherThread(name: String,
       // With old message format, `latestEpoch` will be empty and we use Truncating state
       // to truncate to high watermark.
       val latestEpochInLog = latestEpochFromLog(tp)
+      // For mirrored partitions, use epochs from the local log (which contain source cluster epochs).
+      // For regular followers, use epochs from partition metadata (destination cluster epochs).
       val lastFetchedEpoch: Optional[Integer] = if (initialFetchState.mirrorName.nonEmpty) {
         if (latestEpochInLog.isPresent)
           latestEpochInLog

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -280,16 +280,27 @@ abstract class AbstractFetcherThread(name: String,
   private def updateMirrorCachedLeaderEpoch(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
     val newStates: Map[TopicPartition, PartitionFetchState] = partitionStates.partitionStateMap.asScala
       .map { case (topicPartition, currentFetchState) =>
-        val updatedInitFetchState = partitionToData.get(topicPartition) match {
+        val updatedFetchState = partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
             // if we can't get the epoch from the log, assume it's starting from the beginning
             val latestEpochInLog = latestEpochFromLog(topicPartition).orElse(0)
-            val leaderEpochForState = partitionData.currentLeader().leaderEpoch()
+            val sourceLeaderEpoch = partitionData.currentLeader().leaderEpoch()
+            // Get mirrorLeaderEpoch from response if present, otherwise use sourceLeaderEpoch
+            val sourceMirrorLeaderEpoch = if (partitionData.currentLeader().mirrorLeaderEpoch() >= 0)
+              partitionData.currentLeader().mirrorLeaderEpoch()
+            else
+              sourceLeaderEpoch
+            info(s"==== Discovered epoch: partition=$topicPartition, " +
+              s"currentLeaderEpoch: ${currentFetchState.currentLeaderEpoch} -> $sourceLeaderEpoch, " +
+              s"mirrorLeaderEpoch: ${currentFetchState.mirrorLeaderEpoch} -> $sourceMirrorLeaderEpoch")
+            // Update both currentLeaderEpoch (for fetch validation) and mirrorLeaderEpoch (for batch validation)
+            // from the source cluster's leader epochs
             new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
-              leaderEpochForState, currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog), currentFetchState.delay(), currentFetchState.remoteFetch())
+              sourceLeaderEpoch, currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog),
+              currentFetchState.dueMs(), currentFetchState.remoteFetch(), sourceMirrorLeaderEpoch)
           case None => currentFetchState
         }
-        (topicPartition, updatedInitFetchState)
+        (topicPartition, updatedFetchState)
       }
     info("!!! updateMirrorCachedLeaderEpoch:" + newStates)
     partitionStates.set(newStates.asJava)
@@ -469,10 +480,29 @@ abstract class AbstractFetcherThread(name: String,
                        * request was handled. This is done to make sure that logs are not inconsistent because of log
                        * truncation and append after the FETCH request was handled. See KAFKA-18723 for more details.
                        */
+                      val epochForValidation = if (currentFetchState.remoteFetch() && currentFetchState.mirrorLeaderEpoch >= 0) {
+                        if (currentFetchState.mirrorLeaderEpoch == 0) {
+                          // Bootstrap: use first batch's epoch if available
+                          val firstBatchEpoch = try {
+                            val records = partitionData.records.asInstanceOf[MemoryRecords]
+                            if (records.sizeInBytes() > 0) {
+                              val batches = records.batches().iterator()
+                              if (batches.hasNext) batches.next().partitionLeaderEpoch() else 0
+                            } else 0
+                          } catch {
+                            case _: Exception => 0
+                          }
+                          firstBatchEpoch
+                        } else {
+                          currentFetchState.mirrorLeaderEpoch
+                        }
+                      } else {
+                        currentFetchState.currentLeaderEpoch
+                      }
                       val logAppendInfoOpt = processPartitionData(
                         topicPartition,
                         currentFetchState.fetchOffset,
-                        currentFetchState.currentLeaderEpoch,
+                        epochForValidation,
                         partitionData
                       )
 
@@ -491,14 +521,15 @@ abstract class AbstractFetcherThread(name: String,
                           // epoch validations (batches with epochs higher than fetch epoch are skipped).
                           // For regular partitions, fetch epoch comes from metadata and should not be
                           // updated from batch epochs.
-                          val updatedLeaderEpoch = if (shouldUpdateEpochFromBatches(topicPartition) && logAppendInfo.lastLeaderEpoch.isPresent) {
-                            Math.max(currentFetchState.currentLeaderEpoch, logAppendInfo.lastLeaderEpoch.get)
+                          val updatedMirrorLeaderEpoch = if (shouldUpdateEpochFromBatches(topicPartition) && logAppendInfo.lastLeaderEpoch.isPresent) {
+                            Math.max(currentFetchState.mirrorLeaderEpoch, logAppendInfo.lastLeaderEpoch.get)
                           } else {
-                            currentFetchState.currentLeaderEpoch
+                            currentFetchState.mirrorLeaderEpoch
                           }
                           // Update partitionStates only if there is no exception during processPartitionData
                           val newFetchState = new PartitionFetchState(currentFetchState.topicId, nextOffset, Optional.of(lag),
-                            updatedLeaderEpoch, ReplicaState.FETCHING, lastFetchedEpoch, currentFetchState.remoteFetch(), 0)
+                            currentFetchState.currentLeaderEpoch, ReplicaState.FETCHING, lastFetchedEpoch, currentFetchState.remoteFetch(), 0, updatedMirrorLeaderEpoch)
+                          log.info(s"==== Updating $newFetchState")
                           partitionStates.updateAndMoveToEnd(topicPartition, newFetchState)
                           if (validBytes > 0) fetcherStats.byteRate.mark(validBytes)
                         }
@@ -612,7 +643,7 @@ abstract class AbstractFetcherThread(name: String,
       Option(partitionStates.stateValue(topicPartition)).foreach { state =>
         val newState = new PartitionFetchState(state.topicId, math.min(truncationOffset, state.fetchOffset),
           state.lag, state.currentLeaderEpoch, state.delay, ReplicaState.TRUNCATING,
-          Optional.empty(), state.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds())), state.remoteFetch())
+          Optional.empty(), state.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds())), state.remoteFetch(), state.mirrorLeaderEpoch)
         partitionStates.updateAndMoveToEnd(topicPartition, newState)
         partitionMapCond.signalAll()
       }
@@ -649,13 +680,14 @@ abstract class AbstractFetcherThread(name: String,
       } else latestEpoch(tp)
       val state = if (lastFetchedEpoch.isPresent) ReplicaState.FETCHING else ReplicaState.TRUNCATING
 
-      // if it's readonly, always assume it's 0 so that we can get the current leader epoch from fetch response
-      val leaderEpoch = if (initialFetchState.mirrorName.nonEmpty) 0 else initialFetchState.currentLeaderEpoch
-      new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), leaderEpoch,
-        state, lastFetchedEpoch, initialFetchState.mirrorName.nonEmpty, 0)
-    } else {
+      // For mirrored partition followers, initialize mirrorLeaderEpoch to 0 and wait for FENCED_LEADER_EPOCH to update it
+      val mirrorLeaderEpoch = if (initialFetchState.mirrorName.nonEmpty) 0 else -1
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
-        ReplicaState.TRUNCATING, Optional.empty(), initialFetchState.mirrorName.nonEmpty, 0)
+        state, lastFetchedEpoch, initialFetchState.mirrorName.nonEmpty, 0, mirrorLeaderEpoch)
+    } else {
+      val mirrorLeaderEpoch = if (initialFetchState.mirrorName.nonEmpty) 0 else -1
+      new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
+        ReplicaState.TRUNCATING, Optional.empty(), initialFetchState.mirrorName.nonEmpty, 0, mirrorLeaderEpoch)
     }
   }
 
@@ -708,7 +740,7 @@ abstract class AbstractFetcherThread(name: String,
 
             val delayMs = currentFetchState.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds()))
             new PartitionFetchState(currentFetchState.topicId, offsetTruncationState.offset, currentFetchState.lag,
-              currentFetchState.currentLeaderEpoch, currentFetchState.delay, state, lastFetchedEpoch, delayMs, currentFetchState.remoteFetch())
+              currentFetchState.currentLeaderEpoch, currentFetchState.delay, state, lastFetchedEpoch, delayMs, currentFetchState.remoteFetch(), currentFetchState.mirrorLeaderEpoch)
           case None => currentFetchState
         }
         (topicPartition, maybeTruncationComplete)
@@ -816,8 +848,9 @@ abstract class AbstractFetcherThread(name: String,
       truncate(topicPartition, OffsetTruncationState(leaderEndOffset, truncationCompleted = true))
 
       fetcherLagStats.getAndMaybePut(topicPartition).lag = 0
+      val mirrorLeaderEpoch = if (readOnly) 0 else -1
       new PartitionFetchState(topicId.toJava, leaderEndOffset, Optional.of(0L), currentLeaderEpoch,
-        ReplicaState.FETCHING, latestEpoch(topicPartition), readOnly, 0)
+        ReplicaState.FETCHING, latestEpoch(topicPartition), readOnly, 0, mirrorLeaderEpoch)
     } else {
       /**
        * If the leader's log end offset is greater than the follower's log end offset, there are two possibilities:
@@ -856,8 +889,9 @@ abstract class AbstractFetcherThread(name: String,
 
       val initialLag = leaderEndOffset - offsetToFetch
       fetcherLagStats.getAndMaybePut(topicPartition).lag = initialLag
+      val mirrorLeaderEpoch = if (readOnly) 0 else -1
       new PartitionFetchState(topicId.toJava, offsetToFetch, Optional.of(initialLag), currentLeaderEpoch,
-        ReplicaState.FETCHING, latestEpoch(topicPartition), readOnly, 0)
+        ReplicaState.FETCHING, latestEpoch(topicPartition), readOnly, 0, mirrorLeaderEpoch)
     }
   }
 
@@ -960,7 +994,8 @@ abstract class AbstractFetcherThread(name: String,
                 currentFetchState.state,
                 currentFetchState.lastFetchedEpoch,
                 Optional.of(Long.box(delay + Time.SYSTEM.milliseconds())),
-                currentFetchState.remoteFetch()))
+                currentFetchState.remoteFetch(),
+                currentFetchState.mirrorLeaderEpoch))
           }
         }
       }

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -90,6 +90,15 @@ abstract class AbstractFetcherThread(name: String,
     partitionData: FetchData
   ): Option[LogAppendInfo]
 
+  /**
+   * Check if fetch epoch should be updated from batch epochs for this partition.
+   * This is needed for mirrored partitions where batches contain source cluster epochs.
+   *
+   * @param topicPartition the partition to check
+   * @return true if fetch epoch should be updated from batch epochs
+   */
+  protected def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean
+
   protected def truncate(topicPartition: TopicPartition, truncationState: OffsetTruncationState): Unit
 
   protected def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long): Unit
@@ -477,9 +486,19 @@ abstract class AbstractFetcherThread(name: String,
                         if ((validBytes > 0 || currentFetchState.lag.isEmpty) && partitionStates.contains(topicPartition)) {
                           val lastFetchedEpoch =
                             if (logAppendInfo.lastLeaderEpoch.isPresent) logAppendInfo.lastLeaderEpoch else currentFetchState.lastFetchedEpoch
+                          // For mirrored partitions, update fetch epoch to the highest batch epoch seen.
+                          // This allows source cluster epochs to be progressively accepted while maintaining
+                          // epoch validations (batches with epochs higher than fetch epoch are skipped).
+                          // For regular partitions, fetch epoch comes from metadata and should not be
+                          // updated from batch epochs.
+                          val updatedLeaderEpoch = if (shouldUpdateEpochFromBatches(topicPartition) && logAppendInfo.lastLeaderEpoch.isPresent) {
+                            Math.max(currentFetchState.currentLeaderEpoch, logAppendInfo.lastLeaderEpoch.get)
+                          } else {
+                            currentFetchState.currentLeaderEpoch
+                          }
                           // Update partitionStates only if there is no exception during processPartitionData
                           val newFetchState = new PartitionFetchState(currentFetchState.topicId, nextOffset, Optional.of(lag),
-                            currentFetchState.currentLeaderEpoch, ReplicaState.FETCHING, lastFetchedEpoch, currentFetchState.remoteFetch(), 0)
+                            updatedLeaderEpoch, ReplicaState.FETCHING, lastFetchedEpoch, currentFetchState.remoteFetch(), 0)
                           partitionStates.updateAndMoveToEnd(topicPartition, newFetchState)
                           if (validBytes > 0) fetcherStats.byteRate.mark(validBytes)
                         }

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -97,7 +97,7 @@ abstract class AbstractFetcherThread(name: String,
    * @param topicPartition the partition to check
    * @return true if fetch epoch should be updated from batch epochs
    */
-  protected def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean
+  protected def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean
 
   protected def truncate(topicPartition: TopicPartition, truncationState: OffsetTruncationState): Unit
 
@@ -502,15 +502,11 @@ abstract class AbstractFetcherThread(name: String,
                         if ((validBytes > 0 || currentFetchState.lag.isEmpty) && partitionStates.contains(topicPartition)) {
                           val lastFetchedEpoch =
                             if (logAppendInfo.lastLeaderEpoch.isPresent) logAppendInfo.lastLeaderEpoch else currentFetchState.lastFetchedEpoch
-                          // For mirrored partitions, update fetch epoch to the highest batch epoch seen.
-                          // This allows source cluster epochs to be progressively accepted while maintaining
-                          // epoch validations (batches with epochs higher than fetch epoch are skipped).
-                          // For regular partitions, fetch epoch comes from metadata and should not be
-                          // updated from batch epochs.
-                          val updatedMirrorLeaderEpoch = if (shouldUpdateEpochFromBatches(topicPartition) && logAppendInfo.lastLeaderEpoch.isPresent) {
-                            Math.max(currentFetchState.mirrorLeaderEpoch, logAppendInfo.lastLeaderEpoch.get)
+                          // For mirrored partitions, update fetch epoch to the source epoch from the fetch response
+                          val updatedMirrorLeaderEpoch = if (shouldUpdateMirrorLeaderEpoch(topicPartition)) {
+                            fetchPartitionData.mirrorLeaderEpoch.get().intValue()
                           } else {
-                            currentFetchState.mirrorLeaderEpoch
+                            currentFetchState.currentLeaderEpoch
                           }
                           // Update partitionStates only if there is no exception during processPartitionData
                           val newFetchState = new PartitionFetchState(currentFetchState.topicId, nextOffset, Optional.of(lag),

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -286,8 +286,8 @@ abstract class AbstractFetcherThread(name: String,
             val latestEpochInLog = latestEpochFromLog(topicPartition).orElse(0)
             val sourceLeaderEpoch = partitionData.currentLeader().leaderEpoch()
             // Get mirrorLeaderEpoch from response if present, otherwise use sourceLeaderEpoch
-            val sourceMirrorLeaderEpoch = if (partitionData.currentLeader().mirrorLeaderEpoch() >= 0)
-              partitionData.currentLeader().mirrorLeaderEpoch()
+            val sourceMirrorLeaderEpoch = if (partitionData.mirrorLeaderEpoch() >= 0)
+              partitionData.mirrorLeaderEpoch()
             else
               sourceLeaderEpoch
             info(s"==== Discovered epoch: partition=$topicPartition, " +
@@ -480,22 +480,8 @@ abstract class AbstractFetcherThread(name: String,
                        * request was handled. This is done to make sure that logs are not inconsistent because of log
                        * truncation and append after the FETCH request was handled. See KAFKA-18723 for more details.
                        */
-                      val epochForValidation = if (currentFetchState.remoteFetch() && currentFetchState.mirrorLeaderEpoch >= 0) {
-                        if (currentFetchState.mirrorLeaderEpoch == 0) {
-                          // Bootstrap: use first batch's epoch if available
-                          val firstBatchEpoch = try {
-                            val records = partitionData.records.asInstanceOf[MemoryRecords]
-                            if (records.sizeInBytes() > 0) {
-                              val batches = records.batches().iterator()
-                              if (batches.hasNext) batches.next().partitionLeaderEpoch() else 0
-                            } else 0
-                          } catch {
-                            case _: Exception => 0
-                          }
-                          firstBatchEpoch
-                        } else {
-                          currentFetchState.mirrorLeaderEpoch
-                        }
+                      val epochForValidation = if (currentFetchState.remoteFetch()) {
+                        currentFetchState.mirrorLeaderEpoch
                       } else {
                         currentFetchState.currentLeaderEpoch
                       }
@@ -664,7 +650,7 @@ abstract class AbstractFetcherThread(name: String,
    * From IBP 2.7 onwards, we can rely on truncation based on diverging data returned in fetch responses.
    * For older versions, we can skip the truncation step iff the leader epoch matches the existing epoch.
    */
-  private def partitionFetchState(tp: TopicPartition, initialFetchState: InitialFetchState, currentState: PartitionFetchState): PartitionFetchState = {
+  protected def partitionFetchState(tp: TopicPartition, initialFetchState: InitialFetchState, currentState: PartitionFetchState): PartitionFetchState = {
     if (currentState != null && currentState.currentLeaderEpoch == initialFetchState.currentLeaderEpoch) {
       currentState
     } else if (initialFetchState.initOffset < 0) {
@@ -680,14 +666,13 @@ abstract class AbstractFetcherThread(name: String,
       } else latestEpoch(tp)
       val state = if (lastFetchedEpoch.isPresent) ReplicaState.FETCHING else ReplicaState.TRUNCATING
 
-      // For mirrored partition followers, initialize mirrorLeaderEpoch to 0 and wait for FENCED_LEADER_EPOCH to update it
-      val mirrorLeaderEpoch = if (initialFetchState.mirrorName.nonEmpty) 0 else -1
+      // Default: mirrorLeaderEpoch = -1 (not used)
+      // Subclasses can override partitionFetchState to set different values
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
-        state, lastFetchedEpoch, initialFetchState.mirrorName.nonEmpty, 0, mirrorLeaderEpoch)
+        state, lastFetchedEpoch, initialFetchState.mirrorName.nonEmpty, 0, -1)
     } else {
-      val mirrorLeaderEpoch = if (initialFetchState.mirrorName.nonEmpty) 0 else -1
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
-        ReplicaState.TRUNCATING, Optional.empty(), initialFetchState.mirrorName.nonEmpty, 0, mirrorLeaderEpoch)
+        ReplicaState.TRUNCATING, Optional.empty(), initialFetchState.mirrorName.nonEmpty, 0, -1)
     }
   }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -152,7 +152,7 @@ abstract class AbstractFetcherThread(name: String,
   // deal with partitions with errors, potentially due to leadership changes
   private def handlePartitionsWithErrors(partitions: Iterable[TopicPartition], methodName: String): Unit = {
     if (partitions.nonEmpty) {
-      info(s"Handling errors in $methodName for partitions $partitions")
+      debug(s"Handling errors in $methodName for partitions $partitions")
       delayPartitions(partitions, fetchBackOffMs)
     }
   }
@@ -252,34 +252,59 @@ abstract class AbstractFetcherThread(name: String,
   }
 
   /**
-   * Updates the leader epoch for read-only partitions.
-   * This method updates the partition fetch states with the latest leader epoch information
-   * while preserving other fetch state properties.
+   * Updates the leader epoch in fetch state for read-only (mirrored) partitions.
    *
-   * @param partitionToData Partitions with their updated leader epoch data
+   * This method updates the currentLeaderEpoch in the fetch state to match the source cluster's
+   * current leader epoch, enabling proper epoch validation when fetching from the source.
+   *
+   * For mirrored partitions, the currentLeaderEpoch in fetch state tracks the SOURCE cluster's
+   * leader epoch (not the destination cluster's epoch). This is critical because:
+   * 1. Fetch requests to source cluster include currentLeaderEpoch for validation
+   * 2. Source cluster validates this epoch matches its current leader
+   * 3. Mismatched epochs result in UNKNOWN_LEADER_EPOCH errors
+   *
+   * The method also updates lastFetchedEpoch from the local log to maintain proper epoch
+   * tracking for divergence detection.
+   *
+   * @param partitionToData Map of partitions to their current leader information from source cluster
    */
-  private def updateLeaderEpochForReadOnly(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
+  private def updateMirrorCachedLeaderEpoch(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
     val newStates: Map[TopicPartition, PartitionFetchState] = partitionStates.partitionStateMap.asScala
       .map { case (topicPartition, currentFetchState) =>
         val updatedInitFetchState = partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
-            // if we can't get the log from the log, assume it's starting from the beginning
+            // if we can't get the epoch from the log, assume it's starting from the beginning
             val latestEpochInLog = latestEpochFromLog(topicPartition).orElse(0)
+            val leaderEpochForState = partitionData.currentLeader().leaderEpoch()
             new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
-              partitionData.currentLeader().leaderEpoch(), currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog), currentFetchState.delay(), currentFetchState.remoteFetch())
+              leaderEpochForState, currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog), currentFetchState.delay(), currentFetchState.remoteFetch())
           case None => currentFetchState
         }
         (topicPartition, updatedInitFetchState)
       }
-    info("!!! updateLeaderEpochForReadOnly:" + newStates)
+    info("!!! updateMirrorCachedLeaderEpoch:" + newStates)
     partitionStates.set(newStates.asJava)
   }
 
   /**
-   * Creates or reuses mirror fetcher threads for read-only partitions.
-   * Fetchers are shutdown when idle (no partition assigned) or during system shutdown.
+   * Detects source cluster leader changes for mirrored partitions and reassigns them to new fetcher threads.
    *
-   * @param partitionToData Partitions with their current leader information to be processed
+   * When a partition's leader changes in the source cluster (e.g., during failover), this method
+   * detects the change and reassigns the partition to a fetcher thread that connects to the new
+   * source leader broker endpoint.
+   *
+   * The detection mechanism compares the current source leader endpoint (from partitionToData)
+   * with the endpoint of the fetcher thread currently handling each partition. When they differ,
+   * the partition is reassigned by removing it from the current fetcher and adding it to a
+   * fetcher for the new leader.
+   *
+   * Leader identity is determined by comparing (host, port) rather than broker ID because:
+   * - Consumer-based fetchers may use ID -1 instead of the actual broker ID
+   * - Network addresses (host, port) uniquely identify broker endpoints
+   * - This comparison works correctly across different cluster configurations
+   *
+   * @param partitionToData Map of partitions to their current source cluster leader information
+   *                        obtained from fetch responses
    */
   private def maybeCreateMirrorFetchers(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
     var newStates: Map[TopicPartition, InitialFetchState] = scala.collection.mutable.Map.empty[TopicPartition, InitialFetchState]
@@ -387,7 +412,7 @@ abstract class AbstractFetcherThread(name: String,
     var responseData: Map[TopicPartition, FetchData] = Map.empty
 
     try {
-      info(s"!!! Sending fetch request $fetchRequest")
+      info(s"#### Sending fetch request $fetchRequest")
       responseData = leader.fetch(fetchRequest).asScala
     } catch {
       case t: Throwable =>
@@ -550,7 +575,7 @@ abstract class AbstractFetcherThread(name: String,
     if (divergingEndOffsets.nonEmpty)
       truncateOnFetchResponse(divergingEndOffsets)
     if (readOnlyEndOffsets.nonEmpty)
-      updateLeaderEpochForReadOnly(readOnlyEndOffsets)
+      updateMirrorCachedLeaderEpoch(readOnlyEndOffsets)
     if (recreateFetchers.nonEmpty)
       maybeCreateMirrorFetchers(recreateFetchers)
     if (partitionsWithError.nonEmpty) {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -648,7 +648,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val versionId = request.header.apiVersion
     val clientId = request.header.clientId
     val fetchRequest = request.body[FetchRequest]
-    info("!!! handleFetchRequest:" + fetchRequest)
+    info("#### Handling fetch request: " + fetchRequest)
 
     val topicNames =
       if (fetchRequest.version() >= 13)
@@ -680,7 +680,6 @@ class KafkaApis(val requestChannel: RequestChannel,
           else
             interesting += topicIdPartition -> new PartitionData(data.topicId, data.fetchOffset, data.logStartOffset, data.maxBytes, data.currentLeaderEpoch, data.lastFetchedEpoch)
         }
-        info("!!! interesting:" + interesting.mkString(","))
       } else {
         fetchContext.foreachPartition { (topicIdPartition, _) =>
           erroneous += topicIdPartition -> FetchResponse.partitionResponse(topicIdPartition, Errors.TOPIC_AUTHORIZATION_FAILED)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -677,8 +677,10 @@ class KafkaApis(val requestChannel: RequestChannel,
             erroneous += topicIdPartition -> FetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)
           else if (!metadataCache.contains(topicIdPartition.topicPartition))
             erroneous += topicIdPartition -> FetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_OR_PARTITION)
-          else
-            interesting += topicIdPartition -> new PartitionData(data.topicId, data.fetchOffset, data.logStartOffset, data.maxBytes, data.currentLeaderEpoch, data.lastFetchedEpoch)
+          else {
+            interesting += topicIdPartition -> new PartitionData(data.topicId, data.fetchOffset, data.logStartOffset,
+              data.maxBytes, data.currentLeaderEpoch, data.lastFetchedEpoch, data.mirrorLeaderEpoch)
+          }
         }
       } else {
         fetchContext.foreachPartition { (topicIdPartition, _) =>
@@ -746,6 +748,17 @@ class KafkaApis(val requestChannel: RequestChannel,
               partitionData.currentLeader()
                 .setLeaderId(leaderNode.leaderId)
                 .setLeaderEpoch(leaderNode.leaderEpoch)
+
+              // For mirrored partitions, also set mirrorLeaderEpoch from the log's highest epoch
+              if (versionId >= 19) {
+                replicaManager.getPartition(topicIdPartition.topicPartition()) match {
+                  case HostedPartition.Online(partition) if partition.mirrorName.nonEmpty =>
+                    val mirrorLeaderEpoch = partition.localLogOrException.latestEpoch.orElse(0)
+                    partitionData.currentLeader().setMirrorLeaderEpoch(mirrorLeaderEpoch)
+                  case _ =>
+                    // Not a mirrored partition, leave mirrorLeaderEpoch at default -1
+                }
+              }
             case _ =>
           }
         }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -738,7 +738,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           .setRecords(data.records)
           .setPreferredReadReplica(data.preferredReadReplica.orElse(FetchResponse.INVALID_PREFERRED_REPLICA_ID))
 
-        // For mirrored partitions, also set mirrorLeaderEpoch from the log's highest epoch
+        // For mirrored partitions, set mirrorLeaderEpoch from the log's highest epoch
         if (versionId >= 19) {
           replicaManager.getPartition(topicIdPartition.topicPartition()) match {
             case HostedPartition.Online(partition) if partition.mirrorName.nonEmpty =>

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -738,6 +738,17 @@ class KafkaApis(val requestChannel: RequestChannel,
           .setRecords(data.records)
           .setPreferredReadReplica(data.preferredReadReplica.orElse(FetchResponse.INVALID_PREFERRED_REPLICA_ID))
 
+        // For mirrored partitions, also set mirrorLeaderEpoch from the log's highest epoch
+        if (versionId >= 19) {
+          replicaManager.getPartition(topicIdPartition.topicPartition()) match {
+            case HostedPartition.Online(partition) if partition.mirrorName.nonEmpty =>
+              val latestLeaderEpochInLog = partition.localLogOrException.latestEpoch.orElse(0)
+              partitionData.setMirrorLeaderEpoch(latestLeaderEpochInLog)
+            case _ =>
+            // Not a mirrored partition, leave mirrorLeaderEpoch at default -1
+          }
+        }
+
         if (versionId >= 16) {
           data.error match {
             case Errors.NOT_LEADER_OR_FOLLOWER | Errors.FENCED_LEADER_EPOCH =>
@@ -748,17 +759,6 @@ class KafkaApis(val requestChannel: RequestChannel,
               partitionData.currentLeader()
                 .setLeaderId(leaderNode.leaderId)
                 .setLeaderEpoch(leaderNode.leaderEpoch)
-
-              // For mirrored partitions, also set mirrorLeaderEpoch from the log's highest epoch
-              if (versionId >= 19) {
-                replicaManager.getPartition(topicIdPartition.topicPartition()) match {
-                  case HostedPartition.Online(partition) if partition.mirrorName.nonEmpty =>
-                    val mirrorLeaderEpoch = partition.localLogOrException.latestEpoch.orElse(0)
-                    partitionData.currentLeader().setMirrorLeaderEpoch(mirrorLeaderEpoch)
-                  case _ =>
-                    // Not a mirrored partition, leave mirrorLeaderEpoch at default -1
-                }
-              }
             case _ =>
           }
         }

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -98,7 +98,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
         throw t
     }
     val fetchResponse = clientResponse.responseBody.asInstanceOf[FetchResponse]
-    info("!!! Got fetchResponse: " + fetchResponse)
+    info("#### Got fetch response: " + fetchResponse)
     lastSeenEndpointList.clear()
     fetchResponse.data().nodeEndpoints().forEach(
       node => lastSeenEndpointList.put(node.nodeId(), new Node(node.nodeId(), node.host(), node.port(), node.rack())))
@@ -166,12 +166,12 @@ class RemoteLeaderEndPoint(logPrefix: String,
     }
 
     val epochRequest = OffsetsForLeaderEpochRequest.Builder.forFollower(topics, brokerConfig.brokerId)
-    info(s"Sending offset for leader epoch request $epochRequest")
+    debug(s"Sending offset for leader epoch request $epochRequest")
 
     try {
       val response = blockingSender.sendRequest(epochRequest)
       val responseBody = response.responseBody.asInstanceOf[OffsetsForLeaderEpochResponse]
-      info(s"Received leaderEpoch response $response")
+      debug(s"Received leaderEpoch response $response")
       responseBody.data.topics.asScala.flatMap { offsetForLeaderTopicResult =>
         offsetForLeaderTopicResult.partitions.asScala.map { offsetForLeaderPartitionResult =>
           val tp = new TopicPartition(offsetForLeaderTopicResult.topic, offsetForLeaderPartitionResult.partition)

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -61,6 +61,7 @@ import scala.collection.mutable
  * @param quota Replication quota for throttling fetches
  * @param metadataVersionSupplier Provides the current metadata version, determines fetch request version
  * @param brokerEpochSupplier Provides the current broker epoch for fencing
+ * @param isCrossClusterMirror Whether we are doing cross-cluster mirroring
  */
 class RemoteLeaderEndPoint(logPrefix: String,
                            blockingSender: BlockingSend,
@@ -69,7 +70,8 @@ class RemoteLeaderEndPoint(logPrefix: String,
                            replicaManager: ReplicaManager,
                            quota: ReplicaQuota,
                            metadataVersionSupplier: () => MetadataVersion,
-                           brokerEpochSupplier: () => Long) extends LeaderEndPoint with Logging {
+                           brokerEpochSupplier: () => Long,
+                           isCrossClusterMirror: Boolean = false) extends LeaderEndPoint with Logging {
 
   this.logIdent = logPrefix
 
@@ -205,13 +207,19 @@ class RemoteLeaderEndPoint(logPrefix: String,
             fetchState.lastFetchedEpoch()
           else
             Optional.empty[Integer]
+          // For mirrored partitions, the initial fetch has currentLeaderEpoch=0 and mirrorLeaderEpoch=0
+          val mirrorLeaderEpoch: Optional[Integer] = if (fetchState.mirrorLeaderEpoch() >= 0)
+            Optional.of(Int.box(fetchState.mirrorLeaderEpoch()))
+          else
+            Optional.empty[Integer]
           builder.add(topicPartition, new FetchRequest.PartitionData(
             fetchState.topicId().orElse(Uuid.ZERO_UUID),
             fetchState.fetchOffset(),
             logStartOffset,
             fetchSize,
             Optional.of(fetchState.currentLeaderEpoch()),
-            lastFetchedEpoch))
+            lastFetchedEpoch,
+            mirrorLeaderEpoch))
           if (fetchState.remoteFetch() && fetchState.topicId().isPresent) {
             readOnlyTopics += fetchState.topicId().get()
           }
@@ -234,13 +242,13 @@ class RemoteLeaderEndPoint(logPrefix: String,
       } else {
         metadataVersion.fetchRequestVersion
       }
-      // Use different fetch request types based on whether we're doing cross-cluster mirroring
-      val requestBuilder = if (readOnlyTopics.isEmpty) {
-        // Use replica fetch for intra-cluster replication (readOnlyTopics empty).
-        FetchRequest.Builder.forReplica(version, brokerConfig.brokerId, brokerEpochSupplier(), maxWait, minBytes, fetchData.toSend)
-      } else {
-        // Use consumer fetch for cross-cluster mirroring (readOnlyTopics not empty) to avoid ISR logic.
+      // Use different fetch request types based on whether we're doing cross-cluster mirroring.
+      val requestBuilder = if (isCrossClusterMirror) {
+        // Cross-cluster mirroring (MirrorFetcherThread): Use consumer fetch to skip ISR logic on source cluster.
         FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend).isolationLevel(IsolationLevel.READ_COMMITTED)
+      } else {
+        // Intra-cluster replication (ReplicaFetcherThread): Use replica fetch even when fetching to enable proper epoch validation.
+        FetchRequest.Builder.forReplica(version, brokerConfig.brokerId, brokerEpochSupplier(), maxWait, minBytes, fetchData.toSend)
       }
       requestBuilder
         .setMaxBytes(maxBytes)

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -239,8 +239,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
         // Use replica fetch for intra-cluster replication (readOnlyTopics empty).
         FetchRequest.Builder.forReplica(version, brokerConfig.brokerId, brokerEpochSupplier(), maxWait, minBytes, fetchData.toSend)
       } else {
-        // Use consumer fetch for cross-cluster mirroring (readOnlyTopics not empty).
-        // Consumer fetch requests don't include the replica ID and broker epoch.
+        // Use consumer fetch for cross-cluster mirroring (readOnlyTopics not empty) to avoid ISR logic.
         FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend).isolationLevel(IsolationLevel.READ_COMMITTED)
       }
       requestBuilder

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -236,10 +236,11 @@ class RemoteLeaderEndPoint(logPrefix: String,
       }
       // Use different fetch request types based on whether we're doing cross-cluster mirroring
       val requestBuilder = if (readOnlyTopics.isEmpty) {
-        // For intra-cluster replication (readOnlyTopics empty): Use replica fetch so followers can join ISR
+        // Use replica fetch for intra-cluster replication (readOnlyTopics empty).
         FetchRequest.Builder.forReplica(version, brokerConfig.brokerId, brokerEpochSupplier(), maxWait, minBytes, fetchData.toSend)
       } else {
-        // For cross-cluster mirroring (readOnlyTopics not empty): Use consumer fetch to avoid ACL issues
+        // Use consumer fetch for cross-cluster mirroring (readOnlyTopics not empty).
+        // Consumer fetch requests don't include the replica ID and broker epoch.
         FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend).isolationLevel(IsolationLevel.READ_COMMITTED)
       }
       requestBuilder

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -78,7 +78,7 @@ class ReplicaAlterLogDirsThread(name: String,
   }
 
   // process fetched data
-  override def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = {
+  override def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
     // ReplicaAlterLogDirsThread moves logs between directories on the same broker.
     // It replicates from the current log to the future log, both managed by the same partition.
     // Epoch management is handled by the partition itself, not by batch epochs.

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -78,6 +78,14 @@ class ReplicaAlterLogDirsThread(name: String,
   }
 
   // process fetched data
+  override def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = {
+    // ReplicaAlterLogDirsThread moves logs between directories on the same broker.
+    // It replicates from the current log to the future log, both managed by the same partition.
+    // Epoch management is handled by the partition itself, not by batch epochs.
+    // Therefore, we should not update currentLeaderEpoch from batches.
+    false
+  }
+
   override def processPartitionData(
     topicPartition: TopicPartition,
     fetchOffset: Long,

--- a/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
@@ -37,7 +37,7 @@ class ReplicaFetcherManager(brokerConfig: KafkaConfig,
         numFetchers = brokerConfig.numReplicaFetchers) {
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ReplicaFetcherThread = {
     val threadName = s"ReplicaFetcherThread-$fetcherId-${sourceBroker.id}"
-    val logContext = new LogContext(s"[ReplicaFetcher replicaId=${brokerConfig.brokerId}, leaderId=${sourceBroker.id}, fetcherId=$fetcherId]")
+    val logContext = new LogContext(s"[ReplicaFetcher replicaId=${brokerConfig.brokerId}, leaderId=${sourceBroker.id}, fetcherId=$fetcherId] ")
     val endpoint = new BrokerBlockingSender(sourceBroker, brokerConfig, metrics, time, fetcherId,
       s"broker-${brokerConfig.brokerId}-fetcher-$fetcherId", logContext)
     val fetchSessionHandler = new FetchSessionHandler(logContext, sourceBroker.id)

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -132,23 +132,28 @@ class ReplicaFetcherThread(name: String,
 
     // Determine the leader epoch to use when appending batches to the follower's log.
     //
-    // For mirrored partitions:
-    //   Followers replicate from leaders whose logs contain source cluster epochs. When the leader
-    //   receives new batches from MirrorFetcherThread with source epoch N, this follower's fetch
-    //   state may still have epoch M where M < N. If we use the fetch state epoch, the append will
-    //   be rejected because the batch epoch is higher. Solution: use the batch epoch when it's higher.
+    // For mirrored partitions (followers replicating from read-only leaders):
+    //   The leader's log contains source cluster epochs that can be higher than the follower's
+    //   fetch state epoch. When the leader receives new batches from MirrorFetcherThread with
+    //   source epoch N, this follower's fetch state may still have epoch M where M < N.
+    //   If we use the fetch state epoch, the append will be rejected because batch epochs are higher.
+    //   Solution: use the maximum batch epoch to allow all source epochs to be accepted.
     //
     // For regular partitions:
-    //   Batch epochs should always match the fetch state epoch. If batch epoch > fetch state epoch,
-    //   this indicates an unexpected condition. However, using the batch epoch is safe since it comes
-    //   from the leader's log, which is authoritative.
-    val effectiveLeaderEpoch = {
+    //   Always use the fetch state epoch (partitionLeaderEpoch). This preserves the KAFKA-18723
+    //   protection where batches with epochs higher than the fetch epoch are skipped by
+    //   hasHigherPartitionLeaderEpoch in analyzeAndValidateRecords.
+    val effectiveLeaderEpoch = if (partition.mirrorName != null && partition.mirrorName.nonEmpty) {
+      // Mirrored partition: use max to accept source epochs
       val batches = records.batches().iterator()
       var lastBatchEpoch = partitionLeaderEpoch
       while (batches.hasNext) {
         lastBatchEpoch = batches.next().partitionLeaderEpoch()
       }
       Math.max(lastBatchEpoch, partitionLeaderEpoch)
+    } else {
+      // Regular partition: use fetch state epoch
+      partitionLeaderEpoch
     }
 
     // Append the leader's messages to the log

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -120,6 +120,19 @@ class ReplicaFetcherThread(name: String,
     }
   }
 
+  override protected def partitionFetchState(tp: TopicPartition, initialFetchState: InitialFetchState, currentState: PartitionFetchState): PartitionFetchState = {
+    val baseState = super.partitionFetchState(tp, initialFetchState, currentState)
+    // For followers of mirrored partitions, initialize mirrorLeaderEpoch to 0 for batch validation
+    // MirrorFetcherThread leaders don't override this, so they keep mirrorLeaderEpoch = -1
+    if (initialFetchState.mirrorName.nonEmpty) {
+      new PartitionFetchState(baseState.topicId, baseState.fetchOffset, baseState.lag,
+        baseState.currentLeaderEpoch, baseState.delay, baseState.state,
+        baseState.lastFetchedEpoch, baseState.dueMs, baseState.remoteFetch, 0)
+    } else {
+      baseState
+    }
+  }
+
   // process fetched data
   override def processPartitionData(
     topicPartition: TopicPartition,

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -110,7 +110,7 @@ class ReplicaFetcherThread(name: String,
     completeDelayedFetchRequests()
   }
 
-  override def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = {
+  override def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
     // For followers of mirrored partitions, update epoch from batches to track source epochs.
     // For regular partitions, epoch comes from metadata and should not be updated from batches.
     replicaMgr.getPartition(topicPartition) match {

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -130,8 +130,29 @@ class ReplicaFetcherThread(name: String,
       trace("Follower has replica log end offset %d for partition %s. Received %d bytes of messages and leader hw %d"
         .format(log.logEndOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
 
+    // Determine the leader epoch to use when appending batches to the follower's log.
+    //
+    // For mirrored partitions:
+    //   Followers replicate from leaders whose logs contain source cluster epochs. When the leader
+    //   receives new batches from MirrorFetcherThread with source epoch N, this follower's fetch
+    //   state may still have epoch M where M < N. If we use the fetch state epoch, the append will
+    //   be rejected because the batch epoch is higher. Solution: use the batch epoch when it's higher.
+    //
+    // For regular partitions:
+    //   Batch epochs should always match the fetch state epoch. If batch epoch > fetch state epoch,
+    //   this indicates an unexpected condition. However, using the batch epoch is safe since it comes
+    //   from the leader's log, which is authoritative.
+    val effectiveLeaderEpoch = {
+      val batches = records.batches().iterator()
+      var lastBatchEpoch = partitionLeaderEpoch
+      while (batches.hasNext) {
+        lastBatchEpoch = batches.next().partitionLeaderEpoch()
+      }
+      Math.max(lastBatchEpoch, partitionLeaderEpoch)
+    }
+
     // Append the leader's messages to the log
-    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch)
+    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, effectiveLeaderEpoch)
 
     if (logTrace)
       trace("Follower has replica log end offset %d after appending %d bytes of messages for partition %s"

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -120,19 +120,6 @@ class ReplicaFetcherThread(name: String,
     }
   }
 
-  override protected def partitionFetchState(tp: TopicPartition, initialFetchState: InitialFetchState, currentState: PartitionFetchState): PartitionFetchState = {
-    val baseState = super.partitionFetchState(tp, initialFetchState, currentState)
-    // For followers of mirrored partitions, initialize mirrorLeaderEpoch to 0 for batch validation
-    // MirrorFetcherThread leaders don't override this, so they keep mirrorLeaderEpoch = -1
-    if (initialFetchState.mirrorName.nonEmpty) {
-      new PartitionFetchState(baseState.topicId, baseState.fetchOffset, baseState.lag,
-        baseState.currentLeaderEpoch, baseState.delay, baseState.state,
-        baseState.lastFetchedEpoch, baseState.dueMs, baseState.remoteFetch, 0)
-    } else {
-      baseState
-    }
-  }
-
   // process fetched data
   override def processPartitionData(
     topicPartition: TopicPartition,

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -110,6 +110,16 @@ class ReplicaFetcherThread(name: String,
     completeDelayedFetchRequests()
   }
 
+  override def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = {
+    // For followers of mirrored partitions, update epoch from batches to track source epochs.
+    // For regular partitions, epoch comes from metadata and should not be updated from batches.
+    replicaMgr.getPartition(topicPartition) match {
+      case HostedPartition.Online(partition) =>
+        partition.mirrorName != null && partition.mirrorName.nonEmpty
+      case _ => false
+    }
+  }
+
   // process fetched data
   override def processPartitionData(
     topicPartition: TopicPartition,
@@ -130,34 +140,12 @@ class ReplicaFetcherThread(name: String,
       trace("Follower has replica log end offset %d for partition %s. Received %d bytes of messages and leader hw %d"
         .format(log.logEndOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
 
-    // Determine the leader epoch to use when appending batches to the follower's log.
+    // Append the leader's messages to the log.
     //
-    // For mirrored partitions (followers replicating from read-only leaders):
-    //   The leader's log contains source cluster epochs that can be higher than the follower's
-    //   fetch state epoch. When the leader receives new batches from MirrorFetcherThread with
-    //   source epoch N, this follower's fetch state may still have epoch M where M < N.
-    //   If we use the fetch state epoch, the append will be rejected because batch epochs are higher.
-    //   Solution: use the maximum batch epoch to allow all source epochs to be accepted.
-    //
-    // For regular partitions:
-    //   Always use the fetch state epoch (partitionLeaderEpoch). This preserves the KAFKA-18723
-    //   protection where batches with epochs higher than the fetch epoch are skipped by
-    //   hasHigherPartitionLeaderEpoch in analyzeAndValidateRecords.
-    val effectiveLeaderEpoch = if (partition.mirrorName != null && partition.mirrorName.nonEmpty) {
-      // Mirrored partition: use max to accept source epochs
-      val batches = records.batches().iterator()
-      var lastBatchEpoch = partitionLeaderEpoch
-      while (batches.hasNext) {
-        lastBatchEpoch = batches.next().partitionLeaderEpoch()
-      }
-      Math.max(lastBatchEpoch, partitionLeaderEpoch)
-    } else {
-      // Regular partition: use fetch state epoch
-      partitionLeaderEpoch
-    }
-
-    // Append the leader's messages to the log
-    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, effectiveLeaderEpoch)
+    // The fetch leader epoch from metadata is used for append validation.
+    // For mirrored partitions, this epoch is updated after each append to match the highest batch
+    // epoch seen, allowing source cluster epochs to be accepted while maintaining epoch validations.
+    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch)
 
     if (logTrace)
       trace("Follower has replica log end offset %d after appending %d bytes of messages for partition %s"

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2487,6 +2487,13 @@ class ReplicaManager(val config: KafkaConfig,
           //   high watermark in the checkpoint file (see KAFKA-1647).
           val state = info.partition.toLeaderAndIsrPartitionState(tp, isNew)
           val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
+
+          // For mirrored partitions, set mirrorName so the fetcher can use source epoch logic
+          val mirrorName = info.partition.mirrorName
+          if (mirrorName != null && !mirrorName.isEmpty) {
+            partition.setMirrorName(mirrorName)
+          }
+
           val isNewLeaderEpoch = partition.makeFollower(state, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
           if (isInControlledShutdown && (info.partition.leader == NO_LEADER ||
@@ -2539,11 +2546,14 @@ class ReplicaManager(val config: KafkaConfig,
         nodeOpt match {
           case Some(node) =>
             val log = partition.localLogOrException
+            // Pass mirrorName to InitialFetchState so the fetcher knows to use source epoch logic
+            val mirrorName = if (partition.mirrorName != null && partition.mirrorName.nonEmpty) partition.mirrorName else ""
             partitionAndOffsets.put(topicPartition, InitialFetchState(
               log.topicId.toScala,
               new BrokerEndPoint(node.id, node.host, node.port),
               partition.getLeaderEpoch,
-              initialFetchOffset(log)))
+              initialFetchOffset(log),
+              mirrorName))
           case None =>
             stateChangeLogger.trace(s"Unable to start fetching $topicPartition with topic ID ${partition.topicId} " +
               s"from leader ${partition.leaderReplicaIdOpt} because it is not alive.")

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2533,6 +2533,7 @@ class ReplicaManager(val config: KafkaConfig,
       // Stopping the fetchers must be done first in order to initialize the fetch
       // position correctly.
       replicaFetcherManager.removeFetcherForPartitions(partitionsToStartFetching.keySet)
+      mirrorFetcherManager.removeFetcherForPartitions(partitionsToStartFetching.keySet)
       stateChangeLogger.info(s"Stopped fetchers as part of become-follower for ${partitionsToStartFetching.size} partitions")
 
       val listenerName = config.interBrokerListenerName.value
@@ -2624,7 +2625,7 @@ class ReplicaManager(val config: KafkaConfig,
               val fetchState = InitialFetchState(
                 topicId = Some(info.topicId),
                 leader = leaderEndpoint,
-                currentLeaderEpoch = partition.getLeaderEpoch,
+                currentLeaderEpoch = 0, // this will trigger source epoch discovery through fencing
                 initOffset = partition.localLogOrException.logEndOffset,
                 mirrorName = mirrorName
               )

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -26,7 +26,6 @@ import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, FailedIsrU
 import kafka.server.mirror.{MirrorMetadataManager, MirrorFetcherManager}
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
-import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.{IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.{Plugin, Topic}
@@ -1204,7 +1203,7 @@ class ReplicaManager(val config: KafkaConfig,
             logManager.abortAndPauseCleaning(topicPartition)
 
             val initialFetchState = InitialFetchState(topicId.toScala, new BrokerEndPoint(config.brokerId, "localhost", -1),
-              partition.getLeaderEpoch, futureLog.highWatermark, "")
+              partition.getLeaderEpoch, futureLog.highWatermark)
             replicaAlterLogDirsManager.addFetcherForPartitions(Map(topicPartition -> initialFetchState))
           }
 
@@ -1669,6 +1668,7 @@ class ReplicaManager(val config: KafkaConfig,
                     fetchInfos: Seq[(TopicIdPartition, PartitionData)],
                     quota: ReplicaQuota,
                     responseCallback: Seq[(TopicIdPartition, FetchPartitionData)] => Unit): Unit = {
+
     // check if this fetch request can be satisfied right away
     val logReadResults = readFromLog(params, fetchInfos, quota, readFromPurgatory = false)
     var bytesReadable: Long = 0
@@ -1793,9 +1793,10 @@ class ReplicaManager(val config: KafkaConfig,
         // If we are the leader, determine the preferred read-replica
         val preferredReadReplica = params.clientMetadata.toScala.flatMap(
           metadata => findPreferredReadReplica(partition, metadata, params.replicaId, fetchInfo.fetchOffset, fetchTimeMs))
+
         if (preferredReadReplica.isDefined) {
           replicaSelectorPlugin.foreach { selector =>
-            info(s"Replica selector ${selector.get.getClass.getSimpleName} returned preferred replica " +
+            debug(s"Replica selector ${selector.get.getClass.getSimpleName} returned preferred replica " +
               s"${preferredReadReplica.get} for ${params.clientMetadata}")
           }
           // If a preferred read-replica is set, skip the read
@@ -2067,7 +2068,7 @@ class ReplicaManager(val config: KafkaConfig,
           }
 
           futureReplicasAndInitialOffset.put(topicPartition, InitialFetchState(topicIds(topicPartition.topic), leader,
-            partition.getLeaderEpoch, futureLog.highWatermark, ""))
+            partition.getLeaderEpoch, futureLog.highWatermark))
         }
       }
     }
@@ -2237,7 +2238,7 @@ class ReplicaManager(val config: KafkaConfig,
     new ReplicaFetcherManager(config, this, metrics, time, quotaManager, () => metadataCache.metadataVersion(), brokerEpochSupplier)
   }
 
-  protected def createMirrorFetcherManager(metrics: Metrics, time: Time, quotaManager: ReplicationQuotaManager) = {
+  private def createMirrorFetcherManager(metrics: Metrics, time: Time, quotaManager: ReplicationQuotaManager) = {
     new MirrorFetcherManager(config, this, metrics, time, quotaManager, () => metadataCache.metadataVersion(), brokerEpochSupplier, metadataCache)
   }
 
@@ -2319,13 +2320,13 @@ class ReplicaManager(val config: KafkaConfig,
           stateChangeLogger.info(s"Creating new partition $tp with topic id " + s"$topicId." +
             s"A topic with the same name but different id exists but it resides in an offline log " +
             s"directory.")
-          val clusterLinkName = if (localChanges.readOnlyLeaders().containsKey(tp)) {
+          val mirrorName = if (localChanges.readOnlyLeaders().containsKey(tp)) {
             delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).mirrorName
           } else {
             ""
           }
-          logger.info("!!! Create new partition: " + tp + " " + topicId + " " + clusterLinkName)
-          val partition = Partition(new TopicIdPartition(topicId, tp), time, this, clusterLinkName)
+          logger.info("!!! Create new partition: " + tp + " " + topicId + " " + mirrorName)
+          val partition = Partition(new TopicIdPartition(topicId, tp), time, this, mirrorName)
           allPartitions.put(tp, HostedPartition.Online(partition))
           Some(partition, true)
         }
@@ -2348,13 +2349,13 @@ class ReplicaManager(val config: KafkaConfig,
             s"$topicId.")
         }
         // it's a partition that we don't know about yet, so create it and mark it online
-        val clusterLinkName = if (localChanges.readOnlyLeaders().containsKey(tp)) {
+        val mirrorName = if (localChanges.readOnlyLeaders().containsKey(tp)) {
           delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).mirrorName
         } else {
           ""
         }
-        logger.info("!!! Create new partition: " + tp + " " + topicId + " " + clusterLinkName)
-        val partition = Partition(new TopicIdPartition(topicId, tp), time, this, clusterLinkName)
+        logger.info("!!! Create new partition: " + tp + " " + topicId + " " + mirrorName)
+        val partition = Partition(new TopicIdPartition(topicId, tp), time, this, mirrorName)
         allPartitions.put(tp, HostedPartition.Online(partition))
         Some(partition, true)
     }
@@ -2406,8 +2407,11 @@ class ReplicaManager(val config: KafkaConfig,
         }
         if (!localChanges.followers.isEmpty) {
           applyLocalFollowersDelta(followerChangedPartitions, newImage, delta, lazyOffsetCheckpoints, localChanges.followers.asScala, localChanges.directoryIds.asScala)
-        } else if (!localChanges.readOnlyLeaders().isEmpty) {
-          applyLocalFollowersDelta(followerChangedPartitions, newImage, delta, lazyOffsetCheckpoints, localChanges.readOnlyLeaders.asScala, localChanges.directoryIds.asScala, true)
+        }
+        // Handle read-only leaders: these are leaders (already processed above) that also need
+        // to start MirrorFetcherThreads to fetch from the source cluster
+        if (!localChanges.readOnlyLeaders().isEmpty) {
+          maybeCreateMirrorFetchers(localChanges.readOnlyLeaders.asScala)
         }
 
         maybeAddLogDirFetchers(leaderChangedPartitions ++ followerChangedPartitions, lazyOffsetCheckpoints,
@@ -2434,7 +2438,8 @@ class ReplicaManager(val config: KafkaConfig,
     localLeaders: mutable.Map[TopicPartition, LocalReplicaChanges.PartitionInfo],
     directoryIds: mutable.Map[TopicIdPartition, Uuid]
   ): Unit = {
-    stateChangeLogger.info(s"Transitioning ${localLeaders.size} partition(s) to local leaders.")
+    stateChangeLogger.info(s"Transitioning ${localLeaders.size} partition(s) to " +
+      "local leaders.")
     replicaFetcherManager.removeFetcherForPartitions(localLeaders.keySet)
     localLeaders.foreachEntry { (tp, info) =>
       getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
@@ -2464,26 +2469,16 @@ class ReplicaManager(val config: KafkaConfig,
     delta: TopicsDelta,
     offsetCheckpoints: OffsetCheckpoints,
     localFollowers: mutable.Map[TopicPartition, LocalReplicaChanges.PartitionInfo],
-    directoryIds: mutable.Map[TopicIdPartition, Uuid],
-    hasRemoteLeader: Boolean = false
+    directoryIds: mutable.Map[TopicIdPartition, Uuid]
   ): Unit = {
-    stateChangeLogger.info(s"Transitioning ${localFollowers.size} partition(s) to local followers.")
+    stateChangeLogger.info(s"Transitioning ${localFollowers.size} partition(s) to " +
+      "local followers.")
     val partitionsToStartFetching = new mutable.HashMap[TopicPartition, Partition]
     val partitionsToStopFetching = new mutable.HashMap[TopicPartition, Boolean]
     val followerTopicSet = new mutable.HashSet[String]
     localFollowers.foreachEntry { (tp, info) =>
       getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
         try {
-          val isReadOnly: Boolean = newImage.configs().configProperties(new ConfigResource(ConfigResource.Type.TOPIC, tp.topic))
-            .getOrDefault(TopicConfig.READ_ONLY_CONFIG, "false").asInstanceOf[String].toBoolean
-          logger.info("#### tp = " + tp + ", hasRemoteLeader = " + hasRemoteLeader + ", isReadOnly = " + isReadOnly)
-          if (hasRemoteLeader) {
-            if (!isReadOnly) {
-              // don't create mirror fetcher for partitions with read.only=false
-              return
-            }
-            partition.setMirrorName(info.partition.mirrorName)
-          }
           followerTopicSet.add(tp.topic)
 
           // We always update the follower state.
@@ -2493,8 +2488,7 @@ class ReplicaManager(val config: KafkaConfig,
           //   high watermark in the checkpoint file (see KAFKA-1647).
           val state = info.partition.toLeaderAndIsrPartitionState(tp, isNew)
           val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
-          val isNewLeaderEpoch = !hasRemoteLeader && partition.makeFollower(state, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
-          logger.info("#### isNewLeaderEpoch = " + isNewLeaderEpoch)
+          val isNewLeaderEpoch = partition.makeFollower(state, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
           if (isInControlledShutdown && (info.partition.leader == NO_LEADER ||
               !info.partition.isr.contains(config.brokerId))) {
@@ -2505,14 +2499,7 @@ class ReplicaManager(val config: KafkaConfig,
             // The leader epoch has changed, indicating a new leader was elected (or first-time assignment).
             // Notify listeners so they can react to the leadership change (e.g., cleanup state, reset metrics).
             partition.invokeOnBecomingFollowerListeners()
-            // Restart fetcher thread to handle the new leader:
-            // - Local leader: truncate to divergence point, then fetch from new leader in this cluster.
-            // - Remote leader: connect to source cluster and begin cross-cluster mirroring.
-            partitionsToStartFetching.put(tp, partition)
-          } else if (hasRemoteLeader) {
-            // For remote leaders, always ensure fetcher is started even if leader epoch didn't change.
-            // This handles cases like dynamic read.only=true config changes where the partition
-            // transitions to mirror replication without a leader epoch change.
+            // Restart fetcher thread to fetch from the new leader in this cluster
             partitionsToStartFetching.put(tp, partition)
           }
 
@@ -2522,7 +2509,6 @@ class ReplicaManager(val config: KafkaConfig,
             stateChangeLogger.error(s"Unable to start fetching $tp " +
               s"with topic ID ${info.topicId} due to a storage error ${e.getMessage}", e)
             replicaFetcherManager.addFailedPartition(tp)
-            if (hasRemoteLeader) mirrorFetcherManager.addFailedPartition(tp)
             // If there is an offline log directory, a Partition object may have been created by
             // `getOrCreatePartition()` before `createLogIfNotExists()` failed to create local replica due
             // to KafkaStorageException. In this case `ReplicaManager.allPartitions` will map this topic-partition
@@ -2533,7 +2519,6 @@ class ReplicaManager(val config: KafkaConfig,
             stateChangeLogger.error(s"Unable to start fetching $tp " +
               s"with topic ID ${info.topicId} due to ${e.getClass.getSimpleName}", e)
             replicaFetcherManager.addFailedPartition(tp)
-            if (hasRemoteLeader) mirrorFetcherManager.addFailedPartition(tp)
         }
       }
     }
@@ -2542,20 +2527,15 @@ class ReplicaManager(val config: KafkaConfig,
       // Stopping the fetchers must be done first in order to initialize the fetch
       // position correctly.
       replicaFetcherManager.removeFetcherForPartitions(partitionsToStartFetching.keySet)
-      mirrorFetcherManager.removeFetcherForPartitions(partitionsToStartFetching.keySet)
       stateChangeLogger.info(s"Stopped fetchers as part of become-follower for ${partitionsToStartFetching.size} partitions")
 
       val listenerName = config.interBrokerListenerName.value
       val partitionAndOffsets = new mutable.HashMap[TopicPartition, InitialFetchState]
 
       partitionsToStartFetching.foreachEntry { (topicPartition, partition) =>
-        val nodeOpt = if (!hasRemoteLeader)
-          partition.leaderReplicaIdOpt
-            .flatMap(leaderId => Option(newImage.cluster.broker(leaderId)))
-            .flatMap(_.node(listenerName).toScala)
-        else {
-          Some(mirrorMetadataManager.get.getRemotePartitionLeader(partition.mirrorName, partition.topicPartition))
-        }
+        val nodeOpt = partition.leaderReplicaIdOpt
+          .flatMap(leaderId => Option(newImage.cluster.broker(leaderId)))
+          .flatMap(_.node(listenerName).toScala)
 
         nodeOpt match {
           case Some(node) =>
@@ -2564,30 +2544,15 @@ class ReplicaManager(val config: KafkaConfig,
               log.topicId.toScala,
               new BrokerEndPoint(node.id, node.host, node.port),
               partition.getLeaderEpoch,
-              initialFetchOffset(log),
-              if (hasRemoteLeader) partition.mirrorName else ""
-            ))
+              initialFetchOffset(log)))
           case None =>
             stateChangeLogger.trace(s"Unable to start fetching $topicPartition with topic ID ${partition.topicId} " +
               s"from leader ${partition.leaderReplicaIdOpt} because it is not alive.")
         }
       }
 
-      // Split partitions by cluster mirror and route to appropriate fetcher managers
-      val partitionsWithoutMirror = partitionAndOffsets.filter(_._2.mirrorName.isEmpty)
-      val partitionsWithMirror = partitionAndOffsets.filter(_._2.mirrorName.nonEmpty)
-
-      // Handle regular partitions
-      if (partitionsWithoutMirror.nonEmpty) {
-        replicaFetcherManager.addFetcherForPartitions(partitionsWithoutMirror)
-        stateChangeLogger.info(s"Started fetchers as part of become-follower for ${partitionsWithoutMirror.size} partitions")
-      }
-
-      // Handle remote partitions with cluster mirror
-      if (partitionsWithMirror.nonEmpty) {
-        mirrorFetcherManager.addFetcherForPartitions(partitionsWithMirror)
-        stateChangeLogger.info(s"Started mirror fetchers as part of become-follower for ${partitionsWithMirror.size} partitions")
-      }
+      replicaFetcherManager.addFetcherForPartitions(partitionAndOffsets)
+      stateChangeLogger.info(s"Started fetchers as part of become-follower for ${partitionAndOffsets.size} partitions")
 
       partitionsToStartFetching.foreach { case (topicPartition, partition) =>
         completeDelayedOperationsWhenNotPartitionLeader(topicPartition, partition.topicId)
@@ -2600,6 +2565,74 @@ class ReplicaManager(val config: KafkaConfig,
       val partitionsToStop = partitionsToStopFetching.map { case (tp, deleteLocalLog) => new StopPartition(tp, deleteLocalLog, false, false) }.toSet
       stopPartitions(partitionsToStop)
       stateChangeLogger.info(s"Stopped fetchers as part of controlled shutdown for ${partitionsToStop.size} partitions")
+    }
+  }
+
+  /**
+   * Creates and starts MirrorFetcherThreads for partitions that became read-only leaders.
+   *
+   * This method is called during partition leadership changes when the local broker becomes
+   * a read-only leader for mirrored partitions. Read-only leaders replicate data from a
+   * source cluster partition rather than accepting local writes.
+   *
+   * The method performs the following steps:
+   * 1. Stops any existing fetchers for these partitions to ensure clean state
+   * 2. Sets the mirrorName on each partition for epoch metadata tracking
+   * 3. Queries the mirror metadata manager for the current source cluster leader endpoint
+   * 4. Creates InitialFetchState with source leader info and current log end offset
+   * 5. Starts new MirrorFetcherThreads that will fetch from the source cluster
+   *
+   * The fetch position is initialized to the local log end offset, allowing the mirror
+   * fetcher to continue from where it left off (or start from beginning if log is empty).
+   *
+   * @param readOnlyLeaders Map of partitions to their metadata for partitions that became
+   *                        read-only leaders on this broker
+   */
+  private def maybeCreateMirrorFetchers(readOnlyLeaders: mutable.Map[TopicPartition, LocalReplicaChanges.PartitionInfo]): Unit = {
+    if (readOnlyLeaders.isEmpty) return
+
+    // Stopping the fetchers must be done first in order to initialize the fetch position correctly
+    mirrorFetcherManager.removeFetcherForPartitions(readOnlyLeaders.keySet)
+
+    stateChangeLogger.info(s"Starting mirror fetchers for ${readOnlyLeaders.size} read-only leader partition(s).")
+    val partitionAndOffsets = new mutable.HashMap[TopicPartition, InitialFetchState]
+
+    readOnlyLeaders.foreachEntry { (tp, info) =>
+      getPartition(tp) match {
+        case HostedPartition.Online(partition) =>
+          try {
+            val mirrorName = info.partition.mirrorName
+            if (mirrorName != null && !mirrorName.isEmpty) {
+              // Set mirrorName on partition for management and configuration purposes.
+              // Used when transitioning partition from read-only to writable state.
+              partition.setMirrorName(mirrorName)
+
+              // Get the remote partition leader from mirror metadata manager
+              // This will return the actual leader if known, or a random bootstrap server as fallback
+              val remoteLeader = mirrorMetadataManager.get.getRemotePartitionLeader(mirrorName, tp)
+              val leaderEndpoint = new BrokerEndPoint(remoteLeader.id(), remoteLeader.host(), remoteLeader.port())
+
+              val fetchState = InitialFetchState(
+                topicId = Some(info.topicId),
+                leader = leaderEndpoint,
+                currentLeaderEpoch = partition.getLeaderEpoch,
+                initOffset = partition.localLogOrException.logEndOffset,
+                mirrorName = mirrorName
+              )
+              partitionAndOffsets.put(tp, fetchState)
+            }
+          } catch {
+            case e: Exception =>
+              stateChangeLogger.error(s"Error setting up mirror fetcher for partition $tp", e)
+          }
+        case _ =>
+          stateChangeLogger.warn(s"Skipping mirror fetcher setup for offline partition $tp")
+      }
+    }
+
+    if (partitionAndOffsets.nonEmpty) {
+      mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
+      stateChangeLogger.info(s"Started mirror fetchers for ${partitionAndOffsets.size} read-only leader partitions")
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2308,7 +2308,6 @@ class ReplicaManager(val config: KafkaConfig,
   private[kafka] def getOrCreatePartition(tp: TopicPartition,
                                           delta: TopicsDelta,
                                           topicId: Uuid): Option[(Partition, Boolean)] = {
-    val localChanges = delta.localChanges(config.nodeId)
     getPartition(tp) match {
       case HostedPartition.Offline(offlinePartition) =>
         if (offlinePartition.flatMap(p => p.topicId).contains(topicId)) {
@@ -2320,11 +2319,11 @@ class ReplicaManager(val config: KafkaConfig,
           stateChangeLogger.info(s"Creating new partition $tp with topic id " + s"$topicId." +
             s"A topic with the same name but different id exists but it resides in an offline log " +
             s"directory.")
-          val mirrorName = if (localChanges.readOnlyLeaders().containsKey(tp)) {
-            delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).mirrorName
-          } else {
-            ""
-          }
+          // get mirrorName from metadata (applies to both read-only leaders and their followers)
+          val mirrorName = Option(delta.changedTopics().get(topicId))
+            .flatMap(topicDelta => Option(topicDelta.partitionChanges().get(tp.partition())))
+            .map(_.mirrorName)
+            .getOrElse("")
           logger.info("!!! Create new partition: " + tp + " " + topicId + " " + mirrorName)
           val partition = Partition(new TopicIdPartition(topicId, tp), time, this, mirrorName)
           allPartitions.put(tp, HostedPartition.Online(partition))
@@ -2349,11 +2348,11 @@ class ReplicaManager(val config: KafkaConfig,
             s"$topicId.")
         }
         // it's a partition that we don't know about yet, so create it and mark it online
-        val mirrorName = if (localChanges.readOnlyLeaders().containsKey(tp)) {
-          delta.changedTopics().get(topicId).partitionChanges().get(tp.partition()).mirrorName
-        } else {
-          ""
-        }
+        // get mirrorName from metadata (applies to both read-only leaders and their followers)
+        val mirrorName = Option(delta.changedTopics().get(topicId))
+          .flatMap(topicDelta => Option(topicDelta.partitionChanges().get(tp.partition())))
+          .map(_.mirrorName)
+          .getOrElse("")
         logger.info("!!! Create new partition: " + tp + " " + topicId + " " + mirrorName)
         val partition = Partition(new TopicIdPartition(topicId, tp), time, this, mirrorName)
         allPartitions.put(tp, HostedPartition.Online(partition))

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2547,8 +2547,11 @@ class ReplicaManager(val config: KafkaConfig,
         nodeOpt match {
           case Some(node) =>
             val log = partition.localLogOrException
-            // Pass mirrorName to InitialFetchState so the fetcher knows to use source epoch logic
+
+            // This flag is used is used in AbstractFetcherThread.partitionFetchState to distinguish mirror from regular followers
+            // and it triggers different epoch handling logic throughout the fetch lifecycle.
             val mirrorName = if (partition.mirrorName != null && partition.mirrorName.nonEmpty) partition.mirrorName else ""
+
             partitionAndOffsets.put(topicPartition, InitialFetchState(
               log.topicId.toScala,
               new BrokerEndPoint(node.id, node.host, node.port),
@@ -2595,6 +2598,8 @@ class ReplicaManager(val config: KafkaConfig,
    * The fetch position is initialized to the local log end offset, allowing the mirror
    * fetcher to continue from where it left off (or start from beginning if log is empty).
    *
+   * TODO: we should handle the error cases like in applyLocalFollowersDelta
+   *
    * @param readOnlyLeaders Map of partitions to their metadata for partitions that became
    *                        read-only leaders on this broker
    */
@@ -2613,8 +2618,7 @@ class ReplicaManager(val config: KafkaConfig,
           try {
             val mirrorName = info.partition.mirrorName
             if (mirrorName != null && !mirrorName.isEmpty) {
-              // Set mirrorName on partition for management and configuration purposes.
-              // Used when transitioning partition from read-only to writable state.
+              // Set mirrorName on partition for management and configuration purposes
               partition.setMirrorName(mirrorName)
 
               // Get the remote partition leader from mirror metadata manager

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -61,13 +61,13 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
                            metadataVersionSupplier: () => MetadataVersion,
                            brokerEpochSupplier: () => Long,
                            metadataCache: MetadataCache)
-    extends AbstractFetcherManager[ReplicaFetcherThread](
+    extends AbstractFetcherManager[MirrorFetcherThread](
       name = "MirrorFetcherManager on broker " + brokerConfig.brokerId,
       clientId = "MirrorReplica",
       numFetchers = brokerConfig.numMirrorReplicaFetchers) {
-  private val mirrorFetcherThreadMap = new mutable.HashMap[BrokerAndFetcherIdWithMirror, ReplicaFetcherThread]
+  private val mirrorFetcherThreadMap = new mutable.HashMap[BrokerAndFetcherIdWithMirror, MirrorFetcherThread]
 
-  override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ReplicaFetcherThread = {
+  override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): MirrorFetcherThread = {
     throw new UnsupportedOperationException("Use createMirrorFetcherThread for mirror fetchers")
   }
 
@@ -84,7 +84,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     }
 
     this.synchronized {
-      def addAndStartFetcherThread(remoteFetcherKey: BrokerAndFetcherIdWithMirror): ReplicaFetcherThread = {
+      def addAndStartFetcherThread(remoteFetcherKey: BrokerAndFetcherIdWithMirror): MirrorFetcherThread = {
         val fetcherThread = createMirrorFetcherThread(remoteFetcherKey.fetcherId, remoteFetcherKey.sourceBroker,
           remoteFetcherKey.mirrorName)
         mirrorFetcherThreadMap.put(remoteFetcherKey, fetcherThread)
@@ -116,7 +116,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     info(s"Creating mirror fetcher thread: fetcherId = $fetcherId, sourceBroker = $sourceBroker, mirrorName = $mirrorName")
     val threadName = s"MirrorFetcherThread-${sourceBroker.id}-$fetcherId-$mirrorName"
     val logContext = new LogContext(s"[MirrorFetcher fetcherId=$fetcherId, mirrorName=$mirrorName, " +
-      s"sourceBroker=${sourceBroker.id}, destBroker=${brokerConfig.brokerId}] ")
+      s"srcBroker=${sourceBroker.id}, dstBroker=${brokerConfig.brokerId}] ")
 
     val endpoint = if (mirrorName.nonEmpty) {
       val mirrorProperties = metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName))

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -129,7 +129,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     }
     val fetchSessionHandler = new FetchSessionHandler(logContext, sourceBroker.id)
     val leader: LeaderEndPoint = new RemoteLeaderEndPoint(logContext.logPrefix, endpoint, fetchSessionHandler, brokerConfig,
-      replicaManager, quotaManager, metadataVersionSupplier, brokerEpochSupplier)
+      replicaManager, quotaManager, metadataVersionSupplier, brokerEpochSupplier, isCrossClusterMirror = true)
     new MirrorFetcherThread(threadName, leader, brokerConfig, failedPartitions, replicaManager,
       quotaManager, logContext.logPrefix, mirrorName)
   }

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -19,19 +19,26 @@ package kafka.server.mirror
 
 import kafka.server._
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.message.FetchResponseData
+import org.apache.kafka.common.requests.FetchResponse
 import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState}
+import org.apache.kafka.server.common.OffsetAndEpoch
+import org.apache.kafka.storage.internals.log.{LogAppendInfo, LogStartOffsetIncrementReason}
 
-import scala.collection.{Map, Set}
+import java.util.Optional
+import scala.collection.{Map, Set, mutable}
 
 /**
  * Specialized fetcher thread for cross-cluster mirroring.
  *
- * This class extends ReplicaFetcherThread to handle partitions that replicate from remote clusters.
- * The key difference is that when the remote leader changes, this thread uses the
- * MirrorFetcherManager instead of the regular ReplicaFetcherManager to recreate fetchers.
+ * This class extends AbstractFetcherThread to handle partitions that replicate from remote clusters.
+ * Unlike ReplicaFetcherThread which handles intra-cluster replication, MirrorFetcherThread handles
+ * cross-cluster replication where source and destination clusters have independent leader epochs.
  *
- * This ensures that when a leader election occurs in the source cluster, the mirror fetcher
- * is properly recreated with the new leader's connection details.
+ * Key differences from ReplicaFetcherThread:
+ * - Uses source cluster's leader epoch (not destination's) for append validation
+ * - Routes fetcher operations to MirrorFetcherManager (not ReplicaFetcherManager)
+ * - Syncs destination partition's epoch with source cluster's epoch
  *
  * @param name The name of the thread
  * @param leader The remote leader endpoint to fetch from (RemoteLeaderEndPoint)
@@ -50,22 +57,171 @@ class MirrorFetcherThread(name: String,
                           quota: ReplicaQuota,
                           logPrefix: String,
                           mirrorName: String)
-  extends ReplicaFetcherThread(name, leader, brokerConfig, failedPartitions, replicaMgr, quota, logPrefix, mirrorName) {
-  /**
-   * Uses MirrorFetcherManager instead of regular ReplicaFetcherManager.
-   * This ensures proper handling of cross-cluster fetcher lifecycle when leader changes occur.
-   */
+  extends AbstractFetcherThread(name = name,
+                                clientId = name,
+                                leader = leader,
+                                failedPartitions,
+                                fetchTierStateMachine = new TierStateMachine(leader, replicaMgr, false),
+                                fetchBackOffMs = brokerConfig.replicaFetchBackoffMs,
+                                isInterruptible = false,
+                                replicaMgr.brokerTopicStats,
+                                mirrorName) {
+  this.logIdent = logPrefix
+
+  // Visible for testing
+  private[mirror] val partitionsWithNewHighWatermark = mutable.Buffer[TopicPartition]()
+
+  override def doWork(): Unit = {
+    super.doWork()
+    // Complete delayed fetch requests for consumers waiting on mirrored partitions
+    if (partitionsWithNewHighWatermark.nonEmpty) {
+      replicaMgr.completeDelayedFetchRequests(partitionsWithNewHighWatermark.toSeq)
+      partitionsWithNewHighWatermark.clear()
+    }
+  }
+
   override protected def removeFetcherForPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
     replicaMgr.mirrorFetcherManager.removeFetcherForPartitions(partitions)
   }
 
-  /**
-   * Uses MirrorFetcherManager instead of regular ReplicaFetcherManager.
-   * When the remote leader changes, this method triggers the recreation logic in
-   * MirrorFetcherManager.addFetcherForPartitions, which compares the new
-   * leader's BrokerEndPoint with the existing fetcher's leader and recreates if different.
-   */
   override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
+  }
+
+  // process fetched data
+  override def processPartitionData(
+    topicPartition: TopicPartition,
+    fetchOffset: Long,
+    partitionLeaderEpoch: Int,
+    partitionData: FetchResponseData.PartitionData
+  ): Option[LogAppendInfo] = {
+    val logTrace = isTraceEnabled
+    val partition = replicaMgr.getPartitionOrException(topicPartition)
+    val log = partition.localLogOrException
+    val records = toMemoryRecords(FetchResponse.recordsOrFail(partitionData))
+
+    if (fetchOffset != log.logEndOffset)
+      throw new IllegalStateException("Offset mismatch for partition %s: fetched offset = %d, log end offset = %d.".format(
+        topicPartition, fetchOffset, log.logEndOffset))
+
+    if (logTrace)
+      trace("Mirror follower has replica log end offset %d for partition %s. Received %d bytes of messages and leader hw %d"
+        .format(log.logEndOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
+
+    // Append batches from the source cluster to the destination partition's log, preserving
+    // the original leader epochs from the source cluster.
+    //
+    // Why we preserve source epochs:
+    //   Consumers cache leader epochs from the batches they read. When a consumer reads from
+    //   the source cluster and caches epoch=5 at offset=100, then fails over to the destination
+    //   cluster, it will validate its cached epoch against the destination's log. If we rewrote
+    //   epoch=5 to a different value (e.g., destination epoch=0), the consumer would receive
+    //   FENCED_LEADER_EPOCH and reset its position, causing data loss or duplication.
+    //
+    // Epoch cache synchronization:
+    //   The appendAsFollower operation automatically updates the destination partition's epoch
+    //   cache to match the source cluster's epoch metadata. For each batch appended:
+    //     - Extract the batch's leader epoch (e.g., epoch=5)
+    //     - Record the mapping: epoch -> startOffset (e.g., 5 -> 40)
+    //     - Add entry to epoch cache if this epoch is new
+    //
+    //   This ensures the destination's epoch cache becomes identical to the source's epoch cache,
+    //   enabling correct truncation and divergence detection for all replicas.
+    //
+    // Two-level replication:
+    //   After this append, the destination partition has batches with source epochs in its log.
+    //   When destination followers (ReplicaFetcherThread) replicate from this partition, they
+    //   receive these same batches with source epochs. The effectiveLeaderEpoch logic in
+    //   ReplicaFetcherThread allows them to accept batches whose epochs are higher than the
+    //   destination partition's local leader epoch, ensuring intra-cluster replication succeeds.
+    //
+    //   Result: All replicas (source leader, destination leader, destination followers) have
+    //   identical log contents and epoch cache entries, maintaining consistency across clusters.
+    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch)
+
+    if (logTrace)
+      trace("Mirror follower has replica log end offset %d after appending %d bytes of messages for partition %s"
+        .format(log.logEndOffset, records.sizeInBytes, topicPartition))
+
+    val leaderLogStartOffset = partitionData.logStartOffset
+    var maybeUpdateHighWatermarkMessage = s"but did not update replica high watermark"
+    log.maybeUpdateHighWatermark(partitionData.highWatermark).ifPresent { newHighWatermark =>
+      maybeUpdateHighWatermarkMessage = s"and updated replica high watermark to $newHighWatermark"
+      partitionsWithNewHighWatermark += topicPartition
+    }
+
+    log.maybeIncrementLogStartOffset(leaderLogStartOffset, LogStartOffsetIncrementReason.LeaderOffsetIncremented)
+    if (logTrace)
+      trace(s"Mirror follower received high watermark ${partitionData.highWatermark} from the leader " +
+        s"$maybeUpdateHighWatermarkMessage for partition $topicPartition")
+
+    // Account for replication quota
+    if (quota.isThrottled(topicPartition))
+      quota.record(records.sizeInBytes)
+
+    if (partition.isReassigning && partition.isAddingLocalReplica)
+      brokerTopicStats.updateReassignmentBytesIn(records.sizeInBytes)
+
+    brokerTopicStats.updateReplicationBytesIn(records.sizeInBytes)
+
+    logAppendInfo
+  }
+
+  override def initiateShutdown(): Boolean = {
+    val justShutdown = super.initiateShutdown()
+    if (justShutdown) {
+      try {
+        leader.initiateClose()
+      } catch {
+        case t: Throwable =>
+          error(s"Failed to initiate shutdown of $leader after initiating mirror fetcher thread shutdown", t)
+      }
+    }
+    justShutdown
+  }
+
+  override def awaitShutdown(): Unit = {
+    super.awaitShutdown()
+    try {
+      leader.close()
+    } catch {
+      case t: Throwable =>
+        error(s"Failed to close $leader after shutting down mirror fetcher thread", t)
+    }
+  }
+
+  override def truncate(topicPartition: TopicPartition, truncationState: OffsetTruncationState): Unit = {
+    val partition = replicaMgr.getPartitionOrException(topicPartition)
+    partition.truncateTo(truncationState.offset, isFuture = false)
+  }
+
+  override def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long): Unit = {
+    val partition = replicaMgr.getPartitionOrException(topicPartition)
+    partition.truncateFullyAndStartAt(offset, isFuture = false)
+  }
+
+  override def latestEpoch(topicPartition: TopicPartition): Optional[Integer] = {
+    val partition = replicaMgr.getPartitionOrException(topicPartition)
+    partition.localLogOrException.latestEpoch
+  }
+
+  override def latestEpochFromLog(topicPartition: TopicPartition): Optional[Integer] = {
+    val partition = replicaMgr.getPartitionOrException(topicPartition)
+    partition.localLogOrException.latestEpoch
+  }
+
+  override def logStartOffset(topicPartition: TopicPartition): Long = {
+    val partition = replicaMgr.getPartitionOrException(topicPartition)
+    partition.localLogOrException.logStartOffset
+  }
+
+  override def logEndOffset(topicPartition: TopicPartition): Long = {
+    val partition = replicaMgr.getPartitionOrException(topicPartition)
+    partition.localLogOrException.logEndOffset
+  }
+
+  override def endOffsetForEpoch(topicPartition: TopicPartition, epoch: Int): Optional[OffsetAndEpoch] = {
+    val partition = replicaMgr.getPartitionOrException(topicPartition)
+    partition.localLogOrException.endOffsetForEpoch(epoch)
   }
 }

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -89,6 +89,11 @@ class MirrorFetcherThread(name: String,
   }
 
   // process fetched data
+  override def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = {
+    // MirrorFetcherThread always processes mirrored partitions, so always update from batches
+    true
+  }
+
   override def processPartitionData(
     topicPartition: TopicPartition,
     fetchOffset: Long,

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -88,12 +88,12 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
-  // process fetched data
   override def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
     // MirrorFetcherThread always processes mirrored partitions, so always update from batches
     true
   }
 
+  // process fetched data
   override def processPartitionData(
     topicPartition: TopicPartition,
     fetchOffset: Long,

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -89,7 +89,7 @@ class MirrorFetcherThread(name: String,
   }
 
   // process fetched data
-  override def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = {
+  override def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
     // MirrorFetcherThread always processes mirrored partitions, so always update from batches
     true
   }
@@ -115,33 +115,6 @@ class MirrorFetcherThread(name: String,
 
     // Append batches from the source cluster to the destination partition's log, preserving
     // the original leader epochs from the source cluster.
-    //
-    // Why we preserve source epochs:
-    //   Consumers cache leader epochs from the batches they read. When a consumer reads from
-    //   the source cluster and caches epoch=5 at offset=100, then fails over to the destination
-    //   cluster, it will validate its cached epoch against the destination's log. If we rewrote
-    //   epoch=5 to a different value (e.g., destination epoch=0), the consumer would receive
-    //   FENCED_LEADER_EPOCH and reset its position, causing data loss or duplication.
-    //
-    // Epoch cache synchronization:
-    //   The appendAsFollower operation automatically updates the destination partition's epoch
-    //   cache to match the source cluster's epoch metadata. For each batch appended:
-    //     - Extract the batch's leader epoch (e.g., epoch=5)
-    //     - Record the mapping: epoch -> startOffset (e.g., 5 -> 40)
-    //     - Add entry to epoch cache if this epoch is new
-    //
-    //   This ensures the destination's epoch cache becomes identical to the source's epoch cache,
-    //   enabling correct truncation and divergence detection for all replicas.
-    //
-    // Two-level replication:
-    //   After this append, the destination partition has batches with source epochs in its log.
-    //   When destination followers (ReplicaFetcherThread) replicate from this partition, they
-    //   receive these same batches with source epochs. The effectiveLeaderEpoch logic in
-    //   ReplicaFetcherThread allows them to accept batches whose epochs are higher than the
-    //   destination partition's local leader epoch, ensuring intra-cluster replication succeeds.
-    //
-    //   Result: All replicas (source leader, destination leader, destination followers) have
-    //   identical log contents and epoch cache entries, maintaining consistency across clusters.
     val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch)
 
     if (logTrace)

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
@@ -356,6 +356,7 @@ class AbstractFetcherManagerTest {
     override protected def logEndOffset(topicPartition: TopicPartition): Long = 1
 
     override protected def endOffsetForEpoch(topicPartition: TopicPartition, epoch: Int): Optional[OffsetAndEpoch] = Optional.of(new OffsetAndEpoch(1, 0))
-  }
 
+    override protected def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = false
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
@@ -357,6 +357,6 @@ class AbstractFetcherManagerTest {
 
     override protected def endOffsetForEpoch(topicPartition: TopicPartition, epoch: Int): Optional[OffsetAndEpoch] = Optional.of(new OffsetAndEpoch(1, 0))
 
-    override protected def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = false
+    override protected def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = false
   }
 }

--- a/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
+++ b/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
@@ -194,5 +194,5 @@ class MockFetcherThread(val mockLeader: MockLeaderEndPoint,
     }
   }
 
-  override protected def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = false
+  override protected def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = false
 }

--- a/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
+++ b/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
@@ -193,4 +193,6 @@ class MockFetcherThread(val mockLeader: MockLeaderEndPoint,
       assertEquals(expectedEpoch, fetchState(partition).map(_.lastFetchedEpoch.get()))
     }
   }
+
+  override protected def shouldUpdateEpochFromBatches(topicPartition: TopicPartition): Boolean = false
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -267,7 +267,8 @@ public class ReplicaFetcherThreadBenchmark {
                             replicaManager,
                             replicaQuota,
                             () -> MetadataVersion.MINIMUM_VERSION,
-                            () -> -1L
+                            () -> -1L,
+                            false
                     ) {
                         @Override
                         public OffsetAndEpoch fetchEarliestOffset(TopicPartition topicPartition, int currentLeaderEpoch) {

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -157,7 +157,7 @@ public enum MetadataVersion {
      * <strong>Think carefully before you update this value. ONCE A METADATA VERSION IS PRODUCTION,
      * IT CANNOT BE CHANGED.</strong>
      */
-    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_1_IV1;
+    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_2_IV0;
     // If you change the value above please also update
     // LATEST_STABLE_METADATA_VERSION version in tests/kafkatest/version.py
 
@@ -267,7 +267,9 @@ public enum MetadataVersion {
     }
 
     public short fetchRequestVersion() {
-        if (isAtLeast(IBP_4_1_IV1)) {
+        if (isAtLeast(IBP_4_2_IV0)) {
+            return 19;
+        } else if (isAtLeast(IBP_4_1_IV1)) {
             return 18;
         } else if (isAtLeast(IBP_3_9_IV0)) {
             return 17;

--- a/server/src/main/java/org/apache/kafka/server/PartitionFetchState.java
+++ b/server/src/main/java/org/apache/kafka/server/PartitionFetchState.java
@@ -28,6 +28,23 @@ import java.util.Optional;
  * (1) Truncating its log, for example, having recently become a follower
  * (2) Delayed, for example, due to an error, where we subsequently back off a bit
  * (3) ReadyForFetch, the active state where the thread is actively fetching data.
+ *
+ * @param topicId The topic ID
+ * @param fetchOffset The offset to fetch from
+ * @param lag The lag behind the leader
+ * @param currentLeaderEpoch The current leader epoch for this partition in the local cluster.
+ *                           Used for leader/follower epoch validation and synchronization.
+ * @param delay Optional delay before next fetch
+ * @param state The current replica state (TRUNCATING, FETCHING, etc.)
+ * @param lastFetchedEpoch The last fetched epoch from the log
+ * @param dueMs The time when this partition is due for fetch (if delayed)
+ * @param remoteFetch True if this is a remote fetch (e.g., MirrorFetcherThread), false for local fetch
+ * @param mirrorLeaderEpoch The leader epoch from the source cluster for mirrored partitions.
+ *                          This tracks the source cluster's epoch progression and is used for
+ *                          batch validation to allow batches with source cluster epochs that may
+ *                          be higher than the destination cluster's currentLeaderEpoch.
+ *                          Set to -1 for non-mirrored partitions. Initialized to 0 for mirrored
+ *                          partitions and updated from batch epochs during replication.
  */
 public record PartitionFetchState(
         Optional<Uuid> topicId,
@@ -38,7 +55,8 @@ public record PartitionFetchState(
         ReplicaState state,
         Optional<Integer> lastFetchedEpoch,
         Optional<Long> dueMs,
-        boolean remoteFetch
+        boolean remoteFetch,
+        int mirrorLeaderEpoch
 ) {
     public PartitionFetchState(
             Optional<Uuid> topicId,
@@ -61,7 +79,21 @@ public record PartitionFetchState(
             boolean remoteFetch,
             long dueMs) {
         this(topicId, fetchOffset, lag, currentLeaderEpoch,
-                Optional.empty(), state, lastFetchedEpoch, Optional.empty(), remoteFetch);
+                Optional.empty(), state, lastFetchedEpoch, Optional.empty(), remoteFetch, -1);
+    }
+
+    public PartitionFetchState(
+            Optional<Uuid> topicId,
+            long fetchOffset,
+            Optional<Long> lag,
+            int currentLeaderEpoch,
+            ReplicaState state,
+            Optional<Integer> lastFetchedEpoch,
+            boolean remoteFetch,
+            long dueMs,
+            int mirrorLeaderEpoch) {
+        this(topicId, fetchOffset, lag, currentLeaderEpoch,
+                Optional.empty(), state, lastFetchedEpoch, Optional.empty(), remoteFetch, mirrorLeaderEpoch);
     }
 
     public PartitionFetchState(
@@ -74,7 +106,7 @@ public record PartitionFetchState(
             Optional<Integer> lastFetchedEpoch) {
         this(topicId, fetchOffset, lag, currentLeaderEpoch,
                 delay, state, lastFetchedEpoch,
-                delay.map(aLong -> aLong + Time.SYSTEM.milliseconds()), false);
+                delay.map(aLong -> aLong + Time.SYSTEM.milliseconds()), false, -1);
     }
 
     public boolean isReadyForFetch() {
@@ -98,6 +130,7 @@ public record PartitionFetchState(
         return "FetchState(topicId=" + topicId +
                 ", fetchOffset=" + fetchOffset +
                 ", currentLeaderEpoch=" + currentLeaderEpoch +
+                ", mirrorLeaderEpoch=" + mirrorLeaderEpoch +
                 ", lastFetchedEpoch=" + lastFetchedEpoch +
                 ", state=" + state +
                 ", lag=" + lag +
@@ -108,6 +141,6 @@ public record PartitionFetchState(
     public PartitionFetchState updateTopicId(Optional<Uuid> newTopicId) {
         return new PartitionFetchState(newTopicId, this.fetchOffset, this.lag,
                 this.currentLeaderEpoch, this.delay,
-                this.state, this.lastFetchedEpoch, this.dueMs, this.remoteFetch);
+                this.state, this.lastFetchedEpoch, this.dueMs, this.remoteFetch, this.mirrorLeaderEpoch);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumer.java
@@ -198,8 +198,6 @@ public class ConsoleConsumer {
                 if (!recordIter.hasNext() && (time.milliseconds() - startTimeMs > timeoutMs)) {
                     throw new TimeoutException();
                 }
-                System.out.println("!!! committing");
-                consumer.commitSync();
             }
             return recordIter.next();
         }


### PR DESCRIPTION
This patch fixes the diverging epoch problem between source and destination clusters in Cluster Mirroring. See design document for more info.
