### PR TITLE
Use numReplicaFetchers from MirrorConfig

### DIFF
--- a/core/src/main/scala/kafka/server/mirror/MirrorBlockingSender.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorBlockingSender.scala
@@ -60,15 +60,12 @@ class MirrorBlockingSender(sourceBroker: BrokerEndPoint,
   private val socketTimeout: Int = config.getLong(MirrorConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG).toInt
 
   private val networkClient = {
-    val securityProtocol = SecurityProtocol.forName(mirrorConfig.securityProtocol())
-    val saslMechanism = mirrorConfig.saslMechanism()
-
     val channelBuilder = ChannelBuilders.clientChannelBuilder(
-      securityProtocol,
+      SecurityProtocol.forName(mirrorConfig.securityProtocol()),
       JaasContext.Type.CLIENT,
       config,
       null,
-      saslMechanism,
+      mirrorConfig.saslMechanism(),
       time,
       logContext
     )

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -64,7 +64,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     extends AbstractFetcherManager[MirrorFetcherThread](
       name = "MirrorFetcherManager on broker " + brokerConfig.brokerId,
       clientId = "MirrorReplica",
-      numFetchers = brokerConfig.numMirrorReplicaFetchers) {
+      numFetchers = brokerConfig.mirrorConfig.numReplicaFetchers) {
   private val mirrorFetcherThreadMap = new mutable.HashMap[BrokerAndFetcherIdWithMirror, MirrorFetcherThread]
 
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): MirrorFetcherThread = {

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -91,10 +91,6 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         return getInt(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG);
     }
 
-    public int numMirrorReplicaFetchers() {
-        return getInt(MirrorConfig.NUM_REPLICA_FETCHERS_CONFIG);
-    }
-
     public int numRecoveryThreadsPerDataDir() {
         return getInt(ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG);
     }

--- a/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
@@ -258,7 +258,6 @@ public class MirrorConfig {
     private final short mirrorTopicReplicationFactor;
     private final String securityProtocol;
     private final String saslMechanism;
-    private final String sslProtocol;
 
     public MirrorConfig(AbstractConfig config) {
         this.config = config;
@@ -266,7 +265,6 @@ public class MirrorConfig {
         mirrorTopicReplicationFactor = config.getShort(MIRROR_TOPIC_REPLICATION_FACTOR_CONFIG);
         securityProtocol = config.getString(SECURITY_PROTOCOL_CONFIG);
         saslMechanism = config.getString(SASL_MECHANISM_CONFIG);
-        sslProtocol = config.getString(SSL_PROTOCOL_CONFIG);
     }
 
     /**
@@ -296,10 +294,6 @@ public class MirrorConfig {
 
     public String saslMechanism() {
         return saslMechanism;
-    }
-
-    public String sslProtocol() {
-        return sslProtocol;
     }
 
     public int numReplicaFetchers() {


### PR DESCRIPTION
This patch move numReplicaFetchers configuration to MirrorConfig and removes the unused method sslProtocol.