### PR TITLE
Add mirror.version feature

### DIFF
--- a/clients/src/main/resources/common/message/CreateMirrorRequest.json
+++ b/clients/src/main/resources/common/message/CreateMirrorRequest.json
@@ -18,6 +18,9 @@
   "type": "request",
   "listeners": ["broker", "controller"],
   "name": "CreateMirrorRequest",
+  // The CreateMirrorRequest API is added as part of cluster mirroring.
+  // The API is not exposed by default unless explicitly enabled.
+  "latestVersionUnstable": true,
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [

--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -111,8 +111,7 @@
         { "name": "HighWatermark", "type": "int64", "versions": "18+", "default": "9223372036854775807", "taggedVersions": "18+",
           "tag": 1, "ignorable": true,
           "about": "The high-watermark known by the replica. -1 if the high-watermark is not known and 9223372036854775807 if the feature is not supported." },
-        { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "taggedVersions": "19+",
-          "tag": 2, "ignorable": true,
+        { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "ignorable": true,
           "about": "The mirrored leader epoch of the partition." }
       ]}
     ]},

--- a/clients/src/main/resources/common/message/FetchResponse.json
+++ b/clients/src/main/resources/common/message/FetchResponse.json
@@ -85,8 +85,7 @@
           { "name": "EndOffset", "type": "int64", "versions": "12+", "default": "-1",
             "about": "The end offset of the epoch." }
         ]},
-        { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "taggedVersions": "19+",
-          "tag": 3, "ignorable": true,
+        { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "ignorable": true,
           "about": "The latest known mirrored leader epoch." },
         { "name": "CurrentLeader", "type": "LeaderIdAndEpoch",
           "versions": "12+", "taggedVersions": "12+", "tag": 1,

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -59,7 +59,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.server.{ApiVersionManager, DelegationTokenManager, ProcessRole}
 import org.apache.kafka.server.authorizer.Authorizer
-import org.apache.kafka.server.common.{ApiMessageAndVersion, RequestLocal}
+import org.apache.kafka.server.common.{ApiMessageAndVersion, MirrorVersion, RequestLocal}
 import org.apache.kafka.server.quota.ControllerMutationQuota
 import org.apache.kafka.server.record.BrokerCompressionType
 
@@ -166,8 +166,15 @@ class ControllerApis(
   }
 
   def handleCreateMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    // test
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+
+    // Check if cluster mirroring is supported by the mirror.version feature
+    val mirrorVersionLevel = apiVersionManager.features.finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort)
+    if (mirrorVersionLevel == 0) {
+      throw new UnsupportedVersionException(
+        "Cluster mirroring requires mirror.version >= 1. Current version: " + mirrorVersionLevel)
+    }
+
     val createMirrorRequest = request.body[CreateMirrorRequest]
     info("!!! Create mirror request: " + createMirrorRequest)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal, OptionalLong.empty())

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -65,7 +65,7 @@ import org.apache.kafka.coordinator.share.ShareCoordinator
 import org.apache.kafka.metadata.{ConfigRepository, MetadataCache}
 import org.apache.kafka.server.{ApiVersionManager, ClientMetricsManager, DelegationTokenManager, ProcessRole}
 import org.apache.kafka.server.authorizer._
-import org.apache.kafka.server.common.{GroupVersion, RequestLocal, ShareVersion, StreamsVersion, TransactionVersion}
+import org.apache.kafka.server.common.{GroupVersion, MirrorVersion, RequestLocal, ShareVersion, StreamsVersion, TransactionVersion}
 import org.apache.kafka.server.config.DelegationTokenManagerConfigs
 import org.apache.kafka.server.share.context.ShareFetchContext
 import org.apache.kafka.server.share.{ErroneousAndValidPartitionData, SharePartitionKey}
@@ -275,8 +275,12 @@ class KafkaApis(val requestChannel: RequestChannel,
     logger.info(s"!!! Handling create topics request")
     val mirrorTopic = createTopicsRequest.data.topics.stream().filter(t => t.mirrorName() != null && !t.mirrorName().isEmpty).findFirst()
     if (mirrorTopic.isPresent) {
-      logger.info(s"!!! Handling create mirror topics request: ${mirrorTopic.get().mirrorName()}")
-      mirrorCoordinator.addTopicsToCoordinator(mirrorTopic.get().mirrorName(), util.Set.of(mirrorTopic.get().name()))
+      if (isClusterMirroringEnabled) {
+        logger.info(s"!!! Handling create mirror topics request: ${mirrorTopic.get().mirrorName()}")
+        mirrorCoordinator.addTopicsToCoordinator(mirrorTopic.get().mirrorName(), util.Set.of(mirrorTopic.get().name()))
+      } else {
+        logger.warn("Cluster mirroring is disabled (mirror.version=0), ignoring mirror topic creation request")
+      }
     }
     forwardToController(request)
   }
@@ -4243,6 +4247,14 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   private def isShareGroupProtocolEnabled: Boolean = {
     config.shareGroupConfig.isShareGroupEnabled || shareVersion().supportsShareGroups
+  }
+
+  private def mirrorVersion(): MirrorVersion = {
+    MirrorVersion.fromFeatureLevel(metadataCache.features.finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort))
+  }
+
+  private def isClusterMirroringEnabled: Boolean = {
+    mirrorVersion().isClusterMirroringSupported
   }
 
   private def updateRecordConversionStats(request: RequestChannel.Request,

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.image.publisher.MetadataPublisher
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, TopicDelta}
 import org.apache.kafka.metadata.publisher.AclPublisher
 import org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION
-import org.apache.kafka.server.common.{FinalizedFeatures, RequestLocal, ShareVersion}
+import org.apache.kafka.server.common.{FinalizedFeatures, MirrorVersion, RequestLocal, ShareVersion}
 import org.apache.kafka.server.fault.FaultHandler
 import org.apache.kafka.storage.internals.log.{LogManager => JLogManager}
 
@@ -111,6 +111,11 @@ class BrokerMetadataPublisher(
    * The share version being used in the broker metadata.
    */
   private var finalizedShareVersion: Short = FinalizedFeatures.fromKRaftVersion(MINIMUM_VERSION).finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
+
+  /**
+   * The mirror version being used in the broker metadata.
+   */
+  private var finalizedMirrorVersion: Short = FinalizedFeatures.fromKRaftVersion(MINIMUM_VERSION).finalizedFeatures().getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort)
 
   override def name(): String = "BrokerMetadataPublisher"
 
@@ -215,16 +220,19 @@ class BrokerMetadataPublisher(
           case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating share " +
             s"coordinator with deleted partitions in $deltaName", t)
         }
-        try {
-          // Update the mirror coordinator of topic changes
-          updateCoordinator(newImage,
-            delta,
-            Topic.MIRROR_STATE_TOPIC_NAME,
-            mirrorCoordinator.onElection,
-            (partitionIndex, leaderEpochOpt) => mirrorCoordinator.onResignation(partitionIndex, toOptionalInt(leaderEpochOpt)))
-        } catch {
-          case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating mirror " +
-            s"coordinator with local changes in $deltaName", t)
+        // Only update mirror coordinator if mirror.version is enabled
+        if (finalizedMirrorVersion > 0) {
+          try {
+            // Update the mirror coordinator of topic changes
+            updateCoordinator(newImage,
+              delta,
+              Topic.MIRROR_STATE_TOPIC_NAME,
+              mirrorCoordinator.onElection,
+              (partitionIndex, leaderEpochOpt) => mirrorCoordinator.onResignation(partitionIndex, toOptionalInt(leaderEpochOpt)))
+          } catch {
+            case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating mirror " +
+              s"coordinator with local changes in $deltaName", t)
+          }
         }
       }
 
@@ -269,8 +277,9 @@ class BrokerMetadataPublisher(
       }
 
       if (delta.featuresDelta != null) {
+        val newFinalizedFeatures = new FinalizedFeatures(newImage.features.metadataVersionOrThrow, newImage.features.finalizedVersions, newImage.provenance.lastContainedOffset)
+
         try {
-          val newFinalizedFeatures = new FinalizedFeatures(newImage.features.metadataVersionOrThrow, newImage.features.finalizedVersions, newImage.provenance.lastContainedOffset)
           val newFinalizedShareVersion = newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
           // Share version feature has been toggled.
           if (newFinalizedShareVersion != finalizedShareVersion) {
@@ -282,6 +291,26 @@ class BrokerMetadataPublisher(
         } catch {
           case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating share partition manager " +
             s" with share version feature change in $deltaName", t)
+        }
+
+        try {
+          val newFinalizedMirrorVersion = newFinalizedFeatures.finalizedFeatures().getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort)
+          // Mirror version feature has been toggled.
+          if (newFinalizedMirrorVersion != finalizedMirrorVersion) {
+            finalizedMirrorVersion = newFinalizedMirrorVersion
+            val mirrorVersion: MirrorVersion = MirrorVersion.fromFeatureLevel(finalizedMirrorVersion)
+            info(s"Feature mirror.version has been updated to version $finalizedMirrorVersion")
+            if (mirrorVersion.isClusterMirroringSupported) {
+              info("Cluster mirroring feature is now enabled")
+              mirrorCoordinator.startup()
+            } else {
+              info("Cluster mirroring feature is now disabled")
+              mirrorCoordinator.shutdown()
+            }
+          }
+        } catch {
+          case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating mirror coordinator " +
+            s" with mirror version feature change in $deltaName", t)
         }
       }
 
@@ -407,8 +436,13 @@ class BrokerMetadataPublisher(
       case t: Throwable => fatalFaultHandler.handleFault("Error starting Share coordinator", t)
     }
     try {
-      // Start the mirror coordinator.
-      mirrorCoordinator.startup()
+      // Start the mirror coordinator only if mirror.version is enabled.
+      if (finalizedMirrorVersion > 0) {
+        info(s"Starting mirror coordinator with mirror.version=$finalizedMirrorVersion")
+        mirrorCoordinator.startup()
+      } else {
+        info("Mirror coordinator not started: mirror.version is disabled")
+      }
     } catch {
       case t: Throwable => fatalFaultHandler.handleFault("Error starting topic link coordinator", t)
     }

--- a/server-common/src/main/java/org/apache/kafka/server/common/Feature.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/Feature.java
@@ -48,6 +48,7 @@ public enum Feature {
     ELIGIBLE_LEADER_REPLICAS_VERSION(EligibleLeaderReplicasVersion.FEATURE_NAME, EligibleLeaderReplicasVersion.values(), EligibleLeaderReplicasVersion.LATEST_PRODUCTION),
     SHARE_VERSION(ShareVersion.FEATURE_NAME, ShareVersion.values(), ShareVersion.LATEST_PRODUCTION),
     STREAMS_VERSION(StreamsVersion.FEATURE_NAME, StreamsVersion.values(), StreamsVersion.LATEST_PRODUCTION),
+    MIRROR_VERSION(MirrorVersion.FEATURE_NAME, MirrorVersion.values(), MirrorVersion.LATEST_PRODUCTION),
 
     /**
      * Features defined only for unit tests and are not used in production.

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -137,7 +137,17 @@ public enum MetadataVersion {
     // *** STREAMS GROUPS BECOME PRODUCTION-READY IN THE FUTURE. ITS DEFINITION ALLOWS A STREAMS ***
     // *** GROUPS FEATURE TO BE DEFINED IN 4.1 BUT TURNED OFF BY DEFAULT, ABLE TO BE TURNED ON   ***
     // *** DYNAMICALLY TO TRY OUT THE EARLY ACCESS CAPABILITY.                                   ***
-    IBP_4_2_IV1(29, "4.2", "IV1", false);
+    IBP_4_2_IV1(29, "4.2", "IV1", false),
+
+    // Enables cluster mirroring (early access in 4.2).
+    // Adds FetchRequest/Response v19 with MirrorLeaderEpoch field.
+    // Adds mirrorName field to PartitionRecord for read-only leader identification.
+    //
+    // *** THIS IS A PLACEHOLDER UNSTABLE VERSION WHICH IS USED TO DEFINE THE POINT AT WHICH   ***
+    // *** CLUSTER MIRRORING BECOMES PRODUCTION-READY IN THE FUTURE. ITS DEFINITION ALLOWS THE ***
+    // *** MIRROR FEATURE TO BE DEFINED IN 4.2 BUT TURNED OFF BY DEFAULT, ABLE TO BE TURNED ON ***
+    // *** DYNAMICALLY TO TRY OUT THE EARLY ACCESS CAPABILITY.                                 ***
+    IBP_4_2_IV2(30, "4.2", "IV2", true);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -157,7 +167,7 @@ public enum MetadataVersion {
      * <strong>Think carefully before you update this value. ONCE A METADATA VERSION IS PRODUCTION,
      * IT CANNOT BE CHANGED.</strong>
      */
-    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_2_IV0;
+    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_1_IV1;
     // If you change the value above please also update
     // LATEST_STABLE_METADATA_VERSION version in tests/kafkatest/version.py
 
@@ -267,7 +277,7 @@ public enum MetadataVersion {
     }
 
     public short fetchRequestVersion() {
-        if (isAtLeast(IBP_4_2_IV0)) {
+        if (isAtLeast(IBP_4_2_IV2)) {
             return 19;
         } else if (isAtLeast(IBP_4_1_IV1)) {
             return 18;

--- a/server-common/src/main/java/org/apache/kafka/server/common/MirrorVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MirrorVersion.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.common;
+
+import java.util.Map;
+
+public enum MirrorVersion implements FeatureVersion {
+    // Version 0: the feature is disabled by default.
+    MV_0(0, MetadataVersion.MINIMUM_VERSION, Map.of()),
+
+    // Version 1: the feature is enabled by default.
+    MV_1(1, MetadataVersion.IBP_4_2_IV2, Map.of());
+
+    public static final String FEATURE_NAME = "mirror.version";
+
+    public static final MirrorVersion LATEST_PRODUCTION = MV_0;
+
+    private final short featureLevel;
+    private final MetadataVersion bootstrapMetadataVersion;
+    private final Map<String, Short> dependencies;
+
+    MirrorVersion(
+        int featureLevel,
+        MetadataVersion bootstrapMetadataVersion,
+        Map<String, Short> dependencies
+    ) {
+        this.featureLevel = (short) featureLevel;
+        this.bootstrapMetadataVersion = bootstrapMetadataVersion;
+        this.dependencies = dependencies;
+    }
+
+    @Override
+    public short featureLevel() {
+        return featureLevel;
+    }
+
+    @Override
+    public String featureName() {
+        return FEATURE_NAME;
+    }
+
+    @Override
+    public MetadataVersion bootstrapMetadataVersion() {
+        return bootstrapMetadataVersion;
+    }
+
+    @Override
+    public Map<String, Short> dependencies() {
+        return dependencies;
+    }
+
+    public boolean isClusterMirroringSupported() {
+        return featureLevel >= MV_1.featureLevel;
+    }
+
+    public static MirrorVersion fromFeatureLevel(short version) {
+        switch (version) {
+            case 0:
+                return MV_0;
+            case 1:
+                return MV_1;
+            default:
+                throw new RuntimeException("Unknown mirror feature level: " + (int) version);
+        }
+    }
+}


### PR DESCRIPTION
This patch introduces the mirror.version feature at the early access stage.

Additionally:
- Marked CreateMirror API unstable, so we can still make changes if needed
- Removed unnecessary tag configuration from mirrorLeaderEpoch in Fetch API

To test Cluster Mirroring you have to add the following configurations to all nodes:

```properties
unstable.api.versions.enable=true
unstable.feature.versions.enable=true
```

And dinamically enable mirror.version:

```shell
bin/kafka-features.sh --bootstrap-server :9094 upgrade --feature mirror.version=1
```
