### PR TITLE
don't pass mirror name for followers in target cluster

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2553,16 +2553,11 @@ class ReplicaManager(val config: KafkaConfig,
           case Some(node) =>
             val log = partition.localLogOrException
 
-            // This flag is used is used in AbstractFetcherThread.partitionFetchState to distinguish mirror from regular followers
-            // and it triggers different epoch handling logic throughout the fetch lifecycle.
-            val mirrorName = partition.getMirrorName()
-
             partitionAndOffsets.put(topicPartition, InitialFetchState(
               log.topicId.toScala,
               new BrokerEndPoint(node.id, node.host, node.port),
               partition.getLeaderEpoch,
-              initialFetchOffset(log),
-              mirrorName))
+              initialFetchOffset(log)))
           case None =>
             stateChangeLogger.trace(s"Unable to start fetching $topicPartition with topic ID ${partition.topicId} " +
               s"from leader ${partition.leaderReplicaIdOpt} because it is not alive.")


### PR DESCRIPTION
Because we don't need to have special handling for _followers in the target cluster_, remove the mirror name in the fetch state. We only need it in the `leader in the target cluster` for error handling, like `updateMirrorFetchEpoch`, `maybeCreateMirrorFetchers`, .... For followers, they don't need to update the mirror fetch epoch or create mirror fetchers.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
