### PR TITLE
handle UNKNOWN_LEADER_EPOCH with default delay fetch

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -534,14 +534,9 @@ abstract class AbstractFetcherThread(name: String,
                     partitionsWithError += topicPartition
 
                 case Errors.UNKNOWN_LEADER_EPOCH =>
-                  if (!currentFetchState.isMirrorFetch() && partitionData.currentLeader().leaderEpoch() > -1) {
-                    debug(s"Remote broker has a smaller leader epoch for partition $topicPartition than " +
-                      s"this replica's current leader epoch of ${currentFetchState.currentLeaderEpoch}.")
-                    partitionsWithError += topicPartition
-                  } else {
-                    // cluster mirroring: outaded epoch due to stale metadata
-                    mirrorPartitionsWithNewEpoch += topicPartition -> partitionData
-                  }
+                  debug(s"Remote broker has a smaller leader epoch for partition $topicPartition than " +
+                    s"this replica's current leader epoch of ${currentFetchState.currentLeaderEpoch}.")
+                  partitionsWithError += topicPartition
 
                 case Errors.FENCED_LEADER_EPOCH =>
                   if (!currentFetchState.isMirrorFetch()) {


### PR DESCRIPTION
During testing leadership change in the source cluster, there is an issue happened. The new leader hasn't completed the leadership transition but it got the fetch request from the target cluster leader, it responds with `UNKNOWN_LEADER_EPOCH` with `currentLeaderEpoch=-1`. But in current logic, we'll update the `currentLeaderEpoch` in the target cluster to `-1`, and cause the following fetch request fails due to leaderEpoch (-1) < the batch leader epoch. 



source cluster Node 4 starts to change to fetch from node 2 at `2025-11-21 09:04:52,693`
```
[2025-11-21 09:04:52,691] INFO [MirrorFetcherManager on broker 4] #### Removed mirror fetcher for partitions Set(my-topic-0) (kafka.server.mirror.MirrorFetcherManager)
[2025-11-21 09:04:52,691] INFO #### mirrorFetcherThreadMap: Set(BrokerAndFetcherIdWithMirror(BrokerEndPoint[id=1, host=localhost, port=9091],0,my-link)) (kafka.server.mirror.MirrorFetcherManager)
[2025-11-21 09:04:52,691] INFO #### Creating new mirror fetcher (kafka.server.mirror.MirrorFetcherManager)
[2025-11-21 09:04:52,691] INFO [MirrorFetcherManager on broker 4] Creating mirror fetcher thread: fetcherId = 0, sourceBroker = BrokerEndPoint[id=2, host=localhost, port=9092], mirrorName = my-link (kafka.server.mirror.MirrorFetcherManager)
...
[2025-11-21 09:04:52,693] INFO [MirrorFetcher fetcherId=0, mirrorName=my-link, srcBroker=2, dstBroker=4] #### Sending fetch request (type=FetchRequest, replicaId=-1, maxWait=1000, minBytes=1, maxBytes=10485760, fetchData={my-topic-0=PartitionData(topicId=Da_2Ls0NQqSs9H7mYZu2TQ, fetchOffset=3722, logStartOffset=0, maxBytes=1048576, currentLeaderEpoch=Optional[4], lastFetchedEpoch=Optional[3], mirrorLeaderEpoch=Optional.empty)}, isolationLevel=read_committed, removed=, replaced=, metadata=(sessionId=INVALID, epoch=INITIAL), rackId=) (kafka.server.mirror.MirrorFetcherThread)
```

But source cluster node 2 completes the leader transition at `09:04:52,695`.
```
[2025-11-21 09:04:52,695] INFO [Broker id=2] Leader my-topic-0 with topic id Some(Da_2Ls0NQqSs9H7mYZu2TQ) starts at leader epoch 4 from offset 3723 with partition epoch 5, high watermark 3722, ISR [2], adding replicas [] and removing replicas [] . Previous leader Some(1) and previous leader epoch was 3. (state.change.logger)
```

So node 4 got errorCode=75 (`UNKNOWN_LEADER_EPOCH`) with leader epoch -1.
```
[2025-11-21 09:04:52,713] INFO [MirrorFetcher fetcherId=0, mirrorName=my-link, srcBroker=2, dstBroker=4] #### Got fetch response: FetchResponseData(throttleTimeMs=0, errorCode=0, sessionId=97670469, responses=[FetchableTopicResponse(topic='', topicId=Da_2Ls0NQqSs9H7mYZu2TQ, partitions=[PartitionData(partitionIndex=0, errorCode=75, highWatermark=-1, lastStableOffset=-1, logStartOffset=-1, divergingEpoch=EpochEndOffset(epoch=-1, endOffset=-1), mirrorLeaderEpoch=-1, currentLeader=LeaderIdAndEpoch(leaderId=-1, leaderEpoch=-1), snapshotId=SnapshotId(endOffset=-1, epoch=-1), abortedTransactions=null, preferredReadReplica=-1, records=MemoryRecords(size=0, buffer=java.nio.HeapByteBuffer[pos=0 lim=0 cap=3]))])], nodeEndpoints=[]) (kafka.server.RemoteLeaderEndPoint)
```

Because we only append leader epoch and leader info when `NOT_LEADER_OR_FOLLOWER` and `FENCED_LEADER_EPOCH` [here](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaApis.scala#L647), we should not do any special handling for `UNKNOWN_LEADER_EPOCH` and just leave it as default handler (delay fetch). In the example above, if the node 4 fetch again later with leaderEpoch=4, then everything will work well.