### PR TITLE
Add mirrorName entity type for cluster mirroring RPCs

### DIFF
--- a/clients/src/main/resources/common/message/AddTopicsToMirrorRequest.json
+++ b/clients/src/main/resources/common/message/AddTopicsToMirrorRequest.json
@@ -26,8 +26,8 @@
         { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
         { "name": "TopicName", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
           "about": "The topic name." },
-        { "name": "MirrorName", "type": "string", "versions": "0+", "nullableVersions": "0+",
-          "about": "The mirror link name."}
+        { "name": "MirrorName", "type": "string", "versions": "0+", "nullableVersions": "0+", "entityType": "mirrorName",
+          "about": "The cluster mirror name."}
       ]}
   ]
 }

--- a/clients/src/main/resources/common/message/CreateMirrorRequest.json
+++ b/clients/src/main/resources/common/message/CreateMirrorRequest.json
@@ -24,7 +24,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "MirrorName", "type": "string", "versions": "0+", "nullableVersions": "0+",
+    { "name": "MirrorName", "type": "string", "versions": "0+", "nullableVersions": "0+", "entityType": "mirrorName",
       "about": "The cluster mirror name."},
     { "name": "Config", "type": "[]MirrorConfig", "versions": "0+",
       "about": "The cluster mirror configurations.",  "fields": [

--- a/clients/src/main/resources/common/message/DescribeMirrorsRequest.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsRequest.json
@@ -22,7 +22,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "MirrorNames", "type": "[]string", "versions": "0+",
+    { "name": "MirrorNames", "type": "[]string", "versions": "0+", "entityType": "mirrorName",
       "about": "The names of the mirrors to describe. Null or empty array means all mirrors." },
     { "name": "IncludeAuthorizedOperations", "type": "bool", "versions": "0+", "default": "false",
       "about": "Whether to include authorized operations." }

--- a/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
@@ -27,8 +27,8 @@
       "about": "Each described mirror.", "fields": [
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The error code, or 0 if there was no error." },
-      { "name": "MirrorName", "type": "string", "versions": "0+",
-        "about": "The mirror name." },
+      { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
+        "about": "The cluster mirror name." },
       { "name": "Topics", "type": "[]TopicPartitions", "versions": "0+",
         "about": "Each topic in the mirror.", "fields": [
         { "name": "TopicName", "type": "string", "versions": "0+",

--- a/clients/src/main/resources/common/message/LastMirroredOffsetsRequest.json
+++ b/clients/src/main/resources/common/message/LastMirroredOffsetsRequest.json
@@ -21,7 +21,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "MirrorName", "type": "string", "versions": "0+", "about": "The mirror name." },
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName", "about": "The cluster mirror name." },
     { "name": "Topics", "type": "[]TopicState", "versions": "0",
       "about": "The responses per topic.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/ListMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/ListMirrorsResponse.json
@@ -27,8 +27,8 @@
       "about": "The error code, or 0 if there was no error." },
     { "name": "Mirrors", "type": "[]ListedMirror", "versions": "0+",
       "about": "Each mirror in the response.", "fields": [
-      { "name": "MirrorName", "type": "string", "versions": "0+",
-        "about": "The mirror name." },
+      { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
+        "about": "The cluster mirror name." },
       { "name": "SourceBootstrap", "type": "string", "versions": "0+",
         "about": "The source cluster bootstrap servers." },
       { "name": "TopicCount", "type": "int32", "versions": "0+", "default": "0",

--- a/clients/src/main/resources/common/message/ReadMirrorStatesRequest.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesRequest.json
@@ -21,7 +21,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "MirrorName", "type": "string", "versions": "0+", "about": "The mirror name." },
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName", "about": "The cluster mirror name." },
     { "name": "Topics", "type": "[]TopicState", "versions": "0",
       "about": "The responses per topic.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/WriteMirrorStatesRequest.json
+++ b/clients/src/main/resources/common/message/WriteMirrorStatesRequest.json
@@ -21,7 +21,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "MirrorName", "type": "string", "versions": "0+", "about": "The mirror name." },
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName", "about": "The cluster mirror name." },
     { "name": "TopicsUpdated", "type": "[]TopicState", "versions": "0",
       "about": "The topics to be updated.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/generator/src/main/java/org/apache/kafka/message/EntityType.java
+++ b/generator/src/main/java/org/apache/kafka/message/EntityType.java
@@ -36,7 +36,10 @@ public enum EntityType {
     TOPIC_NAME(FieldType.StringFieldType.INSTANCE),
 
     @JsonProperty("brokerId")
-    BROKER_ID(FieldType.Int32FieldType.INSTANCE);
+    BROKER_ID(FieldType.Int32FieldType.INSTANCE),
+
+    @JsonProperty("mirrorName")
+    MIRROR_NAME(FieldType.StringFieldType.INSTANCE);
 
     private final FieldType baseType;
 

--- a/generator/src/test/java/org/apache/kafka/message/EntityTypeTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/EntityTypeTest.java
@@ -60,6 +60,10 @@ public class EntityTypeTest {
             FieldType.Int32FieldType.INSTANCE);
         EntityType.BROKER_ID.verifyTypeMatches("brokerIdField",
             new FieldType.ArrayType(FieldType.Int32FieldType.INSTANCE));
+        EntityType.MIRROR_NAME.verifyTypeMatches("mirrorNameField",
+            FieldType.StringFieldType.INSTANCE);
+        EntityType.MIRROR_NAME.verifyTypeMatches("mirrorNameField",
+            new FieldType.ArrayType(FieldType.StringFieldType.INSTANCE));
     }
 
     private static void expectException(Runnable r) {
@@ -79,5 +83,7 @@ public class EntityTypeTest {
                 new FieldType.ArrayType(FieldType.Int64FieldType.INSTANCE)));
         expectException(() -> EntityType.BROKER_ID.
             verifyTypeMatches("brokerIdField", FieldType.Int64FieldType.INSTANCE));
+        expectException(() -> EntityType.MIRROR_NAME.
+            verifyTypeMatches("mirrorNameField", FieldType.Int32FieldType.INSTANCE));
     }
 }


### PR DESCRIPTION
Introduce a new `MIRROR_NAME` entity type in the message generator to provide schema-level type validation for mirror name fields, consistent with existing entity types (`topicName`, `groupId`, `brokerId`, etc.). Annotate all `MirrorName` fields across the 8 mirroring API schemas with the new entity type and add corresponding test coverage.

How it works? Simple:
`FieldSpec` constructor calls `verifyTypeMatches()` when the JSON schema is parsed. This is the core function: it prevents you from declaring e.g. "entityType": "mirrorName" on a numeric field. That validation runs during ./gradlew processMessages.
