### PR TITLE
Introduce mirrorId (Uuid) as the internal identifier

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateMirrorResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateMirrorResult.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Uuid;
 
 import java.util.Map;
 
@@ -27,16 +28,16 @@ import java.util.Map;
  * The API of this class is evolving, see {@link Admin} for details.
  */
 public class CreateMirrorResult {
-    private final KafkaFuture<Void> future;
+    private final KafkaFuture<Uuid> future;
 
-    CreateMirrorResult(final KafkaFuture<Void> future) {
+    CreateMirrorResult(final KafkaFuture<Uuid> future) {
         this.future = future;
     }
 
     /**
-     * Return a future which succeeds if the operation is successful.
+     * Return a future which succeeds with the system-generated mirror ID if the operation is successful.
      */
-    public KafkaFuture<Void> all() {
+    public KafkaFuture<Uuid> all() {
         return future;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4835,7 +4835,7 @@ public class KafkaAdminClient extends AdminClient {
 
     @Override
     public CreateMirrorResult createMirror(String mirrorName, Map<String, String> configs, CreateMirrorOptions options) {
-        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final KafkaFutureImpl<Uuid> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
         final Call call = new Call("createMirror", calcDeadlineMs(now, options.timeoutMs()),
                 new LeastLoadedBrokerOrActiveKController()) {
@@ -4852,7 +4852,7 @@ public class KafkaAdminClient extends AdminClient {
                 Errors error = Errors.forCode(response.data().errorCode());
                 switch (error) {
                     case NONE:
-                        future.complete(null);
+                        future.complete(response.data().mirrorId());
                         break;
                     case REQUEST_TIMED_OUT:
                         throw error.exception(response.data().errorMessage());
@@ -4977,6 +4977,7 @@ public class KafkaAdminClient extends AdminClient {
                     for (ListMirrorsResponseData.ListedMirror mirror : response.data().mirrors()) {
                         listings.add(new MirrorListing(
                                 mirror.mirrorName(),
+                                mirror.mirrorId(),
                                 mirror.sourceBootstrap(),
                                 mirror.topicCount()
                         ));
@@ -5134,6 +5135,7 @@ public class KafkaAdminClient extends AdminClient {
         // Accumulated MirrorDescription data from all brokers
         private static class PartialMirrorDescription {
             final String mirrorName;
+            Uuid mirrorId = Uuid.ZERO_UUID;
             final Map<String, Set<MirrorDescription.LeaderState>> topicPartitions;
             final Set<Integer> authorizedOps;
             Throwable error;
@@ -5152,6 +5154,11 @@ public class KafkaAdminClient extends AdminClient {
                         this.error = errorCode.exception();
                     }
                     return;
+                }
+
+                // Capture mirrorId from first response that has it
+                if (!mirror.mirrorId().equals(Uuid.ZERO_UUID)) {
+                    this.mirrorId = mirror.mirrorId();
                 }
 
                 // Merge topic partitions
@@ -5182,6 +5189,7 @@ public class KafkaAdminClient extends AdminClient {
             MirrorDescription toMirrorDescription() {
                 return new MirrorDescription(
                         mirrorName,
+                        mirrorId,
                         topicPartitions,
                         authorizedOps.isEmpty() ? Collections.emptySet() : authorizedOps
                 );

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MirrorDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MirrorDescription.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Collections;
@@ -31,19 +32,32 @@ import java.util.Set;
 @InterfaceStability.Evolving
 public class MirrorDescription {
     private final String mirrorName;
+    private final Uuid mirrorId;
     private final Map<String, Set<LeaderState>> topics;
     private final Set<Integer> authorizedOperations;
 
     public MirrorDescription(String mirrorName,
+                             Uuid mirrorId,
                              Map<String, Set<LeaderState>> topics,
                              Set<Integer> authorizedOperations) {
         this.mirrorName = mirrorName;
+        this.mirrorId = mirrorId;
         this.topics = Collections.unmodifiableMap(topics);
         this.authorizedOperations = authorizedOperations;
     }
 
+    public MirrorDescription(String mirrorName,
+                             Map<String, Set<LeaderState>> topics,
+                             Set<Integer> authorizedOperations) {
+        this(mirrorName, Uuid.ZERO_UUID, topics, authorizedOperations);
+    }
+
     public String mirrorName() {
         return mirrorName;
+    }
+
+    public Uuid mirrorId() {
+        return mirrorId;
     }
 
     public Map<String, Set<LeaderState>> topics() {
@@ -60,19 +74,21 @@ public class MirrorDescription {
         if (o == null || getClass() != o.getClass()) return false;
         MirrorDescription that = (MirrorDescription) o;
         return Objects.equals(mirrorName, that.mirrorName) &&
+               Objects.equals(mirrorId, that.mirrorId) &&
                Objects.equals(topics, that.topics) &&
                Objects.equals(authorizedOperations, that.authorizedOperations);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mirrorName, topics, authorizedOperations);
+        return Objects.hash(mirrorName, mirrorId, topics, authorizedOperations);
     }
 
     @Override
     public String toString() {
         return "MirrorDescription{" +
                "mirrorName='" + mirrorName + '\'' +
+               ", mirrorId=" + mirrorId +
                ", topics=" + topics +
                ", authorizedOperations=" + authorizedOperations +
                '}';

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MirrorListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MirrorListing.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Objects;
@@ -27,6 +28,7 @@ import java.util.Objects;
 @InterfaceStability.Evolving
 public class MirrorListing {
     private final String mirrorName;
+    private final Uuid mirrorId;
     private final String sourceBootstrap;
     private final int topicCount;
 
@@ -34,11 +36,13 @@ public class MirrorListing {
      * Create an instance with the specified parameters.
      *
      * @param mirrorName Mirror name
+     * @param mirrorId System-generated mirror ID
      * @param sourceBootstrap Source cluster bootstrap servers
      * @param topicCount Number of topics configured for this mirror
      */
-    public MirrorListing(String mirrorName, String sourceBootstrap, int topicCount) {
+    public MirrorListing(String mirrorName, Uuid mirrorId, String sourceBootstrap, int topicCount) {
         this.mirrorName = mirrorName;
+        this.mirrorId = mirrorId;
         this.sourceBootstrap = sourceBootstrap;
         this.topicCount = topicCount;
     }
@@ -48,9 +52,20 @@ public class MirrorListing {
      *
      * @param mirrorName Mirror name
      * @param sourceBootstrap Source cluster bootstrap servers
+     * @param topicCount Number of topics configured for this mirror
+     */
+    public MirrorListing(String mirrorName, String sourceBootstrap, int topicCount) {
+        this(mirrorName, Uuid.ZERO_UUID, sourceBootstrap, topicCount);
+    }
+
+    /**
+     * Create an instance with the specified parameters (backwards compatibility).
+     *
+     * @param mirrorName Mirror name
+     * @param sourceBootstrap Source cluster bootstrap servers
      */
     public MirrorListing(String mirrorName, String sourceBootstrap) {
-        this(mirrorName, sourceBootstrap, 0);
+        this(mirrorName, Uuid.ZERO_UUID, sourceBootstrap, 0);
     }
 
     /**
@@ -60,6 +75,15 @@ public class MirrorListing {
      */
     public String mirrorName() {
         return mirrorName;
+    }
+
+    /**
+     * The system-generated mirror ID.
+     *
+     * @return Mirror ID
+     */
+    public Uuid mirrorId() {
+        return mirrorId;
     }
 
     /**
@@ -82,12 +106,12 @@ public class MirrorListing {
 
     @Override
     public String toString() {
-        return "MirrorListing(mirrorName='" + mirrorName + "', sourceBootstrap='" + sourceBootstrap + "', topicCount=" + topicCount + ")";
+        return "MirrorListing(mirrorName='" + mirrorName + "', mirrorId=" + mirrorId + ", sourceBootstrap='" + sourceBootstrap + "', topicCount=" + topicCount + ")";
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mirrorName, sourceBootstrap, topicCount);
+        return Objects.hash(mirrorName, mirrorId, sourceBootstrap, topicCount);
     }
 
     @Override
@@ -97,6 +121,7 @@ public class MirrorListing {
         MirrorListing that = (MirrorListing) o;
         return topicCount == that.topicCount &&
                Objects.equals(mirrorName, that.mirrorName) &&
+               Objects.equals(mirrorId, that.mirrorId) &&
                Objects.equals(sourceBootstrap, that.sourceBootstrap);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -223,6 +223,12 @@ public class TopicConfig {
     public static final String MIRROR_NAME_DOC = "Identifies the mirror that manages this topic. " +
             "Topics with this configuration set are read-only and can only be modified through mirror management APIs.";
 
+    public static final String MIRROR_ID_CONFIG = "mirror.id";
+    public static final String MIRROR_ID_DOC = "System-generated UUID that uniquely identifies the mirror managing this topic. " +
+            "Topics with this configuration set are read-only and can only be modified through mirror management APIs.";
+
+    public static final String MIRROR_REMOVED_SUFFIX = ".removed";
+
     /**
      * @deprecated down-conversion is not possible in Apache Kafka 4.0 and newer, hence this configuration is a no-op,
      *             and it is deprecated for removal in Apache Kafka 5.0.

--- a/clients/src/main/resources/common/message/CreateMirrorResponse.json
+++ b/clients/src/main/resources/common/message/CreateMirrorResponse.json
@@ -25,6 +25,8 @@
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
     { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
-      "about": "The error message, or null if there was no error." }
+      "about": "The error message, or null if there was no error." },
+    { "name": "MirrorId", "type": "uuid", "versions": "0+",
+      "about": "The system-generated mirror ID." }
   ]
 }

--- a/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
@@ -29,6 +29,8 @@
         "about": "The error code, or 0 if there was no error." },
       { "name": "MirrorName", "type": "string", "versions": "0+",
         "about": "The mirror name." },
+      { "name": "MirrorId", "type": "uuid", "versions": "0+",
+        "about": "The system-generated mirror ID." },
       { "name": "Topics", "type": "[]TopicPartitions", "versions": "0+",
         "about": "Each topic in the mirror.", "fields": [
         { "name": "TopicName", "type": "string", "versions": "0+",

--- a/clients/src/main/resources/common/message/ListMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/ListMirrorsResponse.json
@@ -29,6 +29,8 @@
       "about": "Each mirror in the response.", "fields": [
       { "name": "MirrorName", "type": "string", "versions": "0+",
         "about": "The mirror name." },
+      { "name": "MirrorId", "type": "uuid", "versions": "0+",
+        "about": "The system-generated mirror ID." },
       { "name": "SourceBootstrap", "type": "string", "versions": "0+",
         "about": "The source cluster bootstrap servers." },
       { "name": "TopicCount", "type": "int32", "versions": "0+", "default": "0",

--- a/clients/src/main/resources/common/message/ReadMirrorStatesRequest.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesRequest.json
@@ -21,7 +21,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "MirrorName", "type": "string", "versions": "0+", "about": "The mirror name." },
+    { "name": "MirrorId", "type": "uuid", "versions": "0+", "about": "The system-generated mirror ID." },
     { "name": "Topics", "type": "[]TopicState", "versions": "0",
       "about": "The responses per topic.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/WriteMirrorStatesRequest.json
+++ b/clients/src/main/resources/common/message/WriteMirrorStatesRequest.json
@@ -21,7 +21,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "MirrorName", "type": "string", "versions": "0+", "about": "The mirror name." },
+    { "name": "MirrorId", "type": "uuid", "versions": "0+", "about": "The system-generated mirror ID." },
     { "name": "TopicsUpdated", "type": "[]TopicState", "versions": "0",
       "about": "The topics to be updated.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -20,6 +20,7 @@ import kafka.server.KafkaConfig;
 import kafka.server.ReplicaManager;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.WriteMirrorStatesResponseData;
@@ -142,11 +143,11 @@ public class MirrorCoordinator {
     /**
      * Checks if this broker is the coordinator for the given mirror.
      *
-     * @param mirrorName the name of the cluster mirror
+     * @param mirrorId the system-generated mirror ID
      * @return true if this broker is the leader of the coordinator partition for this mirror
      */
-    public boolean isLocalCoordinator(String mirrorName, String topic, int partition) {
-        var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, getCoordinatingPartitionByKey(new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), partition)));
+    public boolean isLocalCoordinator(Uuid mirrorId, String topic, int partition) {
+        var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, getCoordinatingPartitionByKey(new MirrorRecordKey(mirrorId, metadataCache.getTopicId(topic), partition)));
         var optLeaderAndIsr = metadataCache.getLeaderAndIsr(mirrorTopicPartition.topic(), mirrorTopicPartition.partition());
         return optLeaderAndIsr.isPresent() && optLeaderAndIsr.get().leader() == kafkaConfig.nodeId();
     }
@@ -162,20 +163,24 @@ public class MirrorCoordinator {
      * - STOPPED: Marks topics as writable (no action required)
      * - FAILED: Logs failure (recovery actions to be implemented)
      *
-     * @param mirrorName the name of the cluster mirror
+     * @param mirrorId the id of the cluster mirror
      * @param topicPartitions the set of topics transitioning to the new state
      * @param newState the target state after transition
      */
-    private void handleStateTransition(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
+    private void handleStateTransition(Uuid mirrorId, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
+        // Resolve mirrorId -> mirrorName for source cluster connections
+        String mirrorName = mirrorMetadataManager.getMirrorName(mirrorId);
         switch (newState) {
             case PREPARING:
                 LOG.info("!!! PREPARING for topics {}.", topicPartitions);
-                scheduleTruncation(mirrorName, topicPartitions);
+                scheduleTruncation(mirrorId, mirrorName, topicPartitions);
                 break;
             case MIRRORING:
                 LOG.info("!!! MIRRORING topics {}.", topicPartitions);
                 // start mirroring
-                replicaManager.maybeCreateMirrorFetchers(mirrorName, topicPartitions);
+                if (mirrorName != null) {
+                    replicaManager.maybeCreateMirrorFetchers(mirrorName, topicPartitions);
+                }
                 break;
             case STOPPING:
                 LOG.info("!!! STOPPING for topics {}.", topicPartitions);
@@ -183,7 +188,7 @@ public class MirrorCoordinator {
                 // 2. truncating the log into LSO
                 // 3. register the last mirrored offsets for each partition in internal topic
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                truncateLogToLSO(topicPartitions, tp -> updateLastMirroredOffsets(mirrorName, Set.of(tp)));
+                truncateLogToLSO(topicPartitions, tp -> updateLastMirroredOffsets(mirrorId, mirrorName, Set.of(tp)));
                 break;
             case STOPPED:
                 LOG.info("!!! STOPPED for topics {}.", topicPartitions);
@@ -205,28 +210,29 @@ public class MirrorCoordinator {
      * This method updates the state for every partition and then
      * executes the state transition actions after transition.
      *
-     * @param mirrorName the name of the cluster mirror
+     * @param mirrorId the id of the cluster mirror
      * @param topicPartitions the set of topics to transition
      * @param newState the target mirror state
      */
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
+    public void transitionTo(Uuid mirrorId, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
+        String mirrorName = mirrorMetadataManager.getMirrorName(mirrorId);
         topicPartitions.forEach(tp -> {
-            MirrorPartitionState currentState = mirrorMetadataManager.getMirrorPartitionState(mirrorName, tp);
+            MirrorPartitionState currentState = mirrorName != null ? mirrorMetadataManager.getMirrorPartitionState(mirrorName, tp) : null;
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 LOG.info("!!! Transitioning partition {} from {} to {}.", tp, currentState, newState);
-                updateMirrorPartitionState(mirrorName, tp, newState)
+                updateMirrorPartitionState(mirrorId, mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
                                 // TODO: a new component will handle state transitions from a shared queue, so retry means put back in the queue
                                 LOG.error("Failed to update partition state for {}: {}, retrying", tp, ex.getMessage());
-                                scheduler.scheduleOnce("retry-mirror-state-update", () -> updateMirrorPartitionState(mirrorName, tp, newState), 100);
+                                scheduler.scheduleOnce("retry-mirror-state-update", () -> updateMirrorPartitionState(mirrorId, mirrorName, tp, newState), 100);
                             } else {
                                 // successfully writes data into internal log
-                                optTp.ifPresent(tp1 -> handleStateTransition(mirrorName, Set.of(tp1), newState));
+                                optTp.ifPresent(tp1 -> handleStateTransition(mirrorId, Set.of(tp1), newState));
                             }
                         });
             } else {
-                LOG.info("!!! Skipping transition {} to {} for partition {}.", mirrorMetadataManager.getMirrorPartitionState(mirrorName, tp), newState, tp);
+                LOG.info("!!! Skipping transition {} to {} for partition {}.", currentState, newState, tp);
             }
         });
     }
@@ -256,10 +262,11 @@ public class MirrorCoordinator {
      *                      metadata contains the partition index, state, and last mirrored offset
      * @param sendResponseCallback Callback to send the WriteMirrorStatesResponse back to the client
      */
-    public void writeMirrorPartitionMetadata(String mirrorName,
+    public void writeMirrorPartitionMetadata(String mirrorName, Uuid mirrorId,
                                              Map<String, Set<MirrorMetadataManager.MirrorPartitionMetadata>> topicMetadata,
                                              Consumer<WriteMirrorStatesResponse> sendResponseCallback) {
         String updatedMirrorName = MirrorMetadataManager.originalMirrorName(mirrorName);
+        Uuid resolvedMirrorId = mirrorId != null && !mirrorId.equals(Uuid.ZERO_UUID) ? mirrorId : mirrorMetadataManager.getMirrorId(updatedMirrorName);
         Map<String, Map<Integer, Long>> offsets = new HashMap<>();
         Map<String, Set<Integer>> tps = new HashMap<>();
         topicMetadata.forEach((topic, partitions) -> {
@@ -268,7 +275,7 @@ public class MirrorCoordinator {
                 TopicPartition tp = new TopicPartition(topic, partition.partition());
                 partitionIndices.add(tp.partition());
                 if (partition.state() != null && partition.state() != MirrorPartitionState.UNKNOWN) {
-                    updateMirrorPartitionState(updatedMirrorName, tp, partition.state());
+                    updateMirrorPartitionState(resolvedMirrorId, updatedMirrorName, tp, partition.state());
                 }
                 if (partition.offset() != -1) {
                     offsets.putIfAbsent(topic, new HashMap<>());
@@ -278,7 +285,7 @@ public class MirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
-        updateLastMirroredOffsetsMetadata(updatedMirrorName, offsets, false);
+        updateLastMirroredOffsetsMetadata(resolvedMirrorId, updatedMirrorName, offsets, false);
 
         WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
         List<WriteMirrorStatesResponseData.TopicState> topicStates = new ArrayList<>();
@@ -313,10 +320,10 @@ public class MirrorCoordinator {
      * @param partitions map of topic names to their partition indices to query
      * @param sendResponseCallback callback invoked immediately with cached partition states
      */
-    public void readMirrorPartitionMetadataFromCache(String mirrorName,
+    public void readMirrorPartitionMetadataFromCache(String mirrorName, Uuid mirrorId,
                                                      Map<String, Set<Integer>> partitions,
                                                      Consumer<ReadMirrorStatesResponse> sendResponseCallback) {
-        mirrorMetadataManager.readMirrorPartitionMetadataFromCache(mirrorName, partitions, sendResponseCallback);
+        mirrorMetadataManager.readMirrorPartitionMetadataFromCache(mirrorName, mirrorId, partitions, sendResponseCallback);
     }
 
     /**
@@ -330,7 +337,7 @@ public class MirrorCoordinator {
      * @param mirrorName the name of the cluster mirror
      * @param topicPartitions the topic partitions whose offsets should be captured
      */
-    public void updateLastMirroredOffsets(String mirrorName, Set<TopicPartition> topicPartitions) {
+    public void updateLastMirroredOffsets(Uuid mirrorId, String mirrorName, Set<TopicPartition> topicPartitions) {
         Map<String, Map<Integer, Long>> partitionOffsets = new HashMap<>();
         mirrorMetadataManager.convertToTopicToPartitions(topicPartitions).forEach((topic, parts) -> {
             Map<Integer, Long> offsets = new HashMap<>();
@@ -340,7 +347,7 @@ public class MirrorCoordinator {
             partitionOffsets.put(topic, offsets);
         });
 
-        updateLastMirroredOffsetsMetadata(mirrorName, partitionOffsets, true);
+        updateLastMirroredOffsetsMetadata(mirrorId, mirrorName, partitionOffsets, true);
     }
 
     /**
@@ -353,13 +360,13 @@ public class MirrorCoordinator {
      * @param newState The new state for the partition
      * @return A CompletableFuture that completes with the topic partition if successful, or empty if failed
      */
-    public CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(String mirrorName, TopicPartition topicPartition, MirrorPartitionState newState) {
+    public CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(Uuid mirrorId, String mirrorName, TopicPartition topicPartition, MirrorPartitionState newState) {
         CompletableFuture<Optional<TopicPartition>> future = new CompletableFuture<>();
-        if (isLocalCoordinator(mirrorName, topicPartition.topic(), topicPartition.partition())) {
+        if (isLocalCoordinator(mirrorId, topicPartition.topic(), topicPartition.partition())) {
             // this is the leader of the coordinator (async disk I/O operation)
-            var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, getCoordinatingPartitionByKey(new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topicPartition.topic()), topicPartition.partition())));
+            var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, getCoordinatingPartitionByKey(new MirrorRecordKey(mirrorId, metadataCache.getTopicId(topicPartition.topic()), topicPartition.partition())));
             var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
-            var record = generateMirrorPartitionState(mirrorName, topicPartition, newState);
+            var record = generateMirrorPartitionState(mirrorId, topicPartition, newState);
             var keyBytes = serde.serializeKey(record);
             var valueBytes = serde.serializeValue(record);
             var timestamp = time.milliseconds();
@@ -394,7 +401,7 @@ public class MirrorCoordinator {
             // write state data to remote coordinator (async network operation)
             Map<String, Set<MirrorMetadataManager.MirrorPartitionMetadata>> topicMetadata =
                     Map.of(topicPartition.topic(), Set.of(new MirrorMetadataManager.MirrorPartitionMetadata(topicPartition.partition(), newState, -1L)));
-            mirrorMetadataManager.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
+            mirrorMetadataManager.writeStatesToRemoteCoordinator(mirrorId, mirrorName, topicMetadata, Set.of(),
                     res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
                         if (par.errorCode() == Errors.NONE.code()) {
                             mirrorMetadataManager.updateMirrorPartitionState(mirrorName, topicPartition, newState);
@@ -420,7 +427,7 @@ public class MirrorCoordinator {
         }
 
         LOG.info("Starting up.");
-        mirrorMetadataManager.setStateTransitioner((mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state));
+        mirrorMetadataManager.setStateTransitioner((mirrorId, tp, state) -> transitionTo(mirrorId, Set.of(tp), state));
         mirrorMetadataManager.setCoordinatingPartitionFinder(key -> getCoordinatingPartitionByKey(key));
         scheduler.startup();
         // periodically query source cluster to get the metadata
@@ -442,10 +449,10 @@ public class MirrorCoordinator {
      * @param mirrorName the name of the cluster mirror
      * @param topicPartitions the topics to schedule for truncation
      */
-    public void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
+    public void scheduleTruncation(Uuid mirrorId, String mirrorName, Set<TopicPartition> topicPartitions) {
         scheduler.scheduleOnce("last-mirrored-offset-truncation",
             () -> mirrorMetadataManager.maybeTruncateToLastMirroredOffsets(replicaManager, mirrorName, topicPartitions,
-                    partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING)));
+                    partition -> transitionTo(mirrorId, Set.of(partition), MirrorPartitionState.MIRRORING)));
     }
 
     private Map<String, Map<Integer, Long>> lastMirroredOffsetsToCoordinatorRecords(Map<MirrorMetadataManager.MirrorPartitionKey, Long> offsets) {
@@ -479,20 +486,20 @@ public class MirrorCoordinator {
      * @param mirrorName the name of the cluster mirror
      * @param partitionOffsets map of topic names to partition offsets
      */
-    public void updateLastMirroredOffsetsMetadata(String mirrorName, Map<String, Map<Integer, Long>> partitionOffsets, boolean stateChange) {
+    public void updateLastMirroredOffsetsMetadata(Uuid mirrorId, String mirrorName, Map<String, Map<Integer, Long>> partitionOffsets, boolean stateChange) {
         // TODO: We now send a separate WriteMirrorStates request for each individual partition rather than batching. This increases
         // TODO: network overhead significantly, especially for mirrors with many partitions. Partitions that hash to the same
         // TODO: coordinator could still be batched together.
         partitionOffsets.forEach((topic, offsetMap) -> {
             offsetMap.forEach((par, off) -> {
-                if (isLocalCoordinator(mirrorName, topic, par)) {
+                if (isLocalCoordinator(mirrorId, topic, par)) {
                     // this is the leader of the coordinator
-                    var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, getCoordinatingPartitionByKey(new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), par)));
+                    var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, getCoordinatingPartitionByKey(new MirrorRecordKey(mirrorId, metadataCache.getTopicId(topic), par)));
                     var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
 
 
                     var updatedOffsets = mirrorMetadataManager.updateLastMirroredOffsets(mirrorName, Map.of(topic, Map.of(par, off)), Map.of());
-                    var record = generateLastMirroredOffsets(mirrorName, lastMirroredOffsetsToCoordinatorRecords(updatedOffsets));
+                    var record = generateLastMirroredOffsets(mirrorId, lastMirroredOffsetsToCoordinatorRecords(updatedOffsets));
                     var keyBytes = serde.serializeKey(record);
                     var valueBytes = serde.serializeValue(record);
                     var timestamp = time.milliseconds();
@@ -514,7 +521,7 @@ public class MirrorCoordinator {
                     // transition to stopped state after last mirrored offset stored
                     // TODO: now we assume all partitions work without error, we should handle error cases
                     if (stateChange)
-                        transitionTo(mirrorName, Set.of(new TopicPartition(topic, par)), MirrorPartitionState.STOPPED);
+                        transitionTo(mirrorId, Set.of(new TopicPartition(topic, par)), MirrorPartitionState.STOPPED);
                 } else {
                     Map<String, Set<MirrorMetadataManager.MirrorPartitionMetadata>> topicMetadata = new HashMap<>();
                     partitionOffsets.forEach((tp, partitionOffsetMap) -> {
@@ -524,9 +531,9 @@ public class MirrorCoordinator {
                         });
                         topicMetadata.put(tp, mirroredPartitions);
                     });
-                    mirrorMetadataManager.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(), res -> {
+                    mirrorMetadataManager.writeStatesToRemoteCoordinator(mirrorId, mirrorName, topicMetadata, Set.of(), res -> {
                         if (stateChange)
-                            transitionTo(mirrorName, Set.of(new TopicPartition(topic, par)), MirrorPartitionState.STOPPED);
+                            transitionTo(mirrorId, Set.of(new TopicPartition(topic, par)), MirrorPartitionState.STOPPED);
                     });
                 }
             });
@@ -534,15 +541,15 @@ public class MirrorCoordinator {
         });
     }
 
-    private static CoordinatorRecord generateMirrorPartitionState(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
-        var key = new MirrorPartitionStateKey().setMirrorName(mirrorName);
+    private static CoordinatorRecord generateMirrorPartitionState(Uuid mirrorId, TopicPartition topicPartition, MirrorPartitionState state) {
+        var key = new MirrorPartitionStateKey().setMirrorId(mirrorId);
         var val = new MirrorPartitionStateValue().setTopicName(topicPartition.topic()).setPartition(topicPartition.partition()).setState(state.value());
         var apiVersion = new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);
     }
 
-    private static CoordinatorRecord generateLastMirroredOffsets(String mirrorName, Map<String, Map<Integer, Long>> offsets) {
-        var key = new LastMirroredOffsetsKey().setMirrorName(mirrorName);
+    private static CoordinatorRecord generateLastMirroredOffsets(Uuid mirrorId, Map<String, Map<Integer, Long>> offsets) {
+        var key = new LastMirroredOffsetsKey().setMirrorId(mirrorId);
         var val = new LastMirroredOffsetsValue();
         var topics = new ArrayList<LastMirroredOffsetsValue.Topic>();
         offsets.forEach((topic, partitionOffsets) -> {
@@ -558,14 +565,14 @@ public class MirrorCoordinator {
         return CoordinatorRecord.record(key, apiVersion);
     }
 
-    private String readMirrorNameFromKey(ByteBuffer buffer) {
+    private Uuid readMirrorIdFromKey(ByteBuffer buffer) {
         short version = buffer.getShort();
         if (version == CoordinatorRecordType.MIRROR_TOPICS.id()) {
-            return new MirrorTopicsKey(new ByteBufferAccessor(buffer), version).mirrorName();
+            return new MirrorTopicsKey(new ByteBufferAccessor(buffer), version).mirrorId();
         } else if (version == CoordinatorRecordType.LAST_MIRRORED_OFFSETS.id()) {
-            return new LastMirroredOffsetsKey(new ByteBufferAccessor(buffer), version).mirrorName();
+            return new LastMirroredOffsetsKey(new ByteBufferAccessor(buffer), version).mirrorId();
         } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
-            return new MirrorPartitionStateKey(new ByteBufferAccessor(buffer), version).mirrorName();
+            return new MirrorPartitionStateKey(new ByteBufferAccessor(buffer), version).mirrorId();
         } else {
             throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);
         }
@@ -661,17 +668,26 @@ public class MirrorCoordinator {
                             require(record.hasKey(), "Mirror log's key should not be null");
                             short version = record.key().getShort();
                             if (version ==  CoordinatorRecordType.MIRROR_TOPICS.id()) {
-                                String clusterName = readMirrorNameFromKey(record.key());
+                                Uuid mirrorId = readMirrorIdFromKey(record.key());
+                                String clusterName = mirrorMetadataManager.getMirrorName(mirrorId);
                                 Set<String> topics = readMirrorTopicsFromValue(record.value());
-                                mirrorMetadataManager.updateMirrorTopics(clusterName, topics, Set.of());
+                                if (clusterName != null) {
+                                    mirrorMetadataManager.updateMirrorTopics(clusterName, topics, Set.of());
+                                }
                             } else if (version == CoordinatorRecordType.LAST_MIRRORED_OFFSETS.id()) {
-                                String clusterName = readMirrorNameFromKey(record.key());
+                                Uuid mirrorId = readMirrorIdFromKey(record.key());
+                                String clusterName = mirrorMetadataManager.getMirrorName(mirrorId);
                                 Map<String, Map<Integer, Long>> offsets = readLastMirroredOffsetsValue(record.value());
-                                mirrorMetadataManager.updateLastMirroredOffsets(clusterName, offsets, Map.of());
+                                if (clusterName != null) {
+                                    mirrorMetadataManager.updateLastMirroredOffsets(clusterName, offsets, Map.of());
+                                }
                             } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
-                                String clusterName = readMirrorNameFromKey(record.key());
+                                Uuid mirrorId = readMirrorIdFromKey(record.key());
+                                String clusterName = mirrorMetadataManager.getMirrorName(mirrorId);
                                 MirrorMetadataManager.MirrorPartitionStateRecordValue value = readMirrorPartitionStateValue(record.value());
-                                mirrorMetadataManager.updateMirrorPartitionState(clusterName, new TopicPartition(value.topic(), value.partition()), value.state());
+                                if (clusterName != null) {
+                                    mirrorMetadataManager.updateMirrorPartitionState(clusterName, new TopicPartition(value.topic(), value.partition()), value.state());
+                                }
                             } else {
                                 throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);
                             }
@@ -685,8 +701,8 @@ public class MirrorCoordinator {
             }
 
             // we've read all the mirrored records, transition the state for each topic partitions
-            StateTransitionCallback callback = (mirrorName, topics, state)
-                    -> handleStateTransition(mirrorName, topics, state);
+            StateTransitionCallback callback = (mirrorId, topics, state)
+                    -> handleStateTransition(mirrorId, topics, state);
             mirrorMetadataManager.applyLoadedPartitionStates(callback);
 
             return null;
@@ -697,11 +713,11 @@ public class MirrorCoordinator {
         /**
          * Called for each mirror partition state that was loaded from the coordinator log.
          *
-         * @param mirrorName the name of the cluster mirror
+         * @param mirrorId the system-generated mirror ID
          * @param topicPartitions     the topics in this state
          * @param state      the mirror state to operate on
          */
-        void onStateLoaded(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState state);
+        void onStateLoaded(Uuid mirrorId, Set<TopicPartition> topicPartitions, MirrorPartitionState state);
     }
 
     /**
@@ -765,6 +781,26 @@ public class MirrorCoordinator {
      */
     public String getSourceBootstrap(String mirrorName) {
         return mirrorMetadataManager.getSourceBootstrap(mirrorName);
+    }
+
+    /**
+     * Returns the system-generated mirror ID for a given mirror name.
+     *
+     * @param mirrorName the name of the cluster mirror
+     * @return the mirror ID, or null if not found
+     */
+    public Uuid getMirrorId(String mirrorName) {
+        return mirrorMetadataManager.getMirrorId(mirrorName);
+    }
+
+    /**
+     * Returns the mirror name for a given mirror ID.
+     *
+     * @param mirrorId the system-generated mirror ID
+     * @return the mirror name, or null if not found
+     */
+    public String getMirrorName(Uuid mirrorId) {
+        return mirrorMetadataManager.getMirrorName(mirrorId);
     }
 
     /**

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AccessControlEntryFilter;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
@@ -129,7 +130,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
-import static org.apache.kafka.controller.ConfigurationControlManager.REMOVED_TOPIC_SUFFIX;
+import static org.apache.kafka.common.config.TopicConfig.MIRROR_REMOVED_SUFFIX;
 
 /**
  * Manages cluster state synchronization and remote cluster communication for Cluster Mirroring.
@@ -239,10 +240,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return "MirrorMetadataManager(id=" + brokerConfig.nodeId() + ")";
     }
 
-    private boolean isLocalCoordinator(String mirrorName, String topic, int partition) {
+    private boolean isLocalCoordinator(Uuid mirrorId, String topic, int partition) {
         if (coordinatingPartFinder.isPresent()) {
             int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
-                    .partitions().get(coordinatingPartFinder.get().apply(new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), partition))).leader;
+                    .partitions().get(coordinatingPartFinder.get().apply(new MirrorRecordKey(mirrorId, metadataCache.getTopicId(topic), partition))).leader;
             return activeCoordinator == brokerConfig.nodeId();
         }
         return false;
@@ -285,47 +286,58 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         // TODO: coordinator could still be batched together.
         mirrorLeaders.forEach(tp -> {
             boolean stopRequested;
-            String mirrorName = (String) newImage.configs().configProperties(
-                    new ConfigResource(ConfigResource.Type.TOPIC, tp.topic())).get(TopicConfig.MIRROR_NAME_CONFIG);
-            if (mirrorName.endsWith(REMOVED_TOPIC_SUFFIX)) {
+            String mirrorIdStr = (String) newImage.configs().configProperties(
+                    new ConfigResource(ConfigResource.Type.TOPIC, tp.topic())).get(TopicConfig.MIRROR_ID_CONFIG);
+            if (mirrorIdStr.endsWith(MIRROR_REMOVED_SUFFIX)) {
                 stopRequested = true;
-                mirrorName = mirrorName.substring(0, mirrorName.length() - REMOVED_TOPIC_SUFFIX.length());
+                mirrorIdStr = mirrorIdStr.substring(0, mirrorIdStr.length() - MIRROR_REMOVED_SUFFIX.length());
             } else {
                 stopRequested = false;
             }
-            MirrorPartitionKey key = new MirrorPartitionKey(mirrorName, tp.topic(), tp.partition());
-            if (isLocalCoordinator(key.mirrorName, key.topic, key.partition())) {
+            Uuid mirrorId = Uuid.fromString(mirrorIdStr);
+            MirrorPartitionKey key = new MirrorPartitionKey(mirrorId, tp.topic(), tp.partition());
+            // Resolve mirrorId -> mirrorName for topic tracking
+            String mirrorName = getMirrorName(mirrorId);
+            if (mirrorName != null) {
+                mirrorTopics.compute(mirrorName, (k, oldVal) -> {
+                    if (oldVal == null) return Set.of(tp.topic());
+                    Set<String> newSet = new HashSet<>(oldVal);
+                    newSet.add(tp.topic());
+                    return newSet;
+                });
+            }
+            if (isLocalCoordinator(key.mirrorId, key.topic, key.partition())) {
                 MirrorPartitionState curState = mirrorPartitionState.getOrDefault(key, MirrorPartitionState.UNKNOWN);
                 stateTransitioner.ifPresent(t -> {
                     if (stopRequested && curState != MirrorPartitionState.STOPPED) {
-                        t.transitionTo(key.mirrorName, tp, MirrorPartitionState.STOPPING);
+                        t.transitionTo(key.mirrorId, tp, MirrorPartitionState.STOPPING);
                     } else {
                         // moving to preparing_mirroring if it's starting because it's waiting for metadata update.
                         // otherwise, move to what the current state is
                         if (curState == MirrorPartitionState.UNKNOWN || curState == MirrorPartitionState.STOPPED) {
-                            t.transitionTo(key.mirrorName, tp, MirrorPartitionState.PREPARING);
+                            t.transitionTo(key.mirrorId, tp, MirrorPartitionState.PREPARING);
                         } else {
-                            t.transitionTo(key.mirrorName, tp, curState);
+                            t.transitionTo(key.mirrorId, tp, curState);
                         }
                     }
                 });
             } else {
                 // get the state from remote coordinator
-                readStatesFromRemoteCoordinator(key.mirrorName, Map.of(tp.topic(), Set.of(tp.partition())), res -> {
+                readStatesFromRemoteCoordinator(mirrorId, mirrorName, Map.of(tp.topic(), Set.of(tp.partition())), res -> {
                     res.data().topics().forEach(topic -> {
                         topic.partitions().forEach(partition -> {
                             if (partition.state() != -1) {
                                 MirrorPartitionState state = MirrorPartitionState.fromValue(partition.state());
-                                mirrorPartitionState.put(new MirrorPartitionKey(key.mirrorName, tp.topic(), tp.partition()), state);
+                                mirrorPartitionState.put(new MirrorPartitionKey(key.mirrorId, tp.topic(), tp.partition()), state);
                                 stateTransitioner.ifPresent(t -> {
                                     MirrorPartitionState curState = mirrorPartitionState.getOrDefault(key, MirrorPartitionState.UNKNOWN);
                                     if (stopRequested && curState != MirrorPartitionState.STOPPED) {
-                                        t.transitionTo(key.mirrorName, tp, MirrorPartitionState.STOPPING);
+                                        t.transitionTo(key.mirrorId, tp, MirrorPartitionState.STOPPING);
                                     } else {
                                         if (curState == MirrorPartitionState.UNKNOWN || curState == MirrorPartitionState.STOPPED) {
-                                            t.transitionTo(key.mirrorName, tp, MirrorPartitionState.PREPARING);
+                                            t.transitionTo(key.mirrorId, tp, MirrorPartitionState.PREPARING);
                                         } else {
-                                            t.transitionTo(key.mirrorName, tp, state);
+                                            t.transitionTo(key.mirrorId, tp, state);
                                         }
                                     }
                                 });
@@ -358,34 +370,34 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private Set<TopicPartition> getMirrorLeaders(MetadataDelta delta, MetadataImage image) {
         Set<TopicPartition> mirrorLeaderPartitions = new HashSet<>();
 
-        // new partition leader in topicsDelta that has mirror.name not empty
+        // new partition leader in topicsDelta that has mirror.id not empty
         if (delta.topicsDelta() != null) {
             delta.topicsDelta().localChanges(nodeId).leaders().keySet().forEach(tp -> {
                 Properties props = image.configs().configProperties(new ConfigResource(ConfigResource.Type.TOPIC, tp.topic()));
-                if (props.containsKey(TopicConfig.MIRROR_NAME_CONFIG)) {
-                    String mirrorName = (String) props.get(TopicConfig.MIRROR_NAME_CONFIG);
-                    if (mirrorName != null && !mirrorName.isBlank()) {
+                if (props.containsKey(TopicConfig.MIRROR_ID_CONFIG)) {
+                    String mirrorIdStr = (String) props.get(TopicConfig.MIRROR_ID_CONFIG);
+                    if (mirrorIdStr != null && !mirrorIdStr.isBlank()) {
                         mirrorLeaderPartitions.add(tp);
                     }
                 }
             });
         }
 
-        // the config change in configsDelta contains the mirror.name setting from empty to non-empty
+        // the config change in configsDelta contains the mirror.id setting from empty to non-empty
         if (delta.configsDelta() != null) {
-            // get all resources containing the non-empty mirror name change
-            Map<ConfigResource, ConfigurationDelta> mirrorNameChanged = delta.configsDelta().changes().entrySet().stream().filter(entry ->
-                            entry.getValue().changes().containsKey(TopicConfig.MIRROR_NAME_CONFIG) &&
-                                    !entry.getValue().changes().get(TopicConfig.MIRROR_NAME_CONFIG).isEmpty())
+            // get all resources containing the non-empty mirror id change
+            Map<ConfigResource, ConfigurationDelta> mirrorIdChanged = delta.configsDelta().changes().entrySet().stream().filter(entry ->
+                            entry.getValue().changes().containsKey(TopicConfig.MIRROR_ID_CONFIG) &&
+                                    !entry.getValue().changes().get(TopicConfig.MIRROR_ID_CONFIG).isEmpty())
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             // get all topics from the resources
-            Set<String> topicsWithMirrorNameChanged = mirrorNameChanged.keySet().stream()
+            Set<String> topicsWithMirrorIdChanged = mirrorIdChanged.keySet().stream()
                     .filter(configResource -> configResource.type().equals(ConfigResource.Type.TOPIC))
                     .map(configResource -> configResource.name()).collect(Collectors.toSet());
 
             // get the partition leader is the local node
-            topicsWithMirrorNameChanged.stream().forEach(topic -> {
+            topicsWithMirrorIdChanged.stream().forEach(topic -> {
                 TopicImage topicImage = image.topics().getTopic(topic);
                 if (topicImage != null) {
                     topicImage.partitions().forEach((partitionId, partition) -> {
@@ -413,12 +425,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      */
     private void clearFollowersState(Set<TopicPartition> followerDelta, MetadataImage newImage) {
         followerDelta.forEach(followerTp -> {
-            String mirrorName = (String) newImage.configs().configProperties(new ConfigResource(ConfigResource.Type.TOPIC, followerTp.topic())).get(TopicConfig.MIRROR_NAME_CONFIG);
-            if (mirrorName != null && !mirrorName.isEmpty() && !isLocalCoordinator(mirrorName, followerTp.topic(), followerTp.partition())) {
-                String updatedMirrorName = originalMirrorName(mirrorName);
-                MirrorPartitionKey key = new MirrorPartitionKey(updatedMirrorName, followerTp.topic(), followerTp.partition());
-                mirrorPartitionState.remove(key);
-                lastMirroredOffsets.remove(key);
+            String mirrorIdStr = (String) newImage.configs().configProperties(new ConfigResource(ConfigResource.Type.TOPIC, followerTp.topic())).get(TopicConfig.MIRROR_ID_CONFIG);
+            if (mirrorIdStr != null && !mirrorIdStr.isEmpty()) {
+                String cleanMirrorIdStr = originalMirrorName(mirrorIdStr); // strip MIRROR_REMOVED_SUFFIX if present
+                Uuid mirrorId = Uuid.fromString(cleanMirrorIdStr);
+                if (!isLocalCoordinator(mirrorId, followerTp.topic(), followerTp.partition())) {
+                    MirrorPartitionKey key = new MirrorPartitionKey(mirrorId, followerTp.topic(), followerTp.partition());
+                    mirrorPartitionState.remove(key);
+                    lastMirroredOffsets.remove(key);
+                }
             }
         });
     }
@@ -490,7 +505,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     interface StateTransitioner {
-        void transitionTo(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state);
+        void transitionTo(Uuid mirrorId, TopicPartition topicPartition, MirrorPartitionState state);
     }
 
     /**
@@ -521,17 +536,18 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * @param removedTopics set of topic names that have been removed from the mirror
      * @param responseCallback callback invoked with the coordinator's response
      */
-    public void writeStatesToRemoteCoordinator(String mirrorName,
+    public void writeStatesToRemoteCoordinator(Uuid mirrorId, String mirrorName,
                                                Map<String, Set<MirrorPartitionMetadata>> topicMetadata,
                                                Set<String> removedTopics,
                                                Consumer<WriteMirrorStatesResponse> responseCallback) {
-        LOG.info("!!! writeStatesToRemoteCoordinator: {} {} {}", mirrorName, topicMetadata, removedTopics);
+        LOG.info("!!! writeStatesToRemoteCoordinator: {} {} {} {}", mirrorId, mirrorName, topicMetadata, removedTopics);
 
         topicMetadata.forEach((t, metadata) -> {
             metadata.forEach(m -> {
-                WriteMirrorStatesRequestData data = new WriteMirrorStatesRequestData().setMirrorName(mirrorName);
+                WriteMirrorStatesRequestData data = new WriteMirrorStatesRequestData()
+                        .setMirrorId(mirrorId);
                 List<WriteMirrorStatesRequestData.TopicState> topicStates = new ArrayList<>();
-                MirrorRecordKey key = new MirrorRecordKey(mirrorName, metadataCache.getTopicId(t), m.partition);
+                MirrorRecordKey key = new MirrorRecordKey(mirrorId, metadataCache.getTopicId(t), m.partition);
                 Node coordinatorNode = coordinatorNodes.get(key);
                 if (coordinatorNode == null) {
                     coordinatorNode = findMirrorCoordinatorNode(key);
@@ -597,15 +613,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * @param partitions map of topic names to their partition indices to query
      * @param onWriteComplete callback invoked with the coordinator's response containing partition states
      */
-    public void readStatesFromRemoteCoordinator(String mirrorName,
+    public void readStatesFromRemoteCoordinator(Uuid mirrorId, String mirrorName,
                                                 Map<String, Set<Integer>> partitions,
                                                 Consumer<ReadMirrorStatesResponse> onWriteComplete) {
-        LOG.info("!!! readStatesToRemoteCoordinator: {} {}", mirrorName, partitions);
+        LOG.info("!!! readStatesToRemoteCoordinator: {} {} {}", mirrorId, mirrorName, partitions);
 
 
         partitions.forEach((tp, parts) -> {
             parts.forEach(part -> {
-                MirrorRecordKey key = new MirrorRecordKey(mirrorName, metadataCache.getTopicId(tp), part);
+                MirrorRecordKey key = new MirrorRecordKey(mirrorId, metadataCache.getTopicId(tp), part);
                 Node coordinatorNode = coordinatorNodes.get(key);
                 if (coordinatorNode == null) {
                     coordinatorNode = findMirrorCoordinatorNode(key);
@@ -617,7 +633,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 }
                 coordinatorNodes.put(key, coordinatorNode);
 
-                ReadMirrorStatesRequestData data = new ReadMirrorStatesRequestData().setMirrorName(mirrorName);
+                ReadMirrorStatesRequestData data = new ReadMirrorStatesRequestData()
+                        .setMirrorId(mirrorId);
                 List<ReadMirrorStatesRequestData.TopicState> topicStates = new ArrayList<>();
 
                 ReadMirrorStatesRequestData.TopicState state = new ReadMirrorStatesRequestData.TopicState().setName(tp);
@@ -630,7 +647,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 state.setPartitions(partitionStates);
                 topicStates.add(state);
 
-                data.setMirrorName(mirrorName).setTopics(topicStates);
+                data.setTopics(topicStates);
 
                 // send
                 interBrokerSender.enqueue(new RequestAndCompletionHandler(
@@ -646,12 +663,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 readMirrorStatesResponse.data().topics().forEach(topic -> {
                                     topic.partitions().forEach(partition -> {
                                         if (partition.lastMirroredOffset() != -1) {
-                                            lastMirroredOffsets.put(new MirrorPartitionKey(mirrorName, topic.name(), partition.partitionIndex()), partition.lastMirroredOffset());
+                                            lastMirroredOffsets.put(new MirrorPartitionKey(mirrorId, topic.name(), partition.partitionIndex()), partition.lastMirroredOffset());
                                         }
                                         if (partition.state() != -1) {
-                                            mirrorPartitionState.put(new MirrorPartitionKey(mirrorName, topic.name(), partition.partitionIndex()), MirrorPartitionState.fromValue(partition.state()));
+                                            mirrorPartitionState.put(new MirrorPartitionKey(mirrorId, topic.name(), partition.partitionIndex()), MirrorPartitionState.fromValue(partition.state()));
                                         }
-                                        mirrorTopics.compute(mirrorName, (k, oldVal) -> {
+                                        String resolvedName = mirrorName != null ? mirrorName : getMirrorName(mirrorId);
+                                        if (resolvedName != null) mirrorTopics.compute(resolvedName, (k, oldVal) -> {
                                             if (oldVal == null) {
                                                 return Set.of(topic.name());
                                             } else {
@@ -694,9 +712,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * @param partitions map of topic names to their partition indices to query
      * @param responseCallback callback invoked immediately with cached partition states
      */
-    public void readMirrorPartitionMetadataFromCache(String mirrorName,
+    public void readMirrorPartitionMetadataFromCache(String mirrorName, Uuid mirrorId,
                                                      Map<String, Set<Integer>> partitions,
                                                      Consumer<ReadMirrorStatesResponse> responseCallback) {
+        Uuid resolvedMirrorId = mirrorId != null && !mirrorId.equals(Uuid.ZERO_UUID) ? mirrorId : getMirrorId(mirrorName);
         ReadMirrorStatesResponseData data = new ReadMirrorStatesResponseData();
         List<ReadMirrorStatesResponseData.TopicState> topicStates = new ArrayList<>();
         partitions.forEach((tp, parts) -> {
@@ -705,8 +724,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             parts.forEach(part -> {
                 ReadMirrorStatesResponseData.PartitionState partitionState = new ReadMirrorStatesResponseData.PartitionState();
                 partitionState.setPartitionIndex(part);
-                partitionState.setLastMirroredOffset(lastMirroredOffsets.getOrDefault(new MirrorPartitionKey(mirrorName, tp, part), -1L));
-                partitionState.setState(mirrorPartitionState.getOrDefault(new MirrorPartitionKey(mirrorName, tp, part), MirrorPartitionState.UNKNOWN).value());
+                partitionState.setLastMirroredOffset(lastMirroredOffsets.getOrDefault(new MirrorPartitionKey(resolvedMirrorId, tp, part), -1L));
+                partitionState.setState(mirrorPartitionState.getOrDefault(new MirrorPartitionKey(resolvedMirrorId, tp, part), MirrorPartitionState.UNKNOWN).value());
                 partitionStates.add(partitionState);
             });
             state.setPartitions(partitionStates);
@@ -888,7 +907,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * @return The last mirrored offset, or 0L if no offset is cached
      */
     public long getLastMirroredOffset(String clusterName, TopicPartition topicPartition) {
-        MirrorPartitionKey key = new MirrorPartitionKey(clusterName, topicPartition.topic(), topicPartition.partition());
+        Uuid mirrorId = getMirrorId(clusterName);
+        if (mirrorId == null) return 0L;
+        MirrorPartitionKey key = new MirrorPartitionKey(mirrorId, topicPartition.topic(), topicPartition.partition());
         if (lastMirroredOffsets.containsKey(key)) {
             return lastMirroredOffsets.get(key);
         }
@@ -903,7 +924,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * @param mirrorState The new mirror partition state
      */
     public void updateMirrorPartitionState(String clusterName, TopicPartition topicPartition, MirrorPartitionState mirrorState) {
-        mirrorPartitionState.put(new MirrorPartitionKey(clusterName, topicPartition.topic(), topicPartition.partition()), mirrorState);
+        Uuid mirrorId = getMirrorId(clusterName);
+        if (mirrorId != null) {
+            mirrorPartitionState.put(new MirrorPartitionKey(mirrorId, topicPartition.topic(), topicPartition.partition()), mirrorState);
+        }
         mirrorTopics.compute(clusterName, (key, oldVal) -> {
             if (oldVal == null) {
                 return Set.of(topicPartition.topic());
@@ -917,15 +941,22 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     /**
      * Retrieves the current state of a mirror partition from the local cache.
-     * Handles mirror names with REMOVED_TOPIC_SUFFIX by stripping the suffix before lookup.
+     * Handles mirror names with MIRROR_REMOVED_SUFFIX by stripping the suffix before lookup.
      *
-     * @param mirrorName The name of the mirror (may include REMOVED_TOPIC_SUFFIX)
+     * @param mirrorName The name of the mirror (may include MIRROR_REMOVED_SUFFIX)
      * @param topicPartition The topic partition to query
      * @return The mirror partition state, or null if not found in cache
      */
     public MirrorPartitionState getMirrorPartitionState(String mirrorName, TopicPartition topicPartition) {
         String updatedMirrorName = originalMirrorName(mirrorName);
-        return mirrorPartitionState.get(new MirrorPartitionKey(updatedMirrorName, topicPartition.topic(), topicPartition.partition()));
+        Uuid mirrorId = getMirrorId(updatedMirrorName);
+        if (mirrorId == null) return null;
+        return mirrorPartitionState.get(new MirrorPartitionKey(mirrorId, topicPartition.topic(), topicPartition.partition()));
+    }
+
+    public MirrorPartitionState getMirrorPartitionStateByMirrorId(Uuid mirrorId, TopicPartition topicPartition) {
+        if (mirrorId == null) return null;
+        return mirrorPartitionState.get(new MirrorPartitionKey(mirrorId, topicPartition.topic(), topicPartition.partition()));
     }
 
     /**
@@ -937,13 +968,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * @param callback The callback to invoke for each (mirror, state, partitions) group
      */
     public void applyLoadedPartitionStates(MirrorCoordinator.StateTransitionCallback callback) {
-        Map<String, Map<MirrorPartitionState, Set<TopicPartition>>> statesToPartitionsToOperate = new HashMap<>();
+        Map<Uuid, Map<MirrorPartitionState, Set<TopicPartition>>> statesToPartitionsToOperate = new HashMap<>();
         mirrorPartitionState.forEach((key, value) -> {
             LOG.info("!!! operateAll: {} {}", key, value);
             metadataCache.getLeaderAndIsr(key.topic(), key.partition()).ifPresent(metadata -> {
                 // only operate when this node is the leader of the partition
                 if (metadata.leader() == nodeId) {
-                    statesToPartitionsToOperate.compute(key.mirrorName, (k, v) -> {
+                    statesToPartitionsToOperate.compute(key.mirrorId(), (k, v) -> {
                         if (v == null) {
                             Map<MirrorPartitionState, Set<TopicPartition>> map = new HashMap<>();
                             map.put(value, Set.of(new TopicPartition(key.topic(), key.partition())));
@@ -966,9 +997,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             });
         });
 
-        statesToPartitionsToOperate.forEach((mirrorName, statesToPartitionsMap) -> {
+        statesToPartitionsToOperate.forEach((mirrorId, statesToPartitionsMap) -> {
             statesToPartitionsMap.forEach((state, tps) -> {
-                callback.onStateLoaded(mirrorName, tps, state);
+                callback.onStateLoaded(mirrorId, tps, state);
             });
         });
     }
@@ -985,14 +1016,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     public Map<MirrorPartitionKey, Long> updateLastMirroredOffsets(String clusterName,
                                                                    Map<String, Map<Integer, Long>> addedOffsets,
                                                                    Map<String, Map<Integer, Long>> removedOffsets) {
+        Uuid mirrorId = getMirrorId(clusterName);
+        if (mirrorId == null) return lastMirroredOffsets;
         removedOffsets.forEach((topic, partitionOffsets) -> {
             partitionOffsets.forEach((partition, offset) -> {
-                lastMirroredOffsets.remove(new MirrorPartitionKey(clusterName, topic, partition));
+                lastMirroredOffsets.remove(new MirrorPartitionKey(mirrorId, topic, partition));
             });
         });
         addedOffsets.forEach((topic, partitionOffsets) -> {
             partitionOffsets.forEach((partition, offset) -> {
-                lastMirroredOffsets.put(new MirrorPartitionKey(clusterName, topic, partition), offset);
+                lastMirroredOffsets.put(new MirrorPartitionKey(mirrorId, topic, partition), offset);
             });
         });
         return lastMirroredOffsets;
@@ -1191,6 +1224,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     // Ensures the destination cluster's mirror.name setting is never overwritten
                     // by source cluster configs (which wouldn't have this config set)
                     if (con.configSource() == DescribeConfigsResponse.ConfigSource.TOPIC_CONFIG.id()
+                            && !con.name().equals(TopicConfig.MIRROR_ID_CONFIG)
                             && !con.name().equals(TopicConfig.MIRROR_NAME_CONFIG)
                             && !excludePattern.matcher(con.name()).matches()) {
                         if (props.containsKey(con.name())) {
@@ -1472,9 +1506,48 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * @return the set of configured topic names for this mirror
      */
     public Set<String> getConfiguredTopics(String mirrorName) {
+        Uuid mirrorId = getMirrorId(mirrorName);
+        if (mirrorId == null) return Set.of();
+        String mirrorIdStr = mirrorId.toString();
         return metadataCache.getAllTopics().stream()
-                .filter(topic -> mirrorName.equals(metadataCache.topicConfig(topic).get(TopicConfig.MIRROR_NAME_CONFIG)))
+                .filter(topic -> mirrorIdStr.equals(metadataCache.topicConfig(topic).get(TopicConfig.MIRROR_ID_CONFIG)))
                 .collect(java.util.stream.Collectors.toSet());
+    }
+
+    /**
+     * Returns the system-generated mirror ID for a given mirror name by reading the mirror's ConfigResource.
+     *
+     * @param mirrorName the user-provided mirror name
+     * @return the mirror ID, or null if not found
+     */
+    public Uuid getMirrorId(String mirrorName) {
+        if (mirrorName == null) return null;
+        Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName));
+        String mirrorIdStr = (String) props.get(TopicConfig.MIRROR_ID_CONFIG);
+        if (mirrorIdStr != null && !mirrorIdStr.isBlank()) {
+            return Uuid.fromString(mirrorIdStr);
+        }
+        return null;
+    }
+
+    /**
+     * Returns the mirror name for a given mirror ID by searching all MIRROR ConfigResources.
+     *
+     * @param mirrorId the system-generated mirror ID
+     * @return the mirror name, or null if not found
+     */
+    public String getMirrorName(Uuid mirrorId) {
+        if (mirrorId == null || mirrorId.equals(Uuid.ZERO_UUID)) return null;
+        String mirrorIdStr = mirrorId.toString();
+        return metadataImage.configs().resourceData().keySet().stream()
+                .filter(resource -> resource.type() == ConfigResource.Type.MIRROR)
+                .filter(resource -> {
+                    String idStr = (String) metadataImage.configs().configProperties(resource).get(TopicConfig.MIRROR_ID_CONFIG);
+                    return mirrorIdStr.equals(idStr);
+                })
+                .map(ConfigResource::name)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -1497,9 +1570,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * @return partition state map
      */
     public Map<TopicPartition, MirrorPartitionState> getMirrorStates(String mirrorName) {
+        Uuid mirrorId = getMirrorId(mirrorName);
         Map<TopicPartition, MirrorPartitionState> result = new HashMap<>();
+        if (mirrorId == null) return result;
         mirrorPartitionState.forEach((key, state) -> {
-            if (key.mirrorName().equals(mirrorName)) {
+            if (key.mirrorId().equals(mirrorId)) {
                 result.put(new TopicPartition(key.topic(), key.partition()), state);
             }
         });
@@ -1517,18 +1592,18 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
-     * Removes the REMOVED_TOPIC_SUFFIX from a mirror name if present.
+     * Removes the MIRROR_REMOVED_SUFFIX from a mirror name if present.
      * This suffix is appended to mirror names when topics are being removed from mirroring.
      *
-     * @param mirrorName The mirror name, potentially with REMOVED_TOPIC_SUFFIX
+     * @param mirrorName The mirror name, potentially with MIRROR_REMOVED_SUFFIX
      * @return The original mirror name without the suffix, or empty string if input is null
      */
     public static String originalMirrorName(String mirrorName) {
         if (mirrorName == null) {
             return "";
         }
-        if (mirrorName.endsWith(REMOVED_TOPIC_SUFFIX)) {
-            return mirrorName.substring(0, mirrorName.length() - REMOVED_TOPIC_SUFFIX.length());
+        if (mirrorName.endsWith(MIRROR_REMOVED_SUFFIX)) {
+            return mirrorName.substring(0, mirrorName.length() - MIRROR_REMOVED_SUFFIX.length());
         }
         return mirrorName;
     }
@@ -1547,5 +1622,5 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public record MirrorPartitionMetadata(int partition, MirrorPartitionState state, Long offset) { }
     public record MirrorPartitionStateRecordValue(String topic, int partition, MirrorPartitionState state) { }
-    public record MirrorPartitionKey(String mirrorName, String topic, int partition) { }
+    public record MirrorPartitionKey(Uuid mirrorId, String topic, int partition) { }
 }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1384,9 +1384,9 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  def getMirrorName(): String = {
-    val mirrorName = metadataCache.config(new ConfigResource(ConfigResource.Type.TOPIC, topic)).get(TopicConfig.MIRROR_NAME_CONFIG).asInstanceOf[String]
-    if (mirrorName == null) "" else mirrorName
+  def getMirrorId(): String = {
+    val mirrorId = metadataCache.config(new ConfigResource(ConfigResource.Type.TOPIC, topic)).get(TopicConfig.MIRROR_ID_CONFIG).asInstanceOf[String]
+    if (mirrorId == null) "" else mirrorId
   }
 
   private def doAppendRecordsToFollowerOrFutureReplica(
@@ -1400,13 +1400,13 @@ class Partition(val topicPartition: TopicPartition,
       inReadLock(leaderIsrUpdateLock) {
         // Note the replica may be undefined if it is removed by a non-ReplicaAlterLogDirsThread before
         // this method is called
-        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, getMirrorName().nonEmpty && isLeader) }
+        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, getMirrorId().nonEmpty && isLeader) }
       }
     } else {
       // The lock is needed to prevent the follower replica from being updated while ReplicaAlterDirThread
       // is executing maybeReplaceCurrentWithFutureReplica() to replace follower replica with the future replica.
       futureLogLock.synchronized {
-        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, getMirrorName().nonEmpty && isLeader))
+        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, getMirrorId().nonEmpty && isLeader))
       }
     }
   }

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -144,9 +144,10 @@ class ConfigAdminManager(nodeId: Int,
               }
               validateBrokerConfigChange(resource, configResource)
             case TOPIC =>
-                // mirror.name check
-                if (resource.configs().stream().anyMatch(config => TopicConfig.MIRROR_NAME_CONFIG.equals(config.name()))) {
-                  throw new InvalidRequestException("The 'mirror.name' configuration can only be modified through dedicated mirror management APIs.")
+                // mirror.name / mirror.id check
+                if (resource.configs().stream().anyMatch(config =>
+                    TopicConfig.MIRROR_NAME_CONFIG.equals(config.name()) || TopicConfig.MIRROR_ID_CONFIG.equals(config.name()))) {
+                  throw new InvalidRequestException("The 'mirror.name' and 'mirror.id' configurations can only be modified through dedicated mirror management APIs.")
                 }
             case CLIENT_METRICS | GROUP | ConfigResource.Type.MIRROR =>
             // Nothing to do.

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -227,6 +227,14 @@ class ControllerApis(
 
     val createMirrorRequest = request.body[CreateMirrorRequest]
     info("!!! Create mirror request: " + createMirrorRequest)
+
+    // Validate mirror name: only alphanumeric, dash, underscore, and dot allowed
+    val mirrorNameStr = createMirrorRequest.data().mirrorName()
+    if (!mirrorNameStr.matches("[a-zA-Z0-9._-]+")) {
+      throw new InvalidRequestException(
+        s"Mirror name '$mirrorNameStr' is invalid. Mirror names may only contain alphanumeric characters, dots, dashes, and underscores.")
+    }
+
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal, OptionalLong.empty())
     val altersByName = new util.HashMap[String, Entry[AlterConfigOp.OpType, String]]()
     val configChanges = new util.HashMap[ConfigResource, util.Map[String, Entry[AlterConfigOp.OpType, String]]]()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -280,11 +280,12 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleCreateTopics(request: RequestChannel.Request): Unit = {
     val createTopicsRequest = request.body[CreateTopicsRequest]
 
-    // mirror.name check
+    // mirror.name / mirror.id check
     createTopicsRequest.data().topics().stream().forEach(creatableTopic => {
       if (creatableTopic.configs().stream().anyMatch(creatableTopicConfig =>
-        TopicConfig.MIRROR_NAME_CONFIG.equals(creatableTopicConfig.name())))
-        throw new InvalidRequestException("The 'mirror.name' configuration can only be modified through dedicated mirror management APIs.")
+        TopicConfig.MIRROR_NAME_CONFIG.equals(creatableTopicConfig.name()) ||
+        TopicConfig.MIRROR_ID_CONFIG.equals(creatableTopicConfig.name())))
+        throw new InvalidRequestException("The 'mirror.name' and 'mirror.id' configurations can only be modified through dedicated mirror management APIs.")
     })
 
     forwardToController(request)
@@ -294,7 +295,8 @@ class KafkaApis(val requestChannel: RequestChannel,
     if (isClusterMirroringEnabled) {
       val writeMirrorStatesRequest = request.body[WriteMirrorStatesRequest]
       info("!!! writeMirrorStatesRequest:" + writeMirrorStatesRequest)
-      val mirrorName = writeMirrorStatesRequest.data().mirrorName()
+      val mirrorId = writeMirrorStatesRequest.data().mirrorId()
+      val mirrorName = mirrorCoordinator.getMirrorName(mirrorId)
       val partitionMetadata = new util.HashMap[String, util.Set[MirrorPartitionMetadata]]()
       writeMirrorStatesRequest.data().topicsUpdated().forEach(topic => {
         val partMetadata = new util.HashSet[MirrorPartitionMetadata]()
@@ -303,7 +305,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         })
         partitionMetadata.put(topic.name(), partMetadata)
       })
-      mirrorCoordinator.writeMirrorPartitionMetadata(mirrorName, partitionMetadata, res => requestHelper.sendMaybeThrottle(request, res))
+      mirrorCoordinator.writeMirrorPartitionMetadata(mirrorName, mirrorId, partitionMetadata, res => requestHelper.sendMaybeThrottle(request, res))
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring write mirror states request")
       requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
@@ -314,7 +316,8 @@ class KafkaApis(val requestChannel: RequestChannel,
     if (isClusterMirroringEnabled) {
       val readMirrorStatesRequest = request.body[ReadMirrorStatesRequest]
       info("!!! readMirrorStatesRequest:" + readMirrorStatesRequest)
-      val mirrorName = readMirrorStatesRequest.data().mirrorName()
+      val mirrorId = readMirrorStatesRequest.data().mirrorId()
+      val mirrorName = mirrorCoordinator.getMirrorName(mirrorId)
       val partitionMetadata = new util.HashMap[String, util.Set[Integer]]()
       readMirrorStatesRequest.data().topics().forEach(topic => {
         val parts = new util.HashSet[Integer]()
@@ -323,7 +326,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         })
         partitionMetadata.put(topic.name(), parts)
       })
-      mirrorCoordinator.readMirrorPartitionMetadataFromCache(mirrorName, partitionMetadata,
+      mirrorCoordinator.readMirrorPartitionMetadataFromCache(mirrorName, mirrorId, partitionMetadata,
         res => requestHelper.sendMaybeThrottle(request, res))
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring read mirror states request")
@@ -391,8 +394,10 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
         val mirrors = new util.ArrayList[ListMirrorsResponseData.ListedMirror]()
         mirrorCoordinator.getConfiguredMirrors().forEach(mirrorName => {
+          val mirrorId = mirrorCoordinator.getMirrorId(mirrorName)
           mirrors.add(new ListMirrorsResponseData.ListedMirror()
             .setMirrorName(mirrorName)
+            .setMirrorId(if (mirrorId != null) mirrorId else org.apache.kafka.common.Uuid.ZERO_UUID)
             .setSourceBootstrap(if (mirrorCoordinator.getSourceBootstrap(mirrorName) != null)
               mirrorCoordinator.getSourceBootstrap(mirrorName) else "")
             .setTopicCount(mirrorCoordinator.getConfiguredTopics(mirrorName).size()))
@@ -433,8 +438,10 @@ class KafkaApis(val requestChannel: RequestChannel,
           }).toSeq
 
           if (partitionsToReport.nonEmpty) {
+            val mirrorId = mirrorCoordinator.getMirrorId(mirrorName)
             val describedMirror = new DescribeMirrorsResponseData.DescribedMirror()
               .setMirrorName(mirrorName)
+              .setMirrorId(if (mirrorId != null) mirrorId else org.apache.kafka.common.Uuid.ZERO_UUID)
               .setErrorCode(Errors.NONE.code)
 
             // Group partitions by topic

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -27,6 +27,7 @@ import kafka.server.mirror.{MirrorFetcherManager, MirrorLagInfo, MirrorMetadataM
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
 import org.apache.kafka.common.{IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.{Plugin, Topic}
 import org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult
@@ -1411,11 +1412,14 @@ class ReplicaManager(val config: KafkaConfig,
 
     def validateReadOnlyTopic(partition: Partition): Unit = {
       // if it's mirrored topic, it will become writable only when in STOPPED state
-      val mirrorName = partition.getMirrorName()
-      if (mirrorMetadataManager.isDefined && mirrorName.nonEmpty &&
-        mirrorMetadataManager.get.getMirrorPartitionState(mirrorName, partition.topicPartition) != MirrorPartitionState.STOPPED) {
-        throw new ReadOnlyTopicException("Cannot append to read-only partition %s on broker %d (mirrorName=%s)"
-          .format(partition.topicPartition, localBrokerId, mirrorName))
+      val mirrorIdStr = partition.getMirrorId()
+      if (mirrorMetadataManager.isDefined && mirrorIdStr.nonEmpty && !mirrorIdStr.endsWith(TopicConfig.MIRROR_REMOVED_SUFFIX)) {
+        val mirrorId = org.apache.kafka.common.Uuid.fromString(mirrorIdStr)
+        val state = mirrorMetadataManager.get.getMirrorPartitionStateByMirrorId(mirrorId, partition.topicPartition)
+        if (state != null && state != MirrorPartitionState.STOPPED) {
+          throw new ReadOnlyTopicException("Cannot append to read-only partition %s on broker %d (mirrorId=%s)"
+            .format(partition.topicPartition, localBrokerId, mirrorIdStr))
+        }
       }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -20,6 +20,7 @@ package org.apache.kafka.controller;
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.FeatureUpdate;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.ConfigResource.Type;
@@ -69,7 +70,6 @@ import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_
 
 public class ConfigurationControlManager {
     public static final ConfigResource DEFAULT_NODE = new ConfigResource(Type.BROKER, "");
-    public static final String REMOVED_TOPIC_SUFFIX = ".removed";
 
     private final Logger log;
     private final SnapshotRegistry snapshotRegistry;
@@ -225,8 +225,6 @@ public class ConfigurationControlManager {
         RemoveTopicsFromMirrorResponseData data = new RemoveTopicsFromMirrorResponseData();
         List<RemoveTopicsFromMirrorResponseData.TopicResponse> topicResList = new ArrayList<>();
         for (String topic : topics) {
-            String mirrorNameConfig = TopicConfig.MIRROR_NAME_CONFIG;
-
             RemoveTopicsFromMirrorResponseData.TopicResponse topicRes = new RemoveTopicsFromMirrorResponseData.TopicResponse();
 
             ConfigResource configResource = new ConfigResource(Type.TOPIC, topic);
@@ -236,7 +234,7 @@ public class ConfigurationControlManager {
             if (currentConfigs == null) {
                 topicRes.setErrorCode(Errors.INVALID_REQUEST.code());
             } else {
-                curVal = currentConfigs.get(mirrorNameConfig);
+                curVal = currentConfigs.get(TopicConfig.MIRROR_ID_CONFIG);
                 log.info("!!! curVal: {} for topic: {}", curVal, topic);
                 // Verify the current value should not be empty
                 if (curVal == null || curVal.isBlank()) {
@@ -245,9 +243,9 @@ public class ConfigurationControlManager {
                     continue;
                 }
 
-                // decide if we should clear the mirror name or append a stopped symbol
-                String newMirrorName = curVal.endsWith(REMOVED_TOPIC_SUFFIX) ? "" : curVal + REMOVED_TOPIC_SUFFIX;
-                Map<String, Entry<OpType, String>> keyToOps = Map.of(mirrorNameConfig, new AbstractMap.SimpleImmutableEntry<>(SET, newMirrorName));
+                // decide if we should clear the mirror id or append a stopped symbol
+                String newMirrorId = curVal.endsWith(TopicConfig.MIRROR_REMOVED_SUFFIX) ? "" : curVal + TopicConfig.MIRROR_REMOVED_SUFFIX;
+                Map<String, Entry<OpType, String>> keyToOps = Map.of(TopicConfig.MIRROR_ID_CONFIG, new AbstractMap.SimpleImmutableEntry<>(SET, newMirrorId));
 
                 ControllerResult<ApiError> configResult = incrementalAlterConfig(configResource, keyToOps, true);
                 if (configResult.response().isFailure()) {
@@ -277,19 +275,28 @@ public class ConfigurationControlManager {
             AddTopicsToMirrorResponseData.TopicResponse topicRes = new AddTopicsToMirrorResponseData.TopicResponse();
             ConfigResource configResource = new ConfigResource(Type.TOPIC, topic);
 
+            // Resolve mirrorName -> mirrorId
+            Uuid mirrorId = getMirrorId(mirrorName);
+            if (mirrorId == null) {
+                log.error("Mirror '{}' not found or has no mirror.id", mirrorName);
+                topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
+                topicResList.add(topicRes);
+                continue;
+            }
+
             TimelineHashMap<String, String> currentConfigs = configData.get(configResource);
             if (currentConfigs != null) {
-                String currMirrorNameValue = currentConfigs.get(TopicConfig.MIRROR_NAME_CONFIG);
-                log.info("!!! currMirrorNameValue: {} for topic: {}", currMirrorNameValue, topic);
+                String currMirrorIdValue = currentConfigs.get(TopicConfig.MIRROR_ID_CONFIG);
+                log.info("!!! currMirrorIdValue: {} for topic: {}", currMirrorIdValue, topic);
                 // Verify the current value should be empty or ends with removed suffix
-                if (currMirrorNameValue != null && (currMirrorNameValue.isBlank() || !currMirrorNameValue.endsWith(REMOVED_TOPIC_SUFFIX))) {
+                if (currMirrorIdValue != null && !currMirrorIdValue.isBlank() && !currMirrorIdValue.endsWith(TopicConfig.MIRROR_REMOVED_SUFFIX)) {
                     topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
                     topicResList.add(topicRes);
                     continue;
                 }
             }
 
-            Map<String, Entry<OpType, String>> keyToOps = Map.of(TopicConfig.MIRROR_NAME_CONFIG, new AbstractMap.SimpleImmutableEntry<>(SET, mirrorName));
+            Map<String, Entry<OpType, String>> keyToOps = Map.of(TopicConfig.MIRROR_ID_CONFIG, new AbstractMap.SimpleImmutableEntry<>(SET, mirrorId.toString()));
 
             ControllerResult<ApiError> configResult = incrementalAlterConfig(configResource, keyToOps, true);
             if (configResult.response().isFailure()) {
@@ -307,6 +314,24 @@ public class ConfigurationControlManager {
         return ControllerResult.of(records, data);
     }
 
+    /**
+     * Resolves a mirror name to its system-generated mirror ID by reading the mirror's ConfigResource.
+     *
+     * @param mirrorName the user-provided mirror name
+     * @return the mirror ID, or null if the mirror doesn't exist or has no mirror.id configured
+     */
+    private Uuid getMirrorId(String mirrorName) {
+        ConfigResource resource = new ConfigResource(ConfigResource.Type.MIRROR, mirrorName);
+        TimelineHashMap<String, String> configs = configData.get(resource);
+        if (configs != null) {
+            String mirrorIdStr = configs.get(TopicConfig.MIRROR_ID_CONFIG);
+            if (mirrorIdStr != null && !mirrorIdStr.isBlank()) {
+                return Uuid.fromString(mirrorIdStr);
+            }
+        }
+        return null;
+    }
+
     ControllerResult<CreateMirrorResponseData> addMirrorConfig(
             Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
             boolean newlyCreatedResource
@@ -314,10 +339,18 @@ public class ConfigurationControlManager {
         List<ApiMessageAndVersion> outputRecords = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         CreateMirrorResponseData data = new CreateMirrorResponseData();
 
+        // Generate a system-managed mirror ID
+        Uuid mirrorId = Uuid.randomUuid();
+
         for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> resourceEntry :
                 configChanges.entrySet()) {
+            // Add the system-generated mirror.id config before processing user configs
+            Map<String, Entry<OpType, String>> configsWithMirrorId = new HashMap<>(resourceEntry.getValue());
+            configsWithMirrorId.put(TopicConfig.MIRROR_ID_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(SET, mirrorId.toString()));
+
             ApiError apiError = incrementalAlterConfigResource(resourceEntry.getKey(),
-                    resourceEntry.getValue(),
+                    configsWithMirrorId,
                     newlyCreatedResource,
                     outputRecords);
             // TODO: Should handle the error here
@@ -326,6 +359,7 @@ public class ConfigurationControlManager {
         outputRecords.addAll(createClearElrRecordsAsNeeded(outputRecords));
 
         data.setErrorCode((short) 0);
+        data.setMirrorId(mirrorId);
 
         return ControllerResult.atomicOf(outputRecords, data);
     }

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/MirrorRecordKey.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/MirrorRecordKey.java
@@ -17,36 +17,37 @@
 package org.apache.kafka.coordinator.mirror;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.server.share.SharePartitionKey;
 
 import java.util.Objects;
 
 /**
- * This key is used to uniquely identify a cluster mirror by its name.
+ * This key is used to uniquely identify a cluster mirror by its system-generated ID.
+ * The key format is {@code mirrorId:topicId:partition} where all segments are UUID/int,
+ * eliminating the colon-ambiguity problem that existed with user-provided mirror names.
  */
-public record MirrorRecordKey(String mirrorName, Uuid topicId, int partition) {
-    public MirrorRecordKey(String mirrorName, Uuid topicId, int partition) {
-        this.mirrorName = Objects.requireNonNull(mirrorName, "Mirror name cannot be null");
+public record MirrorRecordKey(Uuid mirrorId, Uuid topicId, int partition) {
+    public MirrorRecordKey(Uuid mirrorId, Uuid topicId, int partition) {
+        this.mirrorId = Objects.requireNonNull(mirrorId, "Mirror ID cannot be null");
         this.topicId = Objects.requireNonNull(topicId, "topicId cannot be null");
-        this.partition = Objects.requireNonNull(partition, "partition cannot be null");
+        this.partition = partition;
     }
 
     public static MirrorRecordKey getInstance(String key) {
         validate(key);
         String[] tokens = key.split(":");
         return new MirrorRecordKey(
-                tokens[0].trim(),
+                Uuid.fromString(tokens[0].trim()),
                 Uuid.fromString(tokens[1]),
                 Integer.parseInt(tokens[2])
         );
     }
 
     public String asCoordinatorKey() {
-        return asCoordinatorKey(mirrorName, topicId, partition);
+        return asCoordinatorKey(mirrorId, topicId, partition);
     }
 
-    public static String asCoordinatorKey(String mirrorName, Uuid topicId, int partition) {
-        return String.format("%s:%s:%d", mirrorName, topicId, partition);
+    public static String asCoordinatorKey(Uuid mirrorId, Uuid topicId, int partition) {
+        return String.format("%s:%s:%d", mirrorId, topicId, partition);
     }
 
     public static void validate(String key) {
@@ -57,11 +58,13 @@ public record MirrorRecordKey(String mirrorName, Uuid topicId, int partition) {
 
         String[] tokens = key.split(":");
         if (tokens.length != 3) {
-            throw new IllegalArgumentException("Invalid key format: expected - mirrorName:topic:partition, found -  " + key);
+            throw new IllegalArgumentException("Invalid key format: expected - mirrorId:topicId:partition, found -  " + key);
         }
 
-        if (tokens[0].trim().isEmpty()) {
-            throw new IllegalArgumentException("mirror name must be alphanumeric string");
+        try {
+            Uuid.fromString(tokens[0].trim());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid mirror ID: " + tokens[0], e);
         }
 
         try {

--- a/mirror-coordinator/src/main/resources/common/message/LastMirroredOffsetsKey.json
+++ b/mirror-coordinator/src/main/resources/common/message/LastMirroredOffsetsKey.json
@@ -24,7 +24,7 @@
   "validVersions": "0",
   "flexibleVersions": "none",
   "fields": [
-    { "name": "MirrorName", "type": "string", "versions": "0",
-      "about": "The cluster mirror name."}
+    { "name": "MirrorId", "type": "uuid", "versions": "0",
+      "about": "The system-generated mirror ID."}
   ]
 }

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateKey.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateKey.json
@@ -24,7 +24,7 @@
   "validVersions": "0",
   "flexibleVersions": "none",
   "fields": [
-    { "name": "MirrorName", "type": "string", "versions": "0",
-      "about": "The cluster mirror name."}
+    { "name": "MirrorId", "type": "uuid", "versions": "0",
+      "about": "The system-generated mirror ID."}
   ]
 }

--- a/mirror-coordinator/src/main/resources/common/message/MirrorTopicsKey.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorTopicsKey.json
@@ -24,7 +24,7 @@
   "validVersions": "0",
   "flexibleVersions": "none",
   "fields": [
-    { "name": "MirrorName", "type": "string", "versions": "0",
-      "about": "The cluster mirror name."}
+    { "name": "MirrorId", "type": "uuid", "versions": "0",
+      "about": "The system-generated mirror ID."}
   ]
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -59,6 +59,8 @@ import static org.apache.kafka.common.config.ConfigDef.Type.LIST;
 import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
 import static org.apache.kafka.common.config.ConfigDef.Type.STRING;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
+import static org.apache.kafka.common.config.TopicConfig.MIRROR_ID_CONFIG;
+import static org.apache.kafka.common.config.TopicConfig.MIRROR_ID_DOC;
 import static org.apache.kafka.common.config.TopicConfig.MIRROR_NAME_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.MIRROR_NAME_DOC;
 
@@ -252,6 +254,7 @@ public class LogConfig extends AbstractConfig {
                 .define(TopicConfig.REMOTE_LOG_COPY_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_COPY_DISABLE_DOC)
                 .define(TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_DOC)
                 .defineInternal(MIRROR_NAME_CONFIG, STRING, "", null, MEDIUM, MIRROR_NAME_DOC)
+                .defineInternal(MIRROR_ID_CONFIG, STRING, "", null, MEDIUM, MIRROR_ID_DOC)
                 .defineInternal(INTERNAL_SEGMENT_BYTES_CONFIG, INT, null, null, MEDIUM, INTERNAL_SEGMENT_BYTES_DOC);
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -159,16 +159,17 @@ public abstract class MirrorCommand {
         }
 
         public void createMirror(MirrorCommandOptions opts) throws ExecutionException, InterruptedException {
+            String mirrorName = opts.mirror().get();
             Map<String, String> configMap = new HashMap<>();
             mirrorConfigs.forEach((k, v) -> configMap.put(k.toString(), v.toString()));
 
             CreateMirrorResult result = adminClient.createMirror(
-                opts.mirror().get(),
+                mirrorName,
                 configMap,
                 new CreateMirrorOptions()
             );
-            result.all().get();
-            System.out.printf("Created mirror %s%n", opts.mirror().get());
+            var mirrorId = result.all().get();
+            System.out.printf("Created mirror %s (id: %s)%n", mirrorName, mirrorId);
         }
 
         public void addTopicsToMirror(MirrorCommandOptions opts) throws Exception {
@@ -279,15 +280,17 @@ public abstract class MirrorCommand {
             listings.sort(Comparator.comparing(MirrorListing::mirrorName));
 
             // Print header
-            System.out.printf("%-30s %-10s %-50s%n", "MIRROR", "TOPICS", "SOURCE-BOOTSTRAP");
+            System.out.printf("%-30s %-38s %-10s %-50s%n", "MIRROR", "MIRROR-ID", "TOPICS", "SOURCE-BOOTSTRAP");
 
             // Print each mirror
             for (MirrorListing listing : listings) {
                 String sourceBootstrap = listing.sourceBootstrap() != null && !listing.sourceBootstrap().isEmpty()
                     ? listing.sourceBootstrap()
                     : "-";
-                System.out.printf("%-30s %-10d %-50s%n",
+                String mirrorIdStr = listing.mirrorId() != null ? listing.mirrorId().toString() : "-";
+                System.out.printf("%-30s %-38s %-10d %-50s%n",
                     truncateLeft(listing.mirrorName(), 30),
+                    mirrorIdStr,
                     listing.topicCount(),
                     truncateLeft(sourceBootstrap, 50));
             }


### PR DESCRIPTION
This patch replaces user-provided mirror name strings with system-generated UUIDs as internal identifiers to eliminate colon-separator ambiguity in coordinator keys, enable safe mirror renaming, and align with Kafka's topicId pattern. Mirror names remain as user-facing labels.

Key changes:

- Add MIRROR_ID_CONFIG ("mirror.id") topic/mirror config with auto-generated UUID
- MirrorRecordKey: change from mirrorName to mirrorId (Uuid) for coordinator keys
- MirrorPartitionKey: change cache key from (String mirrorName, ...) to (Uuid mirrorId, ...)
- ConfigurationControlManager: generate UUID on mirror creation, set mirror.id on topics
- MirrorCoordinator/MirrorMetadataManager: full migration of state transitions, coordinator record generation, and cache operations to use mirrorId
- Remove MirrorName from coordinator record key schemas and Read/WriteMirrorStates wire protocol schemas
- Add getMirrorId/getMirrorName resolution helpers for bridging name and ID
- Add mirror name validation (alphanumeric, dots, dashes, underscores)
- Protect mirror.id from direct modification via topic config APIs
- Fix read-only check to handle ".removed" suffix and null partition state
- Display mirrorId in CLI create/list/describe output
