### PR TITLE
return error when topic id is set but some replicas offline

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -710,6 +710,12 @@ public class ReplicationControlManager {
                                  List<ApiMessageAndVersion> configRecords,
                                  boolean authorizedToReturnConfigs) {
         Map<String, String> creationConfigs = translateCreationConfigs(topic.configs());
+        boolean useProvidedTopicId = false;
+        // should keep source topicId for mirror topics
+        if (topic.mirrorInfo() != null && !topic.mirrorInfo().topicId().equals(Uuid.ZERO_UUID)) {
+            useProvidedTopicId = true;
+        }
+
         Map<Integer, PartitionRegistration> newParts = new HashMap<>();
         if (!topic.assignments().isEmpty()) {
             if (topic.replicationFactor() != -1) {
@@ -739,6 +745,14 @@ public class ReplicationControlManager {
                         "All brokers specified in the manual partition assignment for " +
                         "partition " + assignment.partitionIndex() + " are fenced or in controlled shutdown.");
                 }
+
+                if (useProvidedTopicId && isr.size() < assignment.brokerIds().size()) {
+                    return new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
+                        "Some brokers specified in the manual partition assignment for " +
+                        "partition " + assignment.partitionIndex() + " are fenced or in controlled shutdown. " +
+                        "For mirror topic creation, all brokers specified in the manual partition assignment must be active.");
+                }
+
                 newParts.put(
                     assignment.partitionIndex(),
                     buildPartitionRegistration(partitionAssignment, isr)
@@ -786,6 +800,13 @@ public class ReplicationControlManager {
                             "Unable to replicate the partition " + replicationFactor +
                                 " time(s): All brokers are currently fenced or in controlled shutdown.");
                     }
+                    if (useProvidedTopicId && isr.size() < partitionAssignment.replicas().size()) {
+                        return new ApiError(Errors.INVALID_REPLICATION_FACTOR,
+                            "Unable to replicate the partition " + replicationFactor +
+                                " time(s): Some brokers are currently fenced or in controlled shutdown. " +
+                                "For mirror topic creation, all replicas being assigned must be active.");
+                    }
+
                     newParts.put(
                         partitionId,
                         buildPartitionRegistration(partitionAssignment, isr)
@@ -809,11 +830,7 @@ public class ReplicationControlManager {
             return ApiError.fromThrowable(e);
         }
 
-        Uuid topicId = Uuid.randomUuid();
-        // keep source topicId for mirror topics
-        if (topic.mirrorInfo() != null && !topic.mirrorInfo().topicId().equals(Uuid.ZERO_UUID)) {
-            topicId = topic.mirrorInfo().topicId();
-        }
+        Uuid topicId = useProvidedTopicId ? topic.mirrorInfo().topicId() : Uuid.randomUuid();
 
         CreatableTopicResult result = new CreatableTopicResult().
             setName(topic.name()).


### PR DESCRIPTION
Currently, when topic is deleted and replica is offline, we can't delete the physical partition for given topic id. And when broker or log dir comes up again, it'll get stray partition which add suffix `.stray` to partition folder. And if during the broker or log dir down, the same name topic is re-created, when broker/log dir is up, it'll identify that the current partition folder is stale, by comparing the topic id in the log dir and the one in metadata, and moving it to `.stray` folder, and creating a new one.

But in case of mirroring, since we need to create a topic with the source topic ID, not a random uuid, when broker/log dir down, and the same topic with the same topic id is deleted and re-created, and later when broker/log dir is up, it will not be able to identify if the local partition folder is stale or not. 

The scenario is like this:
1. Topic deleted by accident on source, topic metadata deleted immediately
2. online brokers/log die will mark replicas as .delete 
3. One log dir or broker was down so the delete of topic is marked as complete in KRAFT but the physical files not deleted yet from this failed log dir or broker
4. Usually when topic get recreated (via admin client topic get new topic id which make old replicas on offline log dir or broker marked as .stray(no thread delete these btw)
5. However, in Cluster mirroring we reverse the link of mirroring to recreate the topic with same topic id and populate source again from destination which might be lagging behind but at least we recovered a portion of the data which better than nothing 
6. after a while broker or log dir came up again with partition with same topic id so the stray  and delete of old data from consumer client path wouldn't take place as topic id is identical

We can validate if all the replicas for a topic are all online before adding topics to mirror (starting the mirror), but that is too late because even if all replicas are all online, when this mixing old and new logs in leader and followers issue happened, current replication protocol cannot fix it due to the leader epoch conflict. For example:

1. partition foo-0 has record in offset 0, at leader epoch 1.
2. broker 1 is down
3. topic foo is deleted
4. topic foo is recreated with the same topic id, in leader epoch 0.
5. when broker 1 is up, it loads the stale data in local dir since it's the same topic id
6. When broker 1 tries to fetch data from the leader, it'll get failure loop because the leader epoch 1 is unknown to the leader.

In this PR, I fix it in controller topic creation process. When deciding the partition assignment, adding one more validation to make sure all replicas are active. So, at this point of time, we make sure: (1) the topic is not existed (2) all replicas are alive. That is, there's no way there's an old same name topic deleted but stale data still exist in assigned replicas. 


```
> bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9091 --replication-factor 2
Error while executing topic command : Unable to replicate the partition 2 time(s): Some brokers are currently fenced or in controlled shutdown.For mirror topic creation, all replicas being assigned must be active.
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
