### PR TITLE
stop mirror fetcher after stopping

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -183,8 +183,10 @@ public class MirrorCoordinator {
                 break;
             case STOPPING:
                 LOG.info("!!! STOPPING for topics {}.", topicPartitions);
-                // 1. truncating the log into LSO
-                // 2. register the last mirrored offsets for each partition in internal topic
+                // 1. remove mirror fetcher for partitions
+                // 2. truncating the log into LSO
+                // 3. register the last mirrored offsets for each partition in internal topic
+                replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
                 truncateLogToLSO(topicPartitions, tp -> updateLastMirroredOffsets(mirrorName, Set.of(tp)));
                 break;
             case STOPPED:


### PR DESCRIPTION
When removeTopicsFromMirror, we append `.removed` at the end of `mirror.name` config. This change won't trigger `makeLeader` again in replicaManager like before we updating the fields in `partitionRecords`. So we have to remove the fetcher manually.

Even though this PR fixes the issue, I think we still need a `force bump leader epoch` procedure after removeTopicsFromMirror. In the below log sequence, you can see I removed mirror fetcher at 15:58:59:649 though, I can still get response at 15:58:59,909, which is for the fetch request before fetcher removal. This is the issue described in [KAFKA-18723](https://issues.apache.org/jira/browse/KAFKA-18723) that we should not accept batches for leader epoch < current leader epoch, like the late arrival fetch response in this case.

```
[2026-02-05 15:58:59,646] INFO !!! STOPPING for topics [quickstart-events-0]. (kafka.server.mirror.MirrorCoordinator)
[2026-02-05 15:58:59,649] INFO [MirrorFetcherManager on broker 4] !!! Removed mirror fetcher for partitions Set(quickstart-events-0) (kafka.server.mirror.MirrorFetcherManager)
[2026-02-05 15:58:59,649] INFO [ReplicaManager broker=4] !!! maybeTruncate:{quickstart-events-0=0} (kafka.server.ReplicaManager)
[2026-02-05 15:58:59,649] INFO [UnifiedLog partition=quickstart-events-0, dir=/tmp/build/test/server4/data] Truncating to 0 has no effect as the largest offset in the log is -1 (org.apache.kafka.storage.internals.log.UnifiedLog)
[2026-02-05 15:58:59,649] INFO [Partition quickstart-events-0 broker=4] !!! maybeCompleteIsrTruncation: Log(dir=/tmp/build/test/server4/data/quickstart-events-0, topicId=yDmiKLDYQHqy2P8iix9oEA, topic=quickstart-events, partition=0, highWatermark=0, lastStableOffset=0, logStartOffset=0, logEndOffset=0) (kafka.cluster.Partition)
[2026-02-05 15:58:59,651] INFO !!! Transitioning partition quickstart-events-0 from STOPPING to STOPPED. (kafka.server.mirror.MirrorCoordinator)
[2026-02-05 15:58:59,651] INFO !!! STOPPED for topics [quickstart-events-0]. (kafka.server.mirror.MirrorCoordinator)
[2026-02-05 15:58:59,909] INFO [MirrorFetcher fetcherId=0, mirrorName=my-link, srcBroker=1, dstBroker=4] !!! response fetch request Map() (kafka.server.mirror.MirrorFetcherThread)

```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
