### PR TITLE
Add describe mirrors operation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1726,6 +1726,33 @@ public interface Admin extends AutoCloseable {
     RemoveTopicsFromMirrorResult removeTopicsFromMirror(String mirrorName, Set<String> topics, RemoveTopicsFromMirrorOptions options);
 
     /**
+     * Describe cluster mirrors with the default options.
+     *
+     * <p>This is a convenience method for {@link #describeMirrors(Collection, DescribeMirrorsOptions)}
+     * with default options. See the overload for more details.
+     *
+     * @param mirrorNames The names of the mirrors to describe
+     * @return The DescribeMirrorsResult
+     */
+    default DescribeMirrorsResult describeMirrors(Collection<String> mirrorNames) {
+        return describeMirrors(mirrorNames, new DescribeMirrorsOptions());
+    }
+
+    /**
+     * Describe cluster mirrors.
+     *
+     * This operation retrieves detailed information about cluster mirrors including:
+     * - Topics being mirrored
+     * - Partition-level lag information (source offset vs destination offset)
+     * - Mirroring state for each partition (INITIALIZING, PREPARING, MIRRORING, etc.)
+     *
+     * @param mirrorNames The names of the mirrors to describe
+     * @param options The options to use when describing mirrors
+     * @return The DescribeMirrorsResult
+     */
+    DescribeMirrorsResult describeMirrors(Collection<String> mirrorNames, DescribeMirrorsOptions options);
+
+    /**
      * Describe producer state on a set of topic partitions. See
      * {@link #describeProducers(Collection, DescribeProducersOptions)} for more details.
      *

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeMirrorsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeMirrorsOptions.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Options for {@link Admin#describeMirrors(java.util.Collection, DescribeMirrorsOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeMirrorsOptions extends AbstractOptions<DescribeMirrorsOptions> {
+
+    private boolean includeAuthorizedOperations = false;
+
+    /**
+     * Set whether authorized operations should be included in the response.
+     *
+     * @param includeAuthorizedOperations whether to include authorized operations
+     * @return this instance
+     */
+    public DescribeMirrorsOptions includeAuthorizedOperations(boolean includeAuthorizedOperations) {
+        this.includeAuthorizedOperations = includeAuthorizedOperations;
+        return this;
+    }
+
+    /**
+     * Return true if authorized operations should be included in the response.
+     */
+    public boolean includeAuthorizedOperations() {
+        return includeAuthorizedOperations;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeMirrorsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeMirrorsResult.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Map;
+
+/**
+ * The result of the {@link Admin#describeMirrors(java.util.Collection)} call.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeMirrorsResult {
+    private final KafkaFuture<Map<String, MirrorDescription>> future;
+
+    DescribeMirrorsResult(KafkaFuture<Map<String, MirrorDescription>> future) {
+        this.future = future;
+    }
+
+    /**
+     * Return a future which succeeds only if all the mirror descriptions succeed.
+     */
+    public KafkaFuture<Map<String, MirrorDescription>> allDescriptions() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -286,6 +286,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public DescribeMirrorsResult describeMirrors(Collection<String> mirrorNames, DescribeMirrorsOptions options) {
+        return delegate.describeMirrors(mirrorNames, options);
+    }
+
+    @Override
     public AddTopicsToMirrorResult addTopicsToMirror(Map<String, String> topicToMirrorName, AddTopicsToMirrorOptions options) {
         return delegate.addTopicsToMirror(topicToMirrorName, options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -148,6 +148,8 @@ import org.apache.kafka.common.message.DescribeConfigsResponseData;
 import org.apache.kafka.common.message.DescribeLogDirsRequestData;
 import org.apache.kafka.common.message.DescribeLogDirsRequestData.DescribableLogDirTopic;
 import org.apache.kafka.common.message.DescribeLogDirsResponseData;
+import org.apache.kafka.common.message.DescribeMirrorsRequestData;
+import org.apache.kafka.common.message.DescribeMirrorsResponseData;
 import org.apache.kafka.common.message.DescribeQuorumResponseData;
 import org.apache.kafka.common.message.DescribeTopicPartitionsRequestData;
 import org.apache.kafka.common.message.DescribeTopicPartitionsRequestData.TopicRequest;
@@ -227,6 +229,8 @@ import org.apache.kafka.common.requests.DescribeDelegationTokenRequest;
 import org.apache.kafka.common.requests.DescribeDelegationTokenResponse;
 import org.apache.kafka.common.requests.DescribeLogDirsRequest;
 import org.apache.kafka.common.requests.DescribeLogDirsResponse;
+import org.apache.kafka.common.requests.DescribeMirrorsRequest;
+import org.apache.kafka.common.requests.DescribeMirrorsResponse;
 import org.apache.kafka.common.requests.DescribeQuorumRequest;
 import org.apache.kafka.common.requests.DescribeQuorumRequest.Builder;
 import org.apache.kafka.common.requests.DescribeQuorumResponse;
@@ -5062,6 +5066,200 @@ public class KafkaAdminClient extends AdminClient {
         };
         runnable.call(call, now);
         return new RemoveTopicsFromMirrorResult(future);
+    }
+
+    private static final class DescribeMirrorsResults {
+        // Accumulated MirrorDescription data from all brokers
+        private static class PartialMirrorDescription {
+            final String mirrorName;
+            final Map<String, Set<MirrorDescription.LeaderState>> topicPartitions;
+            final Set<Integer> authorizedOps;
+            Throwable error;
+
+            PartialMirrorDescription(String mirrorName) {
+                this.mirrorName = mirrorName;
+                this.topicPartitions = new HashMap<>();
+                this.authorizedOps = new HashSet<>();
+                this.error = null;
+            }
+
+            void merge(DescribeMirrorsResponseData.DescribedMirror mirror) {
+                Errors errorCode = Errors.forCode(mirror.errorCode());
+                if (errorCode != Errors.NONE) {
+                    if (this.error == null) {
+                        this.error = errorCode.exception();
+                    }
+                    return;
+                }
+
+                // Merge topic partitions
+                for (DescribeMirrorsResponseData.TopicPartitions topic : mirror.topics()) {
+                    Set<MirrorDescription.LeaderState> partitions =
+                        topicPartitions.computeIfAbsent(topic.topicName(), k -> new HashSet<>());
+
+                    for (DescribeMirrorsResponseData.PartitionDetail partition : topic.partitions()) {
+                        TopicPartition tp = new TopicPartition(topic.topicName(), partition.partitionIndex());
+                        MirrorDescription.LeaderState leaderState =
+                            new MirrorDescription.LeaderState(
+                                tp,
+                                partition.sourceOffset(),
+                                partition.destinationOffset(),
+                                partition.lag(),
+                                partition.state()
+                            );
+                        partitions.add(leaderState);
+                    }
+                }
+
+                // Merge authorized operations
+                if (mirror.authorizedOperations() != -2147483648) {
+                    authorizedOps.add(mirror.authorizedOperations());
+                }
+            }
+
+            MirrorDescription toMirrorDescription() {
+                return new MirrorDescription(
+                    mirrorName,
+                    topicPartitions,
+                    authorizedOps.isEmpty() ? Collections.emptySet() : authorizedOps
+                );
+            }
+        }
+
+        private final Map<String, PartialMirrorDescription> partialDescriptions;
+        private final Set<String> requestedMirrors;
+        private final boolean describeAll;
+        private final HashSet<Node> remaining;
+        private final KafkaFutureImpl<Map<String, MirrorDescription>> allFuture;
+
+        DescribeMirrorsResults(Collection<Node> brokers,
+                               Collection<String> mirrorNames,
+                               KafkaFutureImpl<Map<String, MirrorDescription>> allFuture) {
+            this.partialDescriptions = new HashMap<>();
+            this.requestedMirrors = new HashSet<>(mirrorNames);
+            this.describeAll = mirrorNames.isEmpty();
+            this.remaining = new HashSet<>(brokers);
+            this.allFuture = allFuture;
+
+            // Pre-populate partial descriptions only if specific mirrors are requested
+            if (!describeAll) {
+                for (String mirrorName : mirrorNames) {
+                    partialDescriptions.put(mirrorName, new PartialMirrorDescription(mirrorName));
+                }
+            }
+            tryComplete();
+        }
+
+        synchronized void handleMirror(DescribeMirrorsResponseData.DescribedMirror mirror) {
+            // Skip if not requested (only in non-describeAll mode)
+            if (!describeAll && !requestedMirrors.contains(mirror.mirrorName())) {
+                return;
+            }
+
+            // Get or create partial description
+            PartialMirrorDescription partial = partialDescriptions.get(mirror.mirrorName());
+            if (partial == null) {
+                partial = new PartialMirrorDescription(mirror.mirrorName());
+                partialDescriptions.put(mirror.mirrorName(), partial);
+            }
+
+            // Merge this broker's data
+            partial.merge(mirror);
+        }
+
+        synchronized void tryComplete(Node broker) {
+            remaining.remove(broker);
+            tryComplete();
+        }
+
+        private synchronized void tryComplete() {
+            if (remaining.isEmpty()) {
+                Map<String, MirrorDescription> descriptions = new HashMap<>(partialDescriptions.size());
+                for (Map.Entry<String, PartialMirrorDescription> entry : partialDescriptions.entrySet()) {
+                    PartialMirrorDescription partial = entry.getValue();
+                    if (partial.error != null) {
+                        // If there was an error for this mirror, we could either skip it or throw
+                        // For now, we'll skip mirrors with errors
+                        continue;
+                    }
+                    descriptions.put(entry.getKey(), partial.toMirrorDescription());
+                }
+                allFuture.complete(descriptions);
+            }
+        }
+
+        synchronized void completeAllExceptionally(Throwable throwable) {
+            if (!allFuture.isDone()) {
+                allFuture.completeExceptionally(throwable);
+            }
+        }
+    }
+
+    @Override
+    public DescribeMirrorsResult describeMirrors(Collection<String> mirrorNames, DescribeMirrorsOptions options) {
+        final KafkaFutureImpl<Map<String, MirrorDescription>> all = new KafkaFutureImpl<>();
+        final long nowMetadata = time.milliseconds();
+        final long deadline = calcDeadlineMs(nowMetadata, options.timeoutMs());
+        // Send describe mirrors RPCs to all brokers and merge results
+        runnable.call(new Call("findAllBrokers", deadline, new LeastLoadedNodeProvider()) {
+            @Override
+            MetadataRequest.Builder createRequest(int timeoutMs) {
+                return new MetadataRequest.Builder(new MetadataRequestData()
+                    .setTopics(Collections.emptyList())
+                    .setAllowAutoTopicCreation(true));
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                MetadataResponse metadataResponse = (MetadataResponse) abstractResponse;
+                Collection<Node> nodes = metadataResponse.brokers();
+                if (nodes.isEmpty())
+                    throw new StaleMetadataException("Metadata fetch failed due to missing broker list");
+
+                HashSet<Node> allNodes = new HashSet<>(nodes);
+                final DescribeMirrorsResults results = new DescribeMirrorsResults(allNodes, mirrorNames, all);
+
+                for (final Node node : allNodes) {
+                    final long nowDescribe = time.milliseconds();
+                    runnable.call(new Call("describeMirrors", deadline, new ConstantNodeIdProvider(node.id())) {
+                        @Override
+                        DescribeMirrorsRequest.Builder createRequest(int timeoutMs) {
+                            DescribeMirrorsRequestData data = new DescribeMirrorsRequestData()
+                                .setMirrorNames(new ArrayList<>(mirrorNames))
+                                .setIncludeAuthorizedOperations(options.includeAuthorizedOperations());
+                            return new DescribeMirrorsRequest.Builder(data);
+                        }
+
+                        @Override
+                        void handleResponse(AbstractResponse abstractResponse) {
+                            final DescribeMirrorsResponse response = (DescribeMirrorsResponse) abstractResponse;
+                            synchronized (results) {
+                                for (DescribeMirrorsResponseData.DescribedMirror mirror : response.data().mirrors()) {
+                                    results.handleMirror(mirror);
+                                }
+                                results.tryComplete(node);
+                            }
+                        }
+
+                        @Override
+                        void handleFailure(Throwable throwable) {
+                            synchronized (results) {
+                                results.completeAllExceptionally(throwable);
+                                results.tryComplete(node);
+                            }
+                        }
+                    }, nowDescribe);
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                KafkaException exception = new KafkaException("Failed to find brokers to send DescribeMirrors", throwable);
+                all.completeExceptionally(exception);
+            }
+        }, nowMetadata);
+
+        return new DescribeMirrorsResult(all);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MirrorDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MirrorDescription.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A detailed description of a single mirror.
+ */
+@InterfaceStability.Evolving
+public class MirrorDescription {
+    private final String mirrorName;
+    private final Map<String, Set<LeaderState>> topics;
+    private final Set<Integer> authorizedOperations;
+
+    public MirrorDescription(String mirrorName,
+                             Map<String, Set<LeaderState>> topics,
+                             Set<Integer> authorizedOperations) {
+        this.mirrorName = mirrorName;
+        this.topics = Collections.unmodifiableMap(topics);
+        this.authorizedOperations = authorizedOperations;
+    }
+
+    public String mirrorName() {
+        return mirrorName;
+    }
+
+    public Map<String, Set<LeaderState>> topics() {
+        return topics;
+    }
+
+    public Set<Integer> authorizedOperations() {
+        return authorizedOperations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MirrorDescription that = (MirrorDescription) o;
+        return Objects.equals(mirrorName, that.mirrorName) &&
+               Objects.equals(topics, that.topics) &&
+               Objects.equals(authorizedOperations, that.authorizedOperations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mirrorName, topics, authorizedOperations);
+    }
+
+    @Override
+    public String toString() {
+        return "MirrorDescription{" +
+               "mirrorName='" + mirrorName + '\'' +
+               ", topics=" + topics +
+               ", authorizedOperations=" + authorizedOperations +
+               '}';
+    }
+
+    /**
+     * Represents the mirroring state of the leader partition.
+     */
+    public static class LeaderState {
+        private final TopicPartition topicPartition;
+        private final long sourceOffset;
+        private final long destinationOffset;
+        private final long lag;
+        private final String state;
+
+        public LeaderState(TopicPartition topicPartition,
+                           long sourceOffset,
+                           long destinationOffset,
+                           long lag,
+                           String state) {
+            this.topicPartition = topicPartition;
+            this.sourceOffset = sourceOffset;
+            this.destinationOffset = destinationOffset;
+            this.lag = lag;
+            this.state = state;
+        }
+
+        public TopicPartition topicPartition() {
+            return topicPartition;
+        }
+
+        public long sourceOffset() {
+            return sourceOffset;
+        }
+
+        public long destinationOffset() {
+            return destinationOffset;
+        }
+
+        public long lag() {
+            return lag;
+        }
+
+        public String state() {
+            return state;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LeaderState that = (LeaderState) o;
+            return sourceOffset == that.sourceOffset &&
+                   destinationOffset == that.destinationOffset &&
+                   lag == that.lag &&
+                   Objects.equals(topicPartition, that.topicPartition) &&
+                   Objects.equals(state, that.state);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(topicPartition, sourceOffset, destinationOffset, lag, state);
+        }
+
+        @Override
+        public String toString() {
+            return "PartitionMirrorState{" +
+                   "topicPartition=" + topicPartition +
+                   ", sourceOffset=" + sourceOffset +
+                   ", destinationOffset=" + destinationOffset +
+                   ", lag=" + lag +
+                   ", state='" + state + '\'' +
+                   '}';
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -140,7 +140,8 @@ public enum ApiKeys {
     ADD_TOPICS_TO_MIRROR(ApiMessageType.ADD_TOPICS_TO_MIRROR, false, true),
     REMOVE_TOPICS_FROM_MIRROR(ApiMessageType.REMOVE_TOPICS_FROM_MIRROR, false, true),
     LAST_MIRRORED_OFFSETS(ApiMessageType.LAST_MIRRORED_OFFSETS),
-    LIST_MIRRORS(ApiMessageType.LIST_MIRRORS);
+    LIST_MIRRORS(ApiMessageType.LIST_MIRRORS),
+    DESCRIBE_MIRRORS(ApiMessageType.DESCRIBE_MIRRORS);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -364,6 +364,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return RemoveTopicsFromMirrorRequest.parse(readable, apiVersion);
             case LIST_MIRRORS:
                 return ListMirrorsRequest.parse(readable, apiVersion);
+            case DESCRIBE_MIRRORS:
+                return DescribeMirrorsRequest.parse(readable, apiVersion);
             case LAST_MIRRORED_OFFSETS:
                 return LastMirroredOffsetsRequest.parse(readable, apiVersion);
             default:

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -301,6 +301,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return RemoveTopicsFromMirrorResponse.parse(readable, version);
             case LIST_MIRRORS:
                 return ListMirrorsResponse.parse(readable, version);
+            case DESCRIBE_MIRRORS:
+                return DescribeMirrorsResponse.parse(readable, version);
             case LAST_MIRRORED_OFFSETS:
                 return LastMirroredOffsetsResponse.parse(readable, version);
             default:

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeMirrorsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeMirrorsRequest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.DescribeMirrorsRequestData;
+import org.apache.kafka.common.message.DescribeMirrorsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Collections;
+
+/**
+ * Possible error codes:
+ *
+ * CLUSTER_AUTHORIZATION_FAILED (31)
+ */
+public class DescribeMirrorsRequest extends AbstractRequest {
+
+    public static class Builder extends AbstractRequest.Builder<DescribeMirrorsRequest> {
+
+        private final DescribeMirrorsRequestData data;
+
+        public Builder(DescribeMirrorsRequestData data) {
+            super(ApiKeys.DESCRIBE_MIRRORS);
+            this.data = data;
+        }
+
+        @Override
+        public DescribeMirrorsRequest build(short version) {
+            return new DescribeMirrorsRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final DescribeMirrorsRequestData data;
+
+    public DescribeMirrorsRequest(DescribeMirrorsRequestData data, short version) {
+        super(ApiKeys.DESCRIBE_MIRRORS, version);
+        this.data = data;
+    }
+
+    @Override
+    public DescribeMirrorsResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        DescribeMirrorsResponseData describeMirrorsResponseData = new DescribeMirrorsResponseData()
+            .setMirrors(Collections.emptyList())
+            .setThrottleTimeMs(throttleTimeMs);
+        return new DescribeMirrorsResponse(describeMirrorsResponseData);
+    }
+
+    public static DescribeMirrorsRequest parse(Readable readable, short version) {
+        return new DescribeMirrorsRequest(new DescribeMirrorsRequestData(readable, version), version);
+    }
+
+    @Override
+    public DescribeMirrorsRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeMirrorsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeMirrorsResponse.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.DescribeMirrorsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DescribeMirrorsResponse extends AbstractResponse {
+
+    private final DescribeMirrorsResponseData data;
+
+    public DescribeMirrorsResponse(DescribeMirrorsResponseData data) {
+        super(ApiKeys.DESCRIBE_MIRRORS);
+        this.data = data;
+    }
+
+    @Override
+    public DescribeMirrorsResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Map<Errors, Integer> errorCounts = new HashMap<>();
+        data.mirrors().forEach(mirror ->
+            updateErrorCounts(errorCounts, Errors.forCode(mirror.errorCode()))
+        );
+        return errorCounts;
+    }
+
+    public static DescribeMirrorsResponse parse(Readable readable, short version) {
+        return new DescribeMirrorsResponse(new DescribeMirrorsResponseData(readable, version));
+    }
+
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+}

--- a/clients/src/main/resources/common/message/DescribeMirrorsRequest.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsRequest.json
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 99,
+  "type": "request",
+  "listeners": ["broker"],
+  "name": "DescribeMirrorsRequest",
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "MirrorNames", "type": "[]string", "versions": "0+",
+      "about": "The names of the mirrors to describe. Null or empty array means all mirrors." },
+    { "name": "IncludeAuthorizedOperations", "type": "bool", "versions": "0+", "default": "false",
+      "about": "Whether to include authorized operations." }
+  ]
+}

--- a/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 99,
+  "type": "response",
+  "name": "DescribeMirrorsResponse",
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "Mirrors", "type": "[]DescribedMirror", "versions": "0+",
+      "about": "Each described mirror.", "fields": [
+      { "name": "ErrorCode", "type": "int16", "versions": "0+",
+        "about": "The error code, or 0 if there was no error." },
+      { "name": "MirrorName", "type": "string", "versions": "0+",
+        "about": "The mirror name." },
+      { "name": "Topics", "type": "[]TopicPartitions", "versions": "0+",
+        "about": "Each topic in the mirror.", "fields": [
+        { "name": "TopicName", "type": "string", "versions": "0+",
+          "about": "The topic name." },
+        { "name": "Partitions", "type": "[]PartitionDetail", "versions": "0+",
+          "about": "Each partition detail.", "fields": [
+          { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+            "about": "The partition index." },
+          { "name": "SourceOffset", "type": "int64", "versions": "0+",
+            "about": "The high watermark offset from the source cluster leader." },
+          { "name": "DestinationOffset", "type": "int64", "versions": "0+",
+            "about": "The log end offset on the destination cluster." },
+          { "name": "Lag", "type": "int64", "versions": "0+",
+            "about": "The lag (source offset - destination offset)." },
+          { "name": "State", "type": "string", "versions": "0+",
+            "about": "The partition state (INITIALIZING, PREPARING, MIRRORING, STOPPING, STOPPED, FAILED)." }
+        ]}
+      ]},
+      { "name": "AuthorizedOperations", "type": "int32", "versions": "0+", "default": "-2147483648",
+        "about": "32-bit bitfield to represent authorized operations for this mirror." }
+    ]}
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1393,6 +1393,23 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public synchronized DescribeMirrorsResult describeMirrors(Collection<String> mirrorNames, DescribeMirrorsOptions options) {
+        Map<String, MirrorDescription> descriptions = new HashMap<>();
+        for (String mirrorName : mirrorNames) {
+            // Return empty description for mock
+            MirrorDescription description = new MirrorDescription(
+                mirrorName,
+                Collections.emptyMap(),
+                Collections.emptySet()
+            );
+            descriptions.put(mirrorName, description);
+        }
+        KafkaFutureImpl<Map<String, MirrorDescription>> future = new KafkaFutureImpl<>();
+        future.complete(descriptions);
+        return new DescribeMirrorsResult(future);
+    }
+
+    @Override
     public DescribeProducersResult describeProducers(Collection<TopicPartition> partitions, DescribeProducersOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -146,7 +146,7 @@ public class MirrorCoordinator {
                 break;
             case MIRRORING:
                 LOG.info("!!! Mirroring topics {}.", topics);
-                mirrorMetadataManager.invokeMirroringCallbacks(mirrorName, topics);
+                mirrorMetadataManager.invokeMirroringCallback(mirrorName, topics);
                 break;
             case STOPPING:
                 LOG.info("!!! Stopping mirror for topics {}.", topics);
@@ -611,8 +611,8 @@ public class MirrorCoordinator {
     /**
      * Returns mirror names managed by this node.
      */
-    public Set<String> getAllMirrorNames() {
-        return mirrorMetadataManager.getAllMirrorNames();
+    public Set<String> getMirrorNames() {
+        return mirrorMetadataManager.getMirrorNames();
     }
 
     /**

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -199,7 +199,7 @@ public class MirrorCoordinator {
     public void transitionTo(String mirrorName, TopicPartition topicPartition, MirrorPartitionState newState, boolean executeActions) {
         LOG.info("!!! Transitioning partition {} from {} to {}.", topicPartition,
                 mirrorMetadataManager.getMirrorPartitionState(mirrorName, topicPartition), newState);
-        updateMirrorPartitionStateMetadata(mirrorName, topicPartition, newState);
+        updateMirrorPartitionState(mirrorName, topicPartition, newState);
         if (executeActions) {
             handleStateTransition(mirrorName, Set.of(topicPartition.topic()), newState);
         }
@@ -231,7 +231,7 @@ public class MirrorCoordinator {
         updateLastMirroredOffsetsMetadata(mirrorName, partitionOffsets);
     }
 
-    public void updateMirrorPartitionStateMetadata(String mirrorName, TopicPartition topicPartition, MirrorPartitionState newState) {
+    public void updateMirrorPartitionState(String mirrorName, TopicPartition topicPartition, MirrorPartitionState newState) {
         var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, getPartitionIndexForKey(new MirrorRecordKey(mirrorName)));
         var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
         var record = generateMirrorPartitionState(mirrorName, topicPartition, newState);

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -609,7 +609,7 @@ public class MirrorCoordinator {
     }
 
     /**
-     * Returns all mirror names managed by this node.
+     * Returns mirror names managed by this node.
      */
     public Set<String> getAllMirrorNames() {
         return mirrorMetadataManager.getAllMirrorNames();
@@ -623,6 +623,16 @@ public class MirrorCoordinator {
      */
     public String getSourceBootstrap(String mirrorName) {
         return mirrorMetadataManager.getSourceBootstrap(mirrorName);
+    }
+
+    /**
+     * Get all topic partitions for a given mirror along with their states.
+     *
+     * @param mirrorName the name of the cluster mirror
+     * @return partition state map
+     */
+    public Map<TopicPartition, MirrorPartitionState> getMirrorPartitions(String mirrorName) {
+        return mirrorMetadataManager.getMirrorPartitions(mirrorName);
     }
 
     /**

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -911,7 +911,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
-     * Get all topic partitions for a given mirror along with their states.
+     * Get topic partitions for a given mirror along with their states.
      *
      * @param mirrorName the name of the cluster mirror
      * @return partition state map

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -911,11 +911,28 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
-     * Clears all cached mirror metadata including topics and remote broker connections.
+     * Get all topic partitions for a given mirror along with their states.
+     *
+     * @param mirrorName the name of the cluster mirror
+     * @return partition state map
+     */
+    public Map<TopicPartition, MirrorPartitionState> getMirrorPartitions(String mirrorName) {
+        Map<TopicPartition, MirrorPartitionState> result = new HashMap<>();
+        mirrorPartitionState.forEach((key, state) -> {
+            if (key.mirrorName().equals(mirrorName)) {
+                result.put(new TopicPartition(key.topic(), key.partition()), state);
+            }
+        });
+        return result;
+    }
+
+    /**
+     * Clears all cached mirror metadata including topics, partition state and remote broker connections.
      * Called when the broker resigns as leader for mirror state topic partitions.
      */
     public void clear() {
         topics.clear();
+        mirrorPartitionState.clear();
         remoteBrokers.clear();
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -479,7 +479,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * @param mirrorName the name of the cluster mirror
      * @param topics the topics that have entered MIRRORING state
      */
-    public void invokeMirroringCallbacks(String mirrorName, Set<String> topics) {
+    public void invokeMirroringCallback(String mirrorName, Set<String> topics) {
         topics.forEach(topic -> metadataCache.numPartitions(topic).ifPresent(numPartitions -> {
             IntStream.range(0, numPartitions).forEach(i -> {
                 MirroredPartitionKey key = new MirroredPartitionKey(mirrorName, topic, i);
@@ -893,7 +893,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     /**
      * Returns mirror names managed by this node.
      */
-    public Set<String> getAllMirrorNames() {
+    public Set<String> getMirrorNames() {
         return new HashSet<>(topics.keySet());
     }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -256,6 +256,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.ADD_TOPICS_TO_MIRROR => handleAddTopicsToMirror(request)
         case ApiKeys.REMOVE_TOPICS_FROM_MIRROR => handleRemoveTopicsFromMirror(request)
         case ApiKeys.LIST_MIRRORS => handleListMirrorsRequest(request)
+        case ApiKeys.DESCRIBE_MIRRORS => handleDescribeMirrorsRequest(request)
         case ApiKeys.LAST_MIRRORED_OFFSETS => handleLastMirroredOffset(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
@@ -359,6 +360,66 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     requestHelper.sendMaybeThrottle(request, new ListMirrorsResponse(responseData))
+  }
+
+  def handleDescribeMirrorsRequest(request: RequestChannel.Request): Unit = {
+    val describeMirrorsRequest = request.body[DescribeMirrorsRequest]
+    val responseData = new DescribeMirrorsResponseData()
+
+    if (authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
+      val requestedMirrors = if (describeMirrorsRequest.data.mirrorNames.isEmpty) {
+        mirrorCoordinator.getAllMirrorNames().asScala.toSeq
+      } else {
+        describeMirrorsRequest.data.mirrorNames.asScala.toSeq
+      }
+
+      requestedMirrors.foreach { mirrorName =>
+        val describedMirror = new DescribeMirrorsResponseData.DescribedMirror()
+          .setMirrorName(mirrorName)
+          .setErrorCode(Errors.NONE.code)
+
+        // Get all partitions for this mirror from metadata manager
+        val mirrorPartitions = mirrorCoordinator.getMirrorPartitions(mirrorName).asScala
+
+        // Get lag information from mirror fetcher manager (only for partitions being actively fetched)
+        val lagInfoMap = replicaManager.getMirrorLagInfo(mirrorName)
+
+        // Group partitions by topic
+        val topicsMap = scala.collection.mutable.Map[String, DescribeMirrorsResponseData.TopicPartitions]()
+
+        // Process all partitions from metadata manager
+        mirrorPartitions.foreach { case (topicPartition, partitionState) =>
+          val topicName = topicPartition.topic()
+          val topicPartitions = topicsMap.getOrElseUpdate(topicName, {
+            val tp = new DescribeMirrorsResponseData.TopicPartitions().setTopicName(topicName)
+            tp.setPartitions(new util.ArrayList[DescribeMirrorsResponseData.PartitionDetail]())
+            tp
+          })
+
+          // Try to get lag info, if available
+          val lagInfo = lagInfoMap.get(topicPartition)
+
+          val partitionDetail = new DescribeMirrorsResponseData.PartitionDetail()
+            .setPartitionIndex(topicPartition.partition())
+            .setSourceOffset(lagInfo.map(_.sourceOffset).getOrElse(-1L))
+            .setDestinationOffset(lagInfo.map(_.destinationOffset).getOrElse(-1L))
+            .setLag(lagInfo.map(_.lag).getOrElse(-1L))
+            .setState(partitionState.name())
+
+          topicPartitions.partitions().add(partitionDetail)
+        }
+
+        val topicsList = new util.ArrayList[DescribeMirrorsResponseData.TopicPartitions]()
+        topicsMap.values.foreach(tp => topicsList.add(tp))
+        describedMirror.setTopics(topicsList)
+        responseData.mirrors().add(describedMirror)
+      }
+    } else {
+      // Authorization failed - return empty list with no error
+      // Individual mirror errors would be set per mirror if needed
+    }
+
+    requestHelper.sendMaybeThrottle(request, new DescribeMirrorsResponse(responseData))
   }
 
   def handleGetReplicaLogInfo(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -345,7 +345,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val responseData = new ListMirrorsResponseData()
 
     if (authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
-      val mirrorNames = mirrorCoordinator.getAllMirrorNames()
+      val mirrorNames = mirrorCoordinator.getMirrorNames()
       val mirrors = new util.ArrayList[ListMirrorsResponseData.ListedMirror]()
       mirrorNames.forEach(mirrorName => {
         val sourceBootstrap = mirrorCoordinator.getSourceBootstrap(mirrorName)
@@ -368,7 +368,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     if (authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
       val requestedMirrors = if (describeMirrorsRequest.data.mirrorNames.isEmpty) {
-        mirrorCoordinator.getAllMirrorNames().asScala.toSeq
+        mirrorCoordinator.getMirrorNames().asScala.toSeq
       } else {
         describeMirrorsRequest.data.mirrorNames.asScala.toSeq
       }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2671,8 +2671,9 @@ class ReplicaManager(val config: KafkaConfig,
   /**
    * Updates the mirroring lag for a partition.
    */
-  def updateMirrorLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long, lag: Long): Unit =
-    mirrorFetcherManager.updateLag(mirrorName, topicPartition, sourceOffset, destinationOffset, lag)
+  def updateMirrorLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long): Unit = {
+    mirrorFetcherManager.updateLag(mirrorName, topicPartition, sourceOffset, destinationOffset)
+  }
 
   /**
    * Retrieves lag information for a specific mirror.

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2670,13 +2670,20 @@ class ReplicaManager(val config: KafkaConfig,
 
   /**
    * Updates the mirroring lag for a partition.
+   *
+   * @param mirrorName mirror name
+   * @param topicPartition partition
+   * @param sourceOffset source HW
+   * @param destinationOffset destination HW
    */
-  def updateMirrorLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long): Unit = {
+  def updateMirrorLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long): Unit =
     mirrorFetcherManager.updateLag(mirrorName, topicPartition, sourceOffset, destinationOffset)
-  }
 
   /**
    * Retrieves lag information for a specific mirror.
+   *
+   * @param mirrorName mirror name
+   * @return lag info
    */
   def getMirrorLagInfo(mirrorName: String): Map[TopicPartition, MirrorLagInfo] =
     mirrorFetcherManager.getLagInfo(mirrorName)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -23,7 +23,7 @@ import kafka.log.LogManager
 import kafka.server.HostedPartition.Online
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
-import kafka.server.mirror.{MirrorFetcherManager, MirrorMetadataManager, MirrorPartitionState}
+import kafka.server.mirror.{MirrorFetcherManager, MirrorLagInfo, MirrorMetadataManager, MirrorPartitionState}
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
 import org.apache.kafka.common.{IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
@@ -2667,4 +2667,16 @@ class ReplicaManager(val config: KafkaConfig,
       () => ()
     )
   }
+
+  /**
+   * Updates the mirroring lag for a partition.
+   */
+  def updateMirrorLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long, lag: Long): Unit =
+    mirrorFetcherManager.updateLag(mirrorName, topicPartition, sourceOffset, destinationOffset, lag)
+
+  /**
+   * Retrieves lag information for a specific mirror.
+   */
+  def getMirrorLagInfo(mirrorName: String): Map[TopicPartition, MirrorLagInfo] =
+    mirrorFetcherManager.getLagInfo(mirrorName)
 }

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -138,8 +138,15 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
   override def removeFetcherForPartitions(partitions: scala.collection.Set[TopicPartition]): scala.collection.Map[TopicPartition, PartitionFetchState] = {
     val fetchStates = mutable.Map.empty[TopicPartition, PartitionFetchState]
     this.synchronized {
-      for (fetcher <- mirrorFetcherThreadMap.values)
-        fetchStates ++= fetcher.removePartitions(partitions)
+      for ((key, fetcher) <- mirrorFetcherThreadMap) {
+        val removed = fetcher.removePartitions(partitions)
+        fetchStates ++= removed
+        // Remove lag cache entries for partitions that were actually removed
+        for (partition <- removed.keys) {
+          val lagKey = MirrorPartitionKey(key.mirrorName, partition)
+          partitionLagCache.remove(lagKey)
+        }
+      }
       failedPartitions.removeAll(partitions)
     }
     if (partitions.nonEmpty)
@@ -174,17 +181,26 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
   }
 
   /**
-   * Updates the mirroring lag for a partition.
+   * Computes and updates the mirroring lag for a partition.
+   *
+   * @param mirrorName mirror name
+   * @param topicPartition partition
+   * @param sourceOffset source HW
+   * @param destinationOffset destination HW
    */
-  def updateLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long, lag: Long): Unit = {
+  def updateLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long): Unit = {
     this.synchronized {
       val key = MirrorPartitionKey(mirrorName, topicPartition)
+      val lag = Math.max(0, sourceOffset - destinationOffset)
       partitionLagCache.put(key, MirrorLagInfo(sourceOffset, destinationOffset, lag, time.milliseconds()))
     }
   }
 
   /**
    * Retrieves lag information for a specific mirror.
+   *
+   * @param mirrorName mirror name
+   * @return lag info
    */
   def getLagInfo(mirrorName: String): Map[TopicPartition, MirrorLagInfo] = {
     this.synchronized {

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -66,6 +66,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
       clientId = "MirrorReplica",
       numFetchers = brokerConfig.mirrorConfig.numReplicaFetchers) {
   private val mirrorFetcherThreadMap = new mutable.HashMap[BrokerAndFetcherIdWithMirror, MirrorFetcherThread]
+  private val partitionLagCache = new mutable.HashMap[MirrorPartitionKey, MirrorLagInfo]
 
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): MirrorFetcherThread = {
     throw new UnsupportedOperationException("Use createMirrorFetcherThread for mirror fetchers")
@@ -172,9 +173,31 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     }
   }
 
+  /**
+   * Updates the mirroring lag for a partition.
+   */
+  def updateLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long, lag: Long): Unit = {
+    this.synchronized {
+      val key = MirrorPartitionKey(mirrorName, topicPartition)
+      partitionLagCache.put(key, MirrorLagInfo(sourceOffset, destinationOffset, lag, time.milliseconds()))
+    }
+  }
+
+  /**
+   * Retrieves lag information for a specific mirror.
+   */
+  def getLagInfo(mirrorName: String): Map[TopicPartition, MirrorLagInfo] = {
+    this.synchronized {
+      partitionLagCache.collect {
+        case (key, lagInfo) if key.mirrorName == mirrorName => key.topicPartition -> lagInfo
+      }.toMap
+    }
+  }
+
   def shutdown(): Unit = {
     info("Shutting down MirrorFetcherManager")
     closeAllFetchers()
+    partitionLagCache.clear()
     info("MirrorFetcherManager shutdown completed")
   }
 }
@@ -209,3 +232,18 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
  * - Different fetcher ID -> NEW thread (load balancing)
  */
 case class BrokerAndFetcherIdWithMirror(sourceBroker: BrokerEndPoint, fetcherId: Int, mirrorName: String)
+
+/**
+ * Key for identifying a partition within a specific mirror.
+ */
+case class MirrorPartitionKey(mirrorName: String, topicPartition: TopicPartition)
+
+/**
+ * Lag information for a mirrored partition.
+ *
+ * @param sourceOffset The high watermark offset from the source cluster leader
+ * @param destinationOffset The log end offset on the destination cluster
+ * @param lag The computed lag (sourceOffset - destinationOffset)
+ * @param lastUpdateMs Timestamp when this lag was last updated
+ */
+case class MirrorLagInfo(sourceOffset: Long, destinationOffset: Long, lag: Long, lastUpdateMs: Long)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -115,6 +115,12 @@ class MirrorFetcherThread(name: String,
 
     log.maybeIncrementLogStartOffset(leaderLogStartOffset, LogStartOffsetIncrementReason.LeaderOffsetIncremented)
 
+    // Compute and update mirroring lag
+    val sourceLeaderHW = partitionData.highWatermark
+    val destinationLEO = log.logEndOffset
+    val lag = Math.max(0, sourceLeaderHW - destinationLEO)
+    replicaMgr.updateMirrorLag(mirrorName, topicPartition, sourceLeaderHW, destinationLEO, lag)
+
     // Account for replication quota
     if (quota.isThrottled(topicPartition))
       quota.record(records.sizeInBytes)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -115,11 +115,8 @@ class MirrorFetcherThread(name: String,
 
     log.maybeIncrementLogStartOffset(leaderLogStartOffset, LogStartOffsetIncrementReason.LeaderOffsetIncremented)
 
-    // Compute and update mirroring lag
-    val sourceLeaderHW = partitionData.highWatermark
-    val destinationLEO = log.logEndOffset
-    val lag = Math.max(0, sourceLeaderHW - destinationLEO)
-    replicaMgr.updateMirrorLag(mirrorName, topicPartition, sourceLeaderHW, destinationLEO, lag)
+    // Update mirroring lag
+    replicaMgr.updateMirrorLag(mirrorName, topicPartition, partitionData.highWatermark, log.highWatermark)
 
     // Account for replication quota
     if (quota.isThrottled(topicPartition))

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -91,6 +91,8 @@ import org.apache.kafka.clients.admin.DescribeLogDirsOptions;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
 import org.apache.kafka.clients.admin.DescribeMetadataQuorumOptions;
 import org.apache.kafka.clients.admin.DescribeMetadataQuorumResult;
+import org.apache.kafka.clients.admin.DescribeMirrorsOptions;
+import org.apache.kafka.clients.admin.DescribeMirrorsResult;
 import org.apache.kafka.clients.admin.DescribeProducersOptions;
 import org.apache.kafka.clients.admin.DescribeProducersResult;
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsOptions;
@@ -439,6 +441,11 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     @Override
     public RemoveTopicsFromMirrorResult removeTopicsFromMirror(final String mirrorName, final Set<String> topics, final RemoveTopicsFromMirrorOptions options) {
         return adminDelegate.removeTopicsFromMirror(mirrorName, topics, options);
+    }
+
+    @Override
+    public DescribeMirrorsResult describeMirrors(final Collection<String> mirrorNames, final DescribeMirrorsOptions options) {
+        return adminDelegate.describeMirrors(mirrorNames, options);
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -300,39 +300,42 @@ public abstract class MirrorCommand {
                 return;
             }
 
-            // Collect topic states from all mirrors (one entry per mirror+topic)
-            List<TopicInfo> topicInfos = new ArrayList<>();
+            // Collect partition states from all mirrors (one entry per mirror+topic+partition)
+            List<PartitionInfo> partitionInfos = new ArrayList<>();
             for (Map.Entry<String, MirrorDescription> mirrorEntry : descriptions.entrySet()) {
                 String mirrorName = mirrorEntry.getKey();
                 MirrorDescription description = mirrorEntry.getValue();
 
                 for (Map.Entry<String, Set<MirrorDescription.LeaderState>> topicEntry : description.topics().entrySet()) {
                     String topic = topicEntry.getKey();
-                    // Pick any partition as representative (they all have the same state for a topic)
-                    MirrorDescription.LeaderState state = topicEntry.getValue().iterator().next();
-                    topicInfos.add(new TopicInfo(
-                        mirrorName,
-                        topic,
-                        state.sourceOffset(),
-                        state.destinationOffset(),
-                        state.lag(),
-                        state.state()
-                    ));
+                    for (MirrorDescription.LeaderState state : topicEntry.getValue()) {
+                        partitionInfos.add(new PartitionInfo(
+                            mirrorName,
+                            topic,
+                            state.topicPartition().partition(),
+                            state.sourceOffset(),
+                            state.destinationOffset(),
+                            state.lag(),
+                            state.state()
+                        ));
+                    }
                 }
             }
 
-            // Sort by mirror, then topic
-            topicInfos.sort(Comparator.comparing(TopicInfo::mirror)
-                .thenComparing(TopicInfo::topic));
+            // Sort by mirror, then topic, then partition
+            partitionInfos.sort(Comparator.comparing(PartitionInfo::mirror)
+                .thenComparing(PartitionInfo::topic)
+                .thenComparing(PartitionInfo::partition));
 
-            // Only print header and results if there are topics to display
-            if (!topicInfos.isEmpty()) {
-                System.out.printf("%-30s %-40s %-15s %-20s %-15s %-15s%n",
-                    "MIRROR", "TOPIC", "SOURCE-OFFSET", "DESTINATION-OFFSET", "LAG", "STATE");
-                for (TopicInfo info : topicInfos) {
-                    System.out.printf("%-30s %-40s %-15d %-20d %-15d %-15s%n",
+            // Only print header and results if there are partitions to display
+            if (!partitionInfos.isEmpty()) {
+                System.out.printf("%-30s %-40s %-10s %-15s %-20s %-15s %-15s%n",
+                    "MIRROR", "TOPIC", "PARTITION", "SOURCE-OFFSET", "DESTINATION-OFFSET", "LAG", "STATE");
+                for (PartitionInfo info : partitionInfos) {
+                    System.out.printf("%-30s %-40s %-10d %-15d %-20d %-15d %-15s%n",
                         truncateLeft(info.mirror, 30),
                         truncateLeft(info.topic, 40),
+                        info.partition,
                         info.sourceOffset,
                         info.destinationOffset,
                         info.lag,
@@ -355,19 +358,22 @@ public abstract class MirrorCommand {
             adminClient.close();
         }
 
-        // Helper class for formatting topic information
-        private static class TopicInfo {
+        // Helper class for formatting partition information
+        // Each partition is an independent replication unit with its own state
+        private static class PartitionInfo {
             private final String mirror;
             private final String topic;
+            private final int partition;
             private final long sourceOffset;
             private final long destinationOffset;
             private final long lag;
             private final String state;
 
-            TopicInfo(String mirror, String topic, long sourceOffset,
-                      long destinationOffset, long lag, String state) {
+            PartitionInfo(String mirror, String topic, int partition, long sourceOffset,
+                          long destinationOffset, long lag, String state) {
                 this.mirror = mirror;
                 this.topic = topic;
+                this.partition = partition;
                 this.sourceOffset = sourceOffset;
                 this.destinationOffset = destinationOffset;
                 this.lag = lag;
@@ -380,6 +386,10 @@ public abstract class MirrorCommand {
 
             String topic() {
                 return topic;
+            }
+
+            int partition() {
+                return partition;
             }
         }
     }

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -508,9 +508,8 @@ public abstract class MirrorCommand {
             CommandLineUtils.maybePrintHelpOrVersion(this, "This tool helps to create cluster mirrors and add topics to them.");
 
             // should have exactly one action
-            long actions = (has(createOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0)
-                    + (has(removeOpt) ? 1 : 0) + (has(listOpt) ? 1 : 0) + (has(describeOpt) ? 1 : 0);
-            if (actions != 1)
+            if ((has(createOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0) + (has(removeOpt) ? 1 : 0)
+                    + (has(listOpt) ? 1 : 0) + (has(describeOpt) ? 1 : 0) != 1)
                 CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --add, --remove, --list, or --describe");
 
             // check required args
@@ -518,7 +517,7 @@ public abstract class MirrorCommand {
                 throw new IllegalArgumentException("--bootstrap-server must be specified");
 
             // --mirror is required for create, add, and remove operations, but optional for list and describe
-            if ((!has(listOpt) && !has(mirrorOpt)) || (!has(describeOpt) && !has(mirrorOpt)))
+            if (!has(listOpt) && !has(describeOpt) && !has(mirrorOpt))
                 throw new IllegalArgumentException("--mirror must be specified");
 
             if (has(createOpt) && !has(mirrorConfigOpt))

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -25,8 +25,11 @@ import org.apache.kafka.clients.admin.CreateMirrorOptions;
 import org.apache.kafka.clients.admin.CreateMirrorResult;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DescribeMirrorsOptions;
+import org.apache.kafka.clients.admin.DescribeMirrorsResult;
 import org.apache.kafka.clients.admin.FindCoordinatorResult;
 import org.apache.kafka.clients.admin.ListMirrorsResult;
+import org.apache.kafka.clients.admin.MirrorDescription;
 import org.apache.kafka.clients.admin.MirrorListing;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.RemoveTopicsFromMirrorOptions;
@@ -42,8 +45,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -88,6 +94,8 @@ public abstract class MirrorCommand {
                 mirrorService.removeTopicsFromMirror(opts);
             } else if (opts.hasListOption()) {
                 mirrorService.listMirrors();
+            } else if (opts.hasDescribeOption()) {
+                mirrorService.describeMirrors(opts);
             }
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
@@ -273,9 +281,106 @@ public abstract class MirrorCommand {
             }
         }
 
+        public void describeMirrors(MirrorCommandOptions opts) throws ExecutionException, InterruptedException {
+            // If --mirror is specified, describe only that mirror; otherwise describe all mirrors
+            List<String> mirrorNames = opts.mirror().isPresent()
+                ? List.of(opts.mirror().get())
+                : List.of();
+
+            // Describe the mirror(s) using the admin client
+            DescribeMirrorsResult result = adminClient.describeMirrors(
+                mirrorNames,
+                new DescribeMirrorsOptions()
+            );
+
+            Map<String, MirrorDescription> descriptions = result.allDescriptions().get();
+
+            if (descriptions.isEmpty()) {
+                System.out.println("No mirrors found");
+                return;
+            }
+
+            // Collect topic states from all mirrors (one entry per mirror+topic)
+            List<TopicInfo> topicInfos = new ArrayList<>();
+            for (Map.Entry<String, MirrorDescription> mirrorEntry : descriptions.entrySet()) {
+                String mirrorName = mirrorEntry.getKey();
+                MirrorDescription description = mirrorEntry.getValue();
+
+                for (Map.Entry<String, Set<MirrorDescription.LeaderState>> topicEntry : description.topics().entrySet()) {
+                    String topic = topicEntry.getKey();
+                    // Pick any partition as representative (they all have the same state for a topic)
+                    MirrorDescription.LeaderState state = topicEntry.getValue().iterator().next();
+                    topicInfos.add(new TopicInfo(
+                        mirrorName,
+                        topic,
+                        state.sourceOffset(),
+                        state.destinationOffset(),
+                        state.lag(),
+                        state.state()
+                    ));
+                }
+            }
+
+            // Sort by mirror, then topic
+            topicInfos.sort(Comparator.comparing(TopicInfo::mirror)
+                .thenComparing(TopicInfo::topic));
+
+            // Only print header and results if there are topics to display
+            if (!topicInfos.isEmpty()) {
+                System.out.printf("%-30s %-40s %-15s %-20s %-15s %-15s%n",
+                    "MIRROR", "TOPIC", "SOURCE-OFFSET", "DESTINATION-OFFSET", "LAG", "STATE");
+                for (TopicInfo info : topicInfos) {
+                    System.out.printf("%-30s %-40s %-15d %-20d %-15d %-15s%n",
+                        truncateLeft(info.mirror, 30),
+                        truncateLeft(info.topic, 40),
+                        info.sourceOffset,
+                        info.destinationOffset,
+                        info.lag,
+                        info.state);
+                }
+            }
+        }
+
+        // Truncate string from the left, keeping the rightmost characters
+        // Example: truncateLeft("my-very-long-mirror-name", 10) -> "...or-name"
+        private String truncateLeft(String str, int maxLength) {
+            if (str.length() <= maxLength) {
+                return str;
+            }
+            return "..." + str.substring(str.length() - (maxLength - 3));
+        }
+
         @Override
         public void close() throws Exception {
             adminClient.close();
+        }
+
+        // Helper class for formatting topic information
+        private static class TopicInfo {
+            private final String mirror;
+            private final String topic;
+            private final long sourceOffset;
+            private final long destinationOffset;
+            private final long lag;
+            private final String state;
+
+            TopicInfo(String mirror, String topic, long sourceOffset,
+                      long destinationOffset, long lag, String state) {
+                this.mirror = mirror;
+                this.topic = topic;
+                this.sourceOffset = sourceOffset;
+                this.destinationOffset = destinationOffset;
+                this.lag = lag;
+                this.state = state;
+            }
+
+            String mirror() {
+                return mirror;
+            }
+
+            String topic() {
+                return topic;
+            }
         }
     }
 
@@ -287,6 +392,7 @@ public abstract class MirrorCommand {
         private final OptionSpecBuilder addOpt;
         private final OptionSpecBuilder removeOpt;
         private final OptionSpecBuilder listOpt;
+        private final OptionSpecBuilder describeOpt;
         private final ArgumentAcceptingOptionSpec<String> mirrorOpt;
         private final ArgumentAcceptingOptionSpec<String> topicOpt;
         private final ArgumentAcceptingOptionSpec<Short> replicationFactorOpt;
@@ -313,6 +419,7 @@ public abstract class MirrorCommand {
             addOpt = parser.accepts("add", "Add topic(s) to an existing cluster mirror (supports regex).");
             removeOpt = parser.accepts("remove", "Remove topic(s) from an existing cluster mirror (supports regex).");
             listOpt = parser.accepts("list", "List all cluster mirrors.");
+            describeOpt = parser.accepts("describe", "Describe a cluster mirror including partition lag and state.");
 
             mirrorOpt = parser.accepts("mirror", "The name of the cluster mirror.")
                 .withRequiredArg()
@@ -357,6 +464,10 @@ public abstract class MirrorCommand {
             return has(listOpt);
         }
 
+        public boolean hasDescribeOption() {
+            return has(describeOpt);
+        }
+
         public Optional<String> bootstrapServer() {
             return valueAsOption(bootstrapServerOpt);
         }
@@ -397,15 +508,17 @@ public abstract class MirrorCommand {
             CommandLineUtils.maybePrintHelpOrVersion(this, "This tool helps to create cluster mirrors and add topics to them.");
 
             // should have exactly one action
-            long actions = (has(createOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0) + (has(removeOpt) ? 1 : 0) + (has(listOpt) ? 1 : 0);
+            long actions = (has(createOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0)
+                    + (has(removeOpt) ? 1 : 0) + (has(listOpt) ? 1 : 0) + (has(describeOpt) ? 1 : 0);
             if (actions != 1)
-                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --add, --remove, or --list");
+                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --add, --remove, --list, or --describe");
 
             // check required args
             if (!has(bootstrapServerOpt))
                 throw new IllegalArgumentException("--bootstrap-server must be specified");
 
-            if (!has(listOpt) && !has(mirrorOpt))
+            // --mirror is required for create, add, and remove operations, but optional for list and describe
+            if ((!has(listOpt) && !has(mirrorOpt)) || (!has(describeOpt) && !has(mirrorOpt)))
                 throw new IllegalArgumentException("--mirror must be specified");
 
             if (has(createOpt) && !has(mirrorConfigOpt))


### PR DESCRIPTION
This patch adds the describe mirrors operation (API, admin, tool).

Example:

```sh
$ bin/kafka-mirrors.sh --bootstrap-server :"${server4[lis]}" --describe
MIRROR                         TOPIC                                    SOURCE-OFFSET   DESTINATION-OFFSET   LAG             STATE          
my-mirror                      bar                                      9               9                    0               MIRRORING      
my-mirror                      foo                                      3               3                    0               MIRRORING      
new-mirror                     baz                                      3               3                    0               MIRRORING
```
