### PR TITLE
fix the wrong output

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -255,7 +255,7 @@ public abstract class MirrorCommand {
                         coordinatorNode.id(), existingTopics, new AddTopicsToMirrorOptions());
                 addResult.all().get();
 
-                System.out.printf("Added %d topic(s) to mirror %s: %s%n", createdTopics.size(), mirrorName, createdTopics);
+                System.out.printf("Added %d topic(s) to mirror %s: %s%n", existingTopics.size(), mirrorName, existingTopics);
             }
         }
 


### PR DESCRIPTION
When addTopicsToMirror after removeTopicsFromMirror, the output is wrong:
```
> bin/kafka-mirrors.sh --bootstrap-server localhost:9094 --remove --topic quickstart-events --mirror my-link
Removed 1 topic(s) from mirror my-link: [quickstart-events]

> bin/kafka-mirrors.sh --bootstrap-server localhost:9094 --add --topic quickstart-events --mirror my-link --mirror-config /tmp/test1.properties
Added 0 topic(s) to mirror my-link: []
```
Fix it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
