### PR TITLE
Add list mirrors operation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1081,6 +1081,26 @@ public interface Admin extends AutoCloseable {
     ListGroupsResult listGroups(ListGroupsOptions options);
 
     /**
+     * List the cluster mirrors available in the cluster with the default options.
+     *
+     * <p>This is a convenience method for {@link #listMirrors(ListMirrorsOptions)} with default options.
+     * See the overload for more details.
+     *
+     * @return The ListMirrorsResult.
+     */
+    default ListMirrorsResult listMirrors() {
+        return listMirrors(new ListMirrorsOptions());
+    }
+
+    /**
+     * List the cluster mirrors available in the cluster.
+     *
+     * @param options The options to use when listing the mirrors.
+     * @return The ListMirrorsResult.
+     */
+    ListMirrorsResult listMirrors(ListMirrorsOptions options);
+
+    /**
      * Elect a replica as leader for topic partitions.
      * <p>
      * This is a convenience method for {@link #electLeaders(ElectionType, Set, ElectLeadersOptions)}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -382,6 +382,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public ListMirrorsResult listMirrors(ListMirrorsOptions options) {
+        return delegate.listMirrors(options);
+    }
+
+    @Override
     public DescribeClassicGroupsResult describeClassicGroups(Collection<String> groupIds, DescribeClassicGroupsOptions options) {
         return delegate.describeClassicGroups(groupIds, options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -164,6 +164,8 @@ import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.ListConfigResourcesRequestData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
+import org.apache.kafka.common.message.ListMirrorsRequestData;
+import org.apache.kafka.common.message.ListMirrorsResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.RemoveRaftVoterRequestData;
@@ -245,6 +247,8 @@ import org.apache.kafka.common.requests.ListConfigResourcesRequest;
 import org.apache.kafka.common.requests.ListConfigResourcesResponse;
 import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
+import org.apache.kafka.common.requests.ListMirrorsRequest;
+import org.apache.kafka.common.requests.ListMirrorsResponse;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ListPartitionReassignmentsRequest;
 import org.apache.kafka.common.requests.ListPartitionReassignmentsResponse;
@@ -3525,6 +3529,48 @@ public class KafkaAdminClient extends AdminClient {
         }
     }
 
+    private static final class ListMirrorsResults {
+        private final List<Throwable> errors;
+        private final HashMap<String, MirrorListing> listings;
+        private final HashSet<Node> remaining;
+        private final KafkaFutureImpl<Collection<Object>> future;
+
+        ListMirrorsResults(Collection<Node> brokers,
+                           KafkaFutureImpl<Collection<Object>> future) {
+            this.errors = new ArrayList<>();
+            this.listings = new HashMap<>();
+            this.remaining = new HashSet<>(brokers);
+            this.future = future;
+            tryComplete();
+        }
+
+        synchronized void addError(Throwable throwable, Node node) {
+            ApiError error = ApiError.fromThrowable(throwable);
+            if (error.message() == null || error.message().isEmpty()) {
+                errors.add(error.error().exception("Error listing mirrors on " + node));
+            } else {
+                errors.add(error.error().exception("Error listing mirrors on " + node + ": " + error.message()));
+            }
+        }
+
+        synchronized void addListing(MirrorListing listing) {
+            listings.put(listing.mirrorName(), listing);
+        }
+
+        synchronized void tryComplete(Node broker) {
+            remaining.remove(broker);
+            tryComplete();
+        }
+
+        private synchronized void tryComplete() {
+            if (remaining.isEmpty()) {
+                ArrayList<Object> results = new ArrayList<>(listings.values());
+                results.addAll(errors);
+                future.complete(results);
+            }
+        }
+    }
+
     @Override
     public ListGroupsResult listGroups(ListGroupsOptions options) {
         final KafkaFutureImpl<Collection<Object>> all = new KafkaFutureImpl<>();
@@ -3630,6 +3676,78 @@ public class KafkaAdminClient extends AdminClient {
         }, nowMetadata);
 
         return new ListGroupsResult(all);
+    }
+
+    @Override
+    public ListMirrorsResult listMirrors(ListMirrorsOptions options) {
+        final KafkaFutureImpl<Collection<Object>> all = new KafkaFutureImpl<>();
+        final long nowMetadata = time.milliseconds();
+        final long deadline = calcDeadlineMs(nowMetadata, options.timeoutMs());
+        // Send list mirrors RPCs to all brokers and merge results
+        runnable.call(new Call("findAllBrokers", deadline, new LeastLoadedNodeProvider()) {
+            @Override
+            MetadataRequest.Builder createRequest(int timeoutMs) {
+                return new MetadataRequest.Builder(new MetadataRequestData()
+                    .setTopics(Collections.emptyList())
+                    .setAllowAutoTopicCreation(true));
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                MetadataResponse metadataResponse = (MetadataResponse) abstractResponse;
+                Collection<Node> nodes = metadataResponse.brokers();
+                if (nodes.isEmpty())
+                    throw new StaleMetadataException("Metadata fetch failed due to missing broker list");
+
+                HashSet<Node> allNodes = new HashSet<>(nodes);
+                final ListMirrorsResults results = new ListMirrorsResults(allNodes, all);
+
+                for (final Node node : allNodes) {
+                    final long nowList = time.milliseconds();
+                    runnable.call(new Call("listMirrors", deadline, new ConstantNodeIdProvider(node.id())) {
+                        @Override
+                        ListMirrorsRequest.Builder createRequest(int timeoutMs) {
+                            return new ListMirrorsRequest.Builder(new ListMirrorsRequestData());
+                        }
+
+                        @Override
+                        void handleResponse(AbstractResponse abstractResponse) {
+                            final ListMirrorsResponse response = (ListMirrorsResponse) abstractResponse;
+                            synchronized (results) {
+                                Errors error = Errors.forCode(response.data().errorCode());
+                                if (error == Errors.COORDINATOR_LOAD_IN_PROGRESS || error == Errors.COORDINATOR_NOT_AVAILABLE) {
+                                    throw error.exception();
+                                } else if (error != Errors.NONE) {
+                                    results.addError(error.exception(), node);
+                                } else {
+                                    for (ListMirrorsResponseData.ListedMirror mirror : response.data().mirrors()) {
+                                        final MirrorListing mirrorListing = new MirrorListing(mirror.mirrorName());
+                                        results.addListing(mirrorListing);
+                                    }
+                                }
+                                results.tryComplete(node);
+                            }
+                        }
+
+                        @Override
+                        void handleFailure(Throwable throwable) {
+                            synchronized (results) {
+                                results.addError(throwable, node);
+                                results.tryComplete(node);
+                            }
+                        }
+                    }, nowList);
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                KafkaException exception = new KafkaException("Failed to find brokers to send ListMirrors", throwable);
+                all.complete(Collections.singletonList(exception));
+            }
+        }, nowMetadata);
+
+        return new ListMirrorsResult(all);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3721,7 +3721,10 @@ public class KafkaAdminClient extends AdminClient {
                                     results.addError(error.exception(), node);
                                 } else {
                                     for (ListMirrorsResponseData.ListedMirror mirror : response.data().mirrors()) {
-                                        final MirrorListing mirrorListing = new MirrorListing(mirror.mirrorName());
+                                        final MirrorListing mirrorListing = new MirrorListing(
+                                            mirror.mirrorName(),
+                                            mirror.sourceBootstrap()
+                                        );
                                         results.addListing(mirrorListing);
                                     }
                                 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListMirrorsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListMirrorsOptions.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Options for {@link Admin#listMirrors()}.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class ListMirrorsOptions extends AbstractOptions<ListMirrorsOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListMirrorsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListMirrorsResult.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The result of the {@link Admin#listMirrors()} call.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class ListMirrorsResult {
+    private final KafkaFutureImpl<Collection<MirrorListing>> all;
+    private final KafkaFutureImpl<Collection<MirrorListing>> valid;
+    private final KafkaFutureImpl<Collection<Throwable>> errors;
+
+    ListMirrorsResult(KafkaFuture<Collection<Object>> future) {
+        this.all = new KafkaFutureImpl<>();
+        this.valid = new KafkaFutureImpl<>();
+        this.errors = new KafkaFutureImpl<>();
+        future.thenApply(results -> {
+            ArrayList<Throwable> curErrors = new ArrayList<>();
+            ArrayList<MirrorListing> curValid = new ArrayList<>();
+            for (Object resultObject : results) {
+                if (resultObject instanceof Throwable) {
+                    curErrors.add((Throwable) resultObject);
+                } else {
+                    curValid.add((MirrorListing) resultObject);
+                }
+            }
+            List<MirrorListing> validResult = Collections.unmodifiableList(curValid);
+            List<Throwable> errorsResult = Collections.unmodifiableList(curErrors);
+            if (!errorsResult.isEmpty()) {
+                all.completeExceptionally(errorsResult.get(0));
+            } else {
+                all.complete(validResult);
+            }
+            valid.complete(validResult);
+            errors.complete(errorsResult);
+            return null;
+        });
+    }
+
+    /**
+     * Returns a future that yields either an exception, or the full set of mirror listings.
+     * <p>
+     * In the event of a failure, the future yields nothing but the first exception which
+     * occurred.
+     */
+    public KafkaFuture<Collection<MirrorListing>> all() {
+        return all;
+    }
+
+    /**
+     * Returns a future which yields just the valid listings.
+     * <p>
+     * This future never fails with an error, no matter what happens.  Errors are completely
+     * ignored.  If nothing can be fetched, an empty collection is yielded.
+     * If there is an error, but some results can be returned, this future will yield
+     * those partial results.  When using this future, it is a good idea to also check
+     * the errors future so that errors can be displayed and handled.
+     */
+    public KafkaFuture<Collection<MirrorListing>> valid() {
+        return valid;
+    }
+
+    /**
+     * Returns a future which yields just the errors which occurred.
+     * <p>
+     * If this future yields a non-empty collection, it is very likely that elements are
+     * missing from the valid() set.
+     * <p>
+     * This future itself never fails with an error.  In the event of an error, this future
+     * will successfully yield a collection containing at least one exception.
+     */
+    public KafkaFuture<Collection<Throwable>> errors() {
+        return errors;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MirrorListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MirrorListing.java
@@ -27,14 +27,17 @@ import java.util.Objects;
 @InterfaceStability.Evolving
 public class MirrorListing {
     private final String mirrorName;
+    private final String sourceBootstrap;
 
     /**
      * Create an instance with the specified parameters.
      *
      * @param mirrorName Mirror name
+     * @param sourceBootstrap Source cluster bootstrap servers
      */
-    public MirrorListing(String mirrorName) {
+    public MirrorListing(String mirrorName, String sourceBootstrap) {
         this.mirrorName = mirrorName;
+        this.sourceBootstrap = sourceBootstrap;
     }
 
     /**
@@ -46,14 +49,23 @@ public class MirrorListing {
         return mirrorName;
     }
 
+    /**
+     * The source cluster bootstrap servers.
+     *
+     * @return Source bootstrap servers, or null if not available
+     */
+    public String sourceBootstrap() {
+        return sourceBootstrap;
+    }
+
     @Override
     public String toString() {
-        return "MirrorListing(mirrorName='" + mirrorName + "')";
+        return "MirrorListing(mirrorName='" + mirrorName + "', sourceBootstrap='" + sourceBootstrap + "')";
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mirrorName);
+        return Objects.hash(mirrorName, sourceBootstrap);
     }
 
     @Override
@@ -61,6 +73,7 @@ public class MirrorListing {
         if (this == o) return true;
         if (!(o instanceof MirrorListing)) return false;
         MirrorListing that = (MirrorListing) o;
-        return Objects.equals(mirrorName, that.mirrorName);
+        return Objects.equals(mirrorName, that.mirrorName) &&
+               Objects.equals(sourceBootstrap, that.sourceBootstrap);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MirrorListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MirrorListing.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Objects;
+
+/**
+ * A listing of a cluster mirror.
+ */
+@InterfaceStability.Evolving
+public class MirrorListing {
+    private final String mirrorName;
+
+    /**
+     * Create an instance with the specified parameters.
+     *
+     * @param mirrorName Mirror name
+     */
+    public MirrorListing(String mirrorName) {
+        this.mirrorName = mirrorName;
+    }
+
+    /**
+     * The mirror name.
+     *
+     * @return Mirror name
+     */
+    public String mirrorName() {
+        return mirrorName;
+    }
+
+    @Override
+    public String toString() {
+        return "MirrorListing(mirrorName='" + mirrorName + "')";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mirrorName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MirrorListing)) return false;
+        MirrorListing that = (MirrorListing) o;
+        return Objects.equals(mirrorName, that.mirrorName);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -139,7 +139,8 @@ public enum ApiKeys {
     CREATE_MIRROR(ApiMessageType.CREATE_MIRROR, false, true),
     ADD_TOPICS_TO_MIRROR(ApiMessageType.ADD_TOPICS_TO_MIRROR, false, true),
     REMOVE_TOPICS_FROM_MIRROR(ApiMessageType.REMOVE_TOPICS_FROM_MIRROR, false, true),
-    LAST_MIRRORED_OFFSETS(ApiMessageType.LAST_MIRRORED_OFFSETS);
+    LAST_MIRRORED_OFFSETS(ApiMessageType.LAST_MIRRORED_OFFSETS),
+    LIST_MIRRORS(ApiMessageType.LIST_MIRRORS);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -362,6 +362,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return AddTopicsToMirrorRequest.parse(readable, apiVersion);
             case REMOVE_TOPICS_FROM_MIRROR:
                 return RemoveTopicsFromMirrorRequest.parse(readable, apiVersion);
+            case LIST_MIRRORS:
+                return ListMirrorsRequest.parse(readable, apiVersion);
             case LAST_MIRRORED_OFFSETS:
                 return LastMirroredOffsetsRequest.parse(readable, apiVersion);
             default:

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -299,6 +299,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return AddTopicsToMirrorResponse.parse(readable, version);
             case REMOVE_TOPICS_FROM_MIRROR:
                 return RemoveTopicsFromMirrorResponse.parse(readable, version);
+            case LIST_MIRRORS:
+                return ListMirrorsResponse.parse(readable, version);
             case LAST_MIRRORED_OFFSETS:
                 return LastMirroredOffsetsResponse.parse(readable, version);
             default:

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListMirrorsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListMirrorsRequest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ListMirrorsRequestData;
+import org.apache.kafka.common.message.ListMirrorsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Collections;
+
+/**
+ * Possible error codes:
+ *
+ * COORDINATOR_LOAD_IN_PROGRESS (14)
+ * COORDINATOR_NOT_AVAILABLE (15)
+ * AUTHORIZATION_FAILED (29)
+ */
+public class ListMirrorsRequest extends AbstractRequest {
+
+    public static class Builder extends AbstractRequest.Builder<ListMirrorsRequest> {
+
+        private final ListMirrorsRequestData data;
+
+        public Builder(ListMirrorsRequestData data) {
+            super(ApiKeys.LIST_MIRRORS);
+            this.data = data;
+        }
+
+        @Override
+        public ListMirrorsRequest build(short version) {
+            return new ListMirrorsRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final ListMirrorsRequestData data;
+
+    public ListMirrorsRequest(ListMirrorsRequestData data, short version) {
+        super(ApiKeys.LIST_MIRRORS, version);
+        this.data = data;
+    }
+
+    @Override
+    public ListMirrorsResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        ListMirrorsResponseData listMirrorsResponseData = new ListMirrorsResponseData()
+            .setMirrors(Collections.emptyList())
+            .setErrorCode(Errors.forException(e).code())
+            .setThrottleTimeMs(throttleTimeMs);
+        return new ListMirrorsResponse(listMirrorsResponseData);
+    }
+
+    public static ListMirrorsRequest parse(Readable readable, short version) {
+        return new ListMirrorsRequest(new ListMirrorsRequestData(readable, version), version);
+    }
+
+    @Override
+    public ListMirrorsRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListMirrorsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListMirrorsResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ListMirrorsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Map;
+
+public class ListMirrorsResponse extends AbstractResponse {
+
+    private final ListMirrorsResponseData data;
+
+    public ListMirrorsResponse(ListMirrorsResponseData data) {
+        super(ApiKeys.LIST_MIRRORS);
+        this.data = data;
+    }
+
+    @Override
+    public ListMirrorsResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return errorCounts(Errors.forCode(data.errorCode()));
+    }
+
+    public static ListMirrorsResponse parse(Readable readable, short version) {
+        return new ListMirrorsResponse(new ListMirrorsResponseData(readable, version));
+    }
+
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+}

--- a/clients/src/main/resources/common/message/ListMirrorsRequest.json
+++ b/clients/src/main/resources/common/message/ListMirrorsRequest.json
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 98,
+  "type": "request",
+  "listeners": ["broker"],
+  "name": "ListMirrorsRequest",
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": []
+}

--- a/clients/src/main/resources/common/message/ListMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/ListMirrorsResponse.json
@@ -28,7 +28,9 @@
     { "name": "Mirrors", "type": "[]ListedMirror", "versions": "0+",
       "about": "Each mirror in the response.", "fields": [
       { "name": "MirrorName", "type": "string", "versions": "0+",
-        "about": "The mirror name." }
+        "about": "The mirror name." },
+      { "name": "SourceBootstrap", "type": "string", "versions": "0+",
+        "about": "The source cluster bootstrap servers." }
     ]}
   ]
 }

--- a/clients/src/main/resources/common/message/ListMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/ListMirrorsResponse.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 98,
+  "type": "response",
+  "name": "ListMirrorsResponse",
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+", "ignorable": true,
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "Mirrors", "type": "[]ListedMirror", "versions": "0+",
+      "about": "Each mirror in the response.", "fields": [
+      { "name": "MirrorName", "type": "string", "versions": "0+",
+        "about": "The mirror name." }
+    ]}
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -737,6 +737,13 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public synchronized ListMirrorsResult listMirrors(ListMirrorsOptions options) {
+        KafkaFutureImpl<Collection<Object>> future = new KafkaFutureImpl<>();
+        future.complete(Collections.emptyList());
+        return new ListMirrorsResult(future);
+    }
+
+    @Override
     public synchronized DescribeConsumerGroupsResult describeConsumerGroups(Collection<String> groupIds, DescribeConsumerGroupsOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -609,6 +609,13 @@ public class MirrorCoordinator {
     }
 
     /**
+     * Returns all mirror names managed by this node.
+     */
+    public Set<String> getAllMirrorNames() {
+        return mirrorMetadataManager.getAllMirrorNames();
+    }
+
+    /**
      * Shuts down the mirror coordinator and releases all resources.
      * Stops periodic metadata refresh and closes metrics.
      */

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -616,6 +616,16 @@ public class MirrorCoordinator {
     }
 
     /**
+     * Returns the source cluster bootstrap servers for a given mirror.
+     *
+     * @param mirrorName the name of the cluster mirror
+     * @return the bootstrap servers string, or null if not found
+     */
+    public String getSourceBootstrap(String mirrorName) {
+        return mirrorMetadataManager.getSourceBootstrap(mirrorName);
+    }
+
+    /**
      * Shuts down the mirror coordinator and releases all resources.
      * Stops periodic metadata refresh and closes metrics.
      */

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -898,6 +898,19 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
+     * Returns the source cluster bootstrap servers for a given mirror.
+     *
+     * @param mirrorName the name of the cluster mirror
+     * @return the bootstrap servers string, or null if not found
+     */
+    public String getSourceBootstrap(String mirrorName) {
+        Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName));
+        return Optional.ofNullable(props.get(BOOTSTRAP_SERVERS_CONFIG))
+                .map(Object::toString)
+                .orElse(null);
+    }
+
+    /**
      * Clears all cached mirror metadata including topics and remote broker connections.
      * Called when the broker resigns as leader for mirror state topic partitions.
      */

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -891,6 +891,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private record ACLChanges(List<AclBinding> aclsToAdd, List<AclBinding> aclsToDelete) { }
 
     /**
+     * Returns mirror names managed by this node.
+     */
+    public Set<String> getAllMirrorNames() {
+        return new HashSet<>(topics.keySet());
+    }
+
+    /**
      * Clears all cached mirror metadata including topics and remote broker connections.
      * Called when the broker resigns as leader for mirror state topic partitions.
      */

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -347,7 +347,10 @@ class KafkaApis(val requestChannel: RequestChannel,
       val mirrorNames = mirrorCoordinator.getAllMirrorNames()
       val mirrors = new util.ArrayList[ListMirrorsResponseData.ListedMirror]()
       mirrorNames.forEach(mirrorName => {
-        mirrors.add(new ListMirrorsResponseData.ListedMirror().setMirrorName(mirrorName))
+        val sourceBootstrap = mirrorCoordinator.getSourceBootstrap(mirrorName)
+        mirrors.add(new ListMirrorsResponseData.ListedMirror()
+          .setMirrorName(mirrorName)
+          .setSourceBootstrap(if (sourceBootstrap != null) sourceBootstrap else ""))
       })
       responseData.setMirrors(mirrors)
       responseData.setErrorCode(Errors.NONE.code)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -255,6 +255,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.CREATE_MIRROR => forwardToController(request)
         case ApiKeys.ADD_TOPICS_TO_MIRROR => handleAddTopicsToMirror(request)
         case ApiKeys.REMOVE_TOPICS_FROM_MIRROR => handleRemoveTopicsFromMirror(request)
+        case ApiKeys.LIST_MIRRORS => handleListMirrorsRequest(request)
         case ApiKeys.LAST_MIRRORED_OFFSETS => handleLastMirroredOffset(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
@@ -337,6 +338,24 @@ class KafkaApis(val requestChannel: RequestChannel,
     // update the cached topics in coordinator
     mirrorCoordinator.transitionTo(removeTopicsFromMirrorRequest.data().mirrorName(), mirrorTopics, MirrorPartitionState.STOPPING)
     forwardToController(request)
+  }
+
+  def handleListMirrorsRequest(request: RequestChannel.Request): Unit = {
+    val responseData = new ListMirrorsResponseData()
+
+    if (authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
+      val mirrorNames = mirrorCoordinator.getAllMirrorNames()
+      val mirrors = new util.ArrayList[ListMirrorsResponseData.ListedMirror]()
+      mirrorNames.forEach(mirrorName => {
+        mirrors.add(new ListMirrorsResponseData.ListedMirror().setMirrorName(mirrorName))
+      })
+      responseData.setMirrors(mirrors)
+      responseData.setErrorCode(Errors.NONE.code)
+    } else {
+      responseData.setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)
+    }
+
+    requestHelper.sendMaybeThrottle(request, new ListMirrorsResponse(responseData))
   }
 
   def handleGetReplicaLogInfo(request: RequestChannel.Request): Unit = {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -124,6 +124,8 @@ import org.apache.kafka.clients.admin.ListConsumerGroupsOptions;
 import org.apache.kafka.clients.admin.ListConsumerGroupsResult;
 import org.apache.kafka.clients.admin.ListGroupsOptions;
 import org.apache.kafka.clients.admin.ListGroupsResult;
+import org.apache.kafka.clients.admin.ListMirrorsOptions;
+import org.apache.kafka.clients.admin.ListMirrorsResult;
 import org.apache.kafka.clients.admin.ListOffsetsOptions;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListPartitionReassignmentsOptions;
@@ -301,6 +303,11 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     @Override
     public ListGroupsResult listGroups(final ListGroupsOptions options) {
         return adminDelegate.listGroups(options);
+    }
+
+    @Override
+    public ListMirrorsResult listMirrors(final ListMirrorsOptions options) {
+        return adminDelegate.listMirrors(options);
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -265,7 +265,11 @@ public abstract class MirrorCommand {
         public void listMirrors() throws ExecutionException, InterruptedException {
             ListMirrorsResult result = adminClient.listMirrors();
             for (MirrorListing listing : result.all().get()) {
-                System.out.println(listing.mirrorName());
+                String output = listing.mirrorName();
+                if (listing.sourceBootstrap() != null && !listing.sourceBootstrap().isEmpty()) {
+                    output += " (source bootstrap: " + listing.sourceBootstrap() + ")";
+                }
+                System.out.println(output);
             }
         }
 

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -26,6 +26,8 @@ import org.apache.kafka.clients.admin.CreateMirrorResult;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.FindCoordinatorResult;
+import org.apache.kafka.clients.admin.ListMirrorsResult;
+import org.apache.kafka.clients.admin.MirrorListing;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.RemoveTopicsFromMirrorOptions;
 import org.apache.kafka.clients.admin.RemoveTopicsFromMirrorResult;
@@ -84,6 +86,8 @@ public abstract class MirrorCommand {
                 mirrorService.addTopicsToMirror(opts);
             } else if (opts.hasRemoveOption()) {
                 mirrorService.removeTopicsFromMirror(opts);
+            } else if (opts.hasListOption()) {
+                mirrorService.listMirrors();
             }
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
@@ -258,6 +262,13 @@ public abstract class MirrorCommand {
             }
         }
 
+        public void listMirrors() throws ExecutionException, InterruptedException {
+            ListMirrorsResult result = adminClient.listMirrors();
+            for (MirrorListing listing : result.all().get()) {
+                System.out.println(listing.mirrorName());
+            }
+        }
+
         @Override
         public void close() throws Exception {
             adminClient.close();
@@ -271,6 +282,7 @@ public abstract class MirrorCommand {
         private final OptionSpecBuilder createOpt;
         private final OptionSpecBuilder addOpt;
         private final OptionSpecBuilder removeOpt;
+        private final OptionSpecBuilder listOpt;
         private final ArgumentAcceptingOptionSpec<String> mirrorOpt;
         private final ArgumentAcceptingOptionSpec<String> topicOpt;
         private final ArgumentAcceptingOptionSpec<Short> replicationFactorOpt;
@@ -296,6 +308,7 @@ public abstract class MirrorCommand {
             createOpt = parser.accepts("create", "Create a new cluster mirror from a source cluster.");
             addOpt = parser.accepts("add", "Add topic(s) to an existing cluster mirror (supports regex).");
             removeOpt = parser.accepts("remove", "Remove topic(s) from an existing cluster mirror (supports regex).");
+            listOpt = parser.accepts("list", "List all cluster mirrors.");
 
             mirrorOpt = parser.accepts("mirror", "The name of the cluster mirror.")
                 .withRequiredArg()
@@ -334,6 +347,10 @@ public abstract class MirrorCommand {
 
         public boolean hasRemoveOption() {
             return has(removeOpt);
+        }
+
+        public boolean hasListOption() {
+            return has(listOpt);
         }
 
         public Optional<String> bootstrapServer() {
@@ -376,15 +393,15 @@ public abstract class MirrorCommand {
             CommandLineUtils.maybePrintHelpOrVersion(this, "This tool helps to create cluster mirrors and add topics to them.");
 
             // should have exactly one action
-            long actions = (has(createOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0) + (has(removeOpt) ? 1 : 0);
+            long actions = (has(createOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0) + (has(removeOpt) ? 1 : 0) + (has(listOpt) ? 1 : 0);
             if (actions != 1)
-                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create or --add");
+                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --add, --remove, or --list");
 
             // check required args
             if (!has(bootstrapServerOpt))
                 throw new IllegalArgumentException("--bootstrap-server must be specified");
 
-            if (!has(mirrorOpt))
+            if (!has(listOpt) && !has(mirrorOpt))
                 throw new IllegalArgumentException("--mirror must be specified");
 
             if (has(createOpt) && !has(mirrorConfigOpt))


### PR DESCRIPTION
This patch adds the list mirrors operation (API, admin, tool).

Example:

```sh
$ bin/kafka-mirrors.sh --bootstrap-server  :"${server4[lis]}" --list
my-mirror
my-mirror-2
```
