### PR TITLE
update producerId to `-(producerId + 2)` to avoid conflict

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
@@ -18,9 +18,13 @@ package org.apache.kafka.common.record;
 
 
 abstract class AbstractRecordBatch implements RecordBatch {
+
+    /*
+     * As long as the producer id is not NO_PRODUCER_ID, it is seen as a valid producer id
+     */
     @Override
     public boolean hasProducerId() {
-        return RecordBatch.NO_PRODUCER_ID == producerId();
+        return RecordBatch.NO_PRODUCER_ID != producerId();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
@@ -20,7 +20,7 @@ package org.apache.kafka.common.record;
 abstract class AbstractRecordBatch implements RecordBatch {
     @Override
     public boolean hasProducerId() {
-        return RecordBatch.NO_PRODUCER_ID < producerId();
+        return RecordBatch.NO_PRODUCER_ID == producerId();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -386,6 +386,10 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
         buffer.putInt(PARTITION_LEADER_EPOCH_OFFSET, epoch);
     }
 
+    public void setProducerId(long producerId) {
+        buffer.putLong(PRODUCER_ID_OFFSET, producerId);
+    }
+
     @Override
     public long checksum() {
         return ByteUtils.readUnsignedInt(buffer, CRC_OFFSET);

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -388,6 +388,9 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
 
     public void setProducerId(long producerId) {
         buffer.putLong(PRODUCER_ID_OFFSET, producerId);
+        // update crc
+        long crc = computeChecksum();
+        ByteUtils.writeUnsignedInt(buffer, CRC_OFFSET, crc);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/MutableRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MutableRecordBatch.java
@@ -51,6 +51,10 @@ public interface MutableRecordBatch extends RecordBatch {
      */
     void setPartitionLeaderEpoch(int epoch);
 
+    /**
+     * Set the producer id for this batch of records.
+     * @param producerId The producer id to use
+     */
     default void setProducerId(long producerId) { }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/record/MutableRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MutableRecordBatch.java
@@ -51,6 +51,8 @@ public interface MutableRecordBatch extends RecordBatch {
      */
     void setPartitionLeaderEpoch(int epoch);
 
+    default void setProducerId(long producerId) { }
+
     /**
      * Write this record batch into an output stream.
      * @param outputStream The buffer to write the batch to

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1327,13 +1327,13 @@ class Partition(val topicPartition: TopicPartition,
       inReadLock(leaderIsrUpdateLock) {
         // Note the replica may be undefined if it is removed by a non-ReplicaAlterLogDirsThread before
         // this method is called
-        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch) }
+        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, !clusterLinkName.isEmpty) }
       }
     } else {
       // The lock is needed to prevent the follower replica from being updated while ReplicaAlterDirThread
       // is executing maybeReplaceCurrentWithFutureReplica() to replace follower replica with the future replica.
       futureLogLock.synchronized {
-        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch))
+        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, !clusterLinkName.isEmpty))
       }
     }
   }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1173,7 +1173,7 @@ public class UnifiedLog implements AutoCloseable {
                                     for (MutableRecordBatch batch : records.batches()) {
                                         // reset to -1
                                         logger.info("!!! resetting batch producer id to -1 for batch {}", batch.baseOffset());
-                                        batch.setProducerId(-1L);
+                                        batch.setProducerId(-(batch.producerId() + 2));
                                     }
                                 }
                                 // we are taking the offsets we are given

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1042,6 +1042,10 @@ public class UnifiedLog implements AutoCloseable {
                 VerificationGuard.SENTINEL, false, recordVersion.value);
     }
 
+    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch) {
+        return appendAsFollower(records, leaderEpoch, false);
+    }
+
     /**
      * Append this message set to the active segment of the local log without assigning offsets or Partition Leader Epochs
      *
@@ -1050,7 +1054,7 @@ public class UnifiedLog implements AutoCloseable {
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @return Information about the appended messages including the first and last offset.
      */
-    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch) {
+    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, boolean mirroredTopic) {
         return append(records,
                       AppendOrigin.REPLICATION,
                       false,
@@ -1058,7 +1062,19 @@ public class UnifiedLog implements AutoCloseable {
                       Optional.empty(),
                       VerificationGuard.SENTINEL,
                       true,
-                      RecordBatch.CURRENT_MAGIC_VALUE);
+                      RecordBatch.CURRENT_MAGIC_VALUE,
+                mirroredTopic);
+    }
+
+    private LogAppendInfo append(MemoryRecords records,
+                                 AppendOrigin origin,
+                                 boolean validateAndAssignOffsets,
+                                 int leaderEpoch,
+                                 Optional<RequestLocal> requestLocal,
+                                 VerificationGuard verificationGuard,
+                                 boolean ignoreRecordSize,
+                                 byte toMagic) {
+        return append(records, origin, validateAndAssignOffsets, leaderEpoch, requestLocal, verificationGuard, ignoreRecordSize, toMagic, false);
     }
 
     /**
@@ -1085,7 +1101,8 @@ public class UnifiedLog implements AutoCloseable {
                                  Optional<RequestLocal> requestLocal,
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
-                                 byte toMagic) {
+                                 byte toMagic,
+                                 boolean mirroredTopic) {
         // We want to ensure the partition metadata file is written to the log dir before any log data is written to disk.
         // This will ensure that any log data can be recovered with the correct topic ID in the case of failure.
         maybeFlushMetadataFile();
@@ -1151,6 +1168,14 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
+                                // luke
+                                if (mirroredTopic) {
+                                    for (MutableRecordBatch batch : records.batches()) {
+                                        // reset to -1
+                                        logger.info("!!! resetting batch producer id to -1 for batch {}", batch.baseOffset());
+                                        batch.setProducerId(-1L);
+                                    }
+                                }
                                 // we are taking the offsets we are given
                                 if (appendInfo.firstOrLastOffsetOfFirstBatch() < localLog.logEndOffset()) {
                                     // we may still be able to recover if the log is empty

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1063,7 +1063,7 @@ public class UnifiedLog implements AutoCloseable {
                       VerificationGuard.SENTINEL,
                       true,
                       RecordBatch.CURRENT_MAGIC_VALUE,
-                mirroredTopic);
+                      mirroredTopic);
     }
 
     private LogAppendInfo append(MemoryRecords records,
@@ -1168,11 +1168,10 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                // luke
                                 if (mirroredTopic) {
                                     for (MutableRecordBatch batch : records.batches()) {
-                                        // reset to -1
-                                        logger.info("!!! resetting batch producer id to -1 for batch {}", batch.baseOffset());
+                                        // reset producer id for mirrored topic
+                                        logger.info("!!! resetting batch producer id to {} for batch {}", -(batch.producerId() + 2), batch.baseOffset());
                                         batch.setProducerId(-(batch.producerId() + 2));
                                     }
                                 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1054,7 +1054,7 @@ public class UnifiedLog implements AutoCloseable {
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @return Information about the appended messages including the first and last offset.
      */
-    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, boolean mirroredTopic) {
+    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, boolean isMirroredTopic) {
         return append(records,
                       AppendOrigin.REPLICATION,
                       false,
@@ -1063,7 +1063,7 @@ public class UnifiedLog implements AutoCloseable {
                       VerificationGuard.SENTINEL,
                       true,
                       RecordBatch.CURRENT_MAGIC_VALUE,
-                      mirroredTopic);
+                      isMirroredTopic);
     }
 
     private LogAppendInfo append(MemoryRecords records,
@@ -1102,7 +1102,7 @@ public class UnifiedLog implements AutoCloseable {
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
                                  byte toMagic,
-                                 boolean mirroredTopic) {
+                                 boolean isMirroredTopic) {
         // We want to ensure the partition metadata file is written to the log dir before any log data is written to disk.
         // This will ensure that any log data can be recovered with the correct topic ID in the case of failure.
         maybeFlushMetadataFile();
@@ -1168,7 +1168,7 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                if (mirroredTopic) {
+                                if (isMirroredTopic) {
                                     for (MutableRecordBatch batch : records.batches()) {
                                         // reset producer id for mirrored topic
                                         logger.info("!!! resetting batch producer id to {} for batch {}", -(batch.producerId() + 2), batch.baseOffset());


### PR DESCRIPTION
Based on [the design](https://docs.google.com/document/d/1fSorXwbBGnooQnzJukBOiARabCl6pbtlY0yLpu-aQSM/edit?disco=AAABs2J0sTs), set the producer id to `-(producerId + 2)` to avoid producer id conflict after the topic becoming writable. The `NO_PRODUCER_ID` semantic is still the same, the legacy or non-idempotent/non-transactional producers, it'll set the producer id to `NO_PRODUCER_ID`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
