### PR TITLE
Allow old version of kafka to be the source cluster

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -254,7 +254,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 String mirrorName = info.partition().mirrorName;
                 if (mirrorName.endsWith(REMOVED_TOPIC_SUFFIX)) {
                     stopRequested = true;
-                    mirrorName = mirrorName.substring(0, mirrorName.length() - 1);
+                    mirrorName = mirrorName.substring(0, mirrorName.length() - REMOVED_TOPIC_SUFFIX.length());
                 } else {
                     stopRequested = false;
                 }
@@ -710,7 +710,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         String updatedMirrorName = mirrorName;
         if (mirrorName != null) {
             if (mirrorName.endsWith(REMOVED_TOPIC_SUFFIX)) {
-                updatedMirrorName = mirrorName.substring(0, mirrorName.length() - 1);
+                updatedMirrorName = mirrorName.substring(0, mirrorName.length() - REMOVED_TOPIC_SUFFIX.length());
             }
         }
         return mirrorPartitionState.get(new MirrorPartitionKey(updatedMirrorName, topicPartition.topic(), topicPartition.partition()));

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -53,6 +53,8 @@ import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ApiVersionsRequest;
+import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.requests.CreateAclsRequest;
 import org.apache.kafka.common.requests.CreatePartitionsRequest;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
@@ -564,6 +566,19 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                                    Consumer<TopicPartition> callback) {
         LOG.info("!!! maybeTruncateToLastMirroredOffsets: {} {}", mirrorName, topicPartitionSet);
         createMirrorConnection(mirrorName);
+
+        // get api versions of the source cluster
+        var apiResponse = getRandomSender(remoteBrokers.get(mirrorName)).sendRequest(new ApiVersionsRequest.Builder());
+
+        if (apiResponse.responseBody() instanceof ApiVersionsResponse apiVersionsResponse) {
+            if (apiVersionsResponse.apiVersion(ApiKeys.LAST_MIRRORED_OFFSETS.id) == null) {
+                LOG.info("!!! LAST_MIRRORED_OFFSETS is not supported in the source cluster, truncate to offset 0 instead.");
+                Map<TopicPartition, Long> offsets = new HashMap<>();
+                topicPartitionSet.forEach(tp -> offsets.put(tp, 0L));
+                replicaManager.maybeTruncate(offsets, callback);
+                return;
+            }
+        }
 
         List<LastMirroredOffsetsRequestData.TopicState> topicStates = new ArrayList<>();
         convertToTopicToPartitions(topicPartitionSet).forEach((topic, partitions) -> {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -152,6 +152,7 @@ import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
 public class ReplicationControlManager {
     static final int MAX_ELECTIONS_PER_IMBALANCE = 1_000;
     static final int MAX_PARTITIONS_PER_BATCH = 10_000;
+    private static final String REMOVED_TOPIC_SUFFIX = ".removed";
 
     static class Builder {
         private SnapshotRegistry snapshotRegistry = null;
@@ -659,7 +660,7 @@ public class ReplicationControlManager {
             for (Entry<Integer, PartitionRegistration> entry : info.parts.entrySet()) {
                 int partitionId = entry.getKey();
                 String mirrorName = info.parts.get(partitionId).mirrorName;
-                String newMirrorName = mirrorName.endsWith("*") ? "" : mirrorName + "*";
+                String newMirrorName = mirrorName.endsWith(REMOVED_TOPIC_SUFFIX) ? "" : mirrorName + REMOVED_TOPIC_SUFFIX;
                 PartitionRegistration partition = info.parts.get(partitionId);
                 PartitionChangeBuilder builder = new PartitionChangeBuilder(
                         partition,


### PR DESCRIPTION
1. Sent apiVersions request to the source cluster before sending lastMirroredOffset request. If the source cluster doesn't know the new `LAST_MIRRORED_OFFSETS` API, we'll directly truncate to offset 0 to start from scratch.
2. Fix the bug when changing the suffix "*" into ".removed"
3. Tested with kafka v4.0.0 source cluster. The mirroring can work and mirror removal can also work well.

Logs when the source cluster is not supported for the `LAST_MIRRORED_OFFSETS` API:
```
[2026-01-29 15:39:03,207] INFO !!! maybeTruncateToLastMirroredOffsets: my-link [quickstart-events-1] (kafka.server.mirror.MirrorMetadataManager)
[2026-01-29 15:39:03,209] INFO !!! LAST_MIRRORED_OFFSETS is not supported in the source cluster, truncate to offset 0 instead. (kafka.server.mirror.MirrorMetadataManager)
[2026-01-29 15:39:03,209] INFO [ReplicaManager broker=4] !!! maybeTruncate:{quickstart-events-1=0} (kafka.server.ReplicaManager)

```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
