### PR TITLE
Add pause and resume for cluster mirroring topics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1724,6 +1724,18 @@ public interface Admin extends AutoCloseable {
      */
     RemoveTopicsFromMirrorResult removeTopicsFromMirror(Set<String> topics, RemoveTopicsFromMirrorOptions options);
 
+    PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics, PauseMirrorTopicsOptions options);
+
+    default PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics) {
+        return pauseMirrorTopics(topics, new PauseMirrorTopicsOptions());
+    }
+
+    ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics, ResumeMirrorTopicsOptions options);
+
+    default ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics) {
+        return resumeMirrorTopics(topics, new ResumeMirrorTopicsOptions());
+    }
+
     /**
      * Describe cluster mirrors with the default options.
      *

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -286,6 +286,16 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics, PauseMirrorTopicsOptions options) {
+        return delegate.pauseMirrorTopics(topics, options);
+    }
+
+    @Override
+    public ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics, ResumeMirrorTopicsOptions options) {
+        return delegate.resumeMirrorTopics(topics, options);
+    }
+
+    @Override
     public AddTopicsToMirrorResult addTopicsToMirror(Map<String, String> topicToMirrorName, AddTopicsToMirrorOptions options) {
         return delegate.addTopicsToMirror(topicToMirrorName, options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -258,12 +258,16 @@ import org.apache.kafka.common.requests.ListPartitionReassignmentsRequest;
 import org.apache.kafka.common.requests.ListPartitionReassignmentsResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.PauseMirrorTopicsRequest;
+import org.apache.kafka.common.requests.PauseMirrorTopicsResponse;
 import org.apache.kafka.common.requests.RemoveRaftVoterRequest;
 import org.apache.kafka.common.requests.RemoveRaftVoterResponse;
 import org.apache.kafka.common.requests.RemoveTopicsFromMirrorRequest;
 import org.apache.kafka.common.requests.RemoveTopicsFromMirrorResponse;
 import org.apache.kafka.common.requests.RenewDelegationTokenRequest;
 import org.apache.kafka.common.requests.RenewDelegationTokenResponse;
+import org.apache.kafka.common.requests.ResumeMirrorTopicsRequest;
+import org.apache.kafka.common.requests.ResumeMirrorTopicsResponse;
 import org.apache.kafka.common.requests.UnregisterBrokerRequest;
 import org.apache.kafka.common.requests.UnregisterBrokerResponse;
 import org.apache.kafka.common.requests.UpdateFeaturesRequest;
@@ -4948,6 +4952,84 @@ public class KafkaAdminClient extends AdminClient {
         };
         runnable.call(call, now);
         return new RemoveTopicsFromMirrorResult(future);
+    }
+
+    @Override
+    public PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics, PauseMirrorTopicsOptions options) {
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+        final Call call = new Call("pauseMirrorTopics", calcDeadlineMs(now, options.timeoutMs()),
+                new LeastLoadedBrokerOrActiveKController()) {
+
+            @Override
+            PauseMirrorTopicsRequest.Builder createRequest(int timeoutMs) {
+                return new PauseMirrorTopicsRequest.Builder(topics);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                final PauseMirrorTopicsResponse response =
+                        (PauseMirrorTopicsResponse) abstractResponse;
+                Errors error = Errors.forCode(response.data().errorCode());
+                switch (error) {
+                    case NONE:
+                        future.complete(null);
+                        break;
+                    case REQUEST_TIMED_OUT:
+                        throw error.exception();
+                    default:
+                        log.error("Mirror topics pause failed: {}", topics);
+                        future.completeExceptionally(error.exception());
+                        break;
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        };
+        runnable.call(call, now);
+        return new PauseMirrorTopicsResult(future);
+    }
+
+    @Override
+    public ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics, ResumeMirrorTopicsOptions options) {
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+        final Call call = new Call("resumeMirrorTopics", calcDeadlineMs(now, options.timeoutMs()),
+                new LeastLoadedBrokerOrActiveKController()) {
+
+            @Override
+            ResumeMirrorTopicsRequest.Builder createRequest(int timeoutMs) {
+                return new ResumeMirrorTopicsRequest.Builder(topics);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                final ResumeMirrorTopicsResponse response =
+                        (ResumeMirrorTopicsResponse) abstractResponse;
+                Errors error = Errors.forCode(response.data().errorCode());
+                switch (error) {
+                    case NONE:
+                        future.complete(null);
+                        break;
+                    case REQUEST_TIMED_OUT:
+                        throw error.exception();
+                    default:
+                        log.error("Mirror topics resume failed: {}", topics);
+                        future.completeExceptionally(error.exception());
+                        break;
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        };
+        runnable.call(call, now);
+        return new ResumeMirrorTopicsResult(future);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/PauseMirrorTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/PauseMirrorTopicsOptions.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+public class PauseMirrorTopicsOptions extends AbstractOptions<PauseMirrorTopicsOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/PauseMirrorTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/PauseMirrorTopicsResult.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+
+public class PauseMirrorTopicsResult {
+    private final KafkaFuture<Void> future;
+
+    PauseMirrorTopicsResult(final KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ResumeMirrorTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ResumeMirrorTopicsOptions.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+public class ResumeMirrorTopicsOptions extends AbstractOptions<ResumeMirrorTopicsOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ResumeMirrorTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ResumeMirrorTopicsResult.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+
+public class ResumeMirrorTopicsResult {
+    private final KafkaFuture<Void> future;
+
+    ResumeMirrorTopicsResult(final KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -143,7 +143,9 @@ public enum ApiKeys {
     WRITE_MIRROR_STATES(ApiMessageType.WRITE_MIRROR_STATES),
     READ_MIRROR_STATES(ApiMessageType.READ_MIRROR_STATES),
     LIST_MIRRORS(ApiMessageType.LIST_MIRRORS),
-    DESCRIBE_MIRRORS(ApiMessageType.DESCRIBE_MIRRORS);
+    DESCRIBE_MIRRORS(ApiMessageType.DESCRIBE_MIRRORS),
+    PAUSE_MIRROR_TOPICS(ApiMessageType.PAUSE_MIRROR_TOPICS, false, true),
+    RESUME_MIRROR_TOPICS(ApiMessageType.RESUME_MIRROR_TOPICS, false, true);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -372,6 +372,10 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return WriteMirrorStatesRequest.parse(readable, apiVersion);
             case READ_MIRROR_STATES:
                 return ReadMirrorStatesRequest.parse(readable, apiVersion);
+            case PAUSE_MIRROR_TOPICS:
+                return PauseMirrorTopicsRequest.parse(readable, apiVersion);
+            case RESUME_MIRROR_TOPICS:
+                return ResumeMirrorTopicsRequest.parse(readable, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -309,6 +309,10 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return WriteMirrorStatesResponse.parse(readable, version);
             case READ_MIRROR_STATES:
                 return ReadMirrorStatesResponse.parse(readable, version);
+            case PAUSE_MIRROR_TOPICS:
+                return PauseMirrorTopicsResponse.parse(readable, version);
+            case RESUME_MIRROR_TOPICS:
+                return ResumeMirrorTopicsResponse.parse(readable, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/PauseMirrorTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/PauseMirrorTopicsRequest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.PauseMirrorTopicsRequestData;
+import org.apache.kafka.common.message.PauseMirrorTopicsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Set;
+
+public class PauseMirrorTopicsRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<PauseMirrorTopicsRequest> {
+
+        private final PauseMirrorTopicsRequestData data;
+
+        public Builder(PauseMirrorTopicsRequestData data) {
+            super(ApiKeys.PAUSE_MIRROR_TOPICS);
+            this.data = data;
+        }
+
+        public Builder(Set<String> topics) {
+            super(ApiKeys.PAUSE_MIRROR_TOPICS, ApiKeys.PAUSE_MIRROR_TOPICS.oldestVersion(),
+                    ApiKeys.PAUSE_MIRROR_TOPICS.latestVersion());
+            PauseMirrorTopicsRequestData data = new PauseMirrorTopicsRequestData();
+            topics.forEach(topic -> data.topics().add(new PauseMirrorTopicsRequestData.TopicData().setTopicName(topic)));
+            this.data = data;
+        }
+
+        @Override
+        public PauseMirrorTopicsRequest build(short version) {
+            return new PauseMirrorTopicsRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final PauseMirrorTopicsRequestData data;
+
+    public PauseMirrorTopicsRequest(PauseMirrorTopicsRequestData data, short version) {
+        super(ApiKeys.PAUSE_MIRROR_TOPICS, version);
+        this.data = data;
+    }
+
+    @Override
+    public PauseMirrorTopicsRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        PauseMirrorTopicsResponseData responseData = new PauseMirrorTopicsResponseData();
+        responseData.setErrorCode(error.code());
+        return new PauseMirrorTopicsResponse(responseData);
+    }
+
+    public static PauseMirrorTopicsRequest parse(Readable readable, short version) {
+        return new PauseMirrorTopicsRequest(
+                new PauseMirrorTopicsRequestData(readable, version),
+                version
+        );
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/PauseMirrorTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/PauseMirrorTopicsResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.PauseMirrorTopicsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PauseMirrorTopicsResponse extends AbstractResponse {
+    private final PauseMirrorTopicsResponseData data;
+
+    public PauseMirrorTopicsResponse(PauseMirrorTopicsResponseData data) {
+        super(ApiKeys.PAUSE_MIRROR_TOPICS);
+        this.data = data;
+    }
+
+    @Override
+    public PauseMirrorTopicsResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Map<Errors, Integer> errorCounts = new HashMap<>();
+        updateErrorCounts(errorCounts, Errors.forCode(data.errorCode()));
+        return errorCounts;
+    }
+
+    public static PauseMirrorTopicsResponse parse(Readable readable, short version) {
+        return new PauseMirrorTopicsResponse(new PauseMirrorTopicsResponseData(readable, version));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ResumeMirrorTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ResumeMirrorTopicsRequest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ResumeMirrorTopicsRequestData;
+import org.apache.kafka.common.message.ResumeMirrorTopicsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.Set;
+
+public class ResumeMirrorTopicsRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<ResumeMirrorTopicsRequest> {
+
+        private final ResumeMirrorTopicsRequestData data;
+
+        public Builder(ResumeMirrorTopicsRequestData data) {
+            super(ApiKeys.RESUME_MIRROR_TOPICS);
+            this.data = data;
+        }
+
+        public Builder(Set<String> topics) {
+            super(ApiKeys.RESUME_MIRROR_TOPICS, ApiKeys.RESUME_MIRROR_TOPICS.oldestVersion(),
+                    ApiKeys.RESUME_MIRROR_TOPICS.latestVersion());
+            ResumeMirrorTopicsRequestData data = new ResumeMirrorTopicsRequestData();
+            topics.forEach(topic -> data.topics().add(new ResumeMirrorTopicsRequestData.TopicData().setTopicName(topic)));
+            this.data = data;
+        }
+
+        @Override
+        public ResumeMirrorTopicsRequest build(short version) {
+            return new ResumeMirrorTopicsRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final ResumeMirrorTopicsRequestData data;
+
+    public ResumeMirrorTopicsRequest(ResumeMirrorTopicsRequestData data, short version) {
+        super(ApiKeys.RESUME_MIRROR_TOPICS, version);
+        this.data = data;
+    }
+
+    @Override
+    public ResumeMirrorTopicsRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        ResumeMirrorTopicsResponseData responseData = new ResumeMirrorTopicsResponseData();
+        responseData.setErrorCode(error.code());
+        return new ResumeMirrorTopicsResponse(responseData);
+    }
+
+    public static ResumeMirrorTopicsRequest parse(Readable readable, short version) {
+        return new ResumeMirrorTopicsRequest(
+                new ResumeMirrorTopicsRequestData(readable, version),
+                version
+        );
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ResumeMirrorTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ResumeMirrorTopicsResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ResumeMirrorTopicsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResumeMirrorTopicsResponse extends AbstractResponse {
+    private final ResumeMirrorTopicsResponseData data;
+
+    public ResumeMirrorTopicsResponse(ResumeMirrorTopicsResponseData data) {
+        super(ApiKeys.RESUME_MIRROR_TOPICS);
+        this.data = data;
+    }
+
+    @Override
+    public ResumeMirrorTopicsResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Map<Errors, Integer> errorCounts = new HashMap<>();
+        updateErrorCounts(errorCounts, Errors.forCode(data.errorCode()));
+        return errorCounts;
+    }
+
+    public static ResumeMirrorTopicsResponse parse(Readable readable, short version) {
+        return new ResumeMirrorTopicsResponse(new ResumeMirrorTopicsResponseData(readable, version));
+    }
+}

--- a/clients/src/main/resources/common/message/PauseMirrorTopicsRequest.json
+++ b/clients/src/main/resources/common/message/PauseMirrorTopicsRequest.json
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 102,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "PauseMirrorTopicsRequest",
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]TopicData", "versions": "0+", "about": "The data for the topics.",
+      "fields": [
+        { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "TopicName", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
+          "about": "The topic name." }
+      ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/PauseMirrorTopicsResponse.json
+++ b/clients/src/main/resources/common/message/PauseMirrorTopicsResponse.json
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 102,
+  "type": "response",
+  "name": "PauseMirrorTopicsResponse",
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "Topics", "type": "[]TopicResult", "versions": "0",
+      "about": "The results for the topics.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "ErrorCode", "type": "int16", "versions": "0",
+        "about": "The error code, or 0 if there was no error." }
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/ResumeMirrorTopicsRequest.json
+++ b/clients/src/main/resources/common/message/ResumeMirrorTopicsRequest.json
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 103,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "ResumeMirrorTopicsRequest",
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]TopicData", "versions": "0+", "about": "The data for the topics.",
+      "fields": [
+        { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+        { "name": "TopicName", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
+          "about": "The topic name." }
+      ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/ResumeMirrorTopicsResponse.json
+++ b/clients/src/main/resources/common/message/ResumeMirrorTopicsResponse.json
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 103,
+  "type": "response",
+  "name": "ResumeMirrorTopicsResponse",
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "Topics", "type": "[]TopicResult", "versions": "0",
+      "about": "The results for the topics.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "ErrorCode", "type": "int16", "versions": "0",
+        "about": "The error code, or 0 if there was no error." }
+    ]}
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1393,6 +1393,16 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics, PauseMirrorTopicsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics, ResumeMirrorTopicsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     public synchronized DescribeMirrorsResult describeMirrors(Collection<String> mirrorNames, DescribeMirrorsOptions options) {
         Map<String, MirrorDescription> descriptions = new HashMap<>();
         for (String mirrorName : mirrorNames) {

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -136,7 +136,8 @@ public class MirrorCoordinator {
             case PAUSING:
                 LOG.info("PAUSING mirroring for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                recordPausedOffsets(mirrorName, topicPartitions);
+                topicPartitions.forEach(tp ->
+                        transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED));
                 break;
             case PAUSED:
                 LOG.info("PAUSED mirroring for topics {}.", topicPartitions);
@@ -183,19 +184,6 @@ public class MirrorCoordinator {
                         mirrorMetadataManager.getPartitionState(mirrorName, tp), newState, tp);
             }
         });
-    }
-
-    private void recordPausedOffsets(String mirrorName, Set<TopicPartition> topicPartitions) {
-        Map<String, Map<Integer, Long>> partitionOffsets = new HashMap<>();
-        MirrorUtils.groupPartitionsByTopic(topicPartitions).forEach((topic, parts) -> {
-            Map<Integer, Long> offsets = new HashMap<>();
-            parts.forEach(i -> replicaManager.getPartitionOrException(
-                    new TopicPartition(topic, i)).log().foreach(log -> offsets.put(i, log.logEndOffset())));
-            partitionOffsets.put(topic, offsets);
-        });
-        updateLastMirroredOffsets(mirrorName, partitionOffsets, false);
-        topicPartitions.forEach(tp ->
-                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED));
     }
 
     private void truncateToLastStableOffset(Set<TopicPartition> topicPartitions,

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -133,17 +133,23 @@ public class MirrorCoordinator {
                 // start mirroring
                 replicaManager.maybeCreateMirrorFetchers(mirrorName, topicPartitions);
                 break;
+            case PAUSING:
+                LOG.info("PAUSING mirroring for topics {}.", topicPartitions);
+                replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
+                recordPausedOffsets(mirrorName, topicPartitions);
+                break;
+            case PAUSED:
+                LOG.info("PAUSED mirroring for topics {}.", topicPartitions);
+                // topic is still read-only
+                break;
             case STOPPING:
                 LOG.debug("STOPPING for topics {}.", topicPartitions);
-                // 1. remove mirror fetcher for partitions
-                // 2. truncating the log into LSO
-                // 3. register the last mirrored offsets for each partition in internal topic
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
                 truncateToLastStableOffset(topicPartitions, tp -> updateLastMirroredOffsets(mirrorName, Set.of(tp)));
                 break;
             case STOPPED:
                 LOG.debug("STOPPED for topics {}.", topicPartitions);
-                // topic becomes writable
+                // topic is writable
                 break;
             case FAILED:
                 LOG.debug("FAILED for topics {}.", topicPartitions);
@@ -177,6 +183,19 @@ public class MirrorCoordinator {
                         mirrorMetadataManager.getPartitionState(mirrorName, tp), newState, tp);
             }
         });
+    }
+
+    private void recordPausedOffsets(String mirrorName, Set<TopicPartition> topicPartitions) {
+        Map<String, Map<Integer, Long>> partitionOffsets = new HashMap<>();
+        MirrorUtils.groupPartitionsByTopic(topicPartitions).forEach((topic, parts) -> {
+            Map<Integer, Long> offsets = new HashMap<>();
+            parts.forEach(i -> replicaManager.getPartitionOrException(
+                    new TopicPartition(topic, i)).log().foreach(log -> offsets.put(i, log.logEndOffset())));
+            partitionOffsets.put(topic, offsets);
+        });
+        updateLastMirroredOffsets(mirrorName, partitionOffsets, false);
+        topicPartitions.forEach(tp ->
+                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED));
     }
 
     private void truncateToLastStableOffset(Set<TopicPartition> topicPartitions,

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -949,11 +949,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     // Transitions mirror partitions to STOPPING when the topic is deleted on the source cluster.
     private void maybeStopDeletedTopics(String mirrorName, Collection<MetadataResponse.TopicMetadata> topicMetadata) {
-        List<String> remoteTopicNamesDeleted = topicMetadata.stream()
+        List<String> deletedSourceTopicNames = topicMetadata.stream()
                 .filter(tm -> tm.error() == Errors.UNKNOWN_TOPIC_OR_PARTITION)
                 .map(MetadataResponse.TopicMetadata::topic).toList();
-        getConfiguredTopics(mirrorName).forEach(name -> {
-            if (remoteTopicNamesDeleted.contains(name)) {
+        getConfiguredTopics(mirrorName, true).forEach(name -> {
+            if (deletedSourceTopicNames.contains(name)) {
                 LOG.info("Detected topic {} deleted in remote cluster {}, stopping mirror partitions", name, mirrorName);
                 partitionStates.keySet().stream()
                         .filter(key -> key.mirrorName().equals(mirrorName) && key.topic().equals(name))
@@ -1271,11 +1271,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     Set<String> getConfiguredTopics(String mirrorName) {
+        return getConfiguredTopics(mirrorName, false);
+    }
+
+    Set<String> getConfiguredTopics(String mirrorName, boolean includePaused) {
         return metadataCache.getAllTopics().stream()
                 .filter(topic -> {
                     String topicMirrorName = (String) metadataCache.topicConfig(topic).get(TopicConfig.MIRROR_NAME_CONFIG);
                     if (topicMirrorName == null) return false;
-                    if (topicMirrorName.endsWith(PAUSED_TOPIC_SUFFIX)) return false;
+                    if (!includePaused && topicMirrorName.endsWith(PAUSED_TOPIC_SUFFIX)) return false;
                     return mirrorName.equals(MirrorUtils.originalMirrorName(topicMirrorName));
                 })
                 .collect(Collectors.toSet());

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -130,6 +130,7 @@ import static kafka.server.mirror.MirrorUtils.groupPartitionsByTopic;
 import static kafka.server.mirror.MirrorUtils.originalMirrorName;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
+import static org.apache.kafka.controller.ConfigurationControlManager.PAUSED_TOPIC_SUFFIX;
 import static org.apache.kafka.controller.ConfigurationControlManager.REMOVED_TOPIC_SUFFIX;
 
 /**
@@ -219,6 +220,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         metricsGroup.newGauge("TopicMetadataRefreshError", metadataRefreshError::get);
         metricsGroup.newGauge("PreparingPartitionState", () -> partitionStateCount(MirrorPartitionState.PREPARING));
         metricsGroup.newGauge("MirroringPartitionState", () -> partitionStateCount(MirrorPartitionState.MIRRORING));
+        metricsGroup.newGauge("PausingPartitionState", () -> partitionStateCount(MirrorPartitionState.PAUSING));
+        metricsGroup.newGauge("PausedPartitionState", () -> partitionStateCount(MirrorPartitionState.PAUSED));
         metricsGroup.newGauge("StoppingPartitionState", () -> partitionStateCount(MirrorPartitionState.STOPPING));
         metricsGroup.newGauge("StoppedPartitionState", () -> partitionStateCount(MirrorPartitionState.STOPPED));
         metricsGroup.newGauge("FailedPartitionState", () -> partitionStateCount(MirrorPartitionState.FAILED));
@@ -258,20 +261,20 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         // Collect remote coordinator partitions grouped by mirrorName for batched reads
         Map<String, Map<String, Set<Integer>>> remotePartitionsByMirror = new HashMap<>();
         Map<String, Map<TopicPartition, Boolean>> remoteStopFlags = new HashMap<>();
+        Map<String, Map<TopicPartition, Boolean>> remotePauseFlags = new HashMap<>();
 
         mirrorLeaders.forEach(tp -> {
             String rawMirrorName = (String) newImage.configs().configProperties(
                     new ConfigResource(ConfigResource.Type.TOPIC, tp.topic())).get(TopicConfig.MIRROR_NAME_CONFIG);
             boolean stopRequested = rawMirrorName.endsWith(REMOVED_TOPIC_SUFFIX);
-            String mirrorName = stopRequested
-                    ? rawMirrorName.substring(0, rawMirrorName.length() - REMOVED_TOPIC_SUFFIX.length())
-                    : rawMirrorName;
+            boolean pauseRequested = rawMirrorName.endsWith(PAUSED_TOPIC_SUFFIX);
+            String mirrorName = MirrorUtils.originalMirrorName(rawMirrorName);
 
             MirrorUtils.PartitionKey key = new MirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
             if (isLocalCoordinator(key.mirrorName(), key.topic(), key.partition())) {
                 // Handle local coordinator partitions inline (no network call needed)
                 MirrorPartitionState curState = partitionStates.getOrDefault(key, MirrorPartitionState.UNKNOWN);
-                applyMirrorStateTransition(key.mirrorName(), tp, curState, null, stopRequested);
+                applyMirrorStateTransition(key.mirrorName(), tp, curState, null, stopRequested, pauseRequested);
             } else {
                 // Collect for batched remote read
                 remotePartitionsByMirror
@@ -281,12 +284,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 remoteStopFlags
                     .computeIfAbsent(mirrorName, k -> new HashMap<>())
                     .put(tp, stopRequested);
+                remotePauseFlags
+                    .computeIfAbsent(mirrorName, k -> new HashMap<>())
+                    .put(tp, pauseRequested);
             }
         });
 
         // Send one batched read per mirrorName (readStatesFromRemoteCoordinator handles per-node batching internally)
         remotePartitionsByMirror.forEach((mirrorName, partitions) -> {
             Map<TopicPartition, Boolean> stopFlags = remoteStopFlags.get(mirrorName);
+            Map<TopicPartition, Boolean> pauseFlags = remotePauseFlags.get(mirrorName);
             readStatesFromRemoteCoordinator(mirrorName, partitions, res ->
                 res.data().topics().forEach(topic ->
                     topic.partitions().forEach(partition -> {
@@ -294,9 +301,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                             TopicPartition resTp = new TopicPartition(topic.name(), partition.partitionIndex());
                             MirrorPartitionState state = MirrorPartitionState.fromValue(partition.state());
                             boolean stopRequested = stopFlags.getOrDefault(resTp, false);
+                            boolean pauseRequested = pauseFlags.getOrDefault(resTp, false);
                             MirrorUtils.PartitionKey mpk = new MirrorUtils.PartitionKey(mirrorName, resTp.topic(), resTp.partition());
                             MirrorPartitionState curState = partitionStates.getOrDefault(mpk, MirrorPartitionState.UNKNOWN);
-                            applyMirrorStateTransition(mirrorName, resTp, curState, state, stopRequested);
+                            applyMirrorStateTransition(mirrorName, resTp, curState, state, stopRequested, pauseRequested);
                         }
                     })));
         });
@@ -360,11 +368,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     // Applies the appropriate state transition based on current state and stop flag
     private void applyMirrorStateTransition(String mirrorName, TopicPartition tp,
                                             MirrorPartitionState curState, MirrorPartitionState fetchedState,
-                                            boolean stopRequested) {
+                                            boolean stopRequested, boolean pauseRequested) {
         stateTransitioner.ifPresent(t -> {
             if (stopRequested && curState != MirrorPartitionState.STOPPED) {
                 t.transitionTo(mirrorName, tp, MirrorPartitionState.STOPPING);
-            } else if (curState == MirrorPartitionState.UNKNOWN || curState == MirrorPartitionState.STOPPED) {
+            } else if (pauseRequested
+                    && curState != MirrorPartitionState.PAUSED
+                    && curState != MirrorPartitionState.PAUSING) {
+                t.transitionTo(mirrorName, tp, MirrorPartitionState.PAUSING);
+            } else if (curState == MirrorPartitionState.UNKNOWN
+                    || curState == MirrorPartitionState.STOPPED
+                    || curState == MirrorPartitionState.PAUSED) {
                 t.transitionTo(mirrorName, tp, MirrorPartitionState.PREPARING);
             } else {
                 t.transitionTo(mirrorName, tp, fetchedState != null ? fetchedState : curState);
@@ -1258,7 +1272,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     Set<String> getConfiguredTopics(String mirrorName) {
         return metadataCache.getAllTopics().stream()
-                .filter(topic -> mirrorName.equals(metadataCache.topicConfig(topic).get(TopicConfig.MIRROR_NAME_CONFIG)))
+                .filter(topic -> {
+                    String topicMirrorName = (String) metadataCache.topicConfig(topic).get(TopicConfig.MIRROR_NAME_CONFIG);
+                    if (topicMirrorName == null) return false;
+                    if (topicMirrorName.endsWith(PAUSED_TOPIC_SUFFIX)) return false;
+                    return mirrorName.equals(MirrorUtils.originalMirrorName(topicMirrorName));
+                })
                 .collect(Collectors.toSet());
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -376,9 +376,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     && curState != MirrorPartitionState.PAUSED
                     && curState != MirrorPartitionState.PAUSING) {
                 t.transitionTo(mirrorName, tp, MirrorPartitionState.PAUSING);
+            } else if (curState == MirrorPartitionState.PAUSED) {
+                t.transitionTo(mirrorName, tp, MirrorPartitionState.MIRRORING);
             } else if (curState == MirrorPartitionState.UNKNOWN
-                    || curState == MirrorPartitionState.STOPPED
-                    || curState == MirrorPartitionState.PAUSED) {
+                    || curState == MirrorPartitionState.STOPPED) {
                 t.transitionTo(mirrorName, tp, MirrorPartitionState.PREPARING);
             } else {
                 t.transitionTo(mirrorName, tp, fetchedState != null ? fetchedState : curState);

--- a/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
@@ -18,56 +18,62 @@ package kafka.server.mirror;
 
 /**
  * Represents the lifecycle states of a mirror partition.
- * FAILED state can be entered from any state when errors occur.
- * <pre>
- * 1. PREPARING
- *    Triggered by: Metadata update callback in MirrorMetadataManager
- *    Actions: Fetch last mirrored offsets, schedule truncation
- *
- * 2. MIRRORING
- *    Triggered by: ISR truncation completion in Partition.checkIsrTruncationAndTransition
- *    Actions: Start MirrorFetcherThread to replicate data
- *
- * 3. PAUSING
- *    Triggered by: PauseMirrorTopics API (appends .paused suffix to mirror.name)
- *    Actions: Remove fetchers
- *
- * 4. PAUSED
- *    Triggered by: Fetchers removed
- *    Result: Partition stays read-only, no active fetchers, no metadata sync
- *
- * 5. STOPPING
- *    Triggered by: RemoveTopicsFromMirror API or topic deletion
- *    Actions: Record last mirrored offsets to internal topic
- *
- * 6. STOPPED
- *    Triggered by: Last mirrored offsets persisted
- *    Result: Topic becomes writable on destination cluster
- * </pre>
  */
 public enum MirrorPartitionState {
-    /** Topics are being prepared for mirroring (truncation may be needed) */
+    /**
+     * The coordinator detects via onMetadataUpdate that it leads a mirror partition.
+     * It fetches last mirrored offsets from the source cluster and truncates logs to
+     * align the local log with the source.
+     * Valid from: null, UNKNOWN, STOPPED, FAILED.
+     */
     PREPARING((byte) 0),
 
-    /** Active mirroring from source cluster is in progress */
+    /**
+     * All ISR members have completed truncation. A MirrorFetcherThread is started to
+     * continuously replicate records from the source cluster.
+     * Valid from: PREPARING, PAUSED.
+     */
     MIRRORING((byte) 1),
 
-    /** Mirroring is being paused; fetchers removed and offsets recorded */
+    /**
+     * Triggered by PauseMirrorTopics API (appends .paused suffix to mirror.name config).
+     * The system removes fetchers for the affected partitions.
+     * Valid from: MIRRORING only.
+     */
     PAUSING((byte) 2),
 
-    /** Mirroring is paused; partition stays read-only with no active fetchers */
+    /**
+     * Fetchers have been removed. The partition stays read-only with no active fetchers
+     * and no metadata sync (configs, consumer groups, ACLs). On resume, transitions
+     * directly to MIRRORING (fetchers resume from local LEO, no truncation needed).
+     * Valid from: PAUSING only.
+     */
     PAUSED((byte) 3),
 
-    /** Mirroring is being gracefully stopped */
+    /**
+     * Triggered by RemoveTopicsFromMirror API (fail over) or topic deletion on the source.
+     * The system records the last mirrored offset to the internal topic.
+     * Valid from: PREPARING, MIRRORING, PAUSING (race guard), PAUSED.
+     */
     STOPPING((byte) 4),
 
-    /** Mirroring has stopped; topic is now writable on this cluster */
+    /**
+     * Last mirrored offsets have been persisted. The topic becomes writable on the
+     * destination cluster (fetcher removed, read-only flag cleared).
+     * Valid from: STOPPING only.
+     */
     STOPPED((byte) 5),
 
-    /** Error occurred during preparation or mirroring */
+    /**
+     * An error occurred. Can transition back to PREPARING to retry.
+     * Valid from: any state.
+     */
     FAILED((byte) 6),
 
-    /** Unknown state */
+    /**
+     * No cached state (broker just became leader, state not loaded yet).
+     * Not an explicit API-driven state, just the absence of state.
+     */
     UNKNOWN((byte) 16);
 
     private final byte value;

--- a/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
@@ -30,11 +30,11 @@ package kafka.server.mirror;
  *
  * 3. PAUSING
  *    Triggered by: PauseMirrorTopics API (appends .paused suffix to mirror.name)
- *    Actions: Remove fetchers, record current LEO offsets
+ *    Actions: Remove fetchers
  *
  * 4. PAUSED
- *    Triggered by: Paused offsets persisted
- *    Result: Partition stays read-only, no active fetchers, metadata sync continues
+ *    Triggered by: Fetchers removed
+ *    Result: Partition stays read-only, no active fetchers, no metadata sync
  *
  * 5. STOPPING
  *    Triggered by: RemoveTopicsFromMirror API or topic deletion
@@ -111,18 +111,19 @@ public enum MirrorPartitionState {
                 return source == null
                         || source == MirrorPartitionState.UNKNOWN
                         || source == MirrorPartitionState.STOPPED
-                        || source == MirrorPartitionState.PAUSED
                         || source == MirrorPartitionState.FAILED;
             case MIRRORING:
-                return source == MirrorPartitionState.PREPARING;
+                return source == MirrorPartitionState.PREPARING
+                        || source == MirrorPartitionState.PAUSED;
             case PAUSING:
-                return source == MirrorPartitionState.MIRRORING
-                        || source == MirrorPartitionState.PREPARING;
+                return source == MirrorPartitionState.MIRRORING;
             case PAUSED:
                 return source == MirrorPartitionState.PAUSING;
             case STOPPING:
+                // TODO: remove PAUSING once state transitions are serialized via the shared queue
                 return source == MirrorPartitionState.PREPARING
                         || source == MirrorPartitionState.MIRRORING
+                        || source == MirrorPartitionState.PAUSING
                         || source == MirrorPartitionState.PAUSED;
             case STOPPED:
                 return source == MirrorPartitionState.STOPPING;

--- a/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
@@ -18,25 +18,29 @@ package kafka.server.mirror;
 
 /**
  * Represents the lifecycle states of a mirror partition.
- * FAILED state can be entered from PREPARING or MIRRORING when errors occur.
+ * FAILED state can be entered from any state when errors occur.
  * <pre>
- * 1. INITIALIZING
- *    Triggered by: AddTopicsToMirror API call
- *    Waits for: Metadata update (partition becomes read-only leader)
- *
- * 2. PREPARING
+ * 1. PREPARING
  *    Triggered by: Metadata update callback in MirrorMetadataManager
  *    Actions: Fetch last mirrored offsets, schedule truncation
  *
- * 3. MIRRORING
+ * 2. MIRRORING
  *    Triggered by: ISR truncation completion in Partition.checkIsrTruncationAndTransition
  *    Actions: Start MirrorFetcherThread to replicate data
  *
- * 4. STOPPING
+ * 3. PAUSING
+ *    Triggered by: PauseMirrorTopics API (appends .paused suffix to mirror.name)
+ *    Actions: Remove fetchers, record current LEO offsets
+ *
+ * 4. PAUSED
+ *    Triggered by: Paused offsets persisted
+ *    Result: Partition stays read-only, no active fetchers, metadata sync continues
+ *
+ * 5. STOPPING
  *    Triggered by: RemoveTopicsFromMirror API or topic deletion
  *    Actions: Record last mirrored offsets to internal topic
  *
- * 5. STOPPED
+ * 6. STOPPED
  *    Triggered by: Last mirrored offsets persisted
  *    Result: Topic becomes writable on destination cluster
  * </pre>
@@ -48,14 +52,20 @@ public enum MirrorPartitionState {
     /** Active mirroring from source cluster is in progress */
     MIRRORING((byte) 1),
 
+    /** Mirroring is being paused; fetchers removed and offsets recorded */
+    PAUSING((byte) 2),
+
+    /** Mirroring is paused; partition stays read-only with no active fetchers */
+    PAUSED((byte) 3),
+
     /** Mirroring is being gracefully stopped */
-    STOPPING((byte) 2),
+    STOPPING((byte) 4),
 
     /** Mirroring has stopped; topic is now writable on this cluster */
-    STOPPED((byte) 4),
+    STOPPED((byte) 5),
 
     /** Error occurred during preparation or mirroring */
-    FAILED((byte) 8),
+    FAILED((byte) 6),
 
     /** Unknown state */
     UNKNOWN((byte) 16);
@@ -77,10 +87,14 @@ public enum MirrorPartitionState {
             case 1:
                 return MIRRORING;
             case 2:
-                return STOPPING;
+                return PAUSING;
+            case 3:
+                return PAUSED;
             case 4:
+                return STOPPING;
+            case 5:
                 return STOPPED;
-            case 8:
+            case 6:
                 return FAILED;
             case 16:
                 return UNKNOWN;
@@ -97,12 +111,19 @@ public enum MirrorPartitionState {
                 return source == null
                         || source == MirrorPartitionState.UNKNOWN
                         || source == MirrorPartitionState.STOPPED
+                        || source == MirrorPartitionState.PAUSED
                         || source == MirrorPartitionState.FAILED;
             case MIRRORING:
                 return source == MirrorPartitionState.PREPARING;
+            case PAUSING:
+                return source == MirrorPartitionState.MIRRORING
+                        || source == MirrorPartitionState.PREPARING;
+            case PAUSED:
+                return source == MirrorPartitionState.PAUSING;
             case STOPPING:
                 return source == MirrorPartitionState.PREPARING
-                        || source == MirrorPartitionState.MIRRORING;
+                        || source == MirrorPartitionState.MIRRORING
+                        || source == MirrorPartitionState.PAUSED;
             case STOPPED:
                 return source == MirrorPartitionState.STOPPING;
             case FAILED:

--- a/core/src/main/java/kafka/server/mirror/MirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorUtils.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.kafka.controller.ConfigurationControlManager.PAUSED_TOPIC_SUFFIX;
 import static org.apache.kafka.controller.ConfigurationControlManager.REMOVED_TOPIC_SUFFIX;
 
 /**
@@ -56,6 +57,9 @@ public final class MirrorUtils {
         }
         if (mirrorName.endsWith(REMOVED_TOPIC_SUFFIX)) {
             return mirrorName.substring(0, mirrorName.length() - REMOVED_TOPIC_SUFFIX.length());
+        }
+        if (mirrorName.endsWith(PAUSED_TOPIC_SUFFIX)) {
+            return mirrorName.substring(0, mirrorName.length() - PAUSED_TOPIC_SUFFIX.length());
         }
         return mirrorName;
     }

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -137,6 +137,8 @@ class ControllerApis(
         case ApiKeys.CREATE_MIRROR => handleCreateMirror(request)
         case ApiKeys.ADD_TOPICS_TO_MIRROR => handleAddTopicsToMirror(request)
         case ApiKeys.REMOVE_TOPICS_FROM_MIRROR => handleRemoveTopicsFromMirror(request)
+        case ApiKeys.PAUSE_MIRROR_TOPICS => handlePauseMirrorTopics(request)
+        case ApiKeys.RESUME_MIRROR_TOPICS => handleResumeMirrorTopics(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -212,6 +214,44 @@ class ControllerApis(
         }
       }
 
+    CompletableFuture.completedFuture[Unit](())
+  }
+
+  def handlePauseMirrorTopics(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val pauseRequest = request.body[PauseMirrorTopicsRequest]
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
+    val topics: util.Set[String] = new util.HashSet[String]()
+    pauseRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
+    controller.pauseMirrorTopics(context, topics)
+      .handle[Unit] { (response, exception) =>
+        if (exception != null) {
+          requestHelper.handleError(request, exception)
+        } else {
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new PauseMirrorTopicsResponse(response.setThrottleTimeMs(throttleMs)))
+        }
+      }
+    CompletableFuture.completedFuture[Unit](())
+  }
+
+  def handleResumeMirrorTopics(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val resumeRequest = request.body[ResumeMirrorTopicsRequest]
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
+    val topics: util.Set[String] = new util.HashSet[String]()
+    resumeRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
+    controller.resumeMirrorTopics(context, topics)
+      .handle[Unit] { (response, exception) =>
+        if (exception != null) {
+          requestHelper.handleError(request, exception)
+        } else {
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new ResumeMirrorTopicsResponse(response.setThrottleTimeMs(throttleMs)))
+        }
+      }
     CompletableFuture.completedFuture[Unit](())
   }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -255,6 +255,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.CREATE_MIRROR => forwardToController(request)
         case ApiKeys.ADD_TOPICS_TO_MIRROR => handleAddTopicsToMirror(request)
         case ApiKeys.REMOVE_TOPICS_FROM_MIRROR => handleRemoveTopicsFromMirror(request)
+        case ApiKeys.PAUSE_MIRROR_TOPICS => handlePauseMirrorTopics(request)
+        case ApiKeys.RESUME_MIRROR_TOPICS => handleResumeMirrorTopics(request)
         case ApiKeys.LIST_MIRRORS => handleListMirrorsRequest(request)
         case ApiKeys.DESCRIBE_MIRRORS => handleDescribeMirrorsRequest(request)
         case ApiKeys.LAST_MIRRORED_OFFSETS => handleLastMirroredOffset(request)
@@ -380,6 +382,26 @@ class KafkaApis(val requestChannel: RequestChannel,
       // update the cached topics in coordinator
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring remove topics from mirror request")
+    }
+    forwardToController(request)
+  }
+
+  def handlePauseMirrorTopics(request: RequestChannel.Request): Unit = {
+    if (!isClusterMirroringEnabled) {
+      requestHelper.sendMaybeThrottle(request,
+        new PauseMirrorTopicsResponse(
+          new PauseMirrorTopicsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
+      return
+    }
+    forwardToController(request)
+  }
+
+  def handleResumeMirrorTopics(request: RequestChannel.Request): Unit = {
+    if (!isClusterMirroringEnabled) {
+      requestHelper.sendMaybeThrottle(request,
+        new ResumeMirrorTopicsResponse(
+          new ResumeMirrorTopicsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
+      return
     }
     forwardToController(request)
   }

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -27,7 +27,9 @@ import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.message.AddTopicsToMirrorResponseData;
 import org.apache.kafka.common.message.CreateMirrorResponseData;
+import org.apache.kafka.common.message.PauseMirrorTopicsResponseData;
 import org.apache.kafka.common.message.RemoveTopicsFromMirrorResponseData;
+import org.apache.kafka.common.message.ResumeMirrorTopicsResponseData;
 import org.apache.kafka.common.metadata.ClearElrRecord;
 import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.common.protocol.Errors;
@@ -70,6 +72,7 @@ import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_
 public class ConfigurationControlManager {
     public static final ConfigResource DEFAULT_NODE = new ConfigResource(Type.BROKER, "");
     public static final String REMOVED_TOPIC_SUFFIX = ".removed";
+    public static final String PAUSED_TOPIC_SUFFIX = ".paused";
 
     private final Logger log;
     private final SnapshotRegistry snapshotRegistry;
@@ -248,6 +251,105 @@ public class ConfigurationControlManager {
                 // decide if we should clear the mirror name or append a stopped symbol
                 String newMirrorName = curVal.endsWith(REMOVED_TOPIC_SUFFIX) ? "" : curVal + REMOVED_TOPIC_SUFFIX;
                 Map<String, Entry<OpType, String>> keyToOps = Map.of(mirrorNameConfig, new AbstractMap.SimpleImmutableEntry<>(SET, newMirrorName));
+
+                ControllerResult<ApiError> configResult = incrementalAlterConfig(configResource, keyToOps, true);
+                if (configResult.response().isFailure()) {
+                    topicRes.setErrorCode(configResult.response().error().code()).setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
+                records.addAll(configResult.records());
+                topicRes.setName(topic);
+                topicResList.add(topicRes);
+            }
+        }
+        data.setTopics(topicResList);
+
+        return ControllerResult.of(records, data);
+    }
+
+    ControllerResult<PauseMirrorTopicsResponseData> pauseMirrorTopics(Set<String> topics) {
+        List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+        PauseMirrorTopicsResponseData data = new PauseMirrorTopicsResponseData();
+        List<PauseMirrorTopicsResponseData.TopicResult> topicResList = new ArrayList<>();
+        for (String topic : topics) {
+            PauseMirrorTopicsResponseData.TopicResult topicRes = new PauseMirrorTopicsResponseData.TopicResult();
+            ConfigResource configResource = new ConfigResource(Type.TOPIC, topic);
+
+            TimelineHashMap<String, String> currentConfigs = configData.get(configResource);
+            if (currentConfigs == null) {
+                topicRes.setErrorCode(Errors.INVALID_REQUEST.code());
+            } else {
+                String curVal = currentConfigs.get(TopicConfig.MIRROR_NAME_CONFIG);
+                if (curVal == null || curVal.isBlank()) {
+                    topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
+                if (curVal.endsWith(PAUSED_TOPIC_SUFFIX)) {
+                    // Already paused, idempotent success
+                    topicRes.setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
+                if (curVal.endsWith(REMOVED_TOPIC_SUFFIX)) {
+                    topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
+                String pausedMirrorName = curVal + PAUSED_TOPIC_SUFFIX;
+                Map<String, Entry<OpType, String>> keyToOps = Map.of(TopicConfig.MIRROR_NAME_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(SET, pausedMirrorName));
+
+                ControllerResult<ApiError> configResult = incrementalAlterConfig(configResource, keyToOps, true);
+                if (configResult.response().isFailure()) {
+                    topicRes.setErrorCode(configResult.response().error().code()).setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
+                records.addAll(configResult.records());
+                topicRes.setName(topic);
+                topicResList.add(topicRes);
+            }
+        }
+        data.setTopics(topicResList);
+
+        return ControllerResult.of(records, data);
+    }
+
+    ControllerResult<ResumeMirrorTopicsResponseData> resumeMirrorTopics(Set<String> topics) {
+        List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+        ResumeMirrorTopicsResponseData data = new ResumeMirrorTopicsResponseData();
+        List<ResumeMirrorTopicsResponseData.TopicResult> topicResList = new ArrayList<>();
+        for (String topic : topics) {
+            ResumeMirrorTopicsResponseData.TopicResult topicRes = new ResumeMirrorTopicsResponseData.TopicResult();
+            ConfigResource configResource = new ConfigResource(Type.TOPIC, topic);
+
+            TimelineHashMap<String, String> currentConfigs = configData.get(configResource);
+            if (currentConfigs == null) {
+                topicRes.setErrorCode(Errors.INVALID_REQUEST.code());
+            } else {
+                String curVal = currentConfigs.get(TopicConfig.MIRROR_NAME_CONFIG);
+                if (curVal == null || curVal.isBlank()) {
+                    topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
+                if (!curVal.endsWith(PAUSED_TOPIC_SUFFIX)) {
+                    topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
+                String originalMirrorName = curVal.substring(0, curVal.length() - PAUSED_TOPIC_SUFFIX.length());
+                Map<String, Entry<OpType, String>> keyToOps = Map.of(TopicConfig.MIRROR_NAME_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(SET, originalMirrorName));
 
                 ControllerResult<ApiError> configResult = incrementalAlterConfig(configResource, keyToOps, true);
                 if (configResult.response().isFailure()) {

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -47,9 +47,11 @@ import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.PauseMirrorTopicsResponseData;
 import org.apache.kafka.common.message.RemoveTopicsFromMirrorResponseData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
+import org.apache.kafka.common.message.ResumeMirrorTopicsResponseData;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
@@ -172,6 +174,16 @@ public interface Controller extends AclMutator, AutoCloseable {
     );
 
     CompletableFuture<RemoveTopicsFromMirrorResponseData> removeTopicsFromMirror(
+            ControllerRequestContext context,
+            Set<String> topics
+    );
+
+    CompletableFuture<PauseMirrorTopicsResponseData> pauseMirrorTopics(
+            ControllerRequestContext context,
+            Set<String> topics
+    );
+
+    CompletableFuture<ResumeMirrorTopicsResponseData> resumeMirrorTopics(
             ControllerRequestContext context,
             Set<String> topics
     );

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -56,9 +56,11 @@ import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.PauseMirrorTopicsResponseData;
 import org.apache.kafka.common.message.RemoveTopicsFromMirrorResponseData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
+import org.apache.kafka.common.message.ResumeMirrorTopicsResponseData;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.metadata.AbortTransactionRecord;
@@ -1795,6 +1797,24 @@ public final class QuorumController implements Controller {
     ) {
         return appendWriteEvent("removeTopicsFromMirror", context.deadlineNs(),
                 () -> configurationControl.removeTopicsFromMirror(topics));
+    }
+
+    @Override
+    public CompletableFuture<PauseMirrorTopicsResponseData> pauseMirrorTopics(
+            ControllerRequestContext context,
+            Set<String> topics
+    ) {
+        return appendWriteEvent("pauseMirrorTopics", context.deadlineNs(),
+                () -> configurationControl.pauseMirrorTopics(topics));
+    }
+
+    @Override
+    public CompletableFuture<ResumeMirrorTopicsResponseData> resumeMirrorTopics(
+            ControllerRequestContext context,
+            Set<String> topics
+    ) {
+        return appendWriteEvent("resumeMirrorTopics", context.deadlineNs(),
+                () -> configurationControl.resumeMirrorTopics(topics));
     }
 
     @Override

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -146,6 +146,8 @@ import org.apache.kafka.clients.admin.NewPartitionReassignment;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.PauseMirrorTopicsOptions;
+import org.apache.kafka.clients.admin.PauseMirrorTopicsResult;
 import org.apache.kafka.clients.admin.RaftVoterEndpoint;
 import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupOptions;
@@ -156,6 +158,8 @@ import org.apache.kafka.clients.admin.RemoveTopicsFromMirrorOptions;
 import org.apache.kafka.clients.admin.RemoveTopicsFromMirrorResult;
 import org.apache.kafka.clients.admin.RenewDelegationTokenOptions;
 import org.apache.kafka.clients.admin.RenewDelegationTokenResult;
+import org.apache.kafka.clients.admin.ResumeMirrorTopicsOptions;
+import org.apache.kafka.clients.admin.ResumeMirrorTopicsResult;
 import org.apache.kafka.clients.admin.TerminateTransactionOptions;
 import org.apache.kafka.clients.admin.TerminateTransactionResult;
 import org.apache.kafka.clients.admin.UnregisterBrokerOptions;
@@ -441,6 +445,16 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     @Override
     public RemoveTopicsFromMirrorResult removeTopicsFromMirror(final Set<String> topics, final RemoveTopicsFromMirrorOptions options) {
         return adminDelegate.removeTopicsFromMirror(topics, options);
+    }
+
+    @Override
+    public PauseMirrorTopicsResult pauseMirrorTopics(final Set<String> topics, final PauseMirrorTopicsOptions options) {
+        return adminDelegate.pauseMirrorTopics(topics, options);
+    }
+
+    @Override
+    public ResumeMirrorTopicsResult resumeMirrorTopics(final Set<String> topics, final ResumeMirrorTopicsOptions options) {
+        return adminDelegate.resumeMirrorTopics(topics, options);
     }
 
     @Override

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -53,9 +53,11 @@ import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.PauseMirrorTopicsResponseData;
 import org.apache.kafka.common.message.RemoveTopicsFromMirrorResponseData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
+import org.apache.kafka.common.message.ResumeMirrorTopicsResponseData;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.protocol.Errors;
@@ -130,6 +132,19 @@ public class MockController implements Controller {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public CompletableFuture<PauseMirrorTopicsResponseData> pauseMirrorTopics(
+            ControllerRequestContext context,
+            Set<String> topics) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<ResumeMirrorTopicsResponseData> resumeMirrorTopics(
+            ControllerRequestContext context,
+            Set<String> topics) {
+        throw new UnsupportedOperationException();
+    }
 
     public static class Builder {
         private final Map<String, MockTopic> initialTopics = new HashMap<>();

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -30,8 +30,12 @@ import org.apache.kafka.clients.admin.ListMirrorsResult;
 import org.apache.kafka.clients.admin.MirrorDescription;
 import org.apache.kafka.clients.admin.MirrorListing;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.PauseMirrorTopicsOptions;
+import org.apache.kafka.clients.admin.PauseMirrorTopicsResult;
 import org.apache.kafka.clients.admin.RemoveTopicsFromMirrorOptions;
 import org.apache.kafka.clients.admin.RemoveTopicsFromMirrorResult;
+import org.apache.kafka.clients.admin.ResumeMirrorTopicsOptions;
+import org.apache.kafka.clients.admin.ResumeMirrorTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.TopicExistsException;
@@ -85,6 +89,10 @@ public abstract class MirrorCommand {
                 mirrorService.addTopicsToMirror(opts);
             } else if (opts.hasRemoveOption()) {
                 mirrorService.removeTopicsFromMirror(opts);
+            } else if (opts.hasPauseOption()) {
+                mirrorService.pauseMirrorTopics(opts);
+            } else if (opts.hasResumeOption()) {
+                mirrorService.resumeMirrorTopics(opts);
             } else if (opts.hasListOption()) {
                 mirrorService.listMirrors();
             } else if (opts.hasDescribeOption()) {
@@ -229,6 +237,28 @@ public abstract class MirrorCommand {
             System.out.printf("Removed %d topic(s) from mirror %s: %s%n", matchingTopics.size(), mirrorName, matchingTopics);
         }
 
+        private void pauseMirrorTopics(MirrorCommandOptions opts) throws Exception {
+            String topicPattern = opts.topic().get();
+
+            var allTopics = adminClient.listTopics().names().get();
+            Set<String> matchingTopics = matchTopics(allTopics, topicPattern);
+
+            PauseMirrorTopicsResult result = adminClient.pauseMirrorTopics(matchingTopics, new PauseMirrorTopicsOptions());
+            result.all().get();
+            System.out.printf("Paused mirroring for %d topic(s): %s%n", matchingTopics.size(), matchingTopics);
+        }
+
+        private void resumeMirrorTopics(MirrorCommandOptions opts) throws Exception {
+            String topicPattern = opts.topic().get();
+
+            var allTopics = adminClient.listTopics().names().get();
+            Set<String> matchingTopics = matchTopics(allTopics, topicPattern);
+
+            ResumeMirrorTopicsResult result = adminClient.resumeMirrorTopics(matchingTopics, new ResumeMirrorTopicsOptions());
+            result.all().get();
+            System.out.printf("Resumed mirroring for %d topic(s): %s%n", matchingTopics.size(), matchingTopics);
+        }
+
         private void listMirrors() throws ExecutionException, InterruptedException {
             ListMirrorsResult result = adminClient.listMirrors();
             List<MirrorListing> listings = new ArrayList<>(result.all().get());
@@ -349,6 +379,8 @@ public abstract class MirrorCommand {
         private final OptionSpecBuilder createOpt;
         private final OptionSpecBuilder addOpt;
         private final OptionSpecBuilder removeOpt;
+        private final OptionSpecBuilder pauseOpt;
+        private final OptionSpecBuilder resumeOpt;
         private final OptionSpecBuilder listOpt;
         private final OptionSpecBuilder describeOpt;
         private final ArgumentAcceptingOptionSpec<String> mirrorOpt;
@@ -376,6 +408,8 @@ public abstract class MirrorCommand {
             createOpt = parser.accepts("create", "Create a new cluster mirror from a source cluster.");
             addOpt = parser.accepts("add", "Add topic(s) to an existing cluster mirror (supports regex).");
             removeOpt = parser.accepts("remove", "Remove topic(s) from an existing cluster mirror (supports regex).");
+            pauseOpt = parser.accepts("pause", "Pause mirroring for topic(s) matching the pattern (supports regex).");
+            resumeOpt = parser.accepts("resume", "Resume mirroring for previously paused topic(s) matching the pattern (supports regex).");
             listOpt = parser.accepts("list", "List all cluster mirrors.");
             describeOpt = parser.accepts("describe", "Describe a cluster mirror including partition lag and state.");
 
@@ -416,6 +450,14 @@ public abstract class MirrorCommand {
 
         private boolean hasRemoveOption() {
             return has(removeOpt);
+        }
+
+        private boolean hasPauseOption() {
+            return has(pauseOpt);
+        }
+
+        private boolean hasResumeOption() {
+            return has(resumeOpt);
         }
 
         private boolean hasListOption() {
@@ -467,15 +509,16 @@ public abstract class MirrorCommand {
 
             // should have exactly one action
             if ((has(createOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0) + (has(removeOpt) ? 1 : 0)
+                    + (has(pauseOpt) ? 1 : 0) + (has(resumeOpt) ? 1 : 0)
                     + (has(listOpt) ? 1 : 0) + (has(describeOpt) ? 1 : 0) != 1)
-                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --add, --remove, --list, or --describe");
+                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --add, --remove, --pause, --resume, --list, or --describe");
 
             // check required args
             if (!has(bootstrapServerOpt))
                 throw new IllegalArgumentException("--bootstrap-server must be specified");
 
-            // --mirror is required for create, add, and remove operations, but optional for list and describe
-            if (!has(listOpt) && !has(describeOpt) && !has(mirrorOpt))
+            // --mirror is required for create, add, and remove operations, but optional for list, describe, pause, and resume
+            if (!has(listOpt) && !has(describeOpt) && !has(pauseOpt) && !has(resumeOpt) && !has(mirrorOpt))
                 throw new IllegalArgumentException("--mirror must be specified");
 
             if (has(createOpt) && !has(mirrorConfigOpt))
@@ -486,6 +529,12 @@ public abstract class MirrorCommand {
 
             if (has(removeOpt) && !has(topicOpt))
                 throw new IllegalArgumentException("--topic must be specified when removing topic(s) from a mirror");
+
+            if (has(pauseOpt) && !has(topicOpt))
+                throw new IllegalArgumentException("--topic must be specified when pausing mirror topic(s)");
+
+            if (has(resumeOpt) && !has(topicOpt))
+                throw new IllegalArgumentException("--topic must be specified when resuming mirror topic(s)");
         }
     }
 }


### PR DESCRIPTION
Introduce `PauseMirrorTopics` and `ResumeMirrorTopics` to allow pausing and resuming mirroring for specific topics. Pausing stops data and metadata replication and records LEO offsets. Resuming transitions `PAUSED` topics back to `PREPARING`, reusing the existing truncation and logic.

The mechanism uses a ".paused" suffix on the mirror.name topic config, following the same pattern as ".removed" for stop.

State machine changes:

```
MIRRORING -> PAUSING -> PAUSED (pause path)
PAUSED -> PREPARING -> MIRRORING (resume path)
PAUSED -> STOPPING -> STOPPED (remove paused topic)
```

CLI examples:

```sh
bin/kafka-mirror.sh --bootstrap-server :9092 --pause --topic orders.*
bin/kafka-mirror.sh --bootstrap-server :9092 --resume --topic orders.*
```
