### PR TITLE
Add epoch rewrite logic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -61,7 +61,6 @@ public class FetchRequest extends AbstractRequest {
         public final int maxBytes;
         public final Optional<Integer> currentLeaderEpoch;
         public final Optional<Integer> lastFetchedEpoch;
-        public final Optional<Integer> mirrorLeaderEpoch;
 
         public PartitionData(
             Uuid topicId,
@@ -70,7 +69,7 @@ public class FetchRequest extends AbstractRequest {
             int maxBytes,
             Optional<Integer> currentLeaderEpoch
         ) {
-            this(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, Optional.empty(), Optional.empty());
+            this(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, Optional.empty());
         }
 
         public PartitionData(
@@ -81,25 +80,12 @@ public class FetchRequest extends AbstractRequest {
                 Optional<Integer> currentLeaderEpoch,
                 Optional<Integer> lastFetchedEpoch
         ) {
-            this(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, lastFetchedEpoch, Optional.empty());
-        }
-
-        public PartitionData(
-                Uuid topicId,
-                long fetchOffset,
-                long logStartOffset,
-                int maxBytes,
-                Optional<Integer> currentLeaderEpoch,
-                Optional<Integer> lastFetchedEpoch,
-                Optional<Integer> mirrorLeaderEpoch
-        ) {
             this.topicId = topicId;
             this.fetchOffset = fetchOffset;
             this.logStartOffset = logStartOffset;
             this.maxBytes = maxBytes;
             this.currentLeaderEpoch = currentLeaderEpoch;
             this.lastFetchedEpoch = lastFetchedEpoch;
-            this.mirrorLeaderEpoch = mirrorLeaderEpoch;
         }
 
         @Override
@@ -112,13 +98,12 @@ public class FetchRequest extends AbstractRequest {
                 logStartOffset == that.logStartOffset &&
                 maxBytes == that.maxBytes &&
                 Objects.equals(currentLeaderEpoch, that.currentLeaderEpoch) &&
-                Objects.equals(lastFetchedEpoch, that.lastFetchedEpoch) &&
-                Objects.equals(mirrorLeaderEpoch, that.mirrorLeaderEpoch);
+                Objects.equals(lastFetchedEpoch, that.lastFetchedEpoch);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, lastFetchedEpoch, mirrorLeaderEpoch);
+            return Objects.hash(topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, lastFetchedEpoch);
         }
 
         @Override
@@ -130,7 +115,6 @@ public class FetchRequest extends AbstractRequest {
                 ", maxBytes=" + maxBytes +
                 ", currentLeaderEpoch=" + currentLeaderEpoch +
                 ", lastFetchedEpoch=" + lastFetchedEpoch +
-                ", mirrorLeaderEpoch=" + mirrorLeaderEpoch +
                 ')';
         }
     }
@@ -311,7 +295,6 @@ public class FetchRequest extends AbstractRequest {
                     .setPartition(topicPartition.partition())
                     .setCurrentLeaderEpoch(partitionData.currentLeaderEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
                     .setLastFetchedEpoch(partitionData.lastFetchedEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
-                    .setMirrorLeaderEpoch(partitionData.mirrorLeaderEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
                     .setFetchOffset(partitionData.fetchOffset)
                     .setLogStartOffset(partitionData.logStartOffset)
                     .setPartitionMaxBytes(partitionData.maxBytes);
@@ -428,8 +411,7 @@ public class FetchRequest extends AbstractRequest {
                         fetchPartition.logStartOffset(),
                         fetchPartition.partitionMaxBytes(),
                         optionalEpoch(fetchPartition.currentLeaderEpoch()),
-                        optionalEpoch(fetchPartition.lastFetchedEpoch()),
-                        optionalEpoch(fetchPartition.mirrorLeaderEpoch())
+                        optionalEpoch(fetchPartition.lastFetchedEpoch())
                     )
                 )
             );

--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -58,9 +58,7 @@
   // Version 17 adds directory id support from KIP-853
   //
   // Version 18 adds high-watermark from KIP-1166
-  //
-  // Version 19 adds MirrorLeaderEpoch for cluster mirroring support
-  "validVersions": "4-19",
+  "validVersions": "4-18",
   "flexibleVersions": "12+",
   "fields": [
     { "name": "ClusterId", "type": "string", "versions": "12+", "nullableVersions": "12+", "default": "null",
@@ -110,9 +108,7 @@
           "about": "The directory id of the follower fetching." },
         { "name": "HighWatermark", "type": "int64", "versions": "18+", "default": "9223372036854775807", "taggedVersions": "18+",
           "tag": 1, "ignorable": true,
-          "about": "The high-watermark known by the replica. -1 if the high-watermark is not known and 9223372036854775807 if the feature is not supported." },
-        { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "ignorable": true,
-          "about": "The mirrored leader epoch of the partition." }
+          "about": "The high-watermark known by the replica. -1 if the high-watermark is not known and 9223372036854775807 if the feature is not supported." }
       ]}
     ]},
     { "name": "ForgottenTopicsData", "type": "[]ForgottenTopic", "versions": "7+", "ignorable": false,

--- a/clients/src/main/resources/common/message/FetchResponse.json
+++ b/clients/src/main/resources/common/message/FetchResponse.json
@@ -50,9 +50,7 @@
   // Version 17 no changes to the response (KIP-853).
   //
   // Version 18 no changes to the response (KIP-1166)
-  //
-  // Version 19 adds MirrorLeaderEpoch for cluster mirroring support
-  "validVersions": "4-19",
+  "validVersions": "4-18",
   "flexibleVersions": "12+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
@@ -85,8 +83,6 @@
           { "name": "EndOffset", "type": "int64", "versions": "12+", "default": "-1",
             "about": "The end offset of the epoch." }
         ]},
-        { "name": "MirrorLeaderEpoch", "type": "int32", "versions": "19+", "default": "-1", "ignorable": true,
-          "about": "The latest known mirrored leader epoch." },
         { "name": "CurrentLeader", "type": "LeaderIdAndEpoch",
           "versions": "12+", "taggedVersions": "12+", "tag": 1,
           "about": "The current leader of the partition.", "fields": [

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -68,7 +68,6 @@ abstract class AbstractFetcherThread(name: String,
   extends ShutdownableThread(name, isInterruptible) with Logging {
 
   this.logIdent = this.logPrefix
-  private val defaultMirrorLeaderEpoch = -1 // mirrorLeaderEpoch not used
 
   type FetchData = FetchResponseData.PartitionData
   type EpochData = OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
@@ -90,15 +89,6 @@ abstract class AbstractFetcherThread(name: String,
     partitionLeaderEpoch: Int,
     partitionData: FetchData
   ): Option[LogAppendInfo]
-
-  /**
-   * Check if fetch epoch should be updated from batch epochs for this partition.
-   * This is needed for mirrored partitions where batches contain source cluster epochs.
-   *
-   * @param topicPartition the partition to check
-   * @return true if fetch epoch should be updated from batch epochs
-   */
-  protected def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean
 
   protected def truncate(topicPartition: TopicPartition, truncationState: OffsetTruncationState): Unit
 
@@ -273,30 +263,29 @@ abstract class AbstractFetcherThread(name: String,
    * 2. Source cluster validates this epoch matches its current leader
    * 3. Mismatched epochs result in UNKNOWN_LEADER_EPOCH errors
    *
-   * The method also updates lastFetchedEpoch from the local log to maintain proper epoch
-   * tracking for divergence detection.
-   *
    * @param partitionToData Map of partitions to their current leader information from source cluster
    */
-  private def updateMirrorLeaderEpoch(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
+  private def updateMirrorFetchEpoch(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
     val newStates: Map[TopicPartition, PartitionFetchState] = partitionStates.partitionStateMap.asScala
       .map { case (topicPartition, currentFetchState) =>
         val updatedFetchState = partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
-            // if we can't get the epoch from the log, assume it's starting from the beginning
-            val latestEpochInLog = latestEpochFromLog(topicPartition).orElse(0)
-            // Update currentLeaderEpoch (for fetch validation) from the source cluster's leader epochs
-            val sourceLeaderEpoch = partitionData.currentLeader().leaderEpoch()
-            info(s"==== Discovered epoch: partition=$topicPartition, " +
-              s"currentLeaderEpoch: ${currentFetchState.currentLeaderEpoch} -> $sourceLeaderEpoch")
+            // Updating currentLeaderEpoch with source cluster leader epoch to pass epoch validation when fetching from source cluster
+            val newCurrentLeaderEpoch = partitionData.currentLeader().leaderEpoch()
+            // Setting lastFetchedEpoch to empty skips cross-cluster log divergence check.
+            // Log divergence may happen only as a result of an unclean leader election in the source or destination clusters.
+            // Unclean leader elections are not supported by Cluster Mirroring as there is no way to reconcile log divergence
+            // without being part of the same local partition epoch.
+            val newLastFetchedEpoch: Optional[Integer] = Optional.empty()
+            info(s"Discovered new fetch epoch for mirrored partition $topicPartition, " +
+              s"currentLeaderEpoch: ${currentFetchState.currentLeaderEpoch} -> $newCurrentLeaderEpoch")
             new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
-              sourceLeaderEpoch, currentFetchState.delay, currentFetchState.state(), Optional.of(latestEpochInLog),
-              currentFetchState.dueMs(), currentFetchState.isMirrorFetch(), defaultMirrorLeaderEpoch)
+              newCurrentLeaderEpoch, currentFetchState.delay, currentFetchState.state(), newLastFetchedEpoch,
+              currentFetchState.dueMs(), currentFetchState.isMirrorFetch())
           case None => currentFetchState
         }
         (topicPartition, updatedFetchState)
       }
-    info("!!! updateMirrorCachedLeaderEpoch:" + newStates)
     partitionStates.set(newStates.asJava)
   }
 
@@ -471,14 +460,15 @@ abstract class AbstractFetcherThread(name: String,
                        * request was handled. This is done to make sure that logs are not inconsistent because of log
                        * truncation and append after the FETCH request was handled. See KAFKA-18723 for more details.
                        *
-                       * For mirrored partition followers, use mirrorLeaderEpoch for validation against source cluster epochs.
+                       * For read-only leaders (mirror leaders), currentFetchState.currentLeaderEpoch tracks the source
+                       * cluster's leader epoch (maintained by updateMirrorFetchEpoch when errors occur), ensuring proper
+                       * validation of fetched batches from the source cluster.
                        */
-                      val epochForValidation = if (currentFetchState.mirrorLeaderEpoch != defaultMirrorLeaderEpoch)
-                        currentFetchState.mirrorLeaderEpoch else currentFetchState.currentLeaderEpoch
+                      val newPartitionLeaderEpoch: Int = currentFetchState.currentLeaderEpoch
                       val logAppendInfoOpt = processPartitionData(
                         topicPartition,
                         currentFetchState.fetchOffset,
-                        epochForValidation,
+                        newPartitionLeaderEpoch,
                         partitionData
                       )
 
@@ -488,22 +478,14 @@ abstract class AbstractFetcherThread(name: String,
                         val lag = Math.max(0L, partitionData.highWatermark - nextOffset)
                         fetcherLagStats.getAndMaybePut(topicPartition).lag = lag
 
-                        // Update fetch state when:
-                        // 1. No data fetched but mirror leader epoch advanced (mirrored partitions only)
-                        // 2. Data was fetched OR this is the first fetch (lag was unknown)
-                        val shouldUpdateState = (validBytes == 0 && partitionData.mirrorLeaderEpoch > currentFetchState.mirrorLeaderEpoch) ||
-                          (validBytes > 0 || currentFetchState.lag.isEmpty)
-
                         // ReplicaDirAlterThread may have removed topicPartition from the partitionStates after processing the partition data
-                        if (partitionStates.contains(topicPartition) && shouldUpdateState) {
+                        if ((validBytes > 0 || currentFetchState.lag.isEmpty) && partitionStates.contains(topicPartition)) {
                           val lastFetchedEpoch =
-                            if (logAppendInfo.lastLeaderEpoch.isPresent) logAppendInfo.lastLeaderEpoch else currentFetchState.lastFetchedEpoch
-                          // For mirrored partitions, update mirror leader epoch from the fetch response
-                          val mirrorLeaderEpoch = if (shouldUpdateMirrorLeaderEpoch(topicPartition)) partitionData.mirrorLeaderEpoch else defaultMirrorLeaderEpoch
+                            if (logAppendInfo.lastLeaderEpoch.isPresent && currentFetchState.lastFetchedEpoch.isPresent)
+                              logAppendInfo.lastLeaderEpoch else currentFetchState.lastFetchedEpoch
                           // Update partitionStates only if there is no exception during processPartitionData
                           val newFetchState = new PartitionFetchState(currentFetchState.topicId, nextOffset, Optional.of(lag),
-                            currentFetchState.currentLeaderEpoch, ReplicaState.FETCHING, lastFetchedEpoch, currentFetchState.isMirrorFetch, 0, mirrorLeaderEpoch)
-                          log.info(s"==== Updating $newFetchState")
+                            currentFetchState.currentLeaderEpoch, ReplicaState.FETCHING, lastFetchedEpoch, currentFetchState.isMirrorFetch, 0)
                           partitionStates.updateAndMoveToEnd(topicPartition, newFetchState)
                           if (validBytes > 0) fetcherStats.byteRate.mark(validBytes)
                         }
@@ -595,7 +577,7 @@ abstract class AbstractFetcherThread(name: String,
     if (divergingEndOffsets.nonEmpty)
       truncateOnFetchResponse(divergingEndOffsets)
     if (mirrorPartitionsWithNewEpoch.nonEmpty)
-      updateMirrorLeaderEpoch(mirrorPartitionsWithNewEpoch)
+      updateMirrorFetchEpoch(mirrorPartitionsWithNewEpoch)
     if (mirrorPartitionsWithNewLeader.nonEmpty)
       maybeCreateMirrorFetchers(mirrorPartitionsWithNewLeader)
     if (partitionsWithError.nonEmpty) {
@@ -613,7 +595,7 @@ abstract class AbstractFetcherThread(name: String,
       Option(partitionStates.stateValue(topicPartition)).foreach { state =>
         val newState = new PartitionFetchState(state.topicId, math.min(truncationOffset, state.fetchOffset),
           state.lag, state.currentLeaderEpoch, state.delay, ReplicaState.TRUNCATING,
-          Optional.empty(), state.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds())), state.isMirrorFetch(), state.mirrorLeaderEpoch)
+          Optional.empty(), state.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds())), state.isMirrorFetch())
         partitionStates.updateAndMoveToEnd(topicPartition, newState)
         partitionMapCond.signalAll()
       }
@@ -640,22 +622,18 @@ abstract class AbstractFetcherThread(name: String,
     } else if (initialFetchState.initOffset < 0) {
       fetchOffsetAndTruncate(tp, initialFetchState.topicId, initialFetchState.currentLeaderEpoch, initialFetchState.mirrorName.nonEmpty)
     } else if (leader.isTruncationOnFetchSupported) {
-      // With old message format, `latestEpoch` will be empty and we use Truncating state
-      // to truncate to high watermark.
-      val latestEpochInLog = latestEpochFromLog(tp)
-      // For mirrored partitions, use epochs from the local log (which contain source cluster epochs).
-      // For regular followers, use epochs from partition metadata (destination cluster epochs).
-      val lastFetchedEpoch: Optional[Integer] = if (initialFetchState.mirrorName.nonEmpty) {
-        if (latestEpochInLog.isPresent)
-          latestEpochInLog
-        else Optional.of(0) // this should only happen when no data in local log
-      } else latestEpoch(tp)
-      val state = if (lastFetchedEpoch.isPresent) ReplicaState.FETCHING else ReplicaState.TRUNCATING
+      // With old message format, `latestEpoch` will be empty and we use Truncating state to truncate to high watermark
+      val lastFetchedEpoch: Optional[Integer] = if (initialFetchState.mirrorName.isEmpty) {
+        latestEpoch(tp)
+      } else {
+        Optional.empty()
+      }
+      val state = if (lastFetchedEpoch.isPresent || initialFetchState.mirrorName.nonEmpty) ReplicaState.FETCHING else ReplicaState.TRUNCATING
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
-        state, lastFetchedEpoch, initialFetchState.mirrorName.nonEmpty, 0, defaultMirrorLeaderEpoch)
+        state, lastFetchedEpoch, initialFetchState.mirrorName.nonEmpty, 0)
     } else {
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
-        ReplicaState.TRUNCATING, Optional.empty(), initialFetchState.mirrorName.nonEmpty, 0, defaultMirrorLeaderEpoch)
+        ReplicaState.TRUNCATING, Optional.empty(), initialFetchState.mirrorName.nonEmpty, 0)
     }
   }
 
@@ -708,7 +686,7 @@ abstract class AbstractFetcherThread(name: String,
 
             val delayMs = currentFetchState.delay.map(t => Long.box(t + Time.SYSTEM.milliseconds()))
             new PartitionFetchState(currentFetchState.topicId, offsetTruncationState.offset, currentFetchState.lag,
-              currentFetchState.currentLeaderEpoch, currentFetchState.delay, state, lastFetchedEpoch, delayMs, currentFetchState.isMirrorFetch(), currentFetchState.mirrorLeaderEpoch)
+              currentFetchState.currentLeaderEpoch, currentFetchState.delay, state, lastFetchedEpoch, delayMs, currentFetchState.isMirrorFetch())
           case None => currentFetchState
         }
         (topicPartition, maybeTruncationComplete)
@@ -816,9 +794,8 @@ abstract class AbstractFetcherThread(name: String,
       truncate(topicPartition, OffsetTruncationState(leaderEndOffset, truncationCompleted = true))
 
       fetcherLagStats.getAndMaybePut(topicPartition).lag = 0
-      val mirrorLeaderEpoch = if (readOnly) 0 else -1
       new PartitionFetchState(topicId.toJava, leaderEndOffset, Optional.of(0L), currentLeaderEpoch,
-        ReplicaState.FETCHING, latestEpoch(topicPartition), readOnly, 0, mirrorLeaderEpoch)
+        ReplicaState.FETCHING, latestEpoch(topicPartition), readOnly, 0)
     } else {
       /**
        * If the leader's log end offset is greater than the follower's log end offset, there are two possibilities:
@@ -857,9 +834,8 @@ abstract class AbstractFetcherThread(name: String,
 
       val initialLag = leaderEndOffset - offsetToFetch
       fetcherLagStats.getAndMaybePut(topicPartition).lag = initialLag
-      val mirrorLeaderEpoch = if (readOnly) 0 else -1
       new PartitionFetchState(topicId.toJava, offsetToFetch, Optional.of(initialLag), currentLeaderEpoch,
-        ReplicaState.FETCHING, latestEpoch(topicPartition), readOnly, 0, mirrorLeaderEpoch)
+        ReplicaState.FETCHING, latestEpoch(topicPartition), readOnly, 0)
     }
   }
 
@@ -962,8 +938,7 @@ abstract class AbstractFetcherThread(name: String,
                 currentFetchState.state,
                 currentFetchState.lastFetchedEpoch,
                 Optional.of(Long.box(delay + Time.SYSTEM.milliseconds())),
-                currentFetchState.isMirrorFetch(),
-                currentFetchState.mirrorLeaderEpoch))
+                currentFetchState.isMirrorFetch()))
           }
         }
       }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -705,7 +705,7 @@ class KafkaApis(val requestChannel: RequestChannel,
             erroneous += topicIdPartition -> FetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_OR_PARTITION)
           else {
             interesting += topicIdPartition -> new PartitionData(data.topicId, data.fetchOffset, data.logStartOffset,
-              data.maxBytes, data.currentLeaderEpoch, data.lastFetchedEpoch, data.mirrorLeaderEpoch)
+              data.maxBytes, data.currentLeaderEpoch, data.lastFetchedEpoch)
           }
         }
       } else {
@@ -763,17 +763,6 @@ class KafkaApis(val requestChannel: RequestChannel,
           .setAbortedTransactions(abortedTransactions)
           .setRecords(data.records)
           .setPreferredReadReplica(data.preferredReadReplica.orElse(FetchResponse.INVALID_PREFERRED_REPLICA_ID))
-
-        // For mirrored partitions, set mirrorLeaderEpoch from the log's highest epoch
-        if (versionId >= 19) {
-          replicaManager.getPartition(topicIdPartition.topicPartition()) match {
-            case HostedPartition.Online(partition) if partition.mirrorName.nonEmpty =>
-              val latestLeaderEpochInLog = partition.localLogOrException.latestEpoch.orElse(0)
-              partitionData.setMirrorLeaderEpoch(latestLeaderEpochInLog)
-            case _ =>
-            // Not a mirrored partition, leave mirrorLeaderEpoch at default -1
-          }
-        }
 
         if (versionId >= 16) {
           data.error match {

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -207,19 +207,13 @@ class RemoteLeaderEndPoint(logPrefix: String,
             fetchState.lastFetchedEpoch()
           else
             Optional.empty[Integer]
-          // For mirrored partitions, the initial fetch has currentLeaderEpoch=0 and mirrorLeaderEpoch=0
-          val mirrorLeaderEpoch: Optional[Integer] = if (fetchState.mirrorLeaderEpoch() >= 0)
-            Optional.of(Int.box(fetchState.mirrorLeaderEpoch()))
-          else
-            Optional.empty[Integer]
           builder.add(topicPartition, new FetchRequest.PartitionData(
             fetchState.topicId().orElse(Uuid.ZERO_UUID),
             fetchState.fetchOffset(),
             logStartOffset,
             fetchSize,
             Optional.of(fetchState.currentLeaderEpoch()),
-            lastFetchedEpoch,
-            mirrorLeaderEpoch))
+            lastFetchedEpoch))
           if (fetchState.isMirrorFetch() && fetchState.topicId().isPresent) {
             readOnlyTopics += fetchState.topicId().get()
           }

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -78,14 +78,6 @@ class ReplicaAlterLogDirsThread(name: String,
   }
 
   // process fetched data
-  override def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
-    // ReplicaAlterLogDirsThread moves logs between directories on the same broker.
-    // It replicates from the current log to the future log, both managed by the same partition.
-    // Epoch management is handled by the partition itself, not by batch epochs.
-    // Therefore, we should not update currentLeaderEpoch from batches.
-    false
-  }
-
   override def processPartitionData(
     topicPartition: TopicPartition,
     fetchOffset: Long,

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -110,16 +110,6 @@ class ReplicaFetcherThread(name: String,
     completeDelayedFetchRequests()
   }
 
-  override def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
-    // For followers of mirrored partitions, update epoch from batches to track source epochs.
-    // For regular partitions, epoch comes from metadata and should not be updated from batches.
-    replicaMgr.getPartition(topicPartition) match {
-      case HostedPartition.Online(partition) =>
-        partition.mirrorName != null && partition.mirrorName.nonEmpty
-      case _ => false
-    }
-  }
-
   // process fetched data
   override def processPartitionData(
     topicPartition: TopicPartition,

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -76,11 +76,6 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
-  override def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
-    // MirrorFetcherThread always processes mirrored partitions, so always update from batches
-    true
-  }
-
   // process fetched data
   override def processPartitionData(
     topicPartition: TopicPartition,

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
@@ -356,7 +356,5 @@ class AbstractFetcherManagerTest {
     override protected def logEndOffset(topicPartition: TopicPartition): Long = 1
 
     override protected def endOffsetForEpoch(topicPartition: TopicPartition, epoch: Int): Optional[OffsetAndEpoch] = Optional.of(new OffsetAndEpoch(1, 0))
-
-    override protected def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = false
   }
 }

--- a/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
+++ b/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
@@ -193,6 +193,4 @@ class MockFetcherThread(val mockLeader: MockLeaderEndPoint,
       assertEquals(expectedEpoch, fetchState(partition).map(_.lastFetchedEpoch.get()))
     }
   }
-
-  override protected def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = false
 }

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -139,8 +139,7 @@ public enum MetadataVersion {
     // *** DYNAMICALLY TO TRY OUT THE EARLY ACCESS CAPABILITY.                                   ***
     IBP_4_2_IV1(29, "4.2", "IV1", false),
 
-    // Enables cluster mirroring (early access in 4.2).
-    // Adds FetchRequest/Response v19 with MirrorLeaderEpoch field.
+    // Enables Cluster Mirroring (early access).
     // Adds mirrorName field to PartitionRecord for read-only leader identification.
     //
     // *** THIS IS A PLACEHOLDER UNSTABLE VERSION WHICH IS USED TO DEFINE THE POINT AT WHICH   ***
@@ -277,9 +276,7 @@ public enum MetadataVersion {
     }
 
     public short fetchRequestVersion() {
-        if (isAtLeast(IBP_4_2_IV2)) {
-            return 19;
-        } else if (isAtLeast(IBP_4_1_IV1)) {
+        if (isAtLeast(IBP_4_1_IV1)) {
             return 18;
         } else if (isAtLeast(IBP_3_9_IV0)) {
             return 17;

--- a/server/src/main/java/org/apache/kafka/server/PartitionFetchState.java
+++ b/server/src/main/java/org/apache/kafka/server/PartitionFetchState.java
@@ -38,11 +38,7 @@ import java.util.Optional;
  * @param state The current replica state (TRUNCATING, FETCHING, etc.)
  * @param lastFetchedEpoch The last fetched epoch from the log
  * @param dueMs The time when this partition is due for fetch (if delayed)
- * @param isMirrorFetch True if this is a mirror fetch (e.g., MirrorFetcherThread), false for local fetch
- * @param mirrorLeaderEpoch The leader epoch from the source cluster for mirrored partitions.
- *                          This tracks the source cluster's epoch progression and is used for
- *                          batch validation to allow batches with source cluster epochs that may
- *                          be higher than the destination cluster's currentLeaderEpoch.
+ * @param isMirrorFetch True if this is a mirroring fetch, false for local fetch
  */
 public record PartitionFetchState(
         Optional<Uuid> topicId,
@@ -53,8 +49,7 @@ public record PartitionFetchState(
         ReplicaState state,
         Optional<Integer> lastFetchedEpoch,
         Optional<Long> dueMs,
-        boolean isMirrorFetch,
-        int mirrorLeaderEpoch
+        boolean isMirrorFetch
 ) {
     public PartitionFetchState(
             Optional<Uuid> topicId,
@@ -77,21 +72,7 @@ public record PartitionFetchState(
             boolean isMirrorFetch,
             long dueMs) {
         this(topicId, fetchOffset, lag, currentLeaderEpoch,
-                Optional.empty(), state, lastFetchedEpoch, Optional.empty(), isMirrorFetch, -1);
-    }
-
-    public PartitionFetchState(
-            Optional<Uuid> topicId,
-            long fetchOffset,
-            Optional<Long> lag,
-            int currentLeaderEpoch,
-            ReplicaState state,
-            Optional<Integer> lastFetchedEpoch,
-            boolean isMirrorFetch,
-            long dueMs,
-            int mirrorLeaderEpoch) {
-        this(topicId, fetchOffset, lag, currentLeaderEpoch,
-                Optional.empty(), state, lastFetchedEpoch, Optional.empty(), isMirrorFetch, mirrorLeaderEpoch);
+                Optional.empty(), state, lastFetchedEpoch, Optional.empty(), isMirrorFetch);
     }
 
     public PartitionFetchState(
@@ -104,7 +85,7 @@ public record PartitionFetchState(
             Optional<Integer> lastFetchedEpoch) {
         this(topicId, fetchOffset, lag, currentLeaderEpoch,
                 delay, state, lastFetchedEpoch,
-                delay.map(aLong -> aLong + Time.SYSTEM.milliseconds()), false, -1);
+                delay.map(aLong -> aLong + Time.SYSTEM.milliseconds()), false);
     }
 
     public boolean isReadyForFetch() {
@@ -128,7 +109,6 @@ public record PartitionFetchState(
         return "FetchState(topicId=" + topicId +
                 ", fetchOffset=" + fetchOffset +
                 ", currentLeaderEpoch=" + currentLeaderEpoch +
-                ", mirrorLeaderEpoch=" + mirrorLeaderEpoch +
                 ", lastFetchedEpoch=" + lastFetchedEpoch +
                 ", state=" + state +
                 ", lag=" + lag +
@@ -139,6 +119,6 @@ public record PartitionFetchState(
     public PartitionFetchState updateTopicId(Optional<Uuid> newTopicId) {
         return new PartitionFetchState(newTopicId, this.fetchOffset, this.lag,
                 this.currentLeaderEpoch, this.delay,
-                this.state, this.lastFetchedEpoch, this.dueMs, this.isMirrorFetch, this.mirrorLeaderEpoch);
+                this.state, this.lastFetchedEpoch, this.dueMs, this.isMirrorFetch);
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1170,7 +1170,7 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                maybeResetProducerIdForMirroredTopic(records, isMirrorLeader);
+                                maybeOverrideProducerIdAndLeaderEpoch(records, isMirrorLeader);
                                 // we are taking the offsets we are given
                                 if (appendInfo.firstOrLastOffsetOfFirstBatch() < localLog.logEndOffset()) {
                                     // we may still be able to recover if the log is empty
@@ -1274,18 +1274,20 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     /**
-     * Reset producer IDs for records being mirrored from a source cluster.
-     * This is only called for read-only leaders (partitions with mirrorName set and acting as leader)
-     * to ensure producer IDs from the source cluster don't conflict with local producer IDs.
+     * Override producer IDs and leader epochs for records being mirrored from a source cluster.
+     * This is only applied to read-only leaders (partition leader with mirrorName set)
+     * to ensure producer IDs from source cluster don't conflict with local producer IDs,
+     * and local epoch-based partition replication can work without changes.
      *
      * @param records The records being appended
      * @param isMirrorLeader True if this is a read-only leader fetching from source cluster
      */
-    private void maybeResetProducerIdForMirroredTopic(MemoryRecords records, boolean isMirrorLeader) {
+    private void maybeOverrideProducerIdAndLeaderEpoch(MemoryRecords records, boolean isMirrorLeader) {
         if (isMirrorLeader) {
             for (MutableRecordBatch batch : records.batches()) {
-                // Reset producer ID to avoid conflicts with local producers
-                // New producer ID = -(originalProducerId + 2)
+                // Keep using local leader epochs
+                batch.setPartitionLeaderEpoch(latestEpoch().orElse(0));
+                // Mirrored producer IDs occupy the negative space to avoid any conflict
                 batch.setProducerId(-(batch.producerId() + 2));
             }
         }


### PR DESCRIPTION
With epoch rewrite, we don't need to modify the Fetch API to add mirrorLeaderEpoch. We now have dual epoch tracking only on mirrored leader that learns it's fetch epoch when getting FENCED_LEADER_EPOCH from source leader.