### PR TITLE
set discoverBrokerVersions to true in networkClient for old version source cluster support

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1249,11 +1249,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private void syncConsumerGroupOffsets(List<MirrorBlockingSender> senders) {
         // 1. list group
         ListGroupsRequest.Builder builder = new ListGroupsRequest.Builder(new ListGroupsRequestData()
-                .setTypesFilter(List.of(GroupType.CLASSIC.name(), GroupType.CONSUMER.name()))
+                // TODO: if the source cluster is in old version, it won't support types filter
+//                .setTypesFilter(List.of(GroupType.CLASSIC.name(), GroupType.CONSUMER.name()))
                 .setStatesFilter(singletonList(GroupState.STABLE.name())));
         var listGroupResponse = getRandomSender(senders).sendRequest(builder);
         if (listGroupResponse.responseBody() instanceof ListGroupsResponse listGroupsRes) {
             LOG.info("!!! Periodic list group: {}", listGroupsRes);
+
+            if (listGroupsRes.data().groups().isEmpty()) {
+                return;
+            }
 
             // 2. get committed offsets for each group
             OffsetFetchRequest.Builder offsetFetchBuilder = OffsetFetchRequest.Builder.forTopicNames(

--- a/core/src/main/scala/kafka/server/mirror/MirrorBlockingSender.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorBlockingSender.scala
@@ -92,7 +92,7 @@ class MirrorBlockingSender(sourceBroker: BrokerEndPoint,
       config.getLong(MirrorConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG).toInt,
       config.getLong(MirrorConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG).toInt,
       time,
-      false,
+      true,
       new ApiVersions,
       logContext,
       MetadataRecoveryStrategy.NONE


### PR DESCRIPTION
set discoverBrokerVersions to true in networkClient for old version source cluster support.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
