### PR TITLE
add mirror throttling

### DIFF
--- a/core/src/main/java/kafka/server/QuotaFactory.java
+++ b/core/src/main/java/kafka/server/QuotaFactory.java
@@ -57,6 +57,7 @@ public class QuotaFactory {
                                 ControllerMutationQuotaManager controllerMutation,
                                 ReplicationQuotaManager leader,
                                 ReplicationQuotaManager follower,
+                                ReplicationQuotaManager mirror,
                                 ReplicationQuotaManager alterLogDirs,
                                 Optional<Plugin<ClientQuotaCallback>> clientQuotaCallbackPlugin) {
 
@@ -85,6 +86,7 @@ public class QuotaFactory {
             new ControllerMutationQuotaManager(clientControllerMutationConfig(cfg), metrics, time, threadNamePrefix, clientQuotaCallbackPlugin),
             new ReplicationQuotaManager(replicationConfig(cfg), metrics, QuotaType.LEADER_REPLICATION, time),
             new ReplicationQuotaManager(replicationConfig(cfg), metrics, QuotaType.FOLLOWER_REPLICATION, time),
+            new ReplicationQuotaManager(replicationConfig(cfg), metrics, QuotaType.MIRROR_REPLICATION, time),
             new ReplicationQuotaManager(alterLogDirsReplicationConfig(cfg), metrics, QuotaType.ALTER_LOG_DIRS_REPLICATION, time),
             clientQuotaCallbackPlugin
         );

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -121,6 +121,7 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
     }
     updateThrottledList(QuotaConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, quotas.leader)
     updateThrottledList(QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, quotas.follower)
+    updateThrottledList(QuotaConfig.MIRROR_REPLICATION_THROTTLED_REPLICAS_CONFIG, quotas.mirror)
   }
 
   def parseThrottledPartitions(topicConfig: Properties, brokerId: Int, prop: String): Seq[Int] = {
@@ -164,6 +165,7 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
     quotaManagers.leader.updateQuota(upperBound(getOrDefault(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG).toDouble))
     quotaManagers.follower.updateQuota(upperBound(getOrDefault(QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG).toDouble))
     quotaManagers.alterLogDirs.updateQuota(upperBound(getOrDefault(QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG).toDouble))
+    quotaManagers.mirror.updateQuota(upperBound(getOrDefault(QuotaConfig.MIRROR_REPLICATION_THROTTLED_RATE_CONFIG).toDouble))
   }
 }
 

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -199,6 +199,9 @@ class RemoteLeaderEndPoint(logPrefix: String,
     val builder = fetchSessionHandler.newBuilder(partitions.size, false)
     val readOnlyTopics = new mutable.HashSet[Uuid]()
     partitions.forEach { (topicPartition, fetchState) =>
+      if (shouldFollowerThrottle(quota, fetchState, topicPartition)) {
+        info(s"Skipping fetch for partition $topicPartition since it is throttled")
+      }
       // We will not include a replica in the fetch request if it should be throttled.
       if (fetchState.isReadyForFetch && !shouldFollowerThrottle(quota, fetchState, topicPartition)) {
         try {

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -261,9 +261,16 @@ class RemoteLeaderEndPoint(logPrefix: String,
   /**
    *  To avoid ISR thrashing, we only throttle a replica on the follower if it's in the throttled replica list,
    *  the quota is exceeded and the replica is not in sync.
+   *
+   *  In async mirroring, because the source cluster doesn't include the target cluster node into ISR,
+   *  we always throttle it if quota exceeded.
    */
   private def shouldFollowerThrottle(quota: ReplicaQuota, fetchState: PartitionFetchState, topicPartition: TopicPartition): Boolean = {
-    !fetchState.isReplicaInSync && quota.isThrottled(topicPartition) && quota.isQuotaExceeded
+    if (fetchState.isMirrorFetch()) {
+      quota.isThrottled(topicPartition) && quota.isQuotaExceeded
+    } else {
+      !fetchState.isReplicaInSync && quota.isThrottled(topicPartition) && quota.isQuotaExceeded
+    }
   }
 
   override def toString: String = s"RemoteLeaderEndPoint(blockingSender=$blockingSender)"

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -265,7 +265,7 @@ class ReplicaManager(val config: KafkaConfig,
   protected val allPartitions = new ConcurrentHashMap[TopicPartition, HostedPartition]
   private val replicaStateChangeLock = new Object
   val replicaFetcherManager = createReplicaFetcherManager(metrics, time, quotaManagers.follower)
-  val mirrorFetcherManager = createMirrorFetcherManager(metrics, time, quotaManagers.follower)
+  val mirrorFetcherManager = createMirrorFetcherManager(metrics, time, quotaManagers.mirror)
   private[server] val replicaAlterLogDirsManager = createReplicaAlterLogDirsManager(quotaManagers.alterLogDirs, brokerTopicStats)
   private val highWatermarkCheckPointThreadStarted = new AtomicBoolean(false)
   @volatile private[server] var highWatermarkCheckpoints: Map[String, OffsetCheckpointFile] = logManager.liveLogDirs.map(dir =>

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -143,6 +143,7 @@ class ControllerApisTest {
     replicaQuotaManager,
     replicaQuotaManager,
     replicaQuotaManager,
+    replicaQuotaManager,
     Optional.empty())
 
   private val quotasAlwaysThrottleControllerMutations = new QuotaManagers(
@@ -150,6 +151,7 @@ class ControllerApisTest {
     clientQuotaManager,
     clientRequestQuotaManager,
     alwaysThrottlingClientControllerQuotaManager,
+    replicaQuotaManager,
     replicaQuotaManager,
     replicaQuotaManager,
     replicaQuotaManager,

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -146,7 +146,7 @@ class KafkaApisTest extends Logging {
   private val clientControllerQuotaManager: ControllerMutationQuotaManager = mock(classOf[ControllerMutationQuotaManager])
   private val replicaQuotaManager: ReplicationQuotaManager = mock(classOf[ReplicationQuotaManager])
   private val quotas = new QuotaManagers(clientQuotaManager, clientQuotaManager, clientRequestQuotaManager,
-    clientControllerQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, util.Optional.empty())
+    clientControllerQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, util.Optional.empty())
   private val fetchManager: FetchManager = mock(classOf[FetchManager])
   private val sharePartitionManager: SharePartitionManager = mock(classOf[SharePartitionManager])
   private val clientMetricsManager: ClientMetricsManager = mock(classOf[ClientMetricsManager])

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -114,7 +114,7 @@ public class KRaftMetadataRequestBenchmark {
     private final ReplicationQuotaManager replicaQuotaManager = Mockito.mock(ReplicationQuotaManager.class);
     private final QuotaFactory.QuotaManagers quotaManagers = new QuotaFactory.QuotaManagers(clientQuotaManager,
             clientQuotaManager, clientRequestQuotaManager, controllerMutationQuotaManager, replicaQuotaManager,
-            replicaQuotaManager, replicaQuotaManager, Optional.empty());
+            replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, Optional.empty());
     private final FetchManager fetchManager = Mockito.mock(FetchManager.class);
     private final SharePartitionManager sharePartitionManager = Mockito.mock(SharePartitionManager.class);
     private final ClientMetricsManager clientMetricsManager = Mockito.mock(ClientMetricsManager.class);

--- a/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
@@ -71,6 +71,13 @@ public class QuotaConfig {
             "all replicas for this topic.";
     public static final List<String> FOLLOWER_REPLICATION_THROTTLED_REPLICAS_DEFAULT = List.of();
 
+    public static final String MIRROR_REPLICATION_THROTTLED_REPLICAS_CONFIG = "mirror.replication.throttled.replicas";
+    public static final String MIRROR_REPLICATION_THROTTLED_REPLICAS_DOC = "A list of replicas for which log replication should be throttled on " +
+            "the mirror follower node. The list should describe a set of " + "replicas in the form " +
+            "[PartitionId]:[BrokerId],[PartitionId]:[BrokerId]:... or alternatively the wildcard '*' can be used to throttle " +
+            "all replicas for this topic.";
+    public static final List<String> MIRROR_REPLICATION_THROTTLED_REPLICAS_DEFAULT = List.of();
+
 
     public static final String LEADER_REPLICATION_THROTTLED_RATE_CONFIG = "leader.replication.throttled.rate";
     public static final String LEADER_REPLICATION_THROTTLED_RATE_DOC = "A long representing the upper bound (bytes/sec) on replication traffic for leaders enumerated in the " +
@@ -81,6 +88,12 @@ public class QuotaConfig {
     public static final String FOLLOWER_REPLICATION_THROTTLED_RATE_DOC = "A long representing the upper bound (bytes/sec) on replication traffic for followers enumerated in the " +
             String.format("property %s (for each topic). This property can be only set dynamically. It is suggested that the ", FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
             "limit be kept above 1MB/s for accurate behaviour.";
+
+    public static final String MIRROR_REPLICATION_THROTTLED_RATE_CONFIG = "mirror.replication.throttled.rate";
+    public static final String MIRROR_REPLICATION_THROTTLED_RATE_DOC = "A long representing the upper bound (bytes/sec) on replication traffic for mirrored follower node enumerated in the " +
+            String.format("property %s (for each topic). This property can be only set dynamically. It is suggested that the ", MIRROR_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
+            "limit be kept above 1MB/s for accurate behaviour.";
+
     public static final String REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG = "replica.alter.log.dirs.io.max.bytes.per.second";
     public static final String REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_DOC = "A long representing the upper bound (bytes/sec) on disk IO used for moving replica between log directories on the same broker. " +
             "This property can be only set dynamically. It is suggested that the limit be kept above 1MB/s for accurate behaviour.";
@@ -222,7 +235,10 @@ public class QuotaConfig {
                         ConfigDef.Importance.MEDIUM, QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_RATE_DOC)
                 .define(QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, ConfigDef.Type.LONG,
                         QuotaConfig.QUOTA_BYTES_PER_SECOND_DEFAULT, ConfigDef.Range.atLeast(0),
-                        ConfigDef.Importance.MEDIUM, QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_DOC);
+                        ConfigDef.Importance.MEDIUM, QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_DOC)
+                .define(QuotaConfig.MIRROR_REPLICATION_THROTTLED_RATE_CONFIG, ConfigDef.Type.LONG,
+                        QuotaConfig.QUOTA_BYTES_PER_SECOND_DEFAULT, ConfigDef.Range.atLeast(0),
+                        ConfigDef.Importance.MEDIUM, QuotaConfig.MIRROR_REPLICATION_THROTTLED_RATE_DOC);
     }
 
     public static ConfigDef userAndClientQuotaConfigs() {

--- a/server-common/src/main/java/org/apache/kafka/server/quota/QuotaType.java
+++ b/server-common/src/main/java/org/apache/kafka/server/quota/QuotaType.java
@@ -23,6 +23,7 @@ public enum QuotaType {
     CONTROLLER_MUTATION("ControllerMutation"),
     LEADER_REPLICATION("LeaderReplication"),
     FOLLOWER_REPLICATION("FollowerReplication"),
+    MIRROR_REPLICATION("MirrorReplication"),
     ALTER_LOG_DIRS_REPLICATION("AlterLogDirsReplication"),
     RLM_COPY("RLMCopy"),
     RLM_FETCH("RLMFetch");

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -241,6 +241,8 @@ public class LogConfig extends AbstractConfig {
                         ThrottledReplicaListValidator.INSTANCE, MEDIUM, QuotaConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_DOC)
                 .define(QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, LIST, QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_DEFAULT,
                         ThrottledReplicaListValidator.INSTANCE, MEDIUM, QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_DOC)
+                .define(QuotaConfig.MIRROR_REPLICATION_THROTTLED_REPLICAS_CONFIG, LIST, QuotaConfig.MIRROR_REPLICATION_THROTTLED_REPLICAS_DEFAULT,
+                        ThrottledReplicaListValidator.INSTANCE, MEDIUM, QuotaConfig.MIRROR_REPLICATION_THROTTLED_REPLICAS_DOC)
                 .define(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, BOOLEAN, DEFAULT_REMOTE_STORAGE_ENABLE, null,
                         MEDIUM, TopicConfig.REMOTE_LOG_STORAGE_ENABLE_DOC)
                 .define(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG, LONG, DEFAULT_LOCAL_RETENTION_MS, atLeast(-2), MEDIUM,


### PR DESCRIPTION
1. added `mirror.replication.throttled.rate` broker level config and `mirror.replication.throttled.replicas` topic level config, working like existing `follower.replication.throttled.rate` and `follower.replication.throttled.replicas` to separate out the mirror fetching throttling and intra-replication throttling.
2. Tested it works.


scripts:
```
> bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9091
> bin/kafka-mirrors.sh --bootstrap-server localhost:9094 --create --mirror my-link --mirror-config /tmp/test1.properties
> bin/kafka-mirrors.sh --bootstrap-server localhost:9094 --add --topic quickstart-events --mirror my-link --mirror-config /tmp/test1.properties

# dynamically update the throttling configs in the target cluster
> bin/kafka-configs.sh --bootstrap-server localhost:9094 --entity-type brokers --entity-name 4 --alter --add-config mirror.replication.throttled.rate=1

> bin/kafka-configs.sh --bootstrap-server localhost:9094 --entity-type topics --entity-name quickstart-events --alter --add-config mirror.replication.throttled.replicas=0:4

# write some data to the source cluster
bin/kafka-producer-perf-test.sh --topic quickstart-events --num-records 10000 --record-size 1024 --throughput -1 --producer-props bootstrap.servers=localhost:9091
```
After that, check the log:
```
INFO [MirrorFetcher fetcherId=0, mirrorName=my-link, srcBroker=1, dstBroker=4] Skipping fetch for partition quickstart-events-0 since it is throttled (kafka.server.RemoteLeaderEndPoint)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
