### PR TITLE
update hw only when minISR all fetched

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1135,6 +1135,12 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
+  def maybeIncrementLeaderHWWithLock(leaderLog: UnifiedLog, currentTimeMs: Long = time.milliseconds): Boolean = {
+    inReadLock(leaderIsrUpdateLock) {
+      maybeIncrementLeaderHW(leaderLog, currentTimeMs)
+    }
+  }
+
   /**
    * Check and maybe increment the high watermark of the partition;
    * this function can be triggered when
@@ -1160,9 +1166,9 @@ class Partition(val topicPartition: TopicPartition,
    *
    * @return true if the HW was incremented, and false otherwise.
    */
-  def maybeIncrementLeaderHW(leaderLog: UnifiedLog, currentTimeMs: Long = time.milliseconds): Boolean = {
+  private def maybeIncrementLeaderHW(leaderLog: UnifiedLog, currentTimeMs: Long = time.milliseconds): Boolean = {
     if (isUnderMinIsr) {
-      trace(s"Not increasing HWM because partition is under min ISR(ISR=${partitionState.isr}")
+      trace(s"Not increasing HWM because partition is under min ISR(ISR=${partitionState.isr})")
       return false
     }
     // maybeIncrementLeaderHW is in the hot path, the following code is written to

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1160,7 +1160,7 @@ class Partition(val topicPartition: TopicPartition,
    *
    * @return true if the HW was incremented, and false otherwise.
    */
-  private def maybeIncrementLeaderHW(leaderLog: UnifiedLog, currentTimeMs: Long = time.milliseconds): Boolean = {
+  def maybeIncrementLeaderHW(leaderLog: UnifiedLog, currentTimeMs: Long = time.milliseconds): Boolean = {
     if (isUnderMinIsr) {
       trace(s"Not increasing HWM because partition is under min ISR(ISR=${partitionState.isr}")
       return false

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -60,7 +60,6 @@ object BrokerMetadataPublisher extends Logging {
   def getTopicDelta(topicName: String,
                     newImage: MetadataImage,
                     delta: MetadataDelta): Option[TopicDelta] = {
-    logger.info(s"!!! Looking for topic delta for topic ${newImage.topics().getTopic(topicName)} ;; ${delta.topicsDelta()}")
     Option(newImage.topics().getTopic(topicName)).flatMap {
       topicImage => Option(delta.topicsDelta()).flatMap {
         topicDelta => Option(topicDelta.changedTopic(topicImage.id()))

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -110,13 +110,12 @@ class MirrorFetcherThread(name: String,
         .format(log.logEndOffset, records.sizeInBytes, topicPartition))
 
     val leaderLogStartOffset = partitionData.logStartOffset
-    val notUpdateHighWatermarkMessage = s"but did not update replica high watermark"
 
     // This works as producer write with acks=1. The leader node will append data into log without HW incremented.
     // The leader's HW will be incremented only when all ISR (at least minISR) are caught up.
-    if (!partition.maybeIncrementLeaderHW(log)) {
+    if (!partition.maybeIncrementLeaderHWWithLock(log)) {
       trace(s"Mirror follower received high watermark ${partitionData.highWatermark} from the leader " +
-        s"$notUpdateHighWatermarkMessage for partition $topicPartition")
+        s"but did not update replica high watermark for partition $topicPartition")
     }
 
     log.maybeIncrementLogStartOffset(leaderLogStartOffset, LogStartOffsetIncrementReason.LeaderOffsetIncremented)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.storage.internals.log.{LogAppendInfo, LogStartOffsetIncrementReason}
 
 import java.util.Optional
-import scala.collection.{Map, Set, mutable}
+import scala.collection.{Map, Set}
 
 /**
  * Specialized fetcher thread for cross-cluster mirroring.
@@ -67,18 +67,6 @@ class MirrorFetcherThread(name: String,
                                 replicaMgr.brokerTopicStats,
                                 mirrorName) {
   this.logIdent = logPrefix
-
-  // Visible for testing
-  private[mirror] val partitionsWithNewHighWatermark = mutable.Buffer[TopicPartition]()
-
-  override def doWork(): Unit = {
-    super.doWork()
-    // Complete delayed fetch requests for consumers waiting on mirrored partitions
-    if (partitionsWithNewHighWatermark.nonEmpty) {
-      replicaMgr.completeDelayedFetchRequests(partitionsWithNewHighWatermark.toSeq)
-      partitionsWithNewHighWatermark.clear()
-    }
-  }
 
   override protected def removeFetcherForPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
     replicaMgr.mirrorFetcherManager.removeFetcherForPartitions(partitions)
@@ -122,16 +110,16 @@ class MirrorFetcherThread(name: String,
         .format(log.logEndOffset, records.sizeInBytes, topicPartition))
 
     val leaderLogStartOffset = partitionData.logStartOffset
-    var maybeUpdateHighWatermarkMessage = s"but did not update replica high watermark"
-    log.maybeUpdateHighWatermark(partitionData.highWatermark).ifPresent { newHighWatermark =>
-      maybeUpdateHighWatermarkMessage = s"and updated replica high watermark to $newHighWatermark"
-      partitionsWithNewHighWatermark += topicPartition
+    val notUpdateHighWatermarkMessage = s"but did not update replica high watermark"
+
+    // This works as producer write with acks=1. The leader node will append data into log without HW incremented.
+    // The leader's HW will be incremented only when all ISR (at least minISR) are caught up.
+    if (!partition.maybeIncrementLeaderHW(log)) {
+      trace(s"Mirror follower received high watermark ${partitionData.highWatermark} from the leader " +
+        s"$notUpdateHighWatermarkMessage for partition $topicPartition")
     }
 
     log.maybeIncrementLogStartOffset(leaderLogStartOffset, LogStartOffsetIncrementReason.LeaderOffsetIncremented)
-    if (logTrace)
-      trace(s"Mirror follower received high watermark ${partitionData.highWatermark} from the leader " +
-        s"$maybeUpdateHighWatermarkMessage for partition $topicPartition")
 
     // Account for replication quota
     if (quota.isThrottled(topicPartition))

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
@@ -132,8 +132,6 @@ public class ProducerAppendInfo {
             }
         } else {
             int currentLastSeq;
-            log.info("!!! updateEntry.isEmpty(): {}, producerEpoch: {}, currentEntry.producerEpoch(): {}",
-                    updatedEntry.isEmpty(), producerEpoch, currentEntry.producerEpoch());
             if (!updatedEntry.isEmpty())
                 currentLastSeq = updatedEntry.lastSeq();
             else if (producerEpoch == currentEntry.producerEpoch())


### PR DESCRIPTION
Currently, when the leader node in the destination cluster increases the high watermark first, it means this situation could happen:

1. Broker 1, 2, 3 in the destination cluster is mirroring topic A from the source cluster
2. Consumer c1 is reading topic A from the destination cluster 
3. Broker 1 (leader) is mirroring offset 10 from source cluster, and move high watermark to 10 (broker 2, 3 haven’t replicated yet)
4. Consumer c1 read the data in offset 10
5. Broker 1 is down, leader moves to Broker 2 with LEO=9 (data loss for offset 10, but it’s fine as long as the source cluster is available, it can always fetch from the source cluster)
6. The source cluster is down, failback to the destination cluster
7. The original data in offset 10 is lost and could have different data after Broker 2 becomes writable. But consumer c1 always read it.

This PR fixes it by incrementing the high watermark only when all ISR (at least minISR) are caught up. It works like the producer writes with acks=1. The leader node will append data into log first, and see if HW needs to update or not. 

Verified with 2 replication-factor in destination cluster, with `min.insync.replicas=2`. When 2 nodes are up, the HW is incremented immediately:
```
[2025-12-04 17:11:04,085] INFO [Partition quickstart-events3-0 broker=5] !!! High watermark updated from (offset=11, segment=[0:462]) to (offset=14, segment=[0:609]) (kafka.cluster.Partition)
```

But when the follower node is shutdown, the HW will not be incremented anymore:
```
[2025-12-04 17:12:33,847] INFO [Partition quickstart-events3-0 broker=5] Not increasing HWM because partition is under min ISR(ISR=Set(5) (kafka.cluster.Partition)
[2025-12-04 17:12:33,847] INFO [MirrorFetcher fetcherId=0, mirrorName=my-link, srcBroker=1, dstBroker=5] !!! Mirror follower received high watermark 14 from the leader but did not update replica high watermark for partition quickstart-events3-0 (kafka.server.mirror.MirrorFetcherThread)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
