### PR TITLE
add last_mirrored_offset API to do truncation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -138,7 +138,8 @@ public enum ApiKeys {
     GET_REPLICA_LOG_INFO(ApiMessageType.GET_REPLICA_LOG_INFO),
     CREATE_MIRROR(ApiMessageType.CREATE_MIRROR, false, true),
     ADD_TOPICS_TO_MIRROR(ApiMessageType.ADD_TOPICS_TO_MIRROR, false, true),
-    REMOVE_TOPICS_FROM_MIRROR(ApiMessageType.REMOVE_TOPICS_FROM_MIRROR, false, true);
+    REMOVE_TOPICS_FROM_MIRROR(ApiMessageType.REMOVE_TOPICS_FROM_MIRROR, false, true),
+    LAST_MIRRORED_OFFSET(ApiMessageType.LAST_MIRRORED_OFFSET);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -362,6 +362,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return AddTopicsToMirrorRequest.parse(readable, apiVersion);
             case REMOVE_TOPICS_FROM_MIRROR:
                 return RemoveTopicsFromMirrorRequest.parse(readable, apiVersion);
+            case LAST_MIRRORED_OFFSET:
+                return LastMirroredOffsetRequest.parse(readable, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -299,6 +299,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return AddTopicsToMirrorResponse.parse(readable, version);
             case REMOVE_TOPICS_FROM_MIRROR:
                 return RemoveTopicsFromMirrorResponse.parse(readable, version);
+            case LAST_MIRRORED_OFFSET:
+                return LastMirroredOffsetResponse.parse(readable, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LastMirroredOffsetRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LastMirroredOffsetRequest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AddTopicsToMirrorRequestData;
+import org.apache.kafka.common.message.AddTopicsToMirrorResponseData;
+import org.apache.kafka.common.message.LastMirroredOffsetRequestData;
+import org.apache.kafka.common.message.LastMirroredOffsetResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+
+public class LastMirroredOffsetRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LastMirroredOffsetRequest> {
+
+        private final LastMirroredOffsetRequestData data;
+
+        public Builder(LastMirroredOffsetRequestData data) {
+            super(ApiKeys.LAST_MIRRORED_OFFSET);
+            this.data = data;
+        }
+
+        public Builder(Set<String> topics) {
+            super(ApiKeys.LAST_MIRRORED_OFFSET, ApiKeys.LAST_MIRRORED_OFFSET.oldestVersion(),
+                    ApiKeys.LAST_MIRRORED_OFFSET.latestVersion());
+            LastMirroredOffsetRequestData data = new LastMirroredOffsetRequestData();
+            data.setTopics(new ArrayList<>(topics));
+            this.data = data;
+        }
+
+        @Override
+        public LastMirroredOffsetRequest build(short version) {
+            return new LastMirroredOffsetRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LastMirroredOffsetRequestData data;
+
+    public LastMirroredOffsetRequest(LastMirroredOffsetRequestData data, short version) {
+        super(ApiKeys.LAST_MIRRORED_OFFSET, version);
+        this.data = data;
+    }
+
+    @Override
+    public LastMirroredOffsetRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        LastMirroredOffsetResponseData responseData = new LastMirroredOffsetResponseData();
+        responseData.setErrorCode(error.code());
+
+        return new LastMirroredOffsetResponse(responseData);
+    }
+
+    public static LastMirroredOffsetRequest parse(Readable readable, short version) {
+        return new LastMirroredOffsetRequest(
+                new LastMirroredOffsetRequestData(readable, version),
+                version
+        );
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LastMirroredOffsetRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LastMirroredOffsetRequest.java
@@ -17,8 +17,6 @@
 
 package org.apache.kafka.common.requests;
 
-import org.apache.kafka.common.message.AddTopicsToMirrorRequestData;
-import org.apache.kafka.common.message.AddTopicsToMirrorResponseData;
 import org.apache.kafka.common.message.LastMirroredOffsetRequestData;
 import org.apache.kafka.common.message.LastMirroredOffsetResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -26,7 +24,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.Set;
 
 public class LastMirroredOffsetRequest extends AbstractRequest {

--- a/clients/src/main/java/org/apache/kafka/common/requests/LastMirroredOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LastMirroredOffsetResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AddTopicsToMirrorResponseData;
+import org.apache.kafka.common.message.LastMirroredOffsetResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LastMirroredOffsetResponse extends AbstractResponse {
+    private final LastMirroredOffsetResponseData data;
+
+    public LastMirroredOffsetResponse(LastMirroredOffsetResponseData data) {
+        super(ApiKeys.LAST_MIRRORED_OFFSET);
+        this.data = data;
+    }
+
+    @Override
+    public LastMirroredOffsetResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Map<Errors, Integer> errorCounts = new HashMap<>();
+        updateErrorCounts(errorCounts, Errors.forCode(data.errorCode()));
+        return errorCounts;
+    }
+
+    public static LastMirroredOffsetResponse parse(Readable readable, short version) {
+        return new LastMirroredOffsetResponse(new LastMirroredOffsetResponseData(readable, version));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LastMirroredOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LastMirroredOffsetResponse.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.common.requests;
 
-import org.apache.kafka.common.message.AddTopicsToMirrorResponseData;
 import org.apache.kafka.common.message.LastMirroredOffsetResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;

--- a/clients/src/main/resources/common/message/LastMirroredOffsetRequest.json
+++ b/clients/src/main/resources/common/message/LastMirroredOffsetRequest.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":97,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "LastMirroredOffsetRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]string", "versions": "0+", "about": "The topic names." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LastMirroredOffsetResponse.json
+++ b/clients/src/main/resources/common/message/LastMirroredOffsetResponse.json
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey":97,
+  "type": "response",
+  "name": "LastMirroredOffsetResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "Topics", "type": "[]OffsetResponseTopic", "versions": "0",
+      "about": "The responses per topic.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]OffsetResponsePartition", "versions": "0",
+        "about": "The responses per partition.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0",
+          "about": "The partition index." },
+        { "name": "CommittedOffset", "type": "int64", "versions": "0",
+          "about": "The committed message offset." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0",
+          "about": "The error code, or 0 if there was no error." }
+      ]}
+    ]}
+  ]
+}

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -134,12 +134,12 @@ public class MirrorCoordinator {
         numPartitions = config.mirrorConfig().mirrorTopicNumPartitions();
     }
 
-    public void maybeScheduleForTruncate(Set<String> topics) {
-        scheduler.scheduleOnce("last-mirrored-offset", () -> maybeTruncate(topics));
+    public void maybeScheduleForTruncate(String mirrorName, Set<String> topics) {
+        scheduler.scheduleOnce("last-mirrored-offset", () -> maybeTruncate(mirrorName, topics));
     }
 
-    private void maybeTruncate(Set<String> topics) {
-
+    private void maybeTruncate(String mirrorName, Set<String> topics) {
+        mirrorMetadataManager.maybeTruncate(replicaManager, mirrorName, topics);
     }
 
     /**

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -134,6 +134,14 @@ public class MirrorCoordinator {
         numPartitions = config.mirrorConfig().mirrorTopicNumPartitions();
     }
 
+    public void maybeScheduleForTruncate(Set<String> topics) {
+        scheduler.scheduleOnce("last-mirrored-offset", () -> maybeTruncate(topics));
+    }
+
+    private void maybeTruncate(Set<String> topics) {
+
+    }
+
     /**
      * Updates the mirror topics metadata for a given cluster mirror.
      * Adds or removes topics from the mirror configuration and persists changes to the internal topic.

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -17,8 +17,8 @@
 package kafka.server.mirror;
 
 import kafka.server.KafkaConfig;
-
 import kafka.server.ReplicaManager;
+
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.admin.AlterConfigOp;

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -18,6 +18,7 @@ package kafka.server.mirror;
 
 import kafka.server.KafkaConfig;
 
+import kafka.server.ReplicaManager;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -36,6 +37,7 @@ import org.apache.kafka.common.message.DeleteAclsRequestData;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;
 import org.apache.kafka.common.message.DescribeConfigsRequestData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
+import org.apache.kafka.common.message.LastMirroredOffsetRequestData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.OffsetFetchRequestData;
@@ -54,6 +56,8 @@ import org.apache.kafka.common.requests.DescribeAclsResponse;
 import org.apache.kafka.common.requests.DescribeConfigsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
+import org.apache.kafka.common.requests.LastMirroredOffsetRequest;
+import org.apache.kafka.common.requests.LastMirroredOffsetResponse;
 import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
@@ -204,6 +208,28 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      */
     @Override
     public void close() throws Exception {
+    }
+
+    public void maybeTruncate(ReplicaManager replicaManager, String mirrorName, Set<String> topics) {
+        LOG.info("!!! maybeTruncate: {} {}", mirrorName, topics);
+        createMirrorConnection(mirrorName);
+
+        var response = getRandomSender(remoteBrokers.get(mirrorName)).sendRequest(
+                new LastMirroredOffsetRequest.Builder(
+                        new LastMirroredOffsetRequestData().setTopics(new ArrayList<>(topics)))
+        );
+
+        if (response.responseBody() instanceof LastMirroredOffsetResponse lastMirroredOffsetResponse) {
+            LOG.info("!!! lastMirroredOffsetResponse: {}", lastMirroredOffsetResponse);
+            Map<TopicPartition, Long> offsets = new HashMap<>();
+            lastMirroredOffsetResponse.data().topics().forEach(topic -> {
+                String name = topic.name();
+                topic.partitions().forEach(partition -> {
+                    offsets.put(new TopicPartition(name, partition.partitionIndex()), partition.committedOffset());
+                });
+            });
+            replicaManager.maybeTruncate(offsets);
+        }
     }
 
     /**

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -255,6 +255,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.CREATE_MIRROR => forwardToController(request)
         case ApiKeys.ADD_TOPICS_TO_MIRROR => handleAddTopicsToMirror(request)
         case ApiKeys.REMOVE_TOPICS_FROM_MIRROR => handleRemoveTopicsFromMirror(request)
+        case ApiKeys.LAST_MIRRORED_OFFSET => handleLastMirroredOffset(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -282,6 +283,36 @@ class KafkaApis(val requestChannel: RequestChannel,
       mirrorCoordinator.updateMirrorTopicsMetadata(mirrorTopic.get().mirrorInfo().mirrorName(), util.Set.of(mirrorTopic.get().name()), util.Set.of())
     }
     forwardToController(request)
+  }
+
+  def handleLastMirroredOffset(request: RequestChannel.Request): Unit = {
+    val lastMirroredOffsetRequest = request.body[LastMirroredOffsetRequest]
+    val responseData = new LastMirroredOffsetResponseData()
+    val topicList = new util.ArrayList[LastMirroredOffsetResponseData.OffsetResponseTopic]()
+    lastMirroredOffsetRequest.data().topics().forEach(topic => {
+      val responseTopic = new LastMirroredOffsetResponseData.OffsetResponseTopic()
+      val partitionList = new util.ArrayList[LastMirroredOffsetResponseData.OffsetResponsePartition]()
+
+      metadataCache.asInstanceOf[KRaftMetadataCache].numPartitions(topic).ifPresent(numPartitions => {
+        for(i <- 0 until numPartitions) {
+          val partition = new TopicPartition(topic, i)
+          val offsetPartition = new LastMirroredOffsetResponseData.OffsetResponsePartition()
+          offsetPartition.setPartitionIndex(i)
+          replicaManager.getPartitionOrError(partition) match {
+            case Left(err) => logger.error(s"Failed to get partition $partition from mirror: ${err.message}")
+            // set the last mirrored offset as LSO in the target cluster since it could be the offset beyond LSO be truncated
+            // after leadership change in the target cluster
+            case Right(partition) => partition.log.foreach(log => offsetPartition.setCommittedOffset(log.lastStableOffset()))
+          }
+        }
+      })
+      responseTopic.setName(topic)
+      responseTopic.setPartitions(partitionList)
+      topicList.add(responseTopic)
+    })
+    responseData.setTopics(topicList)
+
+    requestHelper.sendMaybeThrottle(request, new LastMirroredOffsetResponse(responseData))
   }
 
   def handleAddTopicsToMirror(request: RequestChannel.Request): Unit = {
@@ -317,6 +348,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           val partition = new TopicPartition(topic, i)
           replicaManager.getPartitionOrError(partition) match {
             case Left(err) => logger.error(s"Failed to get partition $partition from mirror: ${err.message}")
+            // use the LSO because the data after LSO might be truncated
             case Right(partition) => partition.log.foreach(log => offsets.put(i, log.lastStableOffset()))
           }
         }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -287,6 +287,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleLastMirroredOffset(request: RequestChannel.Request): Unit = {
     val lastMirroredOffsetRequest = request.body[LastMirroredOffsetRequest]
+    logger.info(s"!!! Handling last mirrored offset request: ${lastMirroredOffsetRequest}")
     val responseData = new LastMirroredOffsetResponseData()
     val topicList = new util.ArrayList[LastMirroredOffsetResponseData.OffsetResponseTopic]()
     lastMirroredOffsetRequest.data().topics().forEach(topic => {
@@ -304,6 +305,7 @@ class KafkaApis(val requestChannel: RequestChannel,
             // after leadership change in the target cluster
             case Right(partition) => partition.log.foreach(log => offsetPartition.setCommittedOffset(log.lastStableOffset()))
           }
+          partitionList.add(offsetPartition)
         }
       })
       responseTopic.setName(topic)
@@ -323,6 +325,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (isClusterMirroringEnabled) {
         logger.info(s"!!! Handling adding mirror topics request: ${mirrorTopic.get().mirrorName()}")
         mirrorCoordinator.updateMirrorTopicsMetadata(mirrorTopic.get().mirrorName(), util.Set.of(mirrorTopic.get().topicName()), util.Set.of())
+        mirrorCoordinator.maybeScheduleForTruncate(mirrorTopic.get().mirrorName(), util.Set.of(mirrorTopic.get().topicName()))
       } else {
         logger.warn("Cluster mirroring is disabled (mirror.version=0), ignoring mirror topic creation request")
       }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1667,6 +1667,15 @@ class ReplicaManager(val config: KafkaConfig,
     delayedRemoteFetchPurgatory.tryCompleteElseWatch(remoteFetch, delayedFetchKeys.asJava)
   }
 
+  def maybeTruncate(offsets: util.Map[TopicPartition, JLong]): Unit = {
+    info("!!! maybeTruncate:" + offsets)
+    offsets.forEach((tp, offset) => {
+      getLog(tp).map(log => {
+        log.truncateTo(offset)
+      })
+    })
+  }
+
   /**
    * Fetch messages from a replica, and wait until enough data can be fetched and return;
    * the callback function will be triggered either when timeout or required fetch info is satisfied.

--- a/server/src/main/java/org/apache/kafka/network/RequestConvertToJson.java
+++ b/server/src/main/java/org/apache/kafka/network/RequestConvertToJson.java
@@ -134,6 +134,8 @@ import org.apache.kafka.common.message.InitializeShareGroupStateRequestDataJsonC
 import org.apache.kafka.common.message.InitializeShareGroupStateResponseDataJsonConverter;
 import org.apache.kafka.common.message.JoinGroupRequestDataJsonConverter;
 import org.apache.kafka.common.message.JoinGroupResponseDataJsonConverter;
+import org.apache.kafka.common.message.LastMirroredOffsetRequestDataJsonConverter;
+import org.apache.kafka.common.message.LastMirroredOffsetResponseDataJsonConverter;
 import org.apache.kafka.common.message.LeaveGroupRequestDataJsonConverter;
 import org.apache.kafka.common.message.LeaveGroupResponseDataJsonConverter;
 import org.apache.kafka.common.message.ListConfigResourcesRequestDataJsonConverter;
@@ -324,6 +326,8 @@ import org.apache.kafka.common.requests.InitializeShareGroupStateRequest;
 import org.apache.kafka.common.requests.InitializeShareGroupStateResponse;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.requests.JoinGroupResponse;
+import org.apache.kafka.common.requests.LastMirroredOffsetRequest;
+import org.apache.kafka.common.requests.LastMirroredOffsetResponse;
 import org.apache.kafka.common.requests.LeaveGroupRequest;
 import org.apache.kafka.common.requests.LeaveGroupResponse;
 import org.apache.kafka.common.requests.ListConfigResourcesRequest;
@@ -594,6 +598,8 @@ public class RequestConvertToJson {
                 return AddTopicsToMirrorRequestDataJsonConverter.write(((AddTopicsToMirrorRequest) request).data(), request.version());
             case REMOVE_TOPICS_FROM_MIRROR:
                 return RemoveTopicsFromMirrorRequestDataJsonConverter.write(((RemoveTopicsFromMirrorRequest) request).data(), request.version());
+            case LAST_MIRRORED_OFFSET:
+                return LastMirroredOffsetRequestDataJsonConverter.write(((LastMirroredOffsetRequest) request).data(), request.version());
             default:
                 throw new IllegalStateException("ApiKey " + request.apiKey() + " is not currently handled in `request`, the " +
                     "code should be updated to do so.");
@@ -788,6 +794,8 @@ public class RequestConvertToJson {
                 return AddTopicsToMirrorResponseDataJsonConverter.write(((AddTopicsToMirrorResponse) response).data(), version);
             case REMOVE_TOPICS_FROM_MIRROR:
                 return RemoveTopicsFromMirrorResponseDataJsonConverter.write(((RemoveTopicsFromMirrorResponse) response).data(), version);
+            case LAST_MIRRORED_OFFSET:
+                return LastMirroredOffsetResponseDataJsonConverter.write(((LastMirroredOffsetResponse) response).data(), version);
             default:
                 throw new IllegalStateException("ApiKey " + response.apiKey() + " is not currently handled in `response`, the " +
                     "code should be updated to do so.");


### PR DESCRIPTION
Test scenario:
```
bin/kafka-server-start.sh /tmp/build/test/server0/config/server.properties 

echo "bootstrap.servers=localhost:9091" > /tmp/test1.properties
echo "bootstrap.servers=localhost:9094" > /tmp/test2.properties

bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9091
bin/kafka-mirrors.sh --bootstrap-server localhost:9094 --create --mirror my-link --mirror-config /tmp/test1.properties
bin/kafka-mirrors.sh --bootstrap-server localhost:9094 --add --topic quickstart-events --mirror my-link  --topic-id "$(bin/kafka-topics.sh --bootstrap-server localhost:9091 --describe --topic quickstart-events | grep "TopicId:" | awk '{print $4}')"

# write some data to server1
bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9091

# remove mirror
bin/kafka-mirrors.sh --bootstrap-server localhost:9094 --remove --topic quickstart-events --mirror my-link 

# write some more data to server1 for later truncation
bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9091

# start mirror from old source
bin/kafka-mirrors.sh --bootstrap-server localhost:9091 --create --mirror my-link2 --mirror-config /tmp/test2.properties

bin/kafka-mirrors.sh --bootstrap-server localhost:9091 --add --topic quickstart-events --mirror my-link2  --topic-id "$(bin/kafka-topics.sh --bootstrap-server localhost:9091 --describe --topic quickstart-events | grep "TopicId:" | awk '{print $4}')"

```
Check logs:

```
[2026-01-13 21:19:14,041] INFO !!! maybeTruncate: my-link2 [quickstart-events] (kafka.server.mirror.MirrorMetadataManager)
[2026-01-13 21:19:14,047] INFO !!! lastMirroredOffsetResponse: LastMirroredOffsetResponseData(throttleTimeMs=0, errorCode=0, topics=[OffsetResponseTopic(name='quickstart-events', partitions=[OffsetResponsePartition(partitionIndex=0, committedOffset=3, errorCode=0)])]) (kafka.server.mirror.MirrorMetadataManager)
[2026-01-13 21:19:14,049] INFO [ReplicaManager broker=1] !!! maybeTruncate:{quickstart-events-0=3} (kafka.server.ReplicaManager)
[2026-01-13 21:19:14,050] WARN [UnifiedLog partition=quickstart-events-0, dir=/tmp/build/test/server1/data] Truncating quickstart-events-0 to offset 3 below high watermark 6 (org.apache.kafka.storage.internals.log.UnifiedLog)
[2026-01-13 21:19:14,050] INFO [UnifiedLog partition=quickstart-events-0, dir=/tmp/build/test/server1/data] Truncating to offset 3 (org.apache.kafka.storage.internals.log.UnifiedLog)
[2026-01-13 21:19:14,051] INFO [UnifiedLog partition=quickstart-events-0, dir=/tmp/build/test/server1/data] Loading producer state till offset 3 (org.apache.kafka.storage.internals.log.UnifiedLog)
[2026-01-13 21:19:14,051] INFO [UnifiedLog partition=quickstart-events-0, dir=/tmp/build/test/server1/data] Reloading from producer snapshot and rebuilding producer state from offset 3 (org.apache.kafka.storage.internals.log.UnifiedLog)
[2026-01-13 21:19:14,057] INFO [ProducerStateManager partition=quickstart-events-0] Wrote producer snapshot at offset 3 with 1 producer ids in 6 ms. (org.apache.kafka.storage.internals.log.ProducerStateManager)
[2026-01-13 21:19:14,057] INFO [UnifiedLog partition=quickstart-events-0, dir=/tmp/build/test/server1/data] Producer state recovery took 0ms for snapshot load and 6ms for segment recovery from offset 3 (org.apache.kafka.storage.internals.log.UnifiedLog)
[2026-01-13 21:19:14,058] WARN [UnifiedLog partition=quickstart-events-0, dir=/tmp/build/test/server1/data] Non-monotonic update of high watermark from (offset=6, segment=[0:174]) to (offset=3, segment=[0:87]) (org.apache.kafka.storage.internals.log.UnifiedLog)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
