### PR TITLE
Add dynamic mirror reconfiguration

### DIFF
--- a/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
@@ -23,6 +23,8 @@
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
     { "name": "Mirrors", "type": "[]DescribedMirror", "versions": "0+",
       "about": "Each described mirror.", "fields": [
       { "name": "ErrorCode", "type": "int16", "versions": "0+",

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -82,7 +82,7 @@ public class MirrorCoordinator {
     private static final Logger LOG = LoggerFactory.getLogger(MirrorCoordinator.class);
 
     private final AtomicBoolean isActive = new AtomicBoolean(false);
-    private final KafkaConfig kafkaConfig;
+    private final KafkaConfig brokerConfig;
     private final ReplicaManager replicaManager;
     private final MirrorMetadataManager mirrorMetadataManager;
     private final Scheduler scheduler;
@@ -95,7 +95,7 @@ public class MirrorCoordinator {
     private volatile int numPartitions = -1;
 
     public MirrorCoordinator(
-            KafkaConfig kafkaConfig,
+            KafkaConfig brokerConfig,
             ReplicaManager replicaManager,
             Scheduler scheduler,
             Metrics metrics,
@@ -103,7 +103,7 @@ public class MirrorCoordinator {
             Time time,
             MirrorMetadataManager mirrorMetadataManager
     ) {
-        this.kafkaConfig = kafkaConfig;
+        this.brokerConfig = brokerConfig;
         this.replicaManager = replicaManager;
         this.mirrorMetadataManager = mirrorMetadataManager;
         this.scheduler = scheduler;
@@ -118,7 +118,7 @@ public class MirrorCoordinator {
         var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME,
                 getCoordinatorPartitionByKey(new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), partition)));
         var optLeaderAndIsr = metadataCache.getLeaderAndIsr(mirrorTopicPartition.topic(), mirrorTopicPartition.partition());
-        return optLeaderAndIsr.isPresent() && optLeaderAndIsr.get().leader() == kafkaConfig.nodeId();
+        return optLeaderAndIsr.isPresent() && optLeaderAndIsr.get().leader() == brokerConfig.nodeId();
     }
 
     // Executes the appropriate actions for a state transition.
@@ -333,7 +333,7 @@ public class MirrorCoordinator {
         }
 
         LOG.info("Starting up.");
-        numPartitions = kafkaConfig.mirrorConfig().topicNumPartitions();
+        numPartitions = brokerConfig.mirrorConfig().topicNumPartitions();
         mirrorMetadataManager.setStateTransitioner((mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state));
         mirrorMetadataManager.setCoordinatorPartitionByKeyFinder(key -> getCoordinatorPartitionByKey(key));
         mirrorMetadataManager.setCoordinatorPartitionByNameFinder(mirrorName -> getCoordinatorPartitionByName(mirrorName));
@@ -341,7 +341,7 @@ public class MirrorCoordinator {
         scheduler.startup();
 
         // periodically query source cluster to get the metadata
-        long metadataRefreshIntervalMs = kafkaConfig.mirrorConfig().metadataRefreshIntervalMs();
+        long metadataRefreshIntervalMs = brokerConfig.mirrorConfig().metadataRefreshIntervalMs();
         scheduler.schedule("mirror-metadata-refresh",
                 () -> {
                     mirrorMetadataManager.syncTopicMetadataFromSourceClusters();

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -153,17 +153,21 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private static final ResourcePatternFilter ANY_RESOURCE = new ResourcePatternFilter(ResourceType.ANY, null, PatternType.ANY);
     private static final AclBindingFilter ANY_RESOURCE_ACL = new AclBindingFilter(ANY_RESOURCE, AccessControlEntryFilter.ANY);
 
-    private final KafkaConfig kafkaConfig;
+    private final KafkaConfig brokerConfig;
     private final int nodeId;
     private final Metrics metrics;
     private final Time time;
     private final Random random;
-    private final NodeToControllerChannelManager channelManager;
-    private final Supplier<GroupCoordinator> groupCoordinatorSupplier;
     private InterBrokerSender interBrokerSender;
     private MetadataImage metadataImage;
     private final MetadataCache metadataCache;
 
+    // components
+    private final NodeToControllerChannelManager channelManager;
+    private final Supplier<GroupCoordinator> groupCoordinatorSupplier;
+    private final Supplier<MirrorFetcherManager> mirrorFetcherManagerSupplier;
+
+    // functions
     private Optional<MirrorUtils.StateTransitioner> stateTransitioner = Optional.empty();
     private Optional<Function<MirrorRecordKey, Integer>> coordinatorPartitionFinder = Optional.empty();
     private Optional<Function<String, Integer>> coordinatorPartitionByNameFinder = Optional.empty();
@@ -184,20 +188,22 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private AtomicLong aclSyncError;
 
     public MirrorMetadataManager(
-        KafkaConfig kafkaConfig,
+        KafkaConfig brokerConfig,
         Metrics metrics,
         Time time,
         MetadataCache metadataCache,
         NodeToControllerChannelManager channelManager,
-        Supplier<GroupCoordinator> groupCoordinatorSupplier
+        Supplier<GroupCoordinator> groupCoordinatorSupplier,
+        Supplier<MirrorFetcherManager> mirrorFetcherManagerSupplier
     ) {
-        this.kafkaConfig = kafkaConfig;
-        this.nodeId = kafkaConfig.nodeId();
+        this.brokerConfig = brokerConfig;
+        this.nodeId = brokerConfig.nodeId();
         this.metrics = metrics;
         this.time = time;
         this.random = new Random();
         this.channelManager = channelManager;
         this.groupCoordinatorSupplier = groupCoordinatorSupplier;
+        this.mirrorFetcherManagerSupplier = mirrorFetcherManagerSupplier;
 
         this.metadataImage = MetadataImage.EMPTY;
         this.metadataCache = metadataCache;
@@ -229,7 +235,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     @Override
     public String name() {
-        return "MirrorMetadataManager(id=" + kafkaConfig.nodeId() + ")";
+        return "MirrorMetadataManager(id=" + brokerConfig.nodeId() + ")";
     }
 
     /**
@@ -242,13 +248,29 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     @Override
     public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage, LoaderManifest manifest) {
         if (interBrokerSender == null) {
-            KafkaClient networkClient = NetworkUtils.buildNetworkClient("MirrorMetadataManager", kafkaConfig, metrics, time, new LogContext(name()));
-            interBrokerSender = new InterBrokerSender("mirror-inter-broker-sender", networkClient, kafkaConfig.requestTimeoutMs(), Time.SYSTEM);
+            KafkaClient networkClient = NetworkUtils.buildNetworkClient("MirrorMetadataManager", brokerConfig, metrics, time, new LogContext(name()));
+            interBrokerSender = new InterBrokerSender("mirror-inter-broker-sender", networkClient, brokerConfig.requestTimeoutMs(), Time.SYSTEM);
             interBrokerSender.start();
         }
 
         // caching the image for query purpose
         this.metadataImage = newImage;
+
+        // detect mirror config changes and close stale connections to trigger reconnection
+        if (delta.configsDelta() != null) {
+            delta.configsDelta().changes().entrySet().stream()
+                .filter(e -> e.getKey().type() == ConfigResource.Type.MIRROR)
+                .forEach(e -> {
+                    String mirrorName = e.getKey().name();
+                    List<MirrorBlockingSender> senders = sourceSenders.remove(mirrorName);
+                    if (senders != null) {
+                        LOG.info("Mirror config changed for '{}'. Closing existing connections "
+                            + "to trigger reconnection with updated configuration.", mirrorName);
+                        senders.forEach(MirrorBlockingSender::close);
+                    }
+                    mirrorFetcherManagerSupplier.get().restartFetchersForMirror(mirrorName);
+                });
+        }
 
         // get all mirror partition leaders on this node based on the delta
         Set<TopicPartition> mirrorLeaders = getMirrorLeaders(delta, newImage);
@@ -407,7 +429,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
                     .partitions().get(coordinatorPartitionFinder.get().apply(
                             new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), partition))).leader;
-            return activeCoordinator == kafkaConfig.nodeId();
+            return activeCoordinator == brokerConfig.nodeId();
         }
         return false;
     }
@@ -416,7 +438,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (coordinatorPartitionByNameFinder.isPresent()) {
             int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
                     .partitions().get(coordinatorPartitionByNameFinder.get().apply(mirrorName)).leader;
-            return activeCoordinator == kafkaConfig.nodeId();
+            return activeCoordinator == brokerConfig.nodeId();
         }
         return false;
     }
@@ -428,7 +450,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 Set<String> topicSet = new HashSet<>();
                 topicSet.add(MIRROR_STATE_TOPIC_NAME);
 
-                var interBrokerListenerName = kafkaConfig.interBrokerListenerName();
+                var interBrokerListenerName = brokerConfig.interBrokerListenerName();
 
                 List<MetadataResponseData.MetadataResponseTopic> topicMetadata = metadataCache.getTopicMetadata(
                         topicSet,
@@ -646,6 +668,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .map(Object::toString)
                 .orElseThrow(() -> new IllegalArgumentException("Remote bootstrap server not found in Cluster Mirror config: " + mirrorName));
 
+        LOG.info("Mirror config for '{}': {}", mirrorName, props);
+
         var addresses = ClientUtils.parseAndValidateAddresses(Arrays.stream(bootstrapServers.split(",")).toList(), "use_all_dns_ips");
         // Use random node id here because we don't know node id of remote brokers
         int rand = random.nextInt(addresses.size());
@@ -655,6 +679,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         MirrorBlockingSender sender = new MirrorBlockingSender(
                 brokerEndpoint,
                 MirrorConfig.fromProperties(props),
+                brokerConfig,
                 metrics,
                 time,
                 brokerEndpoint.id(),
@@ -862,7 +887,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
 
         mirrors.forEach(this::ensureMirrorConnection);
-
         sourceSenders.forEach((mirror, senders) -> syncTopicMetadata(mirror, senders));
 
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -256,7 +256,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         // caching the image for query purpose
         this.metadataImage = newImage;
 
-        // detect mirror config changes and close stale connections to trigger reconnection
+        // detect config changes and close stale connections and fetchers to trigger reconnection
         if (delta.configsDelta() != null) {
             delta.configsDelta().changes().entrySet().stream()
                 .filter(e -> e.getKey().type() == ConfigResource.Type.MIRROR)
@@ -268,7 +268,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                             + "to trigger reconnection with updated configuration.", mirrorName);
                         senders.forEach(MirrorBlockingSender::close);
                     }
-                    mirrorFetcherManagerSupplier.get().restartFetchersForMirror(mirrorName);
+                    mirrorFetcherManagerSupplier.get().removeFetchersForMirror(mirrorName);
                 });
         }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -345,7 +345,8 @@ class BrokerServer(
         time,
         metadataCache,
         clientToControllerChannelManager,
-        () => groupCoordinator
+        () => groupCoordinator,
+        () => _replicaManager.mirrorFetcherManager
       )
 
       this._replicaManager = new ReplicaManager(

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -24,7 +24,8 @@ import kafka.utils._
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.common.config.ConfigDef.ConfigKey
-import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, BROKER_LOGGER, CLIENT_METRICS, GROUP, TOPIC}
+import org.apache.kafka.server.config.MirrorConfig
+import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, BROKER_LOGGER, CLIENT_METRICS, GROUP, MIRROR, TOPIC}
 import org.apache.kafka.common.config.{ConfigDef, ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.{ApiException, InvalidConfigurationException, InvalidRequestException}
 import org.apache.kafka.common.message.{AlterConfigsRequestData, AlterConfigsResponseData, IncrementalAlterConfigsRequestData, IncrementalAlterConfigsResponseData}
@@ -148,8 +149,18 @@ class ConfigAdminManager(nodeId: Int,
                 if (resource.configs().stream().anyMatch(config => TopicConfig.MIRROR_NAME_CONFIG.equals(config.name()))) {
                   throw new InvalidRequestException("The 'mirror.name' configuration can only be modified through dedicated mirror management APIs.")
                 }
-            case CLIENT_METRICS | GROUP | ConfigResource.Type.MIRROR =>
+            case CLIENT_METRICS | GROUP =>
             // Nothing to do.
+            case MIRROR =>
+              val validKeys = MirrorConfig.CONFIG_DEF.names()
+              resource.configs().forEach { config =>
+                if (!validKeys.contains(config.name())) {
+                  throw new InvalidConfigurationException(s"Unknown mirror configuration: ${config.name()}")
+                }
+              }
+              val mirrorProps = new Properties()
+              resource.configs().forEach(config => mirrorProps.put(config.name(), config.value()))
+              MirrorConfig.CONFIG_DEF.parse(mirrorProps)
             case _ =>
               throw new InvalidRequestException(s"Unknown resource type ${resource.resourceType().toInt}")
           }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -352,7 +352,6 @@ class KafkaApis(val requestChannel: RequestChannel,
         topicResults.add(topicResult)
       })
       responseData.setTopics(topicResults)
-
       requestHelper.sendMaybeThrottle(request, new LastMirroredOffsetsResponse(responseData))
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring last mirrored offset request")
@@ -371,21 +370,18 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleRemoveTopicsFromMirror(request: RequestChannel.Request): Unit = {
-    if (isClusterMirroringEnabled) {
-      val removeTopicsFromMirrorRequest = request.body[RemoveTopicsFromMirrorRequest]
-      // TODO: might need to have a better way to pass the cluster mirror
-      val topicNames: util.Set[String] = removeTopicsFromMirrorRequest.data.topics.stream().map(t => t.topicName()).collect(Collectors.toSet())
-    } else {
+    if (!isClusterMirroringEnabled) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring remove topics from mirror request")
+      requestHelper.sendMaybeThrottle(request, new RemoveTopicsFromMirrorResponse(new RemoveTopicsFromMirrorResponseData().setErrorCode(Errors.INVALID_REQUEST.code)))
+      return
     }
     forwardToController(request)
   }
 
   def handlePauseMirrorTopics(request: RequestChannel.Request): Unit = {
     if (!isClusterMirroringEnabled) {
-      requestHelper.sendMaybeThrottle(request,
-        new PauseMirrorTopicsResponse(
-          new PauseMirrorTopicsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
+      logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring pause mirror topics request")
+      requestHelper.sendMaybeThrottle(request, new PauseMirrorTopicsResponse(new PauseMirrorTopicsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
       return
     }
     forwardToController(request)
@@ -393,9 +389,8 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleResumeMirrorTopics(request: RequestChannel.Request): Unit = {
     if (!isClusterMirroringEnabled) {
-      requestHelper.sendMaybeThrottle(request,
-        new ResumeMirrorTopicsResponse(
-          new ResumeMirrorTopicsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
+      logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring resume mirror topics request")
+      requestHelper.sendMaybeThrottle(request, new ResumeMirrorTopicsResponse(new ResumeMirrorTopicsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
       return
     }
     forwardToController(request)
@@ -421,7 +416,6 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), returning empty mirror list")
-      responseData.setErrorCode(Errors.NONE.code)
     }
 
     requestHelper.sendMaybeThrottle(request, new ListMirrorsResponse(responseData))

--- a/core/src/main/scala/kafka/server/mirror/MirrorBlockingSender.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorBlockingSender.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.requests.AbstractRequest.Builder
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.server.config.MirrorConfig
 import org.apache.kafka.server.network.BrokerEndPoint
+import kafka.server.KafkaConfig
 
 import scala.jdk.CollectionConverters._
 
@@ -39,20 +40,20 @@ import scala.jdk.CollectionConverters._
  */
 class MirrorBlockingSender(sourceBroker: BrokerEndPoint,
                            mirrorConfig: MirrorConfig,
+                           brokerConfig: KafkaConfig,
                            metrics: Metrics,
                            time: Time,
                            fetcherId: Int,
                            clientId: String,
                            logContext: LogContext) extends BlockingSend {
   private val sourceNode = new Node(sourceBroker.id, sourceBroker.host, sourceBroker.port)
-  private val config = mirrorConfig.getConfig()
-  private val socketTimeout: Int = config.getLong(MirrorConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG).toInt
+  private val socketTimeout: Int = brokerConfig.replicaSocketTimeoutMs
 
   private val networkClient = {
     val channelBuilder = ChannelBuilders.clientChannelBuilder(
       SecurityProtocol.forName(mirrorConfig.securityProtocol()),
       JaasContext.Type.CLIENT,
-      config,
+      mirrorConfig.getConfig(),
       null,
       mirrorConfig.saslMechanism(),
       time,
@@ -60,7 +61,7 @@ class MirrorBlockingSender(sourceBroker: BrokerEndPoint,
     )
     val selector = new Selector(
       NetworkReceive.UNLIMITED,
-      config.getLong(MirrorConfig.METADATA_MAX_AGE_CONFIG),
+      brokerConfig.connectionsMaxIdleMs,
       metrics,
       time,
       "mirror-" + clientId,
@@ -75,11 +76,11 @@ class MirrorBlockingSender(sourceBroker: BrokerEndPoint,
       1,
       0,
       0,
-      config.getInt(MirrorConfig.SEND_BUFFER_CONFIG),
-      config.getInt(MirrorConfig.RECEIVE_BUFFER_CONFIG),
-      config.getInt(MirrorConfig.REQUEST_TIMEOUT_MS_CONFIG),
-      config.getLong(MirrorConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG).toInt,
-      config.getLong(MirrorConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG).toInt,
+      Selectable.USE_DEFAULT_BUFFER_SIZE,
+      brokerConfig.replicaSocketReceiveBufferBytes,
+      brokerConfig.requestTimeoutMs,
+      brokerConfig.connectionSetupTimeoutMs,
+      brokerConfig.connectionSetupTimeoutMaxMs,
       time,
       true,
       new ApiVersions,

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -207,7 +207,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     }
   }
 
-  def restartFetchersForMirror(mirrorName: String): Unit = {
+  def removeFetchersForMirror(mirrorName: String): Unit = {
     this.synchronized {
       val affectedPartitions = mirrorFetcherThreadMap
         .filter(_._1.mirrorName == mirrorName)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -133,7 +133,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
       val mirrorProperties = metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName))
       info(s"Using mirror properties for $mirrorName: ${mirrorProperties.keySet()}")
       val mirrorConfig = MirrorConfig.fromProperties(mirrorProperties)
-      new MirrorBlockingSender(sourceBroker, mirrorConfig, metrics, time, fetcherId,
+      new MirrorBlockingSender(sourceBroker, mirrorConfig, brokerConfig, metrics, time, fetcherId,
         s"broker-${brokerConfig.brokerId}-fetcher-$fetcherId-mirror-$mirrorName", logContext)
     } else {
       throw new IllegalArgumentException("Mirror name must be provided for remote fetchers")
@@ -204,6 +204,21 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
       lagInfo.collect {
         case (key, lagInfo) if key.mirrorName == mirrorName => key.topicPartition -> lagInfo
       }.toMap
+    }
+  }
+
+  def restartFetchersForMirror(mirrorName: String): Unit = {
+    this.synchronized {
+      val affectedPartitions = mirrorFetcherThreadMap
+        .filter(_._1.mirrorName == mirrorName)
+        .values
+        .flatMap(_.partitions)
+        .toSet
+      if (affectedPartitions.nonEmpty) {
+        info(s"Restarting fetcher threads for mirror '$mirrorName' " +
+          s"affecting ${affectedPartitions.size} partitions")
+        removeFetcherForPartitions(affectedPartitions)
+      }
     }
   }
 

--- a/server-common/src/main/java/org/apache/kafka/server/config/ConfigType.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ConfigType.java
@@ -27,7 +27,7 @@ public enum ConfigType {
     IP("ips"),
     CLIENT_METRICS("client-metrics"),
     GROUP("groups"),
-    MIRROR("mirror");
+    MIRROR("mirrors");
 
     private final String value;
 

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -72,7 +72,7 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         BrokerSecurityConfigs.CONFIG_DEF,
         DelegationTokenManagerConfigs.CONFIG_DEF,
         AddPartitionsToTxnConfig.CONFIG_DEF,
-        MirrorConfig.topicConfigDef()
+        MirrorConfig.brokerConfigDef()
     ));
 
     public AbstractKafkaConfig(ConfigDef definition, Map<?, ?> originals, Map<String, ?> configProviderProps, boolean doLog) {

--- a/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
@@ -103,47 +103,7 @@ public final class MirrorConfig {
 
     // Connection configuration
     public static final String BOOTSTRAP_SERVERS_CONFIG = CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
-    public static final String BOOTSTRAP_SERVERS_DOC = "A list of host/port pairs to use for establishing the initial connection to the Kafka cluster for Cluster Mirror.";
-
-    public static final String METADATA_MAX_AGE_CONFIG = CommonClientConfigs.METADATA_MAX_AGE_CONFIG;
-    public static final long METADATA_MAX_AGE_DEFAULT = 300000L; // 5 minutes
-    public static final String METADATA_MAX_AGE_DOC = "The period of time in milliseconds after which we force a refresh of metadata for Cluster Mirror connections.";
-
-    public static final String SEND_BUFFER_CONFIG = CommonClientConfigs.SEND_BUFFER_CONFIG;
-    public static final int SEND_BUFFER_DEFAULT = 131072; // 128KB
-    public static final String SEND_BUFFER_DOC = "The size of the TCP send buffer (SO_SNDBUF) to use when sending data for Cluster Mirror connections.";
-
-    public static final String RECEIVE_BUFFER_CONFIG = CommonClientConfigs.RECEIVE_BUFFER_CONFIG;
-    public static final int RECEIVE_BUFFER_DEFAULT = 65536; // 64KB
-    public static final String RECEIVE_BUFFER_DOC = "The size of the TCP receive buffer (SO_RCVBUF) to use when reading data for Cluster Mirror connections.";
-
-    public static final String REQUEST_TIMEOUT_MS_CONFIG = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
-    public static final int REQUEST_TIMEOUT_MS_DEFAULT = 30000; // 30 seconds
-    public static final String REQUEST_TIMEOUT_MS_DOC = "The configuration controls the maximum amount of time the client will wait for the response of a request for Cluster Mirror connections.";
-
-    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG;
-    public static final long SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DEFAULT = CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MS; // 10 seconds
-    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC = "The amount of time the client will wait for the socket connection to be established for Cluster Mirror connections.";
-
-    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG;
-    public static final long SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DEFAULT = CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS; // 30 seconds
-    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC = "The maximum amount of time the client will wait for the socket connection to be established for Cluster Mirror connections.";
-
-    public static final String RECONNECT_BACKOFF_MS_CONFIG = CommonClientConfigs.RECONNECT_BACKOFF_MS_CONFIG;
-    public static final long RECONNECT_BACKOFF_MS_DEFAULT = 50L;
-    public static final String RECONNECT_BACKOFF_MS_DOC = "The base amount of time to wait before attempting to reconnect to a given host for Cluster Mirror connections.";
-
-    public static final String RECONNECT_BACKOFF_MAX_MS_CONFIG = CommonClientConfigs.RECONNECT_BACKOFF_MAX_MS_CONFIG;
-    public static final long RECONNECT_BACKOFF_MAX_MS_DEFAULT = 1000L; // 1 second
-    public static final String RECONNECT_BACKOFF_MAX_MS_DOC = "The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect for Cluster Mirror connections.";
-
-    public static final String RETRIES_CONFIG = CommonClientConfigs.RETRIES_CONFIG;
-    public static final int RETRIES_DEFAULT = Integer.MAX_VALUE;
-    public static final String RETRIES_DOC = "Setting a value greater than zero will cause the client to resend any request that fails with a potentially transient error for Cluster Mirror connections.";
-
-    public static final String RETRY_BACKOFF_MS_CONFIG = CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG;
-    public static final long RETRY_BACKOFF_MS_DEFAULT = 100L;
-    public static final String RETRY_BACKOFF_MS_DOC = "The amount of time to wait before attempting to retry a failed request to a given topic partition for Cluster Mirror connections.";
+    public static final String BOOTSTRAP_SERVERS_DOC = "A list of host/port pairs to use for establishing the initial connection to the source cluster.";
 
     // Security configuration
     public static final String SECURITY_PROTOCOL_CONFIG = CommonClientConfigs.SECURITY_PROTOCOL_CONFIG;
@@ -151,10 +111,30 @@ public final class MirrorConfig {
     public static final String SECURITY_PROTOCOL_DOC = "Protocol used to communicate with remote brokers for Cluster Mirror. " +
             "Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.";
 
+    // SASL configuration
+    public static final String SASL_MECHANISM_CONFIG = SaslConfigs.SASL_MECHANISM;
+    public static final String SASL_MECHANISM_DEFAULT = "PLAIN";
+    public static final String SASL_MECHANISM_DOC = "SASL mechanism used for Cluster Mirror authentication.";
+
+    public static final String SASL_JAAS_CONFIG = SaslConfigs.SASL_JAAS_CONFIG;
+    public static final String SASL_JAAS_CONFIG_DOC = "JAAS login context parameters for SASL connections in the format used by JAAS configuration files.";
+
+    public static final String SASL_CLIENT_CALLBACK_HANDLER_CLASS = SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS;
+    public static final String SASL_CLIENT_CALLBACK_HANDLER_CLASS_DOC = "The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.";
+
+    public static final String SASL_LOGIN_CALLBACK_HANDLER_CLASS = SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS;
+    public static final String SASL_LOGIN_CALLBACK_HANDLER_CLASS_DOC = "The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface.";
+
+    public static final String SASL_LOGIN_CLASS = SaslConfigs.SASL_LOGIN_CLASS;
+    public static final String SASL_LOGIN_CLASS_DOC = "The fully qualified name of a class that implements the Login interface.";
+
+    public static final String SASL_KERBEROS_SERVICE_NAME = SaslConfigs.SASL_KERBEROS_SERVICE_NAME;
+    public static final String SASL_KERBEROS_SERVICE_NAME_DOC = "The Kerberos principal name that Kafka runs as.";
+
     // SSL configuration
     public static final String SSL_PROTOCOL_CONFIG = SslConfigs.SSL_PROTOCOL_CONFIG;
     public static final String SSL_PROTOCOL_DEFAULT = SslConfigs.DEFAULT_SSL_PROTOCOL;
-    public static final String SSL_PROTOCOL_DOC = "The SSL protocol used for Cluster Mirror connections.";
+    public static final String SSL_PROTOCOL_DOC = "The SSL protocol used.";
 
     public static final String SSL_PROVIDER_CONFIG = SslConfigs.SSL_PROVIDER_CONFIG;
     public static final String SSL_PROVIDER_DOC = "The name of the security provider used for SSL connections for Cluster Mirror.";
@@ -215,26 +195,6 @@ public final class MirrorConfig {
     public static final String SSL_ENGINE_FACTORY_CLASS_CONFIG = SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG;
     public static final String SSL_ENGINE_FACTORY_CLASS_DOC = "The class of type org.apache.kafka.common.security.auth.SslEngineFactory to provide SSLEngine objects for Cluster Mirror SSL connections.";
 
-    // SASL configuration
-    public static final String SASL_MECHANISM_CONFIG = SaslConfigs.SASL_MECHANISM;
-    public static final String SASL_MECHANISM_DEFAULT = "PLAIN";
-    public static final String SASL_MECHANISM_DOC = "SASL mechanism used for Cluster Mirror authentication.";
-
-    public static final String SASL_JAAS_CONFIG = SaslConfigs.SASL_JAAS_CONFIG;
-    public static final String SASL_JAAS_CONFIG_DOC = "JAAS login context parameters for SASL connections in the format used by JAAS configuration files.";
-
-    public static final String SASL_CLIENT_CALLBACK_HANDLER_CLASS = SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS;
-    public static final String SASL_CLIENT_CALLBACK_HANDLER_CLASS_DOC = "The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface for Cluster Mirror connections.";
-
-    public static final String SASL_LOGIN_CALLBACK_HANDLER_CLASS = SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS;
-    public static final String SASL_LOGIN_CALLBACK_HANDLER_CLASS_DOC = "The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface for Cluster Mirror connections.";
-
-    public static final String SASL_LOGIN_CLASS = SaslConfigs.SASL_LOGIN_CLASS;
-    public static final String SASL_LOGIN_CLASS_DOC = "The fully qualified name of a class that implements the Login interface for Cluster Mirror connections.";
-
-    public static final String SASL_KERBEROS_SERVICE_NAME = SaslConfigs.SASL_KERBEROS_SERVICE_NAME;
-    public static final String SASL_KERBEROS_SERVICE_NAME_DOC = "The Kerberos principal name that Kafka runs as for Cluster Mirror connections.";
-
     /**
      * Configuration definition for Cluster Mirror feature.
      * This includes all supported configurations with proper validation, defaults, and documentation.
@@ -243,21 +203,7 @@ public final class MirrorConfig {
             .define(MIRROR_TOPIC_PROPERTIES_EXCLUDE_CONFIG, LIST, MIRROR_TOPIC_PROPERTIES_EXCLUDE_DEFAULT, LOW, MIRROR_TOPIC_PROPERTIES_EXCLUDE_DOC)
             .define(MIRROR_GROUPS_INCLUDE_CONFIG, LIST, MIRROR_GROUPS_INCLUDE_DEFAULT, LOW, MIRROR_GROUPS_INCLUDE_DOC)
             .define(MIRROR_ACL_INCLUDE_CONFIG, LIST, MIRROR_ACL_INCLUDE_DEFAULT, LOW, MIRROR_ACL_INCLUDE_DOC)
-            .define(MIRROR_TOPIC_NUM_PARTITIONS_CONFIG, INT, MIRROR_TOPIC_NUM_PARTITIONS_DEFAULT, atLeast(1), HIGH, MIRROR_TOPIC_NUM_PARTITIONS_DOC)
-            .define(MIRROR_TOPIC_REPLICATION_FACTOR_CONFIG, SHORT, MIRROR_TOPIC_REPLICATION_FACTOR_DEFAULT, atLeast(1), HIGH, MIRROR_TOPIC_REPLICATION_FACTOR_DOC)
-            .define(NUM_REPLICA_FETCHERS_CONFIG, INT, NUM_REPLICA_FETCHERS_DEFAULT, atLeast(1), HIGH, NUM_REPLICA_FETCHERS_DOC)
-            .define(METADATA_REFRESH_INTERVAL_MS_CONFIG, LONG, METADATA_REFRESH_INTERVAL_MS_DEFAULT, atLeast(0L), MEDIUM, METADATA_REFRESH_INTERVAL_MS_DOC)
             .define(BOOTSTRAP_SERVERS_CONFIG, LIST, null, HIGH, BOOTSTRAP_SERVERS_DOC)
-            .define(METADATA_MAX_AGE_CONFIG, LONG, METADATA_MAX_AGE_DEFAULT, atLeast(0), LOW, METADATA_MAX_AGE_DOC)
-            .define(SEND_BUFFER_CONFIG, INT, SEND_BUFFER_DEFAULT, atLeast(-1), MEDIUM, SEND_BUFFER_DOC)
-            .define(RECEIVE_BUFFER_CONFIG, INT, RECEIVE_BUFFER_DEFAULT, atLeast(-1), MEDIUM, RECEIVE_BUFFER_DOC)
-            .define(REQUEST_TIMEOUT_MS_CONFIG, INT, REQUEST_TIMEOUT_MS_DEFAULT, atLeast(0), MEDIUM, REQUEST_TIMEOUT_MS_DOC)
-            .define(SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG, LONG, SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DEFAULT, atLeast(0L), MEDIUM, SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC)
-            .define(SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG, LONG, SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DEFAULT, atLeast(0L), MEDIUM, SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC)
-            .define(RECONNECT_BACKOFF_MS_CONFIG, LONG, RECONNECT_BACKOFF_MS_DEFAULT, atLeast(0L), LOW, RECONNECT_BACKOFF_MS_DOC)
-            .define(RECONNECT_BACKOFF_MAX_MS_CONFIG, LONG, RECONNECT_BACKOFF_MAX_MS_DEFAULT, atLeast(0L), LOW, RECONNECT_BACKOFF_MAX_MS_DOC)
-            .define(RETRIES_CONFIG, INT, RETRIES_DEFAULT, ConfigDef.Range.between(0, Integer.MAX_VALUE), LOW, RETRIES_DOC)
-            .define(RETRY_BACKOFF_MS_CONFIG, LONG, RETRY_BACKOFF_MS_DEFAULT, atLeast(0L), LOW, RETRY_BACKOFF_MS_DOC)
             .define(SECURITY_PROTOCOL_CONFIG, STRING, SECURITY_PROTOCOL_DEFAULT, ConfigDef.ValidString.in(SecurityProtocol.PLAINTEXT.name, SecurityProtocol.SSL.name,
                     SecurityProtocol.SASL_PLAINTEXT.name, SecurityProtocol.SASL_SSL.name), MEDIUM, SECURITY_PROTOCOL_DOC)
             .define(SASL_MECHANISM_CONFIG, STRING, SASL_MECHANISM_DEFAULT, MEDIUM, SASL_MECHANISM_DOC)
@@ -290,8 +236,6 @@ public final class MirrorConfig {
     private final Pattern topicPropertiesExcludePattern;
     private final Pattern groupsIncludePattern;
     private final List<AclRule> aclIncludeRules;
-    private final int topicNumPartitions;
-    private final short topicReplicationFactor;
     private final String securityProtocol;
     private final String saslMechanism;
 
@@ -301,13 +245,11 @@ public final class MirrorConfig {
      */
     public MirrorConfig(AbstractConfig config) {
         this.config = config;
-        topicNumPartitions = config.getInt(MIRROR_TOPIC_NUM_PARTITIONS_CONFIG);
-        topicReplicationFactor = config.getShort(MIRROR_TOPIC_REPLICATION_FACTOR_CONFIG);
-        securityProtocol = config.getString(SECURITY_PROTOCOL_CONFIG);
-        saslMechanism = config.getString(SASL_MECHANISM_CONFIG);
-        topicPropertiesExcludePattern = compilePatternList(List.of(MIRROR_TOPIC_PROPERTIES_EXCLUDE_DEFAULT));
-        groupsIncludePattern = compilePatternList(List.of(MIRROR_GROUPS_INCLUDE_DEFAULT));
-        aclIncludeRules = parseAclRules(List.of(MIRROR_ACL_INCLUDE_DEFAULT));
+        this.securityProtocol = null;
+        this.saslMechanism = null;
+        this.topicPropertiesExcludePattern = compilePatternList(List.of(MIRROR_TOPIC_PROPERTIES_EXCLUDE_DEFAULT));
+        this.groupsIncludePattern = compilePatternList(List.of(MIRROR_GROUPS_INCLUDE_DEFAULT));
+        this.aclIncludeRules = parseAclRules(List.of(MIRROR_ACL_INCLUDE_DEFAULT));
     }
 
     /**
@@ -330,13 +272,11 @@ public final class MirrorConfig {
                          List<String> groupsInclude,
                          List<String> aclInclude) {
         this.config = config;
-        topicNumPartitions = config.getInt(MIRROR_TOPIC_NUM_PARTITIONS_CONFIG);
-        topicReplicationFactor = config.getShort(MIRROR_TOPIC_REPLICATION_FACTOR_CONFIG);
-        securityProtocol = config.getString(SECURITY_PROTOCOL_CONFIG);
-        saslMechanism = config.getString(SASL_MECHANISM_CONFIG);
-        topicPropertiesExcludePattern = compilePatternList(topicPropertiesExclude);
-        groupsIncludePattern = compilePatternList(groupsInclude);
-        aclIncludeRules = parseAclRules(aclInclude);
+        this.securityProtocol = config.getString(SECURITY_PROTOCOL_CONFIG);
+        this.saslMechanism = config.getString(SASL_MECHANISM_CONFIG);
+        this.topicPropertiesExcludePattern = compilePatternList(topicPropertiesExclude);
+        this.groupsIncludePattern = compilePatternList(groupsInclude);
+        this.aclIncludeRules = parseAclRules(aclInclude);
     }
 
     public Pattern topicPropertiesExcludePattern() {
@@ -352,11 +292,11 @@ public final class MirrorConfig {
     }
 
     public int topicNumPartitions() {
-        return topicNumPartitions;
+        return config.getInt(MIRROR_TOPIC_NUM_PARTITIONS_CONFIG);
     }
 
     public short topicReplicationFactor() {
-        return topicReplicationFactor;
+        return config.getShort(MIRROR_TOPIC_REPLICATION_FACTOR_CONFIG);
     }
 
     public String securityProtocol() {
@@ -414,12 +354,10 @@ public final class MirrorConfig {
     }
 
     /**
-     * Creates a ConfigDef that includes broker-level mirror configurations.
-     * This is used in AbstractKafkaConfig to merge mirror configurations into the broker config.
-     *
-     * @return ConfigDef containing broker-level mirror configurations
+     * Creates a ConfigDef for broker-level mirror configurations.
+     * This is merged into AbstractKafkaConfig for broker config validation.
      */
-    public static ConfigDef topicConfigDef() {
+    public static ConfigDef brokerConfigDef() {
         return new ConfigDef()
             .define(MIRROR_TOPIC_NUM_PARTITIONS_CONFIG, INT, MIRROR_TOPIC_NUM_PARTITIONS_DEFAULT, atLeast(1), HIGH, MIRROR_TOPIC_NUM_PARTITIONS_DOC)
             .define(MIRROR_TOPIC_REPLICATION_FACTOR_CONFIG, SHORT, MIRROR_TOPIC_REPLICATION_FACTOR_DEFAULT, atLeast(1), HIGH, MIRROR_TOPIC_REPLICATION_FACTOR_DOC)

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -20,6 +20,8 @@ import org.apache.kafka.clients.admin.AddTopicsToMirrorOptions;
 import org.apache.kafka.clients.admin.AddTopicsToMirrorResult;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateMirrorOptions;
 import org.apache.kafka.clients.admin.CreateMirrorResult;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
@@ -46,6 +48,7 @@ import org.apache.kafka.server.util.CommandLineUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -85,6 +88,8 @@ public abstract class MirrorCommand {
         try (MirrorService mirrorService = new MirrorService(opts.bootstrapServer(), opts.commandConfig(), opts.mirrorConfig())) {
             if (opts.hasCreateOption()) {
                 mirrorService.createMirror(opts);
+            } else if (opts.hasAlterOption()) {
+                mirrorService.alterMirror(opts);
             } else if (opts.hasAddOption()) {
                 mirrorService.addTopicsToMirror(opts);
             } else if (opts.hasRemoveOption()) {
@@ -140,6 +145,19 @@ public abstract class MirrorCommand {
             );
             result.all().get();
             System.out.printf("Created mirror %s%n", opts.mirror().get());
+        }
+
+        private void alterMirror(MirrorCommandOptions opts) throws ExecutionException, InterruptedException {
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.MIRROR, opts.mirror().get());
+            List<AlterConfigOp> ops = new ArrayList<>();
+            mirrorConfigs.forEach((k, v) ->
+                ops.add(new AlterConfigOp(
+                    new ConfigEntry(k.toString(), v.toString()),
+                    AlterConfigOp.OpType.SET)));
+
+            Map<ConfigResource, Collection<AlterConfigOp>> configs = Map.of(resource, ops);
+            adminClient.incrementalAlterConfigs(configs).all().get();
+            System.out.printf("Altered mirror %s%n", opts.mirror().get());
         }
 
         private void addTopicsToMirror(MirrorCommandOptions opts) throws Exception {
@@ -377,6 +395,7 @@ public abstract class MirrorCommand {
         private final ArgumentAcceptingOptionSpec<String> commandConfigOpt;
         private final ArgumentAcceptingOptionSpec<String> mirrorConfigOpt;
         private final OptionSpecBuilder createOpt;
+        private final OptionSpecBuilder alterOpt;
         private final OptionSpecBuilder addOpt;
         private final OptionSpecBuilder removeOpt;
         private final OptionSpecBuilder pauseOpt;
@@ -406,6 +425,7 @@ public abstract class MirrorCommand {
                 .ofType(String.class);
 
             createOpt = parser.accepts("create", "Create a new cluster mirror from a source cluster.");
+            alterOpt = parser.accepts("alter", "Alter the configuration of an existing cluster mirror.");
             addOpt = parser.accepts("add", "Add topic(s) to an existing cluster mirror (supports regex).");
             removeOpt = parser.accepts("remove", "Remove topic(s) from an existing cluster mirror (supports regex).");
             pauseOpt = parser.accepts("pause", "Pause mirroring for topic(s) matching the pattern (supports regex).");
@@ -442,6 +462,10 @@ public abstract class MirrorCommand {
 
         private boolean hasCreateOption() {
             return has(createOpt);
+        }
+
+        private boolean hasAlterOption() {
+            return has(alterOpt);
         }
 
         private boolean hasAddOption() {
@@ -508,21 +532,24 @@ public abstract class MirrorCommand {
             CommandLineUtils.maybePrintHelpOrVersion(this, "This tool helps to create cluster mirrors and add topics to them.");
 
             // should have exactly one action
-            if ((has(createOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0) + (has(removeOpt) ? 1 : 0)
+            if ((has(createOpt) ? 1 : 0) + (has(alterOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0) + (has(removeOpt) ? 1 : 0)
                     + (has(pauseOpt) ? 1 : 0) + (has(resumeOpt) ? 1 : 0)
                     + (has(listOpt) ? 1 : 0) + (has(describeOpt) ? 1 : 0) != 1)
-                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --add, --remove, --pause, --resume, --list, or --describe");
+                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --alter, --add, --remove, --pause, --resume, --list, or --describe");
 
             // check required args
             if (!has(bootstrapServerOpt))
                 throw new IllegalArgumentException("--bootstrap-server must be specified");
 
-            // --mirror is required for create, add, and remove operations, but optional for list, describe, pause, and resume
+            // --mirror is required for create, alter, add, and remove operations, but optional for list, describe, pause, and resume
             if (!has(listOpt) && !has(describeOpt) && !has(pauseOpt) && !has(resumeOpt) && !has(mirrorOpt))
                 throw new IllegalArgumentException("--mirror must be specified");
 
             if (has(createOpt) && !has(mirrorConfigOpt))
                 throw new IllegalArgumentException("--mirror-config must be specified when creating a mirror");
+
+            if (has(alterOpt) && !has(mirrorConfigOpt))
+                throw new IllegalArgumentException("--mirror-config must be specified when altering a mirror");
 
             if (has(addOpt) && !has(topicOpt))
                 throw new IllegalArgumentException("--topic must be specified when adding topic(s) to a mirror");


### PR DESCRIPTION
This patch adds dynamic mirror reconfiguration using AlterConfig API. All mirror configurations can now be updated dynamically, and this would cause a reconnection of both MMM and fetchers. This happens at the next metadata refresh.

Example:

```sh
# invalid config
$ bin/kafka-configs.sh --bootstrap-server :"${server4[cli]}" --entity-type mirrors --entity-name my-mirror --alter \
    --add-config invalid.config=foo
Error while executing config command with args '--bootstrap-server :9094 --entity-type mirrors --entity-name my-mirror --alter --add-config invalid.config=foo'
java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.InvalidConfigurationException: Unknown mirror configuration: invalid.config
        at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
        at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2096)
        at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:173)
        at kafka.admin.ConfigCommand$.alterResourceConfig(ConfigCommand.scala:432)
        at kafka.admin.ConfigCommand$.alterConfig(ConfigCommand.scala:194)
        at kafka.admin.ConfigCommand$.processCommand(ConfigCommand.scala:166)
        at kafka.admin.ConfigCommand$.main(ConfigCommand.scala:88)
        at kafka.admin.ConfigCommand.main(ConfigCommand.scala)
Caused by: org.apache.kafka.common.errors.InvalidConfigurationException: Unknown mirror configuration: invalid.config

# valid config
$ bin/kafka-configs.sh --bootstrap-server :"${server4[cli]}" --entity-type mirrors --entity-name my-mirror --alter \
    --add-config bootstrap.servers=localhost:"${server2[cli]}"
Completed updating config for mirror my-mirror.
$ bin/kafka-configs.sh --bootstrap-server :"${server4[cli]}" --entity-type mirrors --entity-name my-mirror --describe
Dynamic configs for mirror my-mirror are:
  bootstrap.servers=localhost:9092 sensitive=false synonyms={}
$ bin/kafka-mirrors.sh --bootstrap-server :"${server4[cli]}" --list
MIRROR                         TOPICS     SOURCE-BOOTSTRAP
my-mirror                      1          localhost:9092
```
