### PR TITLE
use `mirrorName` as indicator to identify readonly or not

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -219,10 +219,6 @@ public class TopicConfig {
         "configuration. If message.timestamp.type=CreateTime, the message will be rejected if the difference in " +
         "timestamps exceeds this specified threshold. This configuration is ignored if message.timestamp.type=LogAppendTime.";
 
-    public static final String READ_ONLY_CONFIG = "read.only";
-    public static final String READ_ONLY_DOC = "This configuration is set to true for a mirror topic that only receive " +
-            "data from a source cluster through a mirror connection. Local producers cannot append data to this topic.";
-
     /**
      * @deprecated down-conversion is not possible in Apache Kafka 4.0 and newer, hence this configuration is a no-op,
      *             and it is deprecated for removal in Apache Kafka 5.0.

--- a/clients/src/main/java/org/apache/kafka/common/errors/ReadOnlyTopicException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ReadOnlyTopicException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Map;
+
+/**
+ * This topic is a read-only topic
+ */
+public class ReadOnlyTopicException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ReadOnlyTopicException() {
+        super();
+    }
+
+    public ReadOnlyTopicException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -105,6 +105,7 @@ import org.apache.kafka.common.errors.PositionOutOfRangeException;
 import org.apache.kafka.common.errors.PreferredLeaderNotAvailableException;
 import org.apache.kafka.common.errors.PrincipalDeserializationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.ReadOnlyTopicException;
 import org.apache.kafka.common.errors.ReassignmentInProgressException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RebootstrapRequiredException;
@@ -418,7 +419,8 @@ public enum Errors {
     STREAMS_INVALID_TOPOLOGY(130, "The supplied topology is invalid.", StreamsInvalidTopologyException::new),
     STREAMS_INVALID_TOPOLOGY_EPOCH(131, "The supplied topology epoch is invalid.", StreamsInvalidTopologyEpochException::new),
     STREAMS_TOPOLOGY_FENCED(132, "The supplied topology epoch is outdated.", StreamsTopologyFencedException::new),
-    SHARE_SESSION_LIMIT_REACHED(133, "The limit of share sessions has been reached.", ShareSessionLimitReachedException::new);
+    SHARE_SESSION_LIMIT_REACHED(133, "The limit of share sessions has been reached.", ShareSessionLimitReachedException::new),
+    READ_ONLY_TOPIC(134, "The topic is read-only.", ReadOnlyTopicException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -26,7 +26,6 @@ import kafka.server._
 import kafka.server.share.DelayedShareFetch
 import kafka.utils.CoreUtils.{inReadLock, inWriteLock}
 import kafka.utils._
-import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.{DirectoryId, IsolationLevel, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState
@@ -1380,10 +1379,6 @@ class Partition(val topicPartition: TopicPartition,
     val (info, leaderHWIncremented) = inReadLock(leaderIsrUpdateLock) {
       leaderLogIfLocal match {
         case Some(leaderLog) =>
-          if (leaderLog.config().getBoolean(TopicConfig.READ_ONLY_CONFIG)) {
-            throw new InvalidTopicException("Cannot append to read-only partition %s on broker %d"
-              .format(topicPartition, localBrokerId))
-          }
           val minIsr = effectiveMinIsr(leaderLog)
           val inSyncSize = partitionState.isr.size
 

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -21,7 +21,6 @@ import java.util.{Collections, Properties}
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.utils.Logging
 import org.apache.kafka.server.config.QuotaConfig
-import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.metrics.Quota._
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.server.ClientMetricsManager
@@ -50,19 +49,6 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
   private def updateLogConfig(topic: String,
                               topicConfig: Properties): Unit = {
     val logManager = replicaManager.logManager
-
-    val readOnly = topicConfig.getProperty(TopicConfig.READ_ONLY_CONFIG)
-    if (readOnly != null && !readOnly.toBoolean) {
-      replicaManager.getPartitionByTopic(topic).forEach {
-        case HostedPartition.Online(partition) =>
-          logger.info(s"!!! partition.remoteBootstrapServer: ${partition.mirrorName}")
-          if (partition.mirrorName.nonEmpty) {
-            replicaManager.replicaFetcherManager.removeFetcherForPartitions(Set(partition.topicPartition))
-            replicaManager.replicaAlterLogDirsManager.removeFetcherForPartitions(Set(partition.topicPartition))
-          }
-        case _ =>
-      }
-    }
 
     val logs = logManager.logsByTopic(topic)
     val wasRemoteLogEnabled = logs.exists(_.remoteLogEnabled())

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1410,6 +1410,11 @@ class ReplicaManager(val config: KafkaConfig,
       logStartOffset
     }
 
+    def validateReadOnlyTopic(partition: Partition): Unit = {
+      if (partition.mirrorName.nonEmpty)
+        throw new ReadOnlyTopicException()
+    }
+
     if (traceEnabled)
       trace(s"Append [$entriesPerPartition] to local log")
 
@@ -1426,6 +1431,7 @@ class ReplicaManager(val config: KafkaConfig,
       } else {
         try {
           val partition = getPartitionOrException(topicIdPartition)
+          validateReadOnlyTopic(partition)
           val info = partition.appendRecordsToLeader(records, origin, requiredAcks, requestLocal,
             verificationGuards.getOrElse(topicIdPartition.topicPartition(), VerificationGuard.SENTINEL))
           val numAppendedMessages = info.numMessages
@@ -1451,7 +1457,8 @@ class ReplicaManager(val config: KafkaConfig,
                    _: RecordBatchTooLargeException |
                    _: CorruptRecordException |
                    _: KafkaStorageException |
-                   _: UnknownTopicIdException) =>
+                   _: UnknownTopicIdException |
+                   _: ReadOnlyTopicException) =>
             (topicIdPartition, LogAppendResult(LogAppendInfo.UNKNOWN_LOG_APPEND_INFO, Some(e), hasCustomErrorMessage = false))
           case rve: RecordValidationException =>
             val logStartOffset = processFailedRecord(topicIdPartition, rve.invalidException)

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -138,7 +138,6 @@ public class LogConfig extends AbstractConfig {
     public static final boolean DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE_CONFIG = false;
     public static final long DEFAULT_LOCAL_RETENTION_BYTES = -2; // It indicates the value to be derived from RetentionBytes
     public static final long DEFAULT_LOCAL_RETENTION_MS = -2; // It indicates the value to be derived from RetentionMs
-    public static final boolean DEFAULT_READ_ONLY = false;
 
     public static final String INTERNAL_SEGMENT_BYTES_CONFIG = "internal.segment.bytes";
     public static final String INTERNAL_SEGMENT_BYTES_DOC = "The maximum size of a single log file. This should be used for testing only.";
@@ -248,7 +247,6 @@ public class LogConfig extends AbstractConfig {
                         TopicConfig.LOCAL_LOG_RETENTION_BYTES_DOC)
                 .define(TopicConfig.REMOTE_LOG_COPY_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_COPY_DISABLE_DOC)
                 .define(TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_DOC)
-                .define(TopicConfig.READ_ONLY_CONFIG, BOOLEAN, DEFAULT_READ_ONLY, MEDIUM, TopicConfig.READ_ONLY_DOC)
                 .defineInternal(INTERNAL_SEGMENT_BYTES_CONFIG, INT, null, null, MEDIUM, INTERNAL_SEGMENT_BYTES_DOC);
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -157,10 +157,6 @@ public abstract class MirrorCommand {
                 Optional.of(opts.topicId().get()),
                 Optional.of(mirrorName));
 
-            Map<String, String> configsMap = new HashMap<>();
-            configsMap.put(TopicConfig.READ_ONLY_CONFIG, "true");
-            newTopic.configs(configsMap);
-
             // Create topic using coordinator's bootstrap server
             Node node = coordinator.get();
             String bootstrapServer = node.host() + ":" + node.port();


### PR DESCRIPTION
1. remove `read.only` config
2. use `mirrorName` field in partition as indicator to identify readonly or not

Tests:
```
bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9094
>a
>[2025-12-12 15:27:41,863] ERROR Error when sending message to topic quickstart-events with key: null, value: 1 bytes with error: (org.apache.kafka.clients.producer.internals.ErrorLoggingCallback)
org.apache.kafka.common.errors.ReadOnlyTopicException: The topic is read-only.
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
