### PR TITLE
Add support for multiple bootstrap servers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1081,26 +1081,6 @@ public interface Admin extends AutoCloseable {
     ListGroupsResult listGroups(ListGroupsOptions options);
 
     /**
-     * List the cluster mirrors available in the cluster with the default options.
-     *
-     * <p>This is a convenience method for {@link #listMirrors(ListMirrorsOptions)} with default options.
-     * See the overload for more details.
-     *
-     * @return The ListMirrorsResult.
-     */
-    default ListMirrorsResult listMirrors() {
-        return listMirrors(new ListMirrorsOptions());
-    }
-
-    /**
-     * List the cluster mirrors available in the cluster.
-     *
-     * @param options The options to use when listing the mirrors.
-     * @return The ListMirrorsResult.
-     */
-    ListMirrorsResult listMirrors(ListMirrorsOptions options);
-
-    /**
      * Elect a replica as leader for topic partitions.
      * <p>
      * This is a convenience method for {@link #electLeaders(ElectionType, Set, ElectLeadersOptions)}
@@ -1724,17 +1704,59 @@ public interface Admin extends AutoCloseable {
      */
     RemoveTopicsFromMirrorResult removeTopicsFromMirror(Set<String> topics, RemoveTopicsFromMirrorOptions options);
 
+    /**
+     * Pause mirroring for the specified topics.
+     *
+     * Paused topics remain read-only on the destination cluster but stop fetching new data from the
+     * source cluster. The mirror fetcher threads are removed for these partitions, preserving the
+     * current replicated state. Mirroring can be resumed later with {@link #resumeMirrorTopics}.
+     *
+     * @param topics Set of topic names to pause mirroring for
+     * @param options Options for the pause mirror topics operation
+     * @return The PauseMirrorTopicsResult containing futures for each topic
+     */
     PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics, PauseMirrorTopicsOptions options);
 
     default PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics) {
         return pauseMirrorTopics(topics, new PauseMirrorTopicsOptions());
     }
 
+    /**
+     * Resume mirroring for previously paused topics.
+     *
+     * Resumed topics restart fetching data from the source cluster, picking up from where they
+     * left off. New mirror fetcher threads are created and the partitions transition back to the
+     * MIRRORING state.
+     *
+     * @param topics Set of topic names to resume mirroring for
+     * @param options Options for the resume mirror topics operation
+     * @return The ResumeMirrorTopicsResult containing futures for each topic
+     */
     ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics, ResumeMirrorTopicsOptions options);
 
     default ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics) {
         return resumeMirrorTopics(topics, new ResumeMirrorTopicsOptions());
     }
+
+    /**
+     * List the cluster mirrors available in the cluster with the default options.
+     *
+     * <p>This is a convenience method for {@link #listMirrors(ListMirrorsOptions)} with default options.
+     * See the overload for more details.
+     *
+     * @return The ListMirrorsResult.
+     */
+    default ListMirrorsResult listMirrors() {
+        return listMirrors(new ListMirrorsOptions());
+    }
+
+    /**
+     * List the cluster mirrors available in the cluster.
+     *
+     * @param options The options to use when listing the mirrors.
+     * @return The ListMirrorsResult.
+     */
+    ListMirrorsResult listMirrors(ListMirrorsOptions options);
 
     /**
      * Describe cluster mirrors with the default options.

--- a/core/src/main/java/kafka/server/mirror/InterBrokerSender.java
+++ b/core/src/main/java/kafka/server/mirror/InterBrokerSender.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Queue-based sender for asynchronous inter-broker requests used by {@link MirrorMetadataManager}
- * to forward mirror state updates to remote coordinator brokers.
+ * to forward mirror state updates to other coordinator brokers in the destination cluster.
  */
 class InterBrokerSender extends InterBrokerSendThread {
     private final ConcurrentLinkedQueue<RequestAndCompletionHandler> queue = new ConcurrentLinkedQueue<>();

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.ReadMirrorStatesResponse;
 import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
@@ -52,7 +53,6 @@ import org.apache.kafka.storage.internals.log.AppendOrigin;
 import org.apache.kafka.storage.internals.log.FetchDataInfo;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -79,18 +79,18 @@ import static org.apache.kafka.common.utils.Utils.require;
  * distributed across brokers by hashing the mirror record key to a partition.
  */
 public class MirrorCoordinator {
-    private static final Logger LOG = LoggerFactory.getLogger(MirrorCoordinator.class);
-
+    private final String name;
+    private final Logger log;
     private final AtomicBoolean isActive = new AtomicBoolean(false);
     private final KafkaConfig brokerConfig;
     private final ReplicaManager replicaManager;
-    private final MirrorMetadataManager mirrorMetadataManager;
+    private final MirrorMetadataManager metadataManager;
+    private final Map<String, MirrorSourceSender> sourceSenders;
     private final Scheduler scheduler;
     private final Metrics metrics;
+    private final MetadataCache metadataCache;
     private final Time time;
     private final MirrorRecordSerde serde;
-    private final MetadataCache metadataCache;
-    private final Map<String, MirrorBlockingSender> sourceSenders;
 
     private volatile int numPartitions = -1;
 
@@ -103,9 +103,11 @@ public class MirrorCoordinator {
             Time time,
             MirrorMetadataManager mirrorMetadataManager
     ) {
+        this.name = "[" + MirrorCoordinator.class.getSimpleName() + " id=" + brokerConfig.nodeId() + "] ";
+        this.log = new LogContext(name).logger(MirrorCoordinator.class);
         this.brokerConfig = brokerConfig;
         this.replicaManager = replicaManager;
-        this.mirrorMetadataManager = mirrorMetadataManager;
+        this.metadataManager = mirrorMetadataManager;
         this.scheduler = scheduler;
         this.metrics = metrics;
         this.time = time;
@@ -125,39 +127,39 @@ public class MirrorCoordinator {
     private void handleStateTransition(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
         switch (newState) {
             case PREPARING:
-                LOG.debug("PREPARING for topics {}.", topicPartitions);
+                log.debug("PREPARING for topics {}.", topicPartitions);
                 scheduleTruncation(mirrorName, topicPartitions);
                 break;
             case MIRRORING:
-                LOG.debug("MIRRORING topics {}.", topicPartitions);
+                log.debug("MIRRORING topics {}.", topicPartitions);
                 // start mirroring
                 replicaManager.maybeCreateMirrorFetchers(mirrorName, topicPartitions);
                 break;
             case PAUSING:
-                LOG.info("PAUSING mirroring for topics {}.", topicPartitions);
+                log.info("PAUSING mirroring for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
                 topicPartitions.forEach(tp ->
                         transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED));
                 break;
             case PAUSED:
-                LOG.info("PAUSED mirroring for topics {}.", topicPartitions);
+                log.info("PAUSED mirroring for topics {}.", topicPartitions);
                 // topic is still read-only
                 break;
             case STOPPING:
-                LOG.debug("STOPPING for topics {}.", topicPartitions);
+                log.debug("STOPPING for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
                 truncateToLastStableOffset(topicPartitions, tp -> updateLastMirroredOffsets(mirrorName, Set.of(tp)));
                 break;
             case STOPPED:
-                LOG.debug("STOPPED for topics {}.", topicPartitions);
+                log.debug("STOPPED for topics {}.", topicPartitions);
                 // topic is writable
                 break;
             case FAILED:
-                LOG.debug("FAILED for topics {}.", topicPartitions);
+                log.debug("FAILED for topics {}.", topicPartitions);
                 // TODO: implement recovery actions (i.e. exponential backoff retry)
                 break;
             default:
-                LOG.error("Illegal state transition to " + newState);
+                log.error("Illegal state transition to " + newState);
                 throw new IllegalArgumentException("Illegal state transition to " + newState);
         }
     }
@@ -165,23 +167,27 @@ public class MirrorCoordinator {
     /** Validates and persists partition state, then executes transition actions. */
     public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
         topicPartitions.forEach(tp -> {
-            MirrorPartitionState currentState = mirrorMetadataManager.getPartitionState(mirrorName, tp);
+            MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
-                LOG.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
+                log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
                                 // TODO: a new component will handle state transitions from a shared queue, so retry means put back in the queue
-                                LOG.error("Failed to update partition state for {}: {}, retrying", tp, ex.getMessage());
+                                log.error("Failed to update partition state for {}: {}, retrying", tp, ex.getMessage());
                                 scheduler.scheduleOnce("MirrorStateUpdateRetry", () -> updateMirrorPartitionState(mirrorName, tp, newState), 100);
                             } else {
                                 // successfully writes data into internal log
-                                optTp.ifPresent(tp1 -> handleStateTransition(mirrorName, Set.of(tp1), newState));
+                                try {
+                                    optTp.ifPresent(tp1 -> handleStateTransition(mirrorName, Set.of(tp1), newState));
+                                } catch (Exception e) {
+                                    log.error("Failed to handle state transition to {} for partition {}", newState, tp, e);
+                                }
                             }
                         });
             } else {
-                LOG.warn("Skipping invalid transition from {} to {} for partition {}.",
-                        mirrorMetadataManager.getPartitionState(mirrorName, tp), newState, tp);
+                log.warn("Skipping invalid transition from {} to {} for partition {}.",
+                        metadataManager.getPartitionState(mirrorName, tp), newState, tp);
             }
         });
     }
@@ -193,7 +199,7 @@ public class MirrorCoordinator {
             if (replicaManager.getLog(tp).isDefined()) {
                 offsets.put(tp, replicaManager.getLog(tp).get().lastStableOffset());
             } else {
-                LOG.warn("Cannot get the log for partition: {}. Skipping log truncation.", tp);
+                log.warn("Cannot get the log for partition: {}. Skipping log truncation.", tp);
                 callback.accept(tp);
             }
         });
@@ -247,7 +253,7 @@ public class MirrorCoordinator {
     public void getCachedPartitionMetadata(String mirrorName,
                                            Map<String, Set<Integer>> partitions,
                                            Consumer<ReadMirrorStatesResponse> callback) {
-        mirrorMetadataManager.getCachedPartitionMetadata(mirrorName, partitions, callback);
+        metadataManager.getCachedPartitionMetadata(mirrorName, partitions, callback);
     }
 
     private void updateLastMirroredOffsets(String mirrorName, Set<TopicPartition> topicPartitions) {
@@ -289,10 +295,10 @@ public class MirrorCoordinator {
                         partitionResponses.foreach(partitionRes -> {
                             ProduceResponse.PartitionResponse pr = partitionRes._2;
                             if (pr.error.code() != Errors.NONE.code()) {
-                                LOG.error("Failed to write partition state to coordinator: {}", pr.error.message());
+                                log.error("Failed to write partition state to coordinator: {}", pr.error.message());
                                 future.completeExceptionally(pr.error.exception());
                             } else {
-                                mirrorMetadataManager.updatePartitionState(new MirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
+                                metadataManager.updatePartitionState(new MirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
                                 future.complete(Optional.of(topicPartition));
                             }
                             return null;
@@ -307,14 +313,15 @@ public class MirrorCoordinator {
             // write state data to remote coordinator (async network operation)
             Map<String, Set<MirrorUtils.PartitionStateInfo>> topicMetadata =
                     Map.of(topicPartition.topic(), Set.of(new MirrorUtils.PartitionStateInfo(topicPartition.partition(), newState, -1L)));
-            mirrorMetadataManager.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
                     res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
                         if (par.errorCode() == Errors.NONE.code()) {
-                            mirrorMetadataManager.updatePartitionState(new MirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
+                            metadataManager.updatePartitionState(new MirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
                             future.complete(Optional.of(topicPartition));
                         } else {
-                            LOG.error("Failed to write partition state to remote coordinator: {}", par.errorCode());
-                            future.complete(Optional.empty());
+                            // propagate remote coordinator errors to trigger retry
+                            log.error("Failed to write partition state to remote coordinator: {}", par.errorCode());
+                            future.completeExceptionally(Errors.forCode(par.errorCode()).exception());
                         }
                     })));
 
@@ -328,15 +335,15 @@ public class MirrorCoordinator {
      */
     public void startup() {
         if (!isActive.compareAndSet(false, true)) {
-            LOG.warn("MirrorCoordinator is already running.");
+            log.warn("Is already running.");
             return;
         }
 
-        LOG.info("Starting up.");
+        log.info("Starting up.");
         numPartitions = brokerConfig.mirrorConfig().topicNumPartitions();
-        mirrorMetadataManager.setStateTransitioner((mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state));
-        mirrorMetadataManager.setCoordinatorPartitionByKeyFinder(key -> getCoordinatorPartitionByKey(key));
-        mirrorMetadataManager.setCoordinatorPartitionByNameFinder(mirrorName -> getCoordinatorPartitionByName(mirrorName));
+        metadataManager.setStateTransitioner((mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state));
+        metadataManager.setCoordinatorPartitionByKeyFinder(key -> getCoordinatorPartitionByKey(key));
+        metadataManager.setCoordinatorPartitionByNameFinder(mirrorName -> getCoordinatorPartitionByName(mirrorName));
 
         scheduler.startup();
 
@@ -344,20 +351,20 @@ public class MirrorCoordinator {
         long metadataRefreshIntervalMs = brokerConfig.mirrorConfig().metadataRefreshIntervalMs();
         scheduler.schedule("MirrorMetadataRefresh",
                 () -> {
-                    mirrorMetadataManager.syncTopicMetadata();
-                    mirrorMetadataManager.syncMirrorMetadata();
+                    metadataManager.syncTopicMetadata();
+                    metadataManager.syncMirrorMetadata();
                 },
                 metadataRefreshIntervalMs,
                 metadataRefreshIntervalMs
         );
 
-        LOG.info("Startup complete.");
+        log.info("Startup complete.");
     }
 
     // Schedules truncation to align replicas with last mirrored offsets before resuming.
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
         scheduler.scheduleOnce("LastMirroredOffsetTruncation",
-            () -> mirrorMetadataManager.truncateToLastMirroredOffsets(replicaManager, mirrorName, topicPartitions,
+            () -> metadataManager.truncateToLastMirroredOffsets(replicaManager, mirrorName, topicPartitions,
                     partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING)));
     }
 
@@ -372,7 +379,7 @@ public class MirrorCoordinator {
     }
 
     public long getLastMirroredOffset(String mirrorName, TopicPartition topicPartition) {
-        return mirrorMetadataManager.getLastMirroredOffset(mirrorName, topicPartition);
+        return metadataManager.getLastMirroredOffset(mirrorName, topicPartition);
     }
 
     /** Persists offsets to local or remote coordinators, optionally transitioning to STOPPED. */
@@ -398,7 +405,7 @@ public class MirrorCoordinator {
         });
 
         // Update in-memory cache once with all offsets
-        var updatedOffsets = mirrorMetadataManager.updateLastMirroredOffsets(mirrorName, partitionOffsets, Map.of());
+        var updatedOffsets = metadataManager.updateLastMirroredOffsets(mirrorName, partitionOffsets, Map.of());
 
         // Write to local coordinator partitions (one append per coordinator partition)
         localByCoordPartition.forEach((coordPartition, tps) -> {
@@ -432,7 +439,7 @@ public class MirrorCoordinator {
 
         // Write to remote coordinator (batched by coordinator node internally)
         if (!remoteTopicMetadata.isEmpty()) {
-            mirrorMetadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
                 if (transitionToStopped) {
                     res.data().topics().forEach(topic ->
                         topic.partitions().forEach(partition ->
@@ -506,14 +513,14 @@ public class MirrorCoordinator {
     }
 
     private void loadMirrorMetadata(TopicPartition topicPartition) {
-        LOG.info("Loading mirror metadata from {}.", topicPartition);
+        log.info("Loading mirror metadata from {}.", topicPartition);
         long logEndOffset = replicaManager.getLogEndOffset(topicPartition).getOrElse(() -> -1L);
 
-        replicaManager.getLog(topicPartition).foreach(log -> {
+        replicaManager.getLog(topicPartition).foreach(partitionLog -> {
             ByteBuffer buffer = ByteBuffer.allocate(0);
 
             // loop breaks if leader changes at any time during the load, since logEndOffset is -1
-            long currOffset = log.logStartOffset();
+            long currOffset = partitionLog.logStartOffset();
 
             // loop breaks if no records have been read, since the end of the log has been reached
             boolean readAtLeastOneRecord = true;
@@ -522,8 +529,8 @@ public class MirrorCoordinator {
             try {
                 // might need a lock
                 while (currOffset < logEndOffset && readAtLeastOneRecord && isActive.get()) {
-                    LOG.debug("Reading mirror data from {} at offset {}.", topicPartition, currOffset);
-                    FetchDataInfo fetchDataInfo = log.read(currOffset, maxLength, FetchIsolation.LOG_END, true);
+                    log.debug("Reading mirror data from {} at offset {}.", topicPartition, currOffset);
+                    FetchDataInfo fetchDataInfo = partitionLog.read(currOffset, maxLength, FetchIsolation.LOG_END, true);
 
                     readAtLeastOneRecord = fetchDataInfo.records.sizeInBytes() > 0;
 
@@ -536,10 +543,10 @@ public class MirrorCoordinator {
                         int sizeInBytes = fileRecords.sizeInBytes();
                         int bytesNeeded = Math.max(maxLength, sizeInBytes);
 
-                        // minOneMessage = true in the above log.read means that the buffer may need to be grown to ensure progress can be made
+                        // minOneMessage = true in the above read means that the buffer may need to be grown to ensure progress can be made
                         if (buffer.capacity() < bytesNeeded) {
                             if (maxLength < bytesNeeded)
-                                LOG.warn("Loaded mirror data from {} with buffer larger ({} bytes) than " +
+                                log.warn("Loaded mirror data from {} with buffer larger ({} bytes) than " +
                                         "{} bytes)", topicPartition, bytesNeeded, maxLength);
 
                             buffer = ByteBuffer.allocate(bytesNeeded);
@@ -559,11 +566,11 @@ public class MirrorCoordinator {
                             if (version == CoordinatorRecordType.LAST_MIRRORED_OFFSETS.id()) {
                                 String clusterName = readMirrorNameFromKey(record.key());
                                 Map<String, Map<Integer, Long>> offsets = readLastMirroredOffsetsValue(record.value());
-                                mirrorMetadataManager.updateLastMirroredOffsets(clusterName, offsets, Map.of());
+                                metadataManager.updateLastMirroredOffsets(clusterName, offsets, Map.of());
                             } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
                                 String clusterName = readMirrorNameFromKey(record.key());
                                 MirrorUtils.PartitionStateLogEntry value = readMirrorPartitionStateValue(record.value());
-                                mirrorMetadataManager.updatePartitionState(
+                                metadataManager.updatePartitionState(
                                         new MirrorUtils.PartitionKey(clusterName, value.topic(), value.partition()), value.state());
                             } else {
                                 throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);
@@ -574,13 +581,13 @@ public class MirrorCoordinator {
                     }
                 }
             } catch (Throwable t) {
-                LOG.error("Error loading mirrors from mirror state log {}", topicPartition, t);
+                log.error("Error loading mirrors from mirror state log {}", topicPartition, t);
             }
 
             // we've read all the mirrored records, transition the state for each topic partitions
             MirrorUtils.StateTransitionCallback callback = (mirrorName, topics, state)
                     -> handleStateTransition(mirrorName, topics, state);
-            mirrorMetadataManager.applyLoadedPartitionStates(callback);
+            metadataManager.applyLoadedPartitionStates(callback);
 
             return null;
         });
@@ -604,34 +611,41 @@ public class MirrorCoordinator {
 
     private void clear() {
         sourceSenders.clear();
-        mirrorMetadataManager.clear();
+        metadataManager.clear();
     }
 
     public Set<String> getConfiguredMirrors() {
-        return mirrorMetadataManager.getConfiguredMirrors();
+        return metadataManager.getConfiguredMirrors();
     }
 
     public Set<String> getConfiguredTopics(String mirrorName) {
-        return mirrorMetadataManager.getConfiguredTopics(mirrorName);
+        return metadataManager.getConfiguredTopics(mirrorName);
     }
 
     public String getSourceBootstrap(String mirrorName) {
-        return mirrorMetadataManager.getSourceBootstrap(mirrorName);
+        return metadataManager.getSourceBootstrap(mirrorName);
     }
 
     public Map<TopicPartition, MirrorPartitionState> getMirrorStates(String mirrorName) {
-        return mirrorMetadataManager.getMirrorStates(mirrorName);
+        return metadataManager.getMirrorStates(mirrorName);
     }
 
     public void shutdown() {
         if (!isActive.compareAndSet(true, false)) {
-            LOG.warn("MirrorCoordinator is already shutting down.");
+            log.warn("Is already shutting down.");
             return;
         }
 
-        LOG.info("Shutting down.");
+        log.info("Shutting down.");
+        // stop the coordinator's periodic scheduler to prevent tasks running after shutdown
+        try {
+            scheduler.shutdown();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while shutting down scheduler", e);
+        }
         Utils.closeQuietly(metrics, "MirrorCoordinator metrics");
-        LOG.info("Shutdown complete.");
+        log.info("Shutdown complete.");
     }
 
     public int getCoordinatorPartitionByKey(MirrorRecordKey key) {

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -138,8 +138,7 @@ public class MirrorCoordinator {
             case PAUSING:
                 log.info("PAUSING mirroring for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                topicPartitions.forEach(tp ->
-                        transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED));
+                topicPartitions.forEach(tp -> transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED));
                 break;
             case PAUSED:
                 log.info("PAUSED mirroring for topics {}.", topicPartitions);
@@ -349,29 +348,35 @@ public class MirrorCoordinator {
 
         // periodically query source cluster to get the metadata
         long metadataRefreshIntervalMs = brokerConfig.mirrorConfig().metadataRefreshIntervalMs();
-        scheduler.schedule("MirrorMetadataRefresh",
-                () -> {
-                    metadataManager.syncTopicMetadata();
-                    metadataManager.syncMirrorMetadata();
-                },
-                metadataRefreshIntervalMs,
-                metadataRefreshIntervalMs
-        );
+        scheduler.schedule("MirrorMetadataRefresh", metadataManager::syncMetadata, metadataRefreshIntervalMs, metadataRefreshIntervalMs);
 
         log.info("Startup complete.");
     }
 
-    // Schedules truncation to align replicas with last mirrored offsets before resuming.
+    /** Schedules truncation to align replicas with last mirrored offsets before resuming. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
+        scheduleTruncation(mirrorName, topicPartitions, 0);
+    }
+
+    /** Schedules truncation with retry on failure, using mirror.truncation.backoff.ms as retry delay. */
+    private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions, long delayMs) {
+        long retryDelayMs = brokerConfig.mirrorConfig().truncationBackoffMs();
         scheduler.scheduleOnce("LastMirroredOffsetTruncation",
-            () -> metadataManager.truncateToLastMirroredOffsets(replicaManager, mirrorName, topicPartitions,
-                    partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING)));
+            () -> {
+                try {
+                    metadataManager.truncateToLastMirroredOffsets(replicaManager, mirrorName, topicPartitions,
+                            partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING));
+                } catch (Exception e) {
+                    log.warn("Failed to truncate to last mirrored offsets for mirror {}, retrying in {} ms", mirrorName, retryDelayMs, e);
+                    scheduleTruncation(mirrorName, topicPartitions, retryDelayMs);
+                }
+            }, delayMs);
     }
 
     private Map<String, Map<Integer, Long>> lastMirroredOffsetsToCoordinatorRecords(Map<MirrorUtils.PartitionKey, Long> offsets) {
         Map<String, Map<Integer, Long>> results = new HashMap<>();
         offsets.forEach((key, value) -> {
-            Map<Integer, Long> partitionOffsets = results.getOrDefault(key.topic(), new HashMap<Integer, Long>());
+            Map<Integer, Long> partitionOffsets = results.getOrDefault(key.topic(), new HashMap<>());
             partitionOffsets.put(key.partition(), value);
             results.put(key.topic(), partitionOffsets);
         });

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -173,7 +173,7 @@ public class MirrorCoordinator {
                             if (ex != null) {
                                 // TODO: a new component will handle state transitions from a shared queue, so retry means put back in the queue
                                 LOG.error("Failed to update partition state for {}: {}, retrying", tp, ex.getMessage());
-                                scheduler.scheduleOnce("retry-mirror-state-update", () -> updateMirrorPartitionState(mirrorName, tp, newState), 100);
+                                scheduler.scheduleOnce("MirrorStateUpdateRetry", () -> updateMirrorPartitionState(mirrorName, tp, newState), 100);
                             } else {
                                 // successfully writes data into internal log
                                 optTp.ifPresent(tp1 -> handleStateTransition(mirrorName, Set.of(tp1), newState));
@@ -342,10 +342,10 @@ public class MirrorCoordinator {
 
         // periodically query source cluster to get the metadata
         long metadataRefreshIntervalMs = brokerConfig.mirrorConfig().metadataRefreshIntervalMs();
-        scheduler.schedule("mirror-metadata-refresh",
+        scheduler.schedule("MirrorMetadataRefresh",
                 () -> {
-                    mirrorMetadataManager.syncTopicMetadataFromSourceClusters();
-                    mirrorMetadataManager.syncMirrorMetadataFromSourceClusters();
+                    mirrorMetadataManager.syncTopicMetadata();
+                    mirrorMetadataManager.syncMirrorMetadata();
                 },
                 metadataRefreshIntervalMs,
                 metadataRefreshIntervalMs
@@ -356,7 +356,7 @@ public class MirrorCoordinator {
 
     // Schedules truncation to align replicas with last mirrored offsets before resuming.
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
-        scheduler.scheduleOnce("last-mirrored-offset-truncation",
+        scheduler.scheduleOnce("LastMirroredOffsetTruncation",
             () -> mirrorMetadataManager.truncateToLastMirroredOffsets(replicaManager, mirrorName, topicPartitions,
                     partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING)));
     }
@@ -586,16 +586,15 @@ public class MirrorCoordinator {
         });
     }
 
-    /** Loads mirror metadata from the internal topic on leadership election. */
+    /** Loads metadata from __mirror_state on leadership election. */
     public void onElection(
             int partitionIndex,
             int partitionLeaderEpoch
     ) {
-        // load the data from the internal topic
         loadMirrorMetadata(new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, partitionIndex));
     }
 
-    /** Clears cached mirror metadata on leadership resignation. */
+    /** Clears cached metadata on leadership resignation. */
     public void onResignation(
             int partitionIndex,
             OptionalInt partitionLeaderEpoch

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -606,10 +606,6 @@ public class MirrorCoordinator {
             int partitionIndex,
             OptionalInt partitionLeaderEpoch
     ) {
-        clear();
-    }
-
-    private void clear() {
         sourceSenders.clear();
         metadataManager.clear();
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -174,6 +174,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private Optional<Function<String, Integer>> coordinatorPartitionByNameFinder = Optional.empty();
 
     // cache
+    // thread-safe maps for concurrent access from metadata, scheduler, and fetcher threads
     private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -173,7 +173,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private Optional<Function<MirrorRecordKey, Integer>> coordinatorPartitionFinder = Optional.empty();
     private Optional<Function<String, Integer>> coordinatorPartitionByNameFinder = Optional.empty();
 
-    // cache (thread-safe maps for concurrent access from metadata, scheduler, and fetcher threads)
+    // cache
     private final Map<MirrorRecordKey, Node> coordinatorNodes = new ConcurrentHashMap<>();
     private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -733,9 +733,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         throw new KafkaException("Failed to send request to any source server for mirror " + mirrorName, lastException);
     }
 
-    /** Invalidates cached source leaders, forcing a metadata refresh on next resolution. */
+    /** Invalidates all cached source leaders for a mirror, forcing a full metadata refresh on next resolution. */
     public void invalidateSourceLeader(String mirrorName) {
         sourceLeaders.remove(mirrorName);
+    }
+
+    /** Invalidates cached source leaders for specific partitions, leaving other partitions' cached leaders intact. */
+    public void invalidateSourceLeader(String mirrorName, java.util.Set<TopicPartition> partitions) {
+        var partitionLeaders = sourceLeaders.get(mirrorName);
+        if (partitionLeaders != null) {
+            partitions.forEach(partitionLeaders::remove);
+        }
     }
 
     /** Resolves source partition leader from cache, refreshing metadata synchronously if needed. */

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -22,10 +22,10 @@ import kafka.server.ReplicaManager;
 
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ClientUtils;
-import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AccessControlEntryFilter;
@@ -52,6 +52,7 @@ import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.requests.CreateAclsRequest;
@@ -106,9 +107,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -158,11 +161,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Metrics metrics;
     private final Time time;
     private final Random random;
-    private InterBrokerSender interBrokerSender;
     private MetadataImage metadataImage;
     private final MetadataCache metadataCache;
-
-    // components
+    private InterBrokerSender mirrorStateUpdateSender;
     private final NodeToControllerChannelManager channelManager;
     private final Supplier<GroupCoordinator> groupCoordinatorSupplier;
     private final Supplier<MirrorFetcherManager> mirrorFetcherManagerSupplier;
@@ -172,7 +173,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private Optional<Function<MirrorRecordKey, Integer>> coordinatorPartitionFinder = Optional.empty();
     private Optional<Function<String, Integer>> coordinatorPartitionByNameFinder = Optional.empty();
 
-    // local cache
+    // cache
     private Map<String, List<MirrorBlockingSender>> sourceSenders;
     private Map<String, Map<TopicPartition, Node>> sourceLeaders;
     private Map<MirrorUtils.PartitionKey, Long> lastMirroredOffsets;
@@ -235,7 +236,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     @Override
     public String name() {
-        return "MirrorMetadataManager(id=" + brokerConfig.nodeId() + ")";
+        return "[" + MirrorMetadataManager.class.getSimpleName() + " nodeId=" + nodeId + "] ";
     }
 
     /**
@@ -247,10 +248,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      */
     @Override
     public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage, LoaderManifest manifest) {
-        if (interBrokerSender == null) {
-            KafkaClient networkClient = NetworkUtils.buildNetworkClient("MirrorMetadataManager", brokerConfig, metrics, time, new LogContext(name()));
-            interBrokerSender = new InterBrokerSender("mirror-inter-broker-sender", networkClient, brokerConfig.requestTimeoutMs(), Time.SYSTEM);
-            interBrokerSender.start();
+        if (mirrorStateUpdateSender == null) {
+            mirrorStateUpdateSender = new InterBrokerSender("MirrorStateUpdateSender",
+                    NetworkUtils.buildNetworkClient(MirrorMetadataManager.class.getSimpleName(), brokerConfig, metrics, time, new LogContext(name())),
+                    brokerConfig.requestTimeoutMs(), Time.SYSTEM);
+            mirrorStateUpdateSender.start();
         }
 
         // caching the image for query purpose
@@ -338,7 +340,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        interBrokerSender.shutdown();
+        mirrorStateUpdateSender.shutdown();
+        closeSourceSenders();
     }
 
     // Returns mirror partitions led by this broker, detecting both leadership and config changes
@@ -565,7 +568,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             data.setTopics(topicDataList);
             data.setRemovedTopics(new ArrayList<>(removedTopics));
 
-            interBrokerSender.enqueue(new RequestAndCompletionHandler(
+            mirrorStateUpdateSender.enqueue(new RequestAndCompletionHandler(
                 time.milliseconds(),
                 node,
                 new WriteMirrorStatesRequest.Builder(data),
@@ -598,7 +601,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 if (coordinatorNode == null) {
                     coordinatorNode = findCoordinatorNode(key);
                     if (coordinatorNode.equals(Node.noNode())) {
-                        LOG.error("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, part);
+                        LOG.warn("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, part);
                         return;
                     }
                     coordinatorNodes.put(key, coordinatorNode);
@@ -626,7 +629,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
             data.setTopics(topicDataList);
 
-            interBrokerSender.enqueue(new RequestAndCompletionHandler(
+            mirrorStateUpdateSender.enqueue(new RequestAndCompletionHandler(
                 time.milliseconds(),
                 node,
                 new ReadMirrorStatesRequest.Builder(data),
@@ -679,42 +682,67 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         responseCallback.accept(new ReadMirrorStatesResponse(data));
     }
 
-    private void ensureMirrorConnection(String mirrorName) {
+    private void ensureConnection(String mirrorName) {
         if (sourceSenders.containsKey(mirrorName)) {
             return;
         }
         Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName));
         String bootstrapServers = Optional.ofNullable(props.get(BOOTSTRAP_SERVERS_CONFIG))
                 .map(Object::toString)
-                .orElseThrow(() -> new IllegalArgumentException("Remote bootstrap server not found in Cluster Mirror config: " + mirrorName));
+                .orElseThrow(() -> new IllegalArgumentException("Source bootstrap server not found in Cluster Mirror config: " + mirrorName));
+        LOG.info("Bootstrap servers config for mirror {}: '{}'", mirrorName, bootstrapServers);
 
-        LOG.info("Mirror config for '{}': {}", mirrorName, props);
+        List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
+                Arrays.stream(bootstrapServers.split(",")).toList(), "use_all_dns_ips");
+        Collections.shuffle(addresses, random);
 
-        var addresses = ClientUtils.parseAndValidateAddresses(Arrays.stream(bootstrapServers.split(",")).toList(), "use_all_dns_ips");
-        // Use random node id here because we don't know node id of remote brokers
-        int rand = random.nextInt(addresses.size());
-        var brokerEndpoint = new BrokerEndPoint(random.nextInt(), addresses.get(rand).getHostString(), addresses.get(rand).getPort());
-        var logContext = new LogContext("[" + MirrorMetadataManager.class.getName() + " replicaId=" + nodeId + ", mirrorName=" + mirrorName + "] ");
+        MirrorConfig mirrorConfig = MirrorConfig.fromProperties(props);
 
-        MirrorBlockingSender sender = new MirrorBlockingSender(
-                brokerEndpoint,
-                MirrorConfig.fromProperties(props),
-                brokerConfig,
-                metrics,
-                time,
-                brokerEndpoint.id(),
-                "broker-" + nodeId + "-mirror-metadata-manager-" + mirrorName,
-                logContext
-        );
-        sourceSenders.put(mirrorName, List.of(sender));
+        List<MirrorBlockingSender> senders = new ArrayList<>();
+        for (InetSocketAddress address : addresses) {
+            try {
+                BrokerEndPoint endpoint = new BrokerEndPoint(random.nextInt(), address.getHostString(), address.getPort());
+                String clientId = "nodeId-" + nodeId + "-mirror-" + mirrorName + "-" + address.getHostString() + "-" + address.getPort();
+                LogContext logContext = new LogContext("[" + MirrorMetadataManager.class.getSimpleName() + "nodeId=" + nodeId + " mirrorName=" + mirrorName + "] ");
+                senders.add(MirrorUtils.createSender(endpoint, mirrorConfig, brokerConfig, metrics, time, clientId, logContext));
+            } catch (Exception e) {
+                LOG.warn("Failed to create sender for {} in mirror {}", address, mirrorName, e);
+            }
+        }
+
+        if (senders.isEmpty()) {
+            throw new IllegalStateException("Failed to create any source senders for mirror " + mirrorName);
+        }
+
+        LOG.info("Created {} source sender(s) for mirror {} from {} configured address(es)", senders.size(), mirrorName, addresses.size());
+        sourceSenders.put(mirrorName, senders);
     }
 
-    private MirrorBlockingSender getRandomSender(List<MirrorBlockingSender> senders) {
-        return senders.get(random.nextInt(senders.size()));
+    private ClientResponse trySendRequest(String mirrorName, AbstractRequest.Builder<?> requestBuilder) {
+        List<MirrorBlockingSender> senders = sourceSenders.get(mirrorName);
+        if (senders == null || senders.isEmpty()) {
+            throw new IllegalStateException("No source senders available for mirror " + mirrorName);
+        }
+        Exception lastException = null;
+        for (MirrorBlockingSender sender : senders) {
+            try {
+                return sender.sendRequest(requestBuilder);
+            } catch (Exception e) {
+                lastException = e;
+                LOG.warn("Failed to send request to {} for mirror {}", sender.brokerEndPoint(), mirrorName, e);
+            }
+        }
+        throw new KafkaException("Failed to send request to any source server for mirror " + mirrorName, lastException);
+    }
+
+    /** Invalidates cached source leaders, forcing a metadata refresh on next resolution. */
+    public void invalidateSourceLeader(String mirrorName) {
+        sourceLeaders.remove(mirrorName);
     }
 
     /** Resolves source partition leader from cache, refreshing metadata synchronously if needed. */
     public Node resolveSourceLeader(String mirrorName, TopicPartition tp) {
+        // Try to use cached metadata.
         var partitionLeaders = sourceLeaders.get(mirrorName);
         if (partitionLeaders != null) {
             Node leader = partitionLeaders.get(tp);
@@ -723,13 +751,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
         }
 
-        // No cached metadata.
-        // Refresh synchronously to get correct broker IDs before creating fetcher threads.
+        // No cached metadata. Refresh synchronously before creating fetcher threads.
         LOG.info("No cached metadata for mirror {} partition {}. Refreshing metadata from remote cluster.", mirrorName, tp);
-        ensureMirrorConnection(mirrorName);
-        syncTopicMetadata(mirrorName, sourceSenders.get(mirrorName));
+        ensureConnection(mirrorName);
+        try {
+            syncTopicMetadata(mirrorName);
+        } catch (Exception e) {
+            LOG.error("Failed to refresh topic metadata for mirror {}", mirrorName, e);
+        }
 
-        // Try again after refreshing metadata.
+        // Try to resolve source leader broker.
         partitionLeaders = sourceLeaders.get(mirrorName);
         if (partitionLeaders != null) {
             Node leader = partitionLeaders.get(tp);
@@ -739,20 +770,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
         }
 
-        // Metadata refresh failed or partition not found.
-        // Fall back to random bootstrap server.
+        // Metadata refresh failed or partition not found. Fall back to first bootstrap server.
         // This should rarely happen and indicates a configuration or connectivity issue.
-        LOG.warn("Unable to fetch metadata for mirror {} partition {} after refresh. Falling back to random bootstrap server.", mirrorName, tp);
-        Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName));
-        String bootstrapServers = Optional.ofNullable(props.get(BOOTSTRAP_SERVERS_CONFIG))
-                .map(Object::toString)
-                .orElseThrow(() -> new IllegalArgumentException("Remote bootstrap server not found for mirror " + mirrorName));
+        LOG.warn("Unable to resolve source leader for mirror {} partition {} after refresh. Falling back to bootstrap server.", mirrorName, tp);
+        List<MirrorBlockingSender> senders = sourceSenders.get(mirrorName);
+        if (senders != null && !senders.isEmpty()) {
+            BrokerEndPoint ep = senders.get(0).brokerEndPoint();
+            return new Node(ep.id(), ep.host(), ep.port());
+        }
 
-        var addresses = ClientUtils.parseAndValidateAddresses(Arrays.stream(bootstrapServers.split(",")).toList(), "use_all_dns_ips");
-        int rand = random.nextInt(addresses.size());
-
-        // Use random node id here because we don't know node id of remote brokers.
-        return new Node(random.nextInt(), addresses.get(rand).getHostString(), addresses.get(rand).getPort());
+        throw new IllegalStateException("No source senders available for mirror " + mirrorName);
     }
 
     void updatePartitionState(MirrorUtils.PartitionKey key, MirrorPartitionState newState) {
@@ -850,10 +877,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                        Set<TopicPartition> topicPartitionSet,
                                        Consumer<TopicPartition> callback) {
         LOG.info("Truncating to last mirrored offsets for mirror {}: {}", mirrorName, topicPartitionSet);
-        ensureMirrorConnection(mirrorName);
+        ensureConnection(mirrorName);
 
         // get api versions of the source cluster
-        var apiResponse = getRandomSender(sourceSenders.get(mirrorName)).sendRequest(new ApiVersionsRequest.Builder());
+        var apiResponse = trySendRequest(mirrorName, new ApiVersionsRequest.Builder());
 
         if (apiResponse.responseBody() instanceof ApiVersionsResponse apiVersionsResponse) {
             if (apiVersionsResponse.apiVersion(ApiKeys.LAST_MIRRORED_OFFSETS.id) == null) {
@@ -878,7 +905,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             topicDataList.add(topicData);
         });
 
-        var response = getRandomSender(sourceSenders.get(mirrorName)).sendRequest(
+        var response = trySendRequest(mirrorName,
                 new LastMirroredOffsetsRequest.Builder(
                         new LastMirroredOffsetsRequestData().setMirrorName(mirrorName).setTopics(topicDataList))
         );
@@ -900,44 +927,32 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Syncs topic metadata (partition leaders, partition counts) from all source clusters.
      * Runs on every broker so that all brokers can route mirror fetch requests to the correct partition leaders.
      */
-    void syncTopicMetadataFromSourceClusters() {
+    void syncTopicMetadata() {
         Set<String> mirrors = getConfiguredMirrors();
         if (!mirrors.isEmpty()) {
             LOG.debug("Refreshing mirror metadata for mirrors: {}", mirrors);
         }
 
-        mirrors.forEach(this::ensureMirrorConnection);
-        sourceSenders.forEach((mirror, senders) -> syncTopicMetadata(mirror, senders));
+        mirrors.forEach(this::ensureConnection);
+        for (String mirrorName : sourceSenders.keySet()) {
+            try {
+                syncTopicMetadata(mirrorName);
+            } catch (Exception e) {
+                LOG.error("Failed to refresh topic metadata for mirror {}", mirrorName, e);
+            }
+        }
 
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         metadataRefreshError.incrementAndGet();
     }
 
-    /**
-     * Syncs mirror metadata (configurations, consumer group offsets, ACLs) from source clusters.
-     * Only the coordinator for each mirror name handles this, distributing load across brokers.
-     */
-    void syncMirrorMetadataFromSourceClusters() {
-        getConfiguredMirrors().forEach(mirrorName -> {
-            if (isLocalCoordinator(mirrorName)) {
-                ensureMirrorConnection(mirrorName);
-                List<MirrorBlockingSender> senders = sourceSenders.get(mirrorName);
-                MirrorConfig mirrorConfig = MirrorConfig.fromProperties(
-                        metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName)));
-                syncTopicConfigurations(mirrorName, senders, mirrorConfig);
-                syncConsumerGroupOffsets(mirrorName, senders, mirrorConfig);
-                syncAccessControlLists(mirrorName, senders, mirrorConfig);
-            }
-        });
-    }
-
-    private void syncTopicMetadata(String mirrorName, List<MirrorBlockingSender> senders) {
+    private void syncTopicMetadata(String mirrorName) {
         Set<String> topics = getConfiguredTopics(mirrorName);
         if (topics.isEmpty()) {
             return;
         }
-        var response = getRandomSender(senders).sendRequest(
-            MetadataRequest.Builder.forTopicNames(topics.stream().toList(), false)
+        var response = trySendRequest(mirrorName,
+                MetadataRequest.Builder.forTopicNames(topics.stream().toList(), false)
         );
 
         if (response.responseBody() instanceof MetadataResponse metadataResponse) {
@@ -962,16 +977,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             int sourcePartitionCount = tm.partitionMetadata().size();
 
             tm.partitionMetadata().forEach(partitionMetadata -> partitionLeaders.put(
-                partitionMetadata.topicPartition,
-                brokerNodes.get(partitionMetadata.leaderId.get())
+                    partitionMetadata.topicPartition,
+                    brokerNodes.get(partitionMetadata.leaderId.get())
             ));
 
             if (metadataImage.topics().getTopic(tm.topicId()) != null &&
                     metadataImage.topics().getTopic(tm.topicId()).partitions().size() < sourcePartitionCount) {
                 createPartitionsTopics.add(new CreatePartitionsRequestData.CreatePartitionsTopic()
-                    .setName(tm.topic())
-                    .setCount(sourcePartitionCount)
-                    .setAssignments(null)
+                        .setName(tm.topic())
+                        .setCount(sourcePartitionCount)
+                        .setAssignments(null)
                 );
             }
         });
@@ -984,10 +999,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (!createPartitionsTopics.isEmpty()) {
             LOG.debug("Detected partition count change, sending CreatePartitionsRequest: {}", createPartitionsTopics);
             channelManager.sendRequest(new CreatePartitionsRequest.Builder(
-                new CreatePartitionsRequestData()
-                    .setTopics(createPartitionsTopics)
-                    .setValidateOnly(false)
-                    .setTimeoutMs(3000)
+                    new CreatePartitionsRequestData()
+                            .setTopics(createPartitionsTopics)
+                            .setValidateOnly(false)
+                            .setTimeoutMs(3000)
             ), new TimeoutHandler());
         }
     }
@@ -1008,7 +1023,28 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    private void syncTopicConfigurations(String mirrorName, List<MirrorBlockingSender> senders, MirrorConfig mirrorConfig) {
+    /**
+     * Syncs mirror metadata (configurations, consumer group offsets, ACLs) from source clusters.
+     * Only the coordinator for each mirror name handles this, distributing load across brokers.
+     */
+    void syncMirrorMetadata() {
+        getConfiguredMirrors().forEach(mirrorName -> {
+            if (isLocalCoordinator(mirrorName)) {
+                ensureConnection(mirrorName);
+                try {
+                    MirrorConfig mirrorConfig = MirrorConfig.fromProperties(
+                            metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName)));
+                    syncTopicConfigurations(mirrorName, mirrorConfig);
+                    syncConsumerGroupOffsets(mirrorName, mirrorConfig);
+                    syncAccessControlLists(mirrorName, mirrorConfig);
+                } catch (Exception e) {
+                    LOG.error("Failed to sync mirror metadata for mirror {}", mirrorName, e);
+                }
+            }
+        });
+    }
+
+    private void syncTopicConfigurations(String mirrorName, MirrorConfig mirrorConfig) {
         Set<String> topics = getConfiguredTopics(mirrorName);
         LOG.debug("Describing topic configs for topics: {}", topics);
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
@@ -1024,16 +1060,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         DescribeConfigsRequest.Builder describeConfigsRequest =
             new DescribeConfigsRequest.Builder(new DescribeConfigsRequestData().setResources(describeConfigsResources));
 
-        var describeConfigResponse = getRandomSender(senders).sendRequest(describeConfigsRequest);
+        var describeConfigResponse = trySendRequest(mirrorName, describeConfigsRequest);
         if (describeConfigResponse.responseBody() instanceof DescribeConfigsResponse describeConfigsRes) {
             LOG.debug("Periodic describe config response: {}", describeConfigsRes);
-            warnIfUncleanLeaderElection(mirrorName, describeConfigsRes);
-            Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(mirrorName, describeConfigsRes, mirrorConfig);
+            warnIfUncleanLeaderElection(describeConfigsRes);
+            Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(describeConfigsRes, mirrorConfig);
             applyConfigurationChanges(configsToChange);
         }
     }
 
-    private void warnIfUncleanLeaderElection(String mirrorName, DescribeConfigsResponse describeConfigsRes) {
+    private void warnIfUncleanLeaderElection(DescribeConfigsResponse describeConfigsRes) {
         describeConfigsRes.data().results().forEach(describeConfigResult -> {
             if (describeConfigResult.resourceType() == ConfigResource.Type.TOPIC.id()) {
                 describeConfigResult.configs().stream()
@@ -1055,7 +1091,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     private Map<String, Map<String, String>> detectConfigurationChanges(
-            String mirrorName, DescribeConfigsResponse describeConfigsRes, MirrorConfig mirrorConfig) {
+            DescribeConfigsResponse describeConfigsRes, MirrorConfig mirrorConfig) {
         Map<String, Map<String, String>> configsToChange = new HashMap<>();
         Pattern excludePattern = mirrorConfig.topicPropertiesExcludePattern();
 
@@ -1121,7 +1157,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    private void syncConsumerGroupOffsets(String mirrorName, List<MirrorBlockingSender> senders, MirrorConfig mirrorConfig) {
+    private void syncConsumerGroupOffsets(String mirrorName, MirrorConfig mirrorConfig) {
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         consumerGroupOffsetSyncError.incrementAndGet();
         Pattern groupsIncludePattern = mirrorConfig.groupsIncludePattern();
@@ -1130,7 +1166,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 // TODO: if the source cluster is in old version, it won't support types filter
                 .setTypesFilter(List.of(Group.GroupType.CLASSIC.name(), Group.GroupType.CONSUMER.name()))
                 .setStatesFilter(singletonList(GroupState.STABLE.name())));
-        var listGroupResponse = getRandomSender(senders).sendRequest(builder);
+        var listGroupResponse = trySendRequest(mirrorName, builder);
         if (listGroupResponse.responseBody() instanceof ListGroupsResponse listGroupsRes) {
             LOG.debug("List groups response for mirror {}: {}", mirrorName, listGroupsRes);
 
@@ -1150,7 +1186,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                             .setGroups(matchingGroups.stream().map(group -> new OffsetFetchRequestData.OffsetFetchRequestGroup()
                                     .setGroupId(group.groupId())
                                     .setTopics(null)).toList()), false);
-            var offsetFetchResponse = getRandomSender(senders).sendRequest(offsetFetchBuilder);
+            var offsetFetchResponse = trySendRequest(mirrorName, offsetFetchBuilder);
             if (offsetFetchResponse.responseBody() instanceof OffsetFetchResponse offsetFetchRes) {
                 LOG.debug("Periodic offset fetch response: {}", offsetFetchRes);
 
@@ -1214,7 +1250,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    private void syncAccessControlLists(String mirrorName, List<MirrorBlockingSender> senders, MirrorConfig mirrorConfig) {
+    private void syncAccessControlLists(String mirrorName, MirrorConfig mirrorConfig) {
         // TODO: We currently mirror all ACLs from the source to the target.
         //       Any ACLs added/removed directly on the target will be overwritten
         //       on the next sync to match the source.
@@ -1227,7 +1263,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         // list remote acls
         var describeAclsRequest = new DescribeAclsRequest.Builder(ANY_RESOURCE_ACL);
-        var describeAclsResponse = getRandomSender(senders).sendRequest(describeAclsRequest);
+        var describeAclsResponse = trySendRequest(mirrorName, describeAclsRequest);
         if (!(describeAclsResponse.responseBody() instanceof DescribeAclsResponse aclsResponse)) {
             LOG.warn("Unexpected ACL response type from remote cluster: {}", describeAclsResponse);
             return;
@@ -1352,8 +1388,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         partitionStateCounts.clear();
         lastMirroredOffsets.clear();
         coordinatorNodes.clear();
-        sourceSenders.clear();
+        closeSourceSenders();
         sourceLeaders.clear();
+    }
+
+    private void closeSourceSenders() {
+        sourceSenders.values().forEach(senders -> senders.forEach(MirrorBlockingSender::close));
+        sourceSenders.clear();
     }
 
     private static class TimeoutHandler implements ControllerRequestCompletionHandler {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -733,11 +733,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         throw new KafkaException("Failed to send request to any source server for mirror " + mirrorName, lastException);
     }
 
-    /** Invalidates all cached source leaders for a mirror, forcing a full metadata refresh on next resolution. */
-    public void invalidateSourceLeader(String mirrorName) {
-        sourceLeaders.remove(mirrorName);
-    }
-
     /** Invalidates cached source leaders for specific partitions, leaving other partitions' cached leaders intact. */
     public void invalidateSourceLeader(String mirrorName, java.util.Set<TopicPartition> partitions) {
         var partitionLeaders = sourceLeaders.get(mirrorName);
@@ -958,7 +953,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     /**
      * Discovers source cluster brokers via metadata and adds senders for any newly found brokers.
-     * Sender cleanup only happens via {@link #onMetadataUpdate} or{@link #clear}.
+     * Sender cleanup only happens via {@link #onMetadataUpdate} or {@link #clear}.
      */
     private void discoverSourceBrokers(String mirrorName) {
         var response = trySendRequest(mirrorName, MetadataRequest.Builder.allTopics());

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -174,7 +174,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private Optional<Function<String, Integer>> coordinatorPartitionByNameFinder = Optional.empty();
 
     // cache
-    private final Map<MirrorRecordKey, Node> coordinatorNodes = new ConcurrentHashMap<>();
     private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
@@ -253,14 +252,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         // caching the image for query purpose
         this.metadataImage = newImage;
-
-        // evict stale coordinator node cache when __mirror_state topic leadership changes
-        if (delta.topicsDelta() != null) {
-            TopicImage mirrorStateTopic = newImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME);
-            if (mirrorStateTopic != null && delta.topicsDelta().changedTopic(mirrorStateTopic.id()) != null) {
-                coordinatorNodes.clear();
-            }
-        }
 
         // detect config changes and close stale connections and fetchers to trigger reconnection
         if (delta.configsDelta() != null) {
@@ -540,10 +531,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         topicMetadata.forEach((topic, metadata) -> {
             metadata.forEach(m -> {
                 MirrorRecordKey key = new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), m.partition());
-                // computeIfAbsent to avoid duplicate coordinator lookups from concurrent threads
-                Node coordinatorNode = coordinatorNodes.computeIfAbsent(key, this::findCoordinatorNode);
+                Node coordinatorNode = findCoordinatorNode(key);
                 if (coordinatorNode.equals(Node.noNode())) {
-                    coordinatorNodes.remove(key);
                     log.error("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, m.partition());
                     return;
                 }
@@ -602,10 +591,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         partitions.forEach((topic, parts) -> {
             parts.forEach(part -> {
                 MirrorRecordKey key = new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), part);
-                // computeIfAbsent to avoid duplicate coordinator lookups from concurrent threads
-                Node coordinatorNode = coordinatorNodes.computeIfAbsent(key, this::findCoordinatorNode);
+                Node coordinatorNode = findCoordinatorNode(key);
                 if (coordinatorNode.equals(Node.noNode())) {
-                    coordinatorNodes.remove(key);
                     log.warn("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, part);
                     return;
                 }
@@ -1409,7 +1396,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         partitionStates.clear();
         partitionStateCounts.clear();
         lastMirroredOffsets.clear();
-        coordinatorNodes.clear();
         closeSourceSenders();
         sourceLeaders.clear();
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -104,7 +104,6 @@ import org.apache.kafka.server.network.BrokerEndPoint;
 import org.apache.kafka.server.util.RequestAndCompletionHandler;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -116,6 +115,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
@@ -141,7 +141,7 @@ import static org.apache.kafka.controller.ConfigurationControlManager.REMOVED_TO
  *
  * Implements {@link MetadataPublisher} to detect leadership and config changes, triggering
  * partition state transitions (PREPARING, MIRRORING, STOPPING, STOPPED) via the
- * {@link MirrorCoordinator}. Manages remote cluster connections using {@link MirrorBlockingSender}
+ * {@link MirrorCoordinator}. Manages remote cluster connections using {@link MirrorSourceSender}
  * and periodically syncs topic metadata, configs, consumer group offsets, and ACLs from source
  * clusters.
  *
@@ -152,34 +152,34 @@ import static org.apache.kafka.controller.ConfigurationControlManager.REMOVED_TO
  */
 @SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
 public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
-    private static final Logger LOG = LoggerFactory.getLogger(MirrorMetadataManager.class);
     private static final ResourcePatternFilter ANY_RESOURCE = new ResourcePatternFilter(ResourceType.ANY, null, PatternType.ANY);
     private static final AclBindingFilter ANY_RESOURCE_ACL = new AclBindingFilter(ANY_RESOURCE, AccessControlEntryFilter.ANY);
 
+    private final String name;
+    private final Logger log;
     private final KafkaConfig brokerConfig;
     private final int nodeId;
     private final Metrics metrics;
     private final Time time;
     private final Random random;
-    private MetadataImage metadataImage;
+    // volatile for cross-thread visibility (written by KRaft thread, read by scheduler and fetcher threads)
+    private volatile MetadataImage metadataImage;
     private final MetadataCache metadataCache;
-    private InterBrokerSender mirrorStateUpdateSender;
+    private volatile MirrorStateSender mirrorStateSender;
     private final NodeToControllerChannelManager channelManager;
     private final Supplier<GroupCoordinator> groupCoordinatorSupplier;
     private final Supplier<MirrorFetcherManager> mirrorFetcherManagerSupplier;
-
-    // functions
     private Optional<MirrorUtils.StateTransitioner> stateTransitioner = Optional.empty();
     private Optional<Function<MirrorRecordKey, Integer>> coordinatorPartitionFinder = Optional.empty();
     private Optional<Function<String, Integer>> coordinatorPartitionByNameFinder = Optional.empty();
 
-    // cache
-    private Map<String, List<MirrorBlockingSender>> sourceSenders;
-    private Map<String, Map<TopicPartition, Node>> sourceLeaders;
-    private Map<MirrorUtils.PartitionKey, Long> lastMirroredOffsets;
-    private Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionStates;
-    private Map<MirrorPartitionState, AtomicLong> partitionStateCounts;
-    private Map<MirrorRecordKey, Node> coordinatorNodes;
+    // cache (thread-safe maps for concurrent access from metadata, scheduler, and fetcher threads)
+    private final Map<MirrorRecordKey, Node> coordinatorNodes = new ConcurrentHashMap<>();
+    private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
+    private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
+    private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
+    private final Map<MirrorPartitionState, AtomicLong> partitionStateCounts = new ConcurrentHashMap<>();
+    private final Map<MirrorUtils.PartitionKey, Long> lastMirroredOffsets = new ConcurrentHashMap<>();
 
     // metrics
     private KafkaMetricsGroup metricsGroup;
@@ -197,6 +197,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         Supplier<GroupCoordinator> groupCoordinatorSupplier,
         Supplier<MirrorFetcherManager> mirrorFetcherManagerSupplier
     ) {
+        this.name = "[" + MirrorMetadataManager.class.getSimpleName() + " id=" + brokerConfig.nodeId() + "] ";
+        this.log = new LogContext(name).logger(MirrorMetadataManager.class);
         this.brokerConfig = brokerConfig;
         this.nodeId = brokerConfig.nodeId();
         this.metrics = metrics;
@@ -205,15 +207,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         this.channelManager = channelManager;
         this.groupCoordinatorSupplier = groupCoordinatorSupplier;
         this.mirrorFetcherManagerSupplier = mirrorFetcherManagerSupplier;
-
         this.metadataImage = MetadataImage.EMPTY;
         this.metadataCache = metadataCache;
-        this.sourceSenders = new HashMap<>();
-        this.sourceLeaders = new HashMap<>();
-        this.lastMirroredOffsets = new ConcurrentHashMap<>();
-        this.partitionStates = new ConcurrentHashMap<>();
-        this.partitionStateCounts = new ConcurrentHashMap<>();
-        this.coordinatorNodes = new ConcurrentHashMap<>();
 
         this.metricsGroup = new KafkaMetricsGroup(this.getClass());
         this.metadataRefreshError = new AtomicLong();
@@ -236,27 +231,36 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     @Override
     public String name() {
-        return "[" + MirrorMetadataManager.class.getSimpleName() + " nodeId=" + nodeId + "] ";
+        return name;
     }
 
     /**
      * Called when cluster metadata is updated.
-     * Detects mirror leadership changes and triggers state transitions via batched coordinator reads.
+     * Detects mirror partition leadership changes and triggers state transitions via batched coordinator reads.
      *
+     * This is executed in the KRaft metadata publisher thread.
      * Must be called after ReplicaManager#applyDelta.
      * The metadata cache can't be used here because it is updated concurrently.
      */
     @Override
     public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage, LoaderManifest manifest) {
-        if (mirrorStateUpdateSender == null) {
-            mirrorStateUpdateSender = new InterBrokerSender("MirrorStateUpdateSender",
+        if (mirrorStateSender == null) {
+            mirrorStateSender = new MirrorStateSender(MirrorStateSender.class.getSimpleName(),
                     NetworkUtils.buildNetworkClient(MirrorMetadataManager.class.getSimpleName(), brokerConfig, metrics, time, new LogContext(name())),
                     brokerConfig.requestTimeoutMs(), Time.SYSTEM);
-            mirrorStateUpdateSender.start();
+            mirrorStateSender.start();
         }
 
         // caching the image for query purpose
         this.metadataImage = newImage;
+
+        // evict stale coordinator node cache when __mirror_state topic leadership changes
+        if (delta.topicsDelta() != null) {
+            TopicImage mirrorStateTopic = newImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME);
+            if (mirrorStateTopic != null && delta.topicsDelta().changedTopic(mirrorStateTopic.id()) != null) {
+                coordinatorNodes.clear();
+            }
+        }
 
         // detect config changes and close stale connections and fetchers to trigger reconnection
         if (delta.configsDelta() != null) {
@@ -264,11 +268,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .filter(e -> e.getKey().type() == ConfigResource.Type.MIRROR)
                 .forEach(e -> {
                     String mirrorName = e.getKey().name();
-                    List<MirrorBlockingSender> senders = sourceSenders.remove(mirrorName);
+                    List<MirrorSourceSender> senders = sourceSenders.remove(mirrorName);
+                    // also clear cached source leaders to force re-resolution with new config
+                    sourceLeaders.remove(mirrorName);
                     if (senders != null) {
-                        LOG.info("Mirror config changed for '{}'. Closing existing connections "
+                        log.info("Mirror config changed for '{}'. Closing existing connections "
                             + "to trigger reconnection with updated configuration.", mirrorName);
-                        senders.forEach(MirrorBlockingSender::close);
+                        senders.forEach(MirrorSourceSender::close);
                     }
                     mirrorFetcherManagerSupplier.get().removeFetchersForMirror(mirrorName);
                 });
@@ -280,7 +286,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
 
-        LOG.info("onMetadataUpdate: {}", mirrorLeaders);
+        log.info("onMetadataUpdate: {}", mirrorLeaders);
 
         // Collect remote coordinator partitions grouped by mirrorName for batched reads
         Map<String, Map<String, Set<Integer>>> remotePartitionsByMirror = new HashMap<>();
@@ -321,15 +327,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             readStatesFromRemoteCoordinator(mirrorName, partitions, res ->
                 res.data().topics().forEach(topic ->
                     topic.partitions().forEach(partition -> {
-                        if (partition.state() != -1) {
-                            TopicPartition resTp = new TopicPartition(topic.name(), partition.partitionIndex());
-                            MirrorPartitionState state = MirrorPartitionState.fromValue(partition.state());
-                            boolean stopRequested = stopFlags.getOrDefault(resTp, false);
-                            boolean pauseRequested = pauseFlags.getOrDefault(resTp, false);
-                            MirrorUtils.PartitionKey mpk = new MirrorUtils.PartitionKey(mirrorName, resTp.topic(), resTp.partition());
-                            MirrorPartitionState curState = partitionStates.getOrDefault(mpk, MirrorPartitionState.UNKNOWN);
-                            applyMirrorStateTransition(mirrorName, resTp, curState, state, stopRequested, pauseRequested);
-                        }
+                        TopicPartition resTp = new TopicPartition(topic.name(), partition.partitionIndex());
+                        // treat unrecorded state (-1) as UNKNOWN so the partition can transition to PREPARING
+                        MirrorPartitionState state = partition.state() != -1
+                                ? MirrorPartitionState.fromValue(partition.state())
+                                : MirrorPartitionState.UNKNOWN;
+                        boolean stopRequested = stopFlags.getOrDefault(resTp, false);
+                        boolean pauseRequested = pauseFlags.getOrDefault(resTp, false);
+                        MirrorUtils.PartitionKey mpk = new MirrorUtils.PartitionKey(mirrorName, resTp.topic(), resTp.partition());
+                        MirrorPartitionState curState = partitionStates.getOrDefault(mpk, MirrorPartitionState.UNKNOWN);
+                        applyMirrorStateTransition(mirrorName, resTp, curState, state, stopRequested, pauseRequested);
                     })));
         });
 
@@ -340,7 +347,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        mirrorStateUpdateSender.shutdown();
+        mirrorStateSender.shutdown();
         closeSourceSenders();
     }
 
@@ -410,11 +417,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                             boolean stopRequested, boolean pauseRequested) {
         stateTransitioner.ifPresent(t -> {
             if (stopRequested) {
-              if (curState != MirrorPartitionState.STOPPED) {
-                  t.transitionTo(mirrorName, tp, MirrorPartitionState.STOPPING);
-              } else {
-                  t.transitionTo(mirrorName, tp, MirrorPartitionState.STOPPED);
-              }
+                if (curState != MirrorPartitionState.STOPPED) {
+                    t.transitionTo(mirrorName, tp, MirrorPartitionState.STOPPING);
+                } else {
+                    t.transitionTo(mirrorName, tp, MirrorPartitionState.STOPPED);
+                }
             } else if (pauseRequested) {
                 if (curState != MirrorPartitionState.PAUSED) {
                     t.transitionTo(mirrorName, tp, MirrorPartitionState.PAUSING);
@@ -503,7 +510,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 }
             }
         } catch (Exception e) {
-            LOG.warn("Exception while getting mirror coordinator", e);
+            log.warn("Exception while getting mirror coordinator", e);
         }
         return Node.noNode();
     }
@@ -525,7 +532,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                         Map<String, Set<MirrorUtils.PartitionStateInfo>> topicMetadata,
                                         Set<String> removedTopics,
                                         Consumer<WriteMirrorStatesResponse> callback) {
-        LOG.debug("Writing states to remote coordinator: {} {} {}", mirrorName, topicMetadata, removedTopics);
+        log.debug("Writing states to remote coordinator: {} {} {}", mirrorName, topicMetadata, removedTopics);
 
         // Group partitions by coordinator node for batching
         Map<Node, Map<String, List<WriteMirrorStatesRequestData.PartitionData>>> nodeToTopicPartitions = new HashMap<>();
@@ -533,14 +540,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         topicMetadata.forEach((topic, metadata) -> {
             metadata.forEach(m -> {
                 MirrorRecordKey key = new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), m.partition());
-                Node coordinatorNode = coordinatorNodes.get(key);
-                if (coordinatorNode == null) {
-                    coordinatorNode = findCoordinatorNode(key);
-                    if (coordinatorNode.equals(Node.noNode())) {
-                        LOG.error("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, m.partition());
-                        return;
-                    }
-                    coordinatorNodes.put(key, coordinatorNode);
+                // computeIfAbsent to avoid duplicate coordinator lookups from concurrent threads
+                Node coordinatorNode = coordinatorNodes.computeIfAbsent(key, this::findCoordinatorNode);
+                if (coordinatorNode.equals(Node.noNode())) {
+                    coordinatorNodes.remove(key);
+                    log.error("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, m.partition());
+                    return;
                 }
 
                 WriteMirrorStatesRequestData.PartitionData partitionData = new WriteMirrorStatesRequestData.PartitionData();
@@ -568,12 +573,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             data.setTopics(topicDataList);
             data.setRemovedTopics(new ArrayList<>(removedTopics));
 
-            mirrorStateUpdateSender.enqueue(new RequestAndCompletionHandler(
+            mirrorStateSender.enqueue(new RequestAndCompletionHandler(
                 time.milliseconds(),
                 node,
                 new WriteMirrorStatesRequest.Builder(data),
                 response -> {
-                    LOG.debug("Write states to remote coordinator completed: {}", response.responseBody());
+                    log.debug("Write states to remote coordinator completed: {}", response.responseBody());
                     if (response.responseBody() instanceof WriteMirrorStatesResponse writeMirrorStatesResponse) {
                         callback.accept(writeMirrorStatesResponse);
                     }
@@ -589,7 +594,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private void readStatesFromRemoteCoordinator(String mirrorName,
                                                  Map<String, Set<Integer>> partitions,
                                                  Consumer<ReadMirrorStatesResponse> callback) {
-        LOG.debug("Reading states from remote coordinator: {} {}", mirrorName, partitions);
+        log.debug("Reading states from remote coordinator: {} {}", mirrorName, partitions);
 
         // Group partitions by coordinator node for batching
         Map<Node, Map<String, List<ReadMirrorStatesRequestData.PartitionData>>> nodeToTopicPartitions = new HashMap<>();
@@ -597,14 +602,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         partitions.forEach((topic, parts) -> {
             parts.forEach(part -> {
                 MirrorRecordKey key = new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), part);
-                Node coordinatorNode = coordinatorNodes.get(key);
-                if (coordinatorNode == null) {
-                    coordinatorNode = findCoordinatorNode(key);
-                    if (coordinatorNode.equals(Node.noNode())) {
-                        LOG.warn("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, part);
-                        return;
-                    }
-                    coordinatorNodes.put(key, coordinatorNode);
+                // computeIfAbsent to avoid duplicate coordinator lookups from concurrent threads
+                Node coordinatorNode = coordinatorNodes.computeIfAbsent(key, this::findCoordinatorNode);
+                if (coordinatorNode.equals(Node.noNode())) {
+                    coordinatorNodes.remove(key);
+                    log.warn("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, part);
+                    return;
                 }
 
                 ReadMirrorStatesRequestData.PartitionData partitionData = new ReadMirrorStatesRequestData.PartitionData();
@@ -629,13 +632,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
             data.setTopics(topicDataList);
 
-            mirrorStateUpdateSender.enqueue(new RequestAndCompletionHandler(
+            mirrorStateSender.enqueue(new RequestAndCompletionHandler(
                 time.milliseconds(),
                 node,
                 new ReadMirrorStatesRequest.Builder(data),
                 response -> {
                     if (response.responseBody() instanceof ReadMirrorStatesResponse readMirrorStatesResponse) {
-                        LOG.debug("Read states from remote coordinator completed: {}", response.responseBody());
+                        log.debug("Read states from remote coordinator completed: {}", response.responseBody());
 
                         // Update cache
                         readMirrorStatesResponse.data().topics().forEach(topic -> {
@@ -690,7 +693,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         String bootstrapServers = Optional.ofNullable(props.get(BOOTSTRAP_SERVERS_CONFIG))
                 .map(Object::toString)
                 .orElseThrow(() -> new IllegalArgumentException("Source bootstrap server not found in Cluster Mirror config: " + mirrorName));
-        LOG.info("Bootstrap servers config for mirror {}: '{}'", mirrorName, bootstrapServers);
+        log.info("Bootstrap servers config for mirror {}: '{}'", mirrorName, bootstrapServers);
 
         List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
                 Arrays.stream(bootstrapServers.split(",")).toList(), "use_all_dns_ips");
@@ -698,15 +701,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         MirrorConfig mirrorConfig = MirrorConfig.fromProperties(props);
 
-        List<MirrorBlockingSender> senders = new ArrayList<>();
+        List<MirrorSourceSender> senders = new ArrayList<>();
         for (InetSocketAddress address : addresses) {
             try {
-                BrokerEndPoint endpoint = new BrokerEndPoint(random.nextInt(), address.getHostString(), address.getPort());
-                String clientId = "nodeId-" + nodeId + "-mirror-" + mirrorName + "-" + address.getHostString() + "-" + address.getPort();
-                LogContext logContext = new LogContext("[" + MirrorMetadataManager.class.getSimpleName() + "nodeId=" + nodeId + " mirrorName=" + mirrorName + "] ");
+                // deterministic sender ID to avoid collisions
+                int senderId = Objects.hash(address.getHostString(), address.getPort()) & Integer.MAX_VALUE;
+                BrokerEndPoint endpoint = new BrokerEndPoint(senderId, address.getHostString(), address.getPort());
+                String clientId = "nodeId-" + nodeId + "-" + mirrorName + "-" + address.getHostString() + "-" + address.getPort();
+                LogContext logContext = new LogContext("[" + MirrorMetadataManager.class.getSimpleName() + "Sender id=" + nodeId + " clientId=" + clientId + "] ");
                 senders.add(MirrorUtils.createSender(endpoint, mirrorConfig, brokerConfig, metrics, time, clientId, logContext));
             } catch (Exception e) {
-                LOG.warn("Failed to create sender for {} in mirror {}", address, mirrorName, e);
+                log.warn("Failed to create sender for {} in mirror {}", address, mirrorName, e);
             }
         }
 
@@ -714,22 +719,27 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             throw new IllegalStateException("Failed to create any source senders for mirror " + mirrorName);
         }
 
-        LOG.info("Created {} source sender(s) for mirror {} from {} configured address(es)", senders.size(), mirrorName, addresses.size());
-        sourceSenders.put(mirrorName, senders);
+        log.info("Created {} source sender(s) for mirror {} from {} configured address(es)", senders.size(), mirrorName, addresses.size());
+        // putIfAbsent to avoid overwriting senders created by a concurrent thread
+        List<MirrorSourceSender> existing = sourceSenders.putIfAbsent(mirrorName, senders);
+        if (existing != null) {
+            senders.forEach(MirrorSourceSender::close);
+        }
     }
 
     private ClientResponse trySendRequest(String mirrorName, AbstractRequest.Builder<?> requestBuilder) {
-        List<MirrorBlockingSender> senders = sourceSenders.get(mirrorName);
-        if (senders == null || senders.isEmpty()) {
+        // snapshot sender list to avoid concurrent modification during iteration
+        List<MirrorSourceSender> senders = List.copyOf(sourceSenders.getOrDefault(mirrorName, List.of()));
+        if (senders.isEmpty()) {
             throw new IllegalStateException("No source senders available for mirror " + mirrorName);
         }
         Exception lastException = null;
-        for (MirrorBlockingSender sender : senders) {
+        for (MirrorSourceSender sender : senders) {
             try {
                 return sender.sendRequest(requestBuilder);
             } catch (Exception e) {
                 lastException = e;
-                LOG.warn("Failed to send request to {} for mirror {}", sender.brokerEndPoint(), mirrorName, e);
+                log.warn("Failed to send request to {} for mirror {}: {}", sender.brokerEndPoint(), mirrorName, e.getMessage());
             }
         }
         throw new KafkaException("Failed to send request to any source server for mirror " + mirrorName, lastException);
@@ -752,12 +762,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
 
         // No cached metadata. Refresh synchronously before creating fetcher threads.
-        LOG.info("No cached metadata for mirror {} partition {}. Refreshing metadata from remote cluster.", mirrorName, tp);
+        log.info("No cached metadata for mirror {} partition {}. Refreshing metadata from remote cluster.", mirrorName, tp);
         ensureConnection(mirrorName);
         try {
             syncTopicMetadata(mirrorName);
         } catch (Exception e) {
-            LOG.error("Failed to refresh topic metadata for mirror {}", mirrorName, e);
+            log.error("Failed to refresh topic metadata for mirror {}", mirrorName, e);
         }
 
         // Try to resolve source leader broker.
@@ -765,15 +775,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (partitionLeaders != null) {
             Node leader = partitionLeaders.get(tp);
             if (leader != null) {
-                LOG.debug("Successfully fetched leader for {} from mirror {}: broker {}", tp, mirrorName, leader.id());
+                log.debug("Successfully fetched leader for {} from mirror {}: broker {}", tp, mirrorName, leader.id());
                 return leader;
             }
         }
 
         // Metadata refresh failed or partition not found. Fall back to first bootstrap server.
         // This should rarely happen and indicates a configuration or connectivity issue.
-        LOG.warn("Unable to resolve source leader for mirror {} partition {} after refresh. Falling back to bootstrap server.", mirrorName, tp);
-        List<MirrorBlockingSender> senders = sourceSenders.get(mirrorName);
+        log.warn("Unable to resolve source leader for mirror {} partition {} after refresh. Falling back to bootstrap server.", mirrorName, tp);
+        List<MirrorSourceSender> senders = sourceSenders.get(mirrorName);
         if (senders != null && !senders.isEmpty()) {
             BrokerEndPoint ep = senders.get(0).brokerEndPoint();
             return new Node(ep.id(), ep.host(), ep.port());
@@ -782,21 +792,25 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         throw new IllegalStateException("No source senders available for mirror " + mirrorName);
     }
 
+    // atomic per-key update to keep partition state counts consistent
     void updatePartitionState(MirrorUtils.PartitionKey key, MirrorPartitionState newState) {
-        MirrorPartitionState oldState = partitionStates.put(key, newState);
-        if (oldState != null && oldState != newState) {
-            partitionStateCounts.computeIfAbsent(oldState, s -> new AtomicLong()).decrementAndGet();
-        }
-        if (oldState != newState) {
-            partitionStateCounts.computeIfAbsent(newState, s -> new AtomicLong()).incrementAndGet();
-        }
+        partitionStates.compute(key, (k, oldState) -> {
+            if (oldState != null && oldState != newState) {
+                partitionStateCounts.computeIfAbsent(oldState, s -> new AtomicLong()).decrementAndGet();
+            }
+            if (oldState != newState) {
+                partitionStateCounts.computeIfAbsent(newState, s -> new AtomicLong()).incrementAndGet();
+            }
+            return newState;
+        });
     }
 
+    // atomic remove + counter decrement to keep partition state counts consistent
     private void removePartitionState(MirrorUtils.PartitionKey key) {
-        MirrorPartitionState oldState = partitionStates.remove(key);
-        if (oldState != null) {
+        partitionStates.computeIfPresent(key, (k, oldState) -> {
             partitionStateCounts.computeIfAbsent(oldState, s -> new AtomicLong()).decrementAndGet();
-        }
+            return null;
+        });
     }
 
     private long partitionStateCount(MirrorPartitionState state) {
@@ -813,7 +827,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     void applyLoadedPartitionStates(MirrorUtils.StateTransitionCallback callback) {
         Map<String, Map<MirrorPartitionState, Set<TopicPartition>>> statesToPartitionsToOperate = new HashMap<>();
         partitionStates.forEach((key, value) -> {
-            LOG.debug("Applying loaded partition state: {} {}", key, value);
+            log.debug("Applying loaded partition state: {} {}", key, value);
             metadataCache.getLeaderAndIsr(key.topic(), key.partition()).ifPresent(metadata -> {
                 // only operate when this node is the leader of the partition
                 if (metadata.leader() == nodeId) {
@@ -876,7 +890,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                        String mirrorName,
                                        Set<TopicPartition> topicPartitionSet,
                                        Consumer<TopicPartition> callback) {
-        LOG.info("Truncating to last mirrored offsets for mirror {}: {}", mirrorName, topicPartitionSet);
+        log.info("Truncating to last mirrored offsets for mirror {}: {}", mirrorName, topicPartitionSet);
         ensureConnection(mirrorName);
 
         // get api versions of the source cluster
@@ -884,7 +898,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         if (apiResponse.responseBody() instanceof ApiVersionsResponse apiVersionsResponse) {
             if (apiVersionsResponse.apiVersion(ApiKeys.LAST_MIRRORED_OFFSETS.id) == null) {
-                LOG.debug("The LastMirroredOffsets API is not supported in source cluster, truncating to offset 0");
+                log.debug("The LastMirroredOffsets API is not supported in source cluster, truncating to offset 0");
                 Map<TopicPartition, Long> offsets = new HashMap<>();
                 topicPartitionSet.forEach(tp -> offsets.put(tp, 0L));
                 replicaManager.maybeTruncate(offsets, callback);
@@ -911,7 +925,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         );
 
         if (response.responseBody() instanceof LastMirroredOffsetsResponse lastMirroredOffsetResponse) {
-            LOG.debug("Received last mirrored offset response: {}", lastMirroredOffsetResponse);
+            log.debug("Received last mirrored offset response: {}", lastMirroredOffsetResponse);
             Map<TopicPartition, Long> offsets = new HashMap<>();
             lastMirroredOffsetResponse.data().topics().forEach(topic -> {
                 String name = topic.name();
@@ -930,15 +944,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     void syncTopicMetadata() {
         Set<String> mirrors = getConfiguredMirrors();
         if (!mirrors.isEmpty()) {
-            LOG.debug("Refreshing mirror metadata for mirrors: {}", mirrors);
+            log.debug("Refreshing mirror metadata for mirrors: {}", mirrors);
         }
 
         mirrors.forEach(this::ensureConnection);
-        for (String mirrorName : sourceSenders.keySet()) {
+        // snapshot keyset to avoid ConcurrentModificationException
+        for (String mirrorName : Set.copyOf(sourceSenders.keySet())) {
             try {
                 syncTopicMetadata(mirrorName);
             } catch (Exception e) {
-                LOG.error("Failed to refresh topic metadata for mirror {}", mirrorName, e);
+                log.error("Failed to refresh topic metadata for mirror {}", mirrorName, e);
             }
         }
 
@@ -956,7 +971,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         );
 
         if (response.responseBody() instanceof MetadataResponse metadataResponse) {
-            LOG.debug("Periodic metadata response: {}", metadataResponse);
+            log.debug("Periodic metadata response: {}", metadataResponse);
             Map<Integer, Node> brokerNodes = new HashMap<>();
             metadataResponse.brokers().forEach(broker -> brokerNodes.put(broker.id(), broker));
             var createPartitionsTopics = processTopicMetadata(mirrorName, metadataResponse.topicMetadata(), brokerNodes);
@@ -971,15 +986,21 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         var createPartitionsTopics = new CreatePartitionsRequestData.CreatePartitionsTopicCollection();
 
         topicMetadata.forEach(tm -> {
-            var partitionLeaders = sourceLeaders.computeIfAbsent(mirrorName, k -> new HashMap<>());
+            // use ConcurrentHashMap for thread-safe access from scheduler and fetcher threads
+            var partitionLeaders = sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
 
             // Count partitions for this specific topic only
             int sourcePartitionCount = tm.partitionMetadata().size();
 
-            tm.partitionMetadata().forEach(partitionMetadata -> partitionLeaders.put(
-                    partitionMetadata.topicPartition,
-                    brokerNodes.get(partitionMetadata.leaderId.get())
-            ));
+            // skip partitions with no leader (source broker may be restarting)
+            tm.partitionMetadata().forEach(partitionMetadata -> {
+                if (partitionMetadata.leaderId.isPresent()) {
+                    Node leader = brokerNodes.get(partitionMetadata.leaderId.get());
+                    if (leader != null) {
+                        partitionLeaders.put(partitionMetadata.topicPartition, leader);
+                    }
+                }
+            });
 
             if (metadataImage.topics().getTopic(tm.topicId()) != null &&
                     metadataImage.topics().getTopic(tm.topicId()).partitions().size() < sourcePartitionCount) {
@@ -997,13 +1018,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     // Handles partition scaling by sending create partitions requests
     private void handlePartitionScaling(CreatePartitionsRequestData.CreatePartitionsTopicCollection createPartitionsTopics) {
         if (!createPartitionsTopics.isEmpty()) {
-            LOG.debug("Detected partition count change, sending CreatePartitionsRequest: {}", createPartitionsTopics);
+            log.debug("Detected partition count change, sending CreatePartitionsRequest: {}", createPartitionsTopics);
             channelManager.sendRequest(new CreatePartitionsRequest.Builder(
                     new CreatePartitionsRequestData()
                             .setTopics(createPartitionsTopics)
                             .setValidateOnly(false)
                             .setTimeoutMs(3000)
-            ), new TimeoutHandler());
+            ), new TimeoutHandler(log));
         }
     }
 
@@ -1014,8 +1035,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .map(MetadataResponse.TopicMetadata::topic).toList();
         getConfiguredTopics(mirrorName, true).forEach(name -> {
             if (deletedSourceTopicNames.contains(name)) {
-                LOG.info("Detected topic {} deleted in remote cluster {}, stopping mirror partitions", name, mirrorName);
-                partitionStates.keySet().stream()
+                log.info("Detected topic {} deleted in remote cluster {}, stopping mirror partitions", name, mirrorName);
+                // snapshot keyset to avoid skipping entries during concurrent modification
+                Set.copyOf(partitionStates.keySet()).stream()
                         .filter(key -> key.mirrorName().equals(mirrorName) && key.topic().equals(name))
                         .forEach(key -> stateTransitioner.ifPresent(t ->
                                 t.transitionTo(mirrorName, new TopicPartition(key.topic(), key.partition()), MirrorPartitionState.STOPPING)));
@@ -1038,7 +1060,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     syncConsumerGroupOffsets(mirrorName, mirrorConfig);
                     syncAccessControlLists(mirrorName, mirrorConfig);
                 } catch (Exception e) {
-                    LOG.error("Failed to sync mirror metadata for mirror {}", mirrorName, e);
+                    log.error("Failed to sync mirror metadata for mirror {}", mirrorName, e);
                 }
             }
         });
@@ -1046,7 +1068,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     private void syncTopicConfigurations(String mirrorName, MirrorConfig mirrorConfig) {
         Set<String> topics = getConfiguredTopics(mirrorName);
-        LOG.debug("Describing topic configs for topics: {}", topics);
+        log.debug("Describing topic configs for topics: {}", topics);
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         topicConfigSyncError.incrementAndGet();
 
@@ -1062,7 +1084,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         var describeConfigResponse = trySendRequest(mirrorName, describeConfigsRequest);
         if (describeConfigResponse.responseBody() instanceof DescribeConfigsResponse describeConfigsRes) {
-            LOG.debug("Periodic describe config response: {}", describeConfigsRes);
+            log.debug("Periodic describe config response: {}", describeConfigsRes);
             warnIfUncleanLeaderElection(describeConfigsRes);
             Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(describeConfigsRes, mirrorConfig);
             applyConfigurationChanges(configsToChange);
@@ -1077,11 +1099,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     .findFirst()
                     .ifPresent(con -> {
                         if (con.configSource() == DescribeConfigsResponse.ConfigSource.TOPIC_CONFIG.id()) {
-                            LOG.warn("Mirror topic '{}' has unclean.leader.election.enable=true set at topic level. " +
+                            log.warn("Mirror topic '{}' has unclean.leader.election.enable=true set at topic level. " +
                                     "This is not supported as log divergence cannot be reconciled across clusters.",
                                     describeConfigResult.resourceName());
                         } else {
-                            LOG.warn("Mirror topic '{}' has unclean.leader.election.enable=true (inherited from broker or cluster default). " +
+                            log.warn("Mirror topic '{}' has unclean.leader.election.enable=true (inherited from broker or cluster default). " +
                                     "This is not supported as log divergence cannot be reconciled across clusters.",
                                     describeConfigResult.resourceName());
                         }
@@ -1126,7 +1148,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     private void applyConfigurationChanges(Map<String, Map<String, String>> configsToChange) {
-        LOG.debug("Applying config change: {}", configsToChange);
+        log.debug("Applying config change: {}", configsToChange);
 
         Map<ConfigResource, Collection<AlterConfigOp>> configOps = new HashMap<>();
         configsToChange.forEach((name, changes) -> {
@@ -1153,7 +1175,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         .setResourceName(resource.name()).setConfigs(alterableConfigSet);
                 data.resources().add(alterConfigsResource);
             }
-            channelManager.sendRequest(new IncrementalAlterConfigsRequest.Builder(data), new TimeoutHandler());
+            channelManager.sendRequest(new IncrementalAlterConfigsRequest.Builder(data), new TimeoutHandler(log));
         }
     }
 
@@ -1168,7 +1190,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .setStatesFilter(singletonList(GroupState.STABLE.name())));
         var listGroupResponse = trySendRequest(mirrorName, builder);
         if (listGroupResponse.responseBody() instanceof ListGroupsResponse listGroupsRes) {
-            LOG.debug("List groups response for mirror {}: {}", mirrorName, listGroupsRes);
+            log.debug("List groups response for mirror {}: {}", mirrorName, listGroupsRes);
 
             // Filter groups by include pattern
             var matchingGroups = listGroupsRes.data().groups().stream()
@@ -1188,7 +1210,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                     .setTopics(null)).toList()), false);
             var offsetFetchResponse = trySendRequest(mirrorName, offsetFetchBuilder);
             if (offsetFetchResponse.responseBody() instanceof OffsetFetchResponse offsetFetchRes) {
-                LOG.debug("Periodic offset fetch response: {}", offsetFetchRes);
+                log.debug("Periodic offset fetch response: {}", offsetFetchRes);
 
                 // 3. commit offsets to consumer group coordinator
                 // TODO: need to find the current group coordinator for each group
@@ -1245,7 +1267,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         .setTopics(topicList),
                 RequestLocal.noCaching().bufferSupplier()
         ).handle((data, exception) -> {
-            LOG.debug("Periodic offset commit result: {}, exception: {}", data, exception);
+            log.debug("Periodic offset commit result: {}, exception: {}", data, exception);
             return null;
         });
     }
@@ -1265,11 +1287,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         var describeAclsRequest = new DescribeAclsRequest.Builder(ANY_RESOURCE_ACL);
         var describeAclsResponse = trySendRequest(mirrorName, describeAclsRequest);
         if (!(describeAclsResponse.responseBody() instanceof DescribeAclsResponse aclsResponse)) {
-            LOG.warn("Unexpected ACL response type from remote cluster: {}", describeAclsResponse);
+            log.warn("Unexpected ACL response type from remote cluster: {}", describeAclsResponse);
             return;
         }
 
-        LOG.debug("Describe ACLs response from remote cluster {}: {}", mirrorName, aclsResponse);
+        log.debug("Describe ACLs response from remote cluster {}: {}", mirrorName, aclsResponse);
 
         // Filter ACLs by include rules
         List<MirrorConfig.AclRule> aclIncludeRules = mirrorConfig.aclIncludeRules();
@@ -1305,7 +1327,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private void applyAccessControlListChanges(String mirrorName, ACLChanges aclChanges) {
         // send createAcls request
         if (!aclChanges.aclsToAdd().isEmpty()) {
-            LOG.debug("Adding {} ACLs from remote cluster {}", aclChanges.aclsToAdd().size(), mirrorName);
+            log.debug("Adding {} ACLs from remote cluster {}", aclChanges.aclsToAdd().size(), mirrorName);
             var requestData = aclChanges.aclsToAdd().stream().map(
                     aclBinding -> new CreateAclsRequestData.AclCreation()
                             .setResourceType(aclBinding.pattern().resourceType().code())
@@ -1318,13 +1340,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     .toList();
             channelManager.sendRequest(
                     new CreateAclsRequest.Builder(new CreateAclsRequestData().setCreations(requestData)),
-                    new TimeoutHandler()
+                    new TimeoutHandler(log)
             );
         }
 
         // send deleteAcls request
         if (!aclChanges.aclsToDelete().isEmpty()) {
-            LOG.debug("Removing {} ACLs from remote cluster {}", aclChanges.aclsToDelete().size(), mirrorName);
+            log.debug("Removing {} ACLs from remote cluster {}", aclChanges.aclsToDelete().size(), mirrorName);
             var requestData = aclChanges.aclsToDelete().stream().map(
                     aclBinding -> new DeleteAclsRequestData.DeleteAclsFilter()
                             .setResourceTypeFilter(aclBinding.pattern().resourceType().code())
@@ -1337,7 +1359,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     .toList();
             channelManager.sendRequest(
                     new DeleteAclsRequest.Builder(new DeleteAclsRequestData().setFilters(requestData)),
-                    new TimeoutHandler()
+                    new TimeoutHandler(log)
             );
         }
     }
@@ -1393,20 +1415,27 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     private void closeSourceSenders() {
-        sourceSenders.values().forEach(senders -> senders.forEach(MirrorBlockingSender::close));
+        // snapshot and clear first, then close to avoid use-after-close races
+        Map<String, List<MirrorSourceSender>> snapshot = new HashMap<>(sourceSenders);
         sourceSenders.clear();
+        snapshot.values().forEach(senders -> senders.forEach(MirrorSourceSender::close));
     }
 
     private static class TimeoutHandler implements ControllerRequestCompletionHandler {
+        private final Logger log;
+
+        TimeoutHandler(Logger log) {
+            this.log = log;
+        }
+
         @Override
         public void onTimeout() {
-            LOG.warn("Controller request timed out");
+            log.warn("Controller request timed out");
         }
 
         @Override
         public void onComplete(ClientResponse response) {
-            LOG.debug("Controller request completed: {}", response);
+            log.debug("Controller request completed: {}", response);
         }
     }
-
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -259,9 +259,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .filter(e -> e.getKey().type() == ConfigResource.Type.MIRROR)
                 .forEach(e -> {
                     String mirrorName = e.getKey().name();
-                    List<MirrorSourceSender> senders = sourceSenders.remove(mirrorName);
-                    // also clear cached source leaders to force re-resolution with new config
                     sourceLeaders.remove(mirrorName);
+                    List<MirrorSourceSender> senders = sourceSenders.remove(mirrorName);
                     if (senders != null) {
                         log.info("Mirror config changed for '{}'. Closing existing connections "
                             + "to trigger reconnection with updated configuration.", mirrorName);
@@ -342,7 +341,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         closeSourceSenders();
     }
 
-    // Returns mirror partitions led by this broker, detecting both leadership and config changes
+    /** Returns mirror partitions led by this broker, detecting both leadership and config changes */
     private Set<TopicPartition> getMirrorLeaders(MetadataDelta delta, MetadataImage image) {
         Set<TopicPartition> mirrorLeaderPartitions = new HashSet<>();
 
@@ -672,6 +671,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         responseCallback.accept(new ReadMirrorStatesResponse(data));
     }
 
+    /** Creates initial source senders from bootstrap addresses if not already connected. */
     private void ensureConnection(String mirrorName) {
         if (sourceSenders.containsKey(mirrorName)) {
             return;
@@ -714,6 +714,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
+    /** Sends a request to the source cluster, iterating available senders with fallback on failure. */
     private ClientResponse trySendRequest(String mirrorName, AbstractRequest.Builder<?> requestBuilder) {
         // snapshot sender list to avoid concurrent modification during iteration
         List<MirrorSourceSender> senders = List.copyOf(sourceSenders.getOrDefault(mirrorName, List.of()));
@@ -924,11 +925,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    /**
-     * Syncs topic metadata (partition leaders, partition counts) from all source clusters.
-     * Runs on every broker so that all brokers can route mirror fetch requests to the correct partition leaders.
-     */
-    void syncTopicMetadata() {
+    /** Syncs metadata from all source clusters. */
+    void syncMetadata() {
         Set<String> mirrors = getConfiguredMirrors();
         if (!mirrors.isEmpty()) {
             log.debug("Refreshing mirror metadata for mirrors: {}", mirrors);
@@ -938,9 +936,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         // snapshot keyset to avoid ConcurrentModificationException
         for (String mirrorName : Set.copyOf(sourceSenders.keySet())) {
             try {
+                discoverSourceBrokers(mirrorName);
                 syncTopicMetadata(mirrorName);
+                syncMirrorMetadata(mirrorName);
             } catch (Exception e) {
-                log.error("Failed to refresh topic metadata for mirror {}", mirrorName, e);
+                log.error("Failed to refresh metadata for mirror {}", mirrorName, e);
             }
         }
 
@@ -948,6 +948,65 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         metadataRefreshError.incrementAndGet();
     }
 
+    /**
+     * Discovers source cluster brokers via metadata and adds senders for any newly found brokers.
+     * Sender cleanup only happens via {@link #onMetadataUpdate} or{@link #clear}.
+     */
+    private void discoverSourceBrokers(String mirrorName) {
+        var response = trySendRequest(mirrorName, MetadataRequest.Builder.allTopics());
+        if (!(response.responseBody() instanceof MetadataResponse metadataResponse)) {
+            return;
+        }
+
+        Collection<Node> discoveredBrokers = metadataResponse.brokers();
+        if (discoveredBrokers.isEmpty()) {
+            return;
+        }
+        List<MirrorSourceSender> currentSenders = sourceSenders.get(mirrorName);
+        if (currentSenders == null) {
+            return;
+        }
+
+        Set<String> currentEndpoints = currentSenders.stream()
+                .map(s -> s.brokerEndPoint().host() + ":" + s.brokerEndPoint().port())
+                .collect(Collectors.toSet());
+
+        List<Node> newBrokers = discoveredBrokers.stream()
+                .filter(n -> !currentEndpoints.contains(n.host() + ":" + n.port()))
+                .toList();
+
+        if (newBrokers.isEmpty()) {
+            return;
+        }
+
+        Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName));
+        MirrorConfig mirrorConfig = MirrorConfig.fromProperties(props);
+
+        List<MirrorSourceSender> addedSenders = new ArrayList<>();
+        for (Node broker : newBrokers) {
+            try {
+                BrokerEndPoint endpoint = new BrokerEndPoint(broker.id(), broker.host(), broker.port());
+                String clientId = "nodeId-" + nodeId + "-" + mirrorName + "-" + broker.host() + "-" + broker.port();
+                LogContext logContext = new LogContext("[" + MirrorMetadataManager.class.getSimpleName() + "Sender id=" + nodeId + " clientId=" + clientId + "] ");
+                addedSenders.add(MirrorUtils.createSender(endpoint, mirrorConfig, brokerConfig, metrics, time, clientId, logContext));
+            } catch (Exception e) {
+                log.warn("Failed to create sender for broker {} in mirror {}", broker, mirrorName, e);
+            }
+        }
+
+        if (addedSenders.isEmpty()) {
+            return;
+        }
+
+        List<MirrorSourceSender> merged = new ArrayList<>(currentSenders);
+        merged.addAll(addedSenders);
+        log.info("Adding {} discovered broker(s) to source senders for mirror {}: {}",
+                addedSenders.size(), mirrorName,
+                addedSenders.stream().map(s -> s.brokerEndPoint().toString()).collect(Collectors.joining(", ")));
+        sourceSenders.put(mirrorName, merged);
+    }
+
+    /** Fetches topic metadata from the source cluster and updates partition leaders, counts, and deletions. */
     private void syncTopicMetadata(String mirrorName) {
         Set<String> topics = getConfiguredTopics(mirrorName);
         if (topics.isEmpty()) {
@@ -967,7 +1026,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    // Processes topic metadata and returns topics that need partition scaling
+    /** Processes topic metadata and returns topics that need partition scaling */
     private CreatePartitionsRequestData.CreatePartitionsTopicCollection processTopicMetadata(
             String mirrorName, Collection<MetadataResponse.TopicMetadata> topicMetadata, Map<Integer, Node> brokerNodes) {
         var createPartitionsTopics = new CreatePartitionsRequestData.CreatePartitionsTopicCollection();
@@ -1002,7 +1061,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return createPartitionsTopics;
     }
 
-    // Handles partition scaling by sending create partitions requests
+    /** Handles partition scaling by sending create partitions requests */
     private void handlePartitionScaling(CreatePartitionsRequestData.CreatePartitionsTopicCollection createPartitionsTopics) {
         if (!createPartitionsTopics.isEmpty()) {
             log.debug("Detected partition count change, sending CreatePartitionsRequest: {}", createPartitionsTopics);
@@ -1015,7 +1074,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    // Transitions mirror partitions to STOPPING when the topic is deleted on the source cluster.
+    /** Transitions mirror partitions to STOPPING when the topic is deleted on the source cluster. */
     private void maybeStopDeletedTopics(String mirrorName, Collection<MetadataResponse.TopicMetadata> topicMetadata) {
         List<String> deletedSourceTopicNames = topicMetadata.stream()
                 .filter(tm -> tm.error() == Errors.UNKNOWN_TOPIC_OR_PARTITION)
@@ -1036,21 +1095,19 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Syncs mirror metadata (configurations, consumer group offsets, ACLs) from source clusters.
      * Only the coordinator for each mirror name handles this, distributing load across brokers.
      */
-    void syncMirrorMetadata() {
-        getConfiguredMirrors().forEach(mirrorName -> {
-            if (isLocalCoordinator(mirrorName)) {
-                ensureConnection(mirrorName);
-                try {
-                    MirrorConfig mirrorConfig = MirrorConfig.fromProperties(
-                            metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName)));
-                    syncTopicConfigurations(mirrorName, mirrorConfig);
-                    syncConsumerGroupOffsets(mirrorName, mirrorConfig);
-                    syncAccessControlLists(mirrorName, mirrorConfig);
-                } catch (Exception e) {
-                    log.error("Failed to sync mirror metadata for mirror {}", mirrorName, e);
-                }
+    void syncMirrorMetadata(String mirrorName) {
+        if (isLocalCoordinator(mirrorName)) {
+            ensureConnection(mirrorName);
+            try {
+                MirrorConfig mirrorConfig = MirrorConfig.fromProperties(
+                        metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName)));
+                syncTopicConfigurations(mirrorName, mirrorConfig);
+                syncConsumerGroupOffsets(mirrorName, mirrorConfig);
+                syncAccessControlLists(mirrorName, mirrorConfig);
+            } catch (Exception e) {
+                log.error("Failed to sync mirror metadata for mirror {}", mirrorName, e);
             }
-        });
+        }
     }
 
     private void syncTopicConfigurations(String mirrorName, MirrorConfig mirrorConfig) {
@@ -1360,10 +1417,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .collect(Collectors.toSet());
     }
 
+    /** Returns the set of topic names configured for the given mirror, excluding paused topics. */
     Set<String> getConfiguredTopics(String mirrorName) {
         return getConfiguredTopics(mirrorName, false);
     }
 
+    /** Returns the set of topic names configured for the given mirror, optionally including paused topics. */
     Set<String> getConfiguredTopics(String mirrorName, boolean includePaused) {
         return metadataCache.getAllTopics().stream()
                 .filter(topic -> {

--- a/core/src/main/java/kafka/server/mirror/MirrorStateSender.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorStateSender.java
@@ -30,10 +30,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * Queue-based sender for asynchronous inter-broker requests used by {@link MirrorMetadataManager}
  * to forward mirror state updates to other coordinator brokers in the destination cluster.
  */
-class InterBrokerSender extends InterBrokerSendThread {
+class MirrorStateSender extends InterBrokerSendThread {
     private final ConcurrentLinkedQueue<RequestAndCompletionHandler> queue = new ConcurrentLinkedQueue<>();
 
-    InterBrokerSender(String name, KafkaClient networkClient, int requestTimeoutMs, Time time) {
+    MirrorStateSender(String name, KafkaClient networkClient, int requestTimeoutMs, Time time) {
         super(name, networkClient, requestTimeoutMs, time);
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorUtils.java
@@ -16,7 +16,14 @@
  */
 package kafka.server.mirror;
 
+import kafka.server.KafkaConfig;
+
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.config.MirrorConfig;
+import org.apache.kafka.server.network.BrokerEndPoint;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,6 +38,17 @@ import static org.apache.kafka.controller.ConfigurationControlManager.REMOVED_TO
  */
 public final class MirrorUtils {
     private MirrorUtils() {}
+
+    public static MirrorBlockingSender createSender(BrokerEndPoint brokerEndpoint,
+                                                    MirrorConfig mirrorConfig,
+                                                    KafkaConfig brokerConfig,
+                                                    Metrics metrics,
+                                                    Time time,
+                                                    String clientId,
+                                                    LogContext logContext) {
+        return new MirrorBlockingSender(brokerEndpoint, mirrorConfig, brokerConfig,
+                metrics, time, brokerEndpoint.id(), clientId, logContext);
+    }
 
     public static Map<String, Set<Integer>> groupPartitionsByTopic(Set<TopicPartition> topicPartitions) {
         Map<String, Set<Integer>> topicToPartitions = new HashMap<>();

--- a/core/src/main/java/kafka/server/mirror/MirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorUtils.java
@@ -39,14 +39,14 @@ import static org.apache.kafka.controller.ConfigurationControlManager.REMOVED_TO
 public final class MirrorUtils {
     private MirrorUtils() {}
 
-    public static MirrorBlockingSender createSender(BrokerEndPoint brokerEndpoint,
-                                                    MirrorConfig mirrorConfig,
-                                                    KafkaConfig brokerConfig,
-                                                    Metrics metrics,
-                                                    Time time,
-                                                    String clientId,
-                                                    LogContext logContext) {
-        return new MirrorBlockingSender(brokerEndpoint, mirrorConfig, brokerConfig,
+    public static MirrorSourceSender createSender(BrokerEndPoint brokerEndpoint,
+                                                  MirrorConfig mirrorConfig,
+                                                  KafkaConfig brokerConfig,
+                                                  Metrics metrics,
+                                                  Time time,
+                                                  String clientId,
+                                                  LogContext logContext) {
+        return new MirrorSourceSender(brokerEndpoint, mirrorConfig, brokerConfig,
                 metrics, time, brokerEndpoint.id(), clientId, logContext);
     }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -205,30 +205,32 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
     fetchStates
   }
 
+  // collect idle fetchers under lock, shut down outside to avoid deadlock
   def shutdownIdleFetcherThreads(): Unit = {
-    lock synchronized {
+    val idleFetchers = lock synchronized {
       val keysToBeRemoved = new mutable.HashSet[BrokerIdAndFetcherId]
+      val fetchersToShutdown = new mutable.ArrayBuffer[AbstractFetcherThread]
       for ((key, fetcher) <- fetcherThreadMap) {
         if (fetcher.partitionCount <= 0) {
-          fetcher.shutdown()
+          fetchersToShutdown += fetcher
           keysToBeRemoved += key
         }
       }
       fetcherThreadMap --= keysToBeRemoved
+      fetchersToShutdown
     }
+    idleFetchers.foreach(_.shutdown())
   }
 
+  // initiate shutdown under lock, await termination outside to avoid deadlock
   def closeAllFetchers(): Unit = {
-    lock synchronized {
-      for ((_, fetcher) <- fetcherThreadMap) {
-        fetcher.initiateShutdown()
-      }
-
-      for ((_, fetcher) <- fetcherThreadMap) {
-        fetcher.shutdown()
-      }
+    val fetchers = lock synchronized {
+      val all = fetcherThreadMap.values.toSeq
+      all.foreach(_.initiateShutdown())
       fetcherThreadMap.clear()
+      all
     }
+    fetchers.foreach(_.shutdown())
   }
 }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -82,8 +82,6 @@ abstract class AbstractFetcherThread(name: String,
   val fetcherStats = new FetcherStats(metricId)
   val fetcherLagStats = new FetcherLagStats(metricId)
 
-  @volatile private var consecutiveFetchErrors: Int = 0
-
   /* callbacks to be defined in subclass */
 
   // process fetched data
@@ -261,7 +259,7 @@ abstract class AbstractFetcherThread(name: String,
    * This method updates the currentLeaderEpoch in the fetch state to match the source cluster's
    * current leader epoch, enabling proper epoch validation when fetching from the source.
    */
-  private def updateMirrorFetchEpoch(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
+  private def updateMirrorFetchEpoch(partitionToData: Map[TopicPartition, PartitionData]): Unit = inLock(partitionMapLock) {
     val newStates: Map[TopicPartition, PartitionFetchState] = partitionStates.partitionStateMap.asScala
       .map { case (topicPartition, currentFetchState) =>
         val updatedFetchState = partitionToData.get(topicPartition) match {
@@ -288,7 +286,8 @@ abstract class AbstractFetcherThread(name: String,
   /** Reassigns mirrored partitions to new fetcher threads after source leader change. */
   private def maybeCreateMirrorFetchers(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
     var newStates: Map[TopicPartition, InitialFetchState] = scala.collection.mutable.Map.empty[TopicPartition, InitialFetchState]
-      partitionStates.partitionStateMap.asScala
+      // snapshot to avoid ConcurrentModificationException from concurrent addFetcherForPartitions
+      partitionStates.partitionStateMap.asScala.toMap
       .foreach { case (topicPartition, currentFetchState) =>
         partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
@@ -412,7 +411,6 @@ abstract class AbstractFetcherThread(name: String,
     fetcherStats.requestRate.mark()
 
     if (responseData.nonEmpty) {
-      consecutiveFetchErrors = 0
       // process fetched data
       inLock(partitionMapLock) {
         responseData.foreachEntry { (topicPartition, partitionData) =>
@@ -570,15 +568,11 @@ abstract class AbstractFetcherThread(name: String,
     if (mirrorPartitionsWithNewLeader.nonEmpty)
       maybeCreateMirrorFetchers(mirrorPartitionsWithNewLeader)
     if (fetchException.exists(_.isInstanceOf[IOException]) && partitionsWithError.nonEmpty && mirrorName.nonEmpty) {
-      consecutiveFetchErrors += 1
-      if (consecutiveFetchErrors >= 3) {
-        consecutiveFetchErrors = 0
-        try {
-          handleMirrorFetchConnectionFailure(partitionsWithError.toSet)
-        } catch {
-          case t: Throwable =>
-            warn(s"Failed to re-resolve source leader for mirror $mirrorName", t)
-        }
+      try {
+        handleMirrorFetchConnectionFailure(partitionsWithError.toSet)
+      } catch {
+        case t: Throwable =>
+          warn(s"Failed to re-resolve source leader for mirror $mirrorName", t)
       }
     }
     if (partitionsWithError.nonEmpty) {
@@ -674,7 +668,7 @@ abstract class AbstractFetcherThread(name: String,
    *
    * @param fetchOffsets the partitions to update fetch offset and maybe mark truncation complete
    */
-  private def updateFetchOffsetAndMaybeMarkTruncationComplete(fetchOffsets: Map[TopicPartition, OffsetTruncationState]): Unit = {
+  private def updateFetchOffsetAndMaybeMarkTruncationComplete(fetchOffsets: Map[TopicPartition, OffsetTruncationState]): Unit = inLock(partitionMapLock) {
     val newStates: Map[TopicPartition, PartitionFetchState] = partitionStates.partitionStateMap.asScala
       .map { case (topicPartition, currentFetchState) =>
         val maybeTruncationComplete = fetchOffsets.get(topicPartition) match {

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -43,6 +43,7 @@ import org.apache.kafka.server.util.ShutdownableThread
 import org.apache.kafka.storage.internals.log.LogAppendInfo
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 
+import java.io.IOException
 import java.nio.ByteBuffer
 import java.util
 import java.util.Optional
@@ -393,12 +394,14 @@ abstract class AbstractFetcherThread(name: String,
     val mirrorPartitionsWithNewEpoch = mutable.Map.empty[TopicPartition, PartitionData]
     val mirrorPartitionsWithNewLeader = mutable.Map.empty[TopicPartition, PartitionData]
     var responseData: Map[TopicPartition, FetchData] = Map.empty
+    var fetchException: Option[Throwable] = None
 
     try {
       debug(s"!!! Sending fetch request $fetchRequest")
       responseData = leader.fetch(fetchRequest).asScala
     } catch {
       case t: Throwable =>
+        fetchException = Some(t)
         if (isRunning) {
           warn(s"Error in response for fetch request $fetchRequest", t)
           inLock(partitionMapLock) {
@@ -566,8 +569,7 @@ abstract class AbstractFetcherThread(name: String,
       updateMirrorFetchEpoch(mirrorPartitionsWithNewEpoch)
     if (mirrorPartitionsWithNewLeader.nonEmpty)
       maybeCreateMirrorFetchers(mirrorPartitionsWithNewLeader)
-    if (responseData.isEmpty && partitionsWithError.nonEmpty && mirrorName.nonEmpty) {
-      // Handle TCP connection failures (IOException)
+    if (fetchException.exists(_.isInstanceOf[IOException]) && partitionsWithError.nonEmpty && mirrorName.nonEmpty) {
       consecutiveFetchErrors += 1
       if (consecutiveFetchErrors >= 3) {
         consecutiveFetchErrors = 0

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -38,6 +38,7 @@ import org.apache.kafka.server.ReplicaState
 import org.apache.kafka.server.PartitionFetchState
 import org.apache.kafka.server.log.remote.storage.RetriableRemoteStorageException
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
+import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.util.ShutdownableThread
 import org.apache.kafka.storage.internals.log.LogAppendInfo
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
@@ -80,6 +81,8 @@ abstract class AbstractFetcherThread(name: String,
   val fetcherStats = new FetcherStats(metricId)
   val fetcherLagStats = new FetcherLagStats(metricId)
 
+  @volatile private var consecutiveFetchErrors: Int = 0
+
   /* callbacks to be defined in subclass */
 
   // process fetched data
@@ -110,6 +113,8 @@ abstract class AbstractFetcherThread(name: String,
   }
 
   protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {}
+
+  protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {}
 
   override def shutdown(): Unit = {
     initiateShutdown()
@@ -252,18 +257,8 @@ abstract class AbstractFetcherThread(name: String,
   }
 
   /**
-   * Updates the leader epoch in fetch state for mirrored partitions.
-   *
    * This method updates the currentLeaderEpoch in the fetch state to match the source cluster's
    * current leader epoch, enabling proper epoch validation when fetching from the source.
-   *
-   * For mirrored partitions, the currentLeaderEpoch in fetch state tracks the SOURCE cluster's
-   * leader epoch (not the destination cluster's epoch). This is critical because:
-   * 1. Fetch requests to source cluster include currentLeaderEpoch for validation
-   * 2. Source cluster validates this epoch matches its current leader
-   * 3. Mismatched epochs result in UNKNOWN_LEADER_EPOCH errors
-   *
-   * @param partitionToData Map of partitions to their current leader information from source cluster
    */
   private def updateMirrorFetchEpoch(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
     val newStates: Map[TopicPartition, PartitionFetchState] = partitionStates.partitionStateMap.asScala
@@ -289,42 +284,31 @@ abstract class AbstractFetcherThread(name: String,
     partitionStates.set(newStates.asJava)
   }
 
-  /**
-   * Reassigns mirrored partitions to new fetcher threads after source leader change.
-   *
-   * The detection mechanism compares the current source leader endpoint (from partitionToData)
-   * with the endpoint of the fetcher thread currently handling each partition. When they differ,
-   * the partition is reassigned by removing it from the current fetcher and adding it to a
-   * fetcher for the new leader.
-   *
-   * Leader identity is determined by comparing (host, port) rather than broker ID because:
-   * - Consumer-based fetchers may use ID -1 instead of the actual broker ID
-   * - Network addresses (host, port) uniquely identify broker endpoints
-   * - This comparison works correctly across different cluster configurations
-   *
-   * @param partitionToData Map of partitions to their current leader information from source cluster
-   */
+  /** Reassigns mirrored partitions to new fetcher threads after source leader change. */
   private def maybeCreateMirrorFetchers(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
     var newStates: Map[TopicPartition, InitialFetchState] = scala.collection.mutable.Map.empty[TopicPartition, InitialFetchState]
       partitionStates.partitionStateMap.asScala
       .foreach { case (topicPartition, currentFetchState) =>
         partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
-            val leaderNode = if (leader.lastSeenEndpoints().isEmpty) Optional.empty() else Optional.of(leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId()))
-            // if leader node change, we need to update it.
-            // Note: we can't compare the node id because it might be different from the original node id (ex: replied as consumer id -1)
+            val leaderNode = if (leader.lastSeenEndpoints().isEmpty) Optional.empty()
+              else Optional.of(leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId()))
+            // If leader node change, we need to update it.
+            // Note: we can't compare the node id because it might be different from the original node id (ex: replied as consumer id -1).
             if (leaderNode.isPresent && (!leaderNode.get().host.equals(leader.brokerEndPoint().host()) ||
               leaderNode.get().port != leader.brokerEndPoint().port)) {
-                val brokerEndpoint = new org.apache.kafka.server.network.BrokerEndPoint(leaderNode.get.id(), leaderNode.get.host, leaderNode.get.port)
+                val brokerEndpoint = new BrokerEndPoint(leaderNode.get.id(), leaderNode.get.host, leaderNode.get.port)
                 newStates += topicPartition -> InitialFetchState(currentFetchState.topicId().toScala, brokerEndpoint,
                   partitionData.currentLeader().leaderEpoch(), currentFetchState.fetchOffset(), mirrorName)
             }
           case _ =>
         }
       }
-    info("!!! createFetcherForReadOnly:" + newStates)
-    removeFetcherForPartitions(newStates.keySet)
-    addFetcherForPartitions(newStates)
+    if (newStates.nonEmpty) {
+      info("!!! maybeCreateMirrorFetchers: " + newStates)
+      removeFetcherForPartitions(newStates.keySet)
+      addFetcherForPartitions(newStates)
+    }
   }
 
   // Visible for testing
@@ -381,11 +365,7 @@ abstract class AbstractFetcherThread(name: String,
     new ResultWithPartitions(fetchOffsets, partitionsWithError.asJava)
   }
 
-  /**
-   * remove the partition if the partition state is NOT updated. Otherwise, keep the partition active.
-   *
-   * @return true if the epoch in this thread is updated. otherwise, false
-   */
+  /** Remove the partition if the partition state is NOT updated. Otherwise, keep the partition active. */
   private def onPartitionFenced(tp: TopicPartition, requestEpoch: Optional[Integer]): Boolean = inLock(partitionMapLock) {
     Option(partitionStates.stateValue(tp)).exists { currentFetchState =>
       val currentLeaderEpoch = currentFetchState.currentLeaderEpoch
@@ -429,6 +409,7 @@ abstract class AbstractFetcherThread(name: String,
     fetcherStats.requestRate.mark()
 
     if (responseData.nonEmpty) {
+      consecutiveFetchErrors = 0
       // process fetched data
       inLock(partitionMapLock) {
         responseData.foreachEntry { (topicPartition, partitionData) =>
@@ -585,14 +566,27 @@ abstract class AbstractFetcherThread(name: String,
       updateMirrorFetchEpoch(mirrorPartitionsWithNewEpoch)
     if (mirrorPartitionsWithNewLeader.nonEmpty)
       maybeCreateMirrorFetchers(mirrorPartitionsWithNewLeader)
+    if (responseData.isEmpty && partitionsWithError.nonEmpty && mirrorName.nonEmpty) {
+      // Handle TCP connection failures (IOException)
+      consecutiveFetchErrors += 1
+      if (consecutiveFetchErrors >= 3) {
+        consecutiveFetchErrors = 0
+        try {
+          handleMirrorFetchConnectionFailure(partitionsWithError.toSet)
+        } catch {
+          case t: Throwable =>
+            warn(s"Failed to re-resolve source leader for mirror $mirrorName", t)
+        }
+      }
+    }
     if (partitionsWithError.nonEmpty) {
       handlePartitionsWithErrors(partitionsWithError, "processFetchRequest")
     }
   }
 
   /**
-   * This is used to mark partitions for truncation in ReplicaAlterLogDirsThread after leader
-   * offsets are known.
+   * This is used to mark partitions for truncation in ReplicaAlterLogDirsThread
+   * after leader offsets are known.
    */
   def markPartitionsForTruncation(topicPartition: TopicPartition, truncationOffset: Long): Unit = {
     partitionMapLock.lockInterruptibly()
@@ -701,26 +695,7 @@ abstract class AbstractFetcherThread(name: String,
 
   /**
    * Called from ReplicaFetcherThread and ReplicaAlterLogDirsThread maybeTruncate for each topic
-   * partition. Returns truncation offset and whether this is the final offset to truncate to
-   *
-   * For each topic partition, the offset to truncate to is calculated based on leader's returned
-   * epoch and offset:
-   *  -- If the leader replied with undefined epoch offset, we must use the high watermark. This can
-   *  happen if 1) the leader is still using message format older than IBP_0_11_0; 2) the follower
-   *  requested leader epoch < the first leader epoch known to the leader.
-   *  -- If the leader replied with the valid offset but undefined leader epoch, we truncate to
-   *  leader's offset if it is lower than follower's Log End Offset. This may happen if the
-   *  leader is on the inter-broker protocol version < IBP_2_0_IV0
-   *  -- If the leader replied with leader epoch not known to the follower, we truncate to the
-   *  end offset of the largest epoch that is smaller than the epoch the leader replied with, and
-   *  send OffsetsForLeaderEpochRequest with that leader epoch. In a more rare case, where the
-   *  follower was not tracking epochs smaller than the epoch the leader replied with, we
-   *  truncate the leader's offset (and do not send any more leader epoch requests).
-   *  -- Otherwise, truncate to min(leader's offset, end offset on the follower for epoch that
-   *  leader replied with, follower's Log End Offset).
-   *
-   * @param tp                Topic partition
-   * @param leaderEpochOffset Epoch end offset received from the leader for this topic partition
+   * partition. Returns truncation offset and whether this is the final offset to truncate to.
    */
   private def getOffsetTruncationState(tp: TopicPartition,
                                        leaderEpochOffset: EpochEndOffset): OffsetTruncationState = inLock(partitionMapLock) {
@@ -775,9 +750,7 @@ abstract class AbstractFetcherThread(name: String,
     }
   }
 
-  /**
-   * Handle a partition whose offset is out of range and return a new fetch offset.
-   */
+  /** Handle a partition whose offset is out of range and return a new fetch offset. */
   private def fetchOffsetAndTruncate(topicPartition: TopicPartition, topicId: Option[Uuid], currentLeaderEpoch: Int, mirrorName: String): PartitionFetchState = {
     val replicaEndOffset = logEndOffset(topicPartition)
 
@@ -844,20 +817,7 @@ abstract class AbstractFetcherThread(name: String,
     }
   }
 
-  /**
-   * Handles the out of range error for the given topic partition.
-   *
-   * Returns true if
-   *    - the request succeeded or
-   *    - it was fenced and this thread hasn't received new epoch, which means we need not backoff and retry as the
-   *    partition is moved to failed state.
-   *
-   * Returns false if there was a retriable error.
-   *
-   * @param topicPartition topic partition
-   * @param fetchState current fetch state
-   * @param leaderEpochInRequest current leader epoch sent in the fetch request.
-   */
+  /** Handles the out of range error for the given topic partition. */
   private def handleOutOfRangeError(topicPartition: TopicPartition,
                                     fetchState: PartitionFetchState,
                                     leaderEpochInRequest: Optional[Integer]): Boolean = {
@@ -883,21 +843,7 @@ abstract class AbstractFetcherThread(name: String,
     }
   }
 
-  /**
-   * Handles the offset moved to tiered storage error for the given topic partition.
-   *
-   * Returns true if
-   *    - the request succeeded or
-   *    - it was fenced and this thread haven't received new epoch, which means we need not backoff and retry as the
-   *    partition is moved to failed state.
-   *
-   * Returns false if there was a retriable error.
-   *
-   * @param topicPartition topic partition
-   * @param fetchState current partition fetch state
-   * @param leaderEpochInRequest current leader epoch sent in the fetch request
-   * @param fetchPartitionData the fetch response data for this topic partition
-   */
+  /** Handles the offset moved to tiered storage error for the given topic partition. */
   private def handleOffsetsMovedToTieredStorage(topicPartition: TopicPartition,
                                                 fetchState: PartitionFetchState,
                                                 leaderEpochInRequest: Optional[Integer],

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -691,7 +691,26 @@ abstract class AbstractFetcherThread(name: String,
 
   /**
    * Called from ReplicaFetcherThread and ReplicaAlterLogDirsThread maybeTruncate for each topic
-   * partition. Returns truncation offset and whether this is the final offset to truncate to.
+   * partition. Returns truncation offset and whether this is the final offset to truncate to
+   *
+   * For each topic partition, the offset to truncate to is calculated based on leader's returned
+   * epoch and offset:
+   *  -- If the leader replied with undefined epoch offset, we must use the high watermark. This can
+   *  happen if 1) the leader is still using message format older than IBP_0_11_0; 2) the follower
+   *  requested leader epoch < the first leader epoch known to the leader.
+   *  -- If the leader replied with the valid offset but undefined leader epoch, we truncate to
+   *  leader's offset if it is lower than follower's Log End Offset. This may happen if the
+   *  leader is on the inter-broker protocol version < IBP_2_0_IV0
+   *  -- If the leader replied with leader epoch not known to the follower, we truncate to the
+   *  end offset of the largest epoch that is smaller than the epoch the leader replied with, and
+   *  send OffsetsForLeaderEpochRequest with that leader epoch. In a more rare case, where the
+   *  follower was not tracking epochs smaller than the epoch the leader replied with, we
+   *  truncate the leader's offset (and do not send any more leader epoch requests).
+   *  -- Otherwise, truncate to min(leader's offset, end offset on the follower for epoch that
+   *  leader replied with, follower's Log End Offset).
+   *
+   * @param tp                Topic partition
+   * @param leaderEpochOffset Epoch end offset received from the leader for this topic partition
    */
   private def getOffsetTruncationState(tp: TopicPartition,
                                        leaderEpochOffset: EpochEndOffset): OffsetTruncationState = inLock(partitionMapLock) {

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -183,7 +183,6 @@ class ControllerApis(
     val configChanges = new util.HashMap[ConfigResource, util.Map[String, Entry[AlterConfigOp.OpType, String]]]()
     val resource = new ConfigResource(ConfigResource.Type.forId(64), createMirrorRequest.data().mirrorName())
     createMirrorRequest.data().config.forEach { config =>
-      // TODO: currently assume always SET value
       altersByName.put(config.name, new util.AbstractMap.SimpleEntry[AlterConfigOp.OpType, String](
         AlterConfigOp.OpType.forId(0), config.value))
     }

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -49,7 +49,7 @@ import scala.collection.mutable
  * Key Differences from LocalLeaderEndPoint:
  * - Takes a BlockingSend parameter for network communication (enables testing with mocks)
  * - Supports both replica fetch (intra-cluster) and consumer fetch (cross-cluster) modes
- * - Can use cluster-specific credentials via MirrorBlockingSender for cross-cluster scenarios
+ * - Can use cluster-specific credentials via MirrorSourceSender for cross-cluster scenarios
  *
  * This is not thread-safe. Each instance is used by a single ReplicaFetcherThread or MirrorFetcherThread.
  *

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -61,7 +61,7 @@ import scala.collection.mutable
  * @param quota Replication quota for throttling fetches
  * @param metadataVersionSupplier Provides the current metadata version, determines fetch request version
  * @param brokerEpochSupplier Provides the current broker epoch for fencing
- * @param isCrossClusterMirror Whether we are doing cross-cluster mirroring
+ * @param isClusterMirror Whether we are doing cross-cluster mirroring
  */
 class RemoteLeaderEndPoint(logPrefix: String,
                            blockingSender: BlockingSend,
@@ -71,7 +71,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
                            quota: ReplicaQuota,
                            metadataVersionSupplier: () => MetadataVersion,
                            brokerEpochSupplier: () => Long,
-                           isCrossClusterMirror: Boolean = false) extends LeaderEndPoint with Logging {
+                           isClusterMirror: Boolean = false) extends LeaderEndPoint with Logging {
 
   this.logIdent = logPrefix
 
@@ -240,7 +240,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
         metadataVersion.fetchRequestVersion
       }
       // Use different fetch request types based on whether we're doing cross-cluster mirroring.
-      val requestBuilder = if (isCrossClusterMirror) {
+      val requestBuilder = if (isClusterMirror) {
         // Cross-cluster mirroring (MirrorFetcherThread): Use consumer fetch to skip ISR logic on source cluster.
         FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend).isolationLevel(IsolationLevel.READ_COMMITTED)
       } else {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2583,10 +2583,6 @@ class ReplicaManager(val config: KafkaConfig,
   /**
    * Creates and starts MirrorFetcherThreads for partitions that became read-only leaders.
    *
-   * This method is called during partition leadership changes when the local broker becomes
-   * a read-only leader for mirrored partitions. Read-only leaders replicate data from a
-   * source cluster partition rather than accepting local writes.
-   *
    * TODO: we should handle the error cases like in applyLocalFollowersDelta
    *
    * @param mirrorLeaders Map of partitions to their metadata for partitions that became
@@ -2631,7 +2627,7 @@ class ReplicaManager(val config: KafkaConfig,
             }
           } catch {
             case e: Exception =>
-              stateChangeLogger.error(s"Error setting up mirror fetcher for partition $tp", e)
+              stateChangeLogger.error(s"Error setting up mirror fetcher for partition $tp: ${e.getMessage}")
           }
         case _ =>
           stateChangeLogger.warn(s"Skipping mirror fetcher setup for offline partition $tp")
@@ -2639,8 +2635,13 @@ class ReplicaManager(val config: KafkaConfig,
     }
 
     if (partitionAndOffsets.nonEmpty) {
-      mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
-      stateChangeLogger.info(s"Started mirror fetchers for ${partitionAndOffsets.size} read-only leader partitions")
+      try {
+        mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
+        stateChangeLogger.info(s"Started mirror fetchers for ${partitionAndOffsets.size} read-only leader partitions")
+      } catch {
+        case e: Exception =>
+          stateChangeLogger.error(s"Error adding mirror fetcher for partitions ${partitionAndOffsets.keySet}", e)
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2587,16 +2587,6 @@ class ReplicaManager(val config: KafkaConfig,
    * a read-only leader for mirrored partitions. Read-only leaders replicate data from a
    * source cluster partition rather than accepting local writes.
    *
-   * The method performs the following steps:
-   * 1. Stops any existing fetchers for these partitions to ensure clean state
-   * 2. Sets the mirrorName on each partition for epoch metadata tracking
-   * 3. Queries the mirror metadata manager for the current source cluster leader endpoint
-   * 4. Creates InitialFetchState with source leader info and current log end offset
-   * 5. Starts new MirrorFetcherThreads that will fetch from the source cluster
-   *
-   * The fetch position is initialized to the local log end offset, allowing the mirror
-   * fetcher to continue from where it left off (or start from beginning if log is empty).
-   *
    * TODO: we should handle the error cases like in applyLocalFollowersDelta
    *
    * @param mirrorLeaders Map of partitions to their metadata for partitions that became
@@ -2613,7 +2603,7 @@ class ReplicaManager(val config: KafkaConfig,
         case HostedPartition.Online(partition) =>
           try {
             if (mirrorName != null && !mirrorName.isEmpty) {
-              // Get the source partition leader from mirror metadata manager
+              // Get the source partition leader
               val sourceLeader = mirrorMetadataManager.get.resolveSourceLeader(mirrorName, tp)
               val leaderEndpoint = new BrokerEndPoint(sourceLeader.id(), sourceLeader.host(), sourceLeader.port())
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -139,8 +139,9 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     val fetchSessionHandler = new FetchSessionHandler(logContext, srcEndpoint.id)
     val endpoint: LeaderEndPoint = new RemoteLeaderEndPoint(logContext.logPrefix, sender, fetchSessionHandler, brokerConfig,
       replicaManager, quotaManager, metadataVersionSupplier, brokerEpochSupplier, isClusterMirror = true)
+    val mirrorFetchBackoffMs = brokerConfig.mirrorConfig.fetchBackoffMs.toInt
     new MirrorFetcherThread(threadName, endpoint, brokerConfig, failedPartitions, replicaManager,
-      quotaManager, logContext.logPrefix, mirrorName)
+      quotaManager, logContext.logPrefix, mirrorName, mirrorFetchBackoffMs)
   }
 
   override def removeFetcherForPartitions(partitions: scala.collection.Set[TopicPartition]): scala.collection.Map[TopicPartition, PartitionFetchState] = {

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -67,7 +67,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
   }
 
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): MirrorFetcherThread = {
-    throw new UnsupportedOperationException("Use createMirrorFetcherThread for mirror fetchers")
+    throw new UnsupportedOperationException("Use createFetcherThread for mirror fetchers")
   }
 
   override def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
@@ -84,8 +84,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
 
     this.synchronized {
       def addAndStartFetcherThread(fetcherKey: FetcherThreadKey): MirrorFetcherThread = {
-        val fetcherThread = createMirrorFetcherThread(fetcherKey.fetcherId, fetcherKey.sourceBroker,
-          fetcherKey.mirrorName)
+        val fetcherThread = createFetcherThread(fetcherKey.fetcherId, fetcherKey.mirrorName, fetcherKey.sourceBroker)
         mirrorFetcherThreadMap.put(fetcherKey, fetcherThread)
         fetcherThread.start()
         fetcherThread
@@ -123,25 +122,24 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     }
   }
 
-  private def createMirrorFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint, mirrorName: String): MirrorFetcherThread = {
-    info(s"Creating mirror fetcher thread: fetcherId = $fetcherId, sourceBroker = $sourceBroker, mirrorName = $mirrorName")
-    val threadName = s"MirrorFetcherThread-${sourceBroker.id}-$fetcherId-$mirrorName"
-    val logContext = new LogContext(s"[MirrorFetcher fetcherId=$fetcherId, mirrorName=$mirrorName, " +
-      s"srcBroker=${sourceBroker.id}, dstBroker=${brokerConfig.brokerId}] ")
+  private def createFetcherThread(fetcherId: Int, mirrorName: String, srcEndpoint: BrokerEndPoint): MirrorFetcherThread = {
+    info(s"Creating mirror fetcher thread: fetcherId = $fetcherId, mirrorName = $mirrorName, srcEndpoint = $srcEndpoint")
+    val threadName = s"MirrorFetcherThread nodeId=${brokerConfig.brokerId} fetcherId=$fetcherId mirrorName=$mirrorName srcNodeId=${srcEndpoint.id}"
+    val logContext = new LogContext(s"[" + threadName + "] ")
 
-    val endpoint = if (mirrorName.nonEmpty) {
+    val sender = if (mirrorName.nonEmpty) {
       val mirrorProperties = metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName))
       info(s"Using mirror properties for $mirrorName: ${mirrorProperties.keySet()}")
       val mirrorConfig = MirrorConfig.fromProperties(mirrorProperties)
-      new MirrorBlockingSender(sourceBroker, mirrorConfig, brokerConfig, metrics, time, fetcherId,
-        s"broker-${brokerConfig.brokerId}-fetcher-$fetcherId-mirror-$mirrorName", logContext)
+      val clientId = s"fetcherId-$fetcherId-mirrorName-$mirrorName"
+      MirrorUtils.createSender(srcEndpoint, mirrorConfig, brokerConfig, metrics, time, clientId, logContext)
     } else {
       throw new IllegalArgumentException("Mirror name must be provided for remote fetchers")
     }
-    val fetchSessionHandler = new FetchSessionHandler(logContext, sourceBroker.id)
-    val leader: LeaderEndPoint = new RemoteLeaderEndPoint(logContext.logPrefix, endpoint, fetchSessionHandler, brokerConfig,
-      replicaManager, quotaManager, metadataVersionSupplier, brokerEpochSupplier, isCrossClusterMirror = true)
-    new MirrorFetcherThread(threadName, leader, brokerConfig, failedPartitions, replicaManager,
+    val fetchSessionHandler = new FetchSessionHandler(logContext, srcEndpoint.id)
+    val endpoint: LeaderEndPoint = new RemoteLeaderEndPoint(logContext.logPrefix, sender, fetchSessionHandler, brokerConfig,
+      replicaManager, quotaManager, metadataVersionSupplier, brokerEpochSupplier, isClusterMirror = true)
+    new MirrorFetcherThread(threadName, endpoint, brokerConfig, failedPartitions, replicaManager,
       quotaManager, logContext.logPrefix, mirrorName)
   }
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -43,10 +43,10 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
                            brokerEpochSupplier: () => Long,
                            metadataCache: MetadataCache)
     extends AbstractFetcherManager[MirrorFetcherThread](
-      name = "MirrorFetcherManager on broker " + brokerConfig.brokerId,
+      name = "MirrorFetcherManager id=" + brokerConfig.brokerId,
       clientId = "MirrorReplica",
       numFetchers = brokerConfig.mirrorConfig.numReplicaFetchers) {
-  private val mirrorFetcherThreadMap = new mutable.HashMap[FetcherThreadKey, MirrorFetcherThread]
+  private val mirrorFetcherThreadMap = new mutable.HashMap[FetcherKey, MirrorFetcherThread]
   private val lagInfo = new mutable.HashMap[PartitionLagKey, LagInfo]
 
   override def deadThreadCount: Int = lock synchronized { mirrorFetcherThreadMap.values.count(_.isThreadFailed) }
@@ -75,15 +75,15 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     // Ensures partitions with different cluster mirrors get separate fetcher threads.
     // This is crucial because different cluster mirrors may require different authentication credentials.
     val partitionsPerFetcher = partitionAndOffsets.groupBy { case (topicPartition, brokerAndInitialFetchOffset) =>
-      FetcherThreadKey(
-        brokerAndInitialFetchOffset.leader,
+      FetcherKey(
         getFetcherId(topicPartition),
+        brokerAndInitialFetchOffset.leader,
         brokerAndInitialFetchOffset.mirrorName
       )
     }
 
     this.synchronized {
-      def addAndStartFetcherThread(fetcherKey: FetcherThreadKey): MirrorFetcherThread = {
+      def addAndStartFetcherThread(fetcherKey: FetcherKey): MirrorFetcherThread = {
         val fetcherThread = createFetcherThread(fetcherKey.fetcherId, fetcherKey.mirrorName, fetcherKey.sourceBroker)
         mirrorFetcherThreadMap.put(fetcherKey, fetcherThread)
         fetcherThread.start()
@@ -124,8 +124,8 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
 
   private def createFetcherThread(fetcherId: Int, mirrorName: String, srcEndpoint: BrokerEndPoint): MirrorFetcherThread = {
     info(s"Creating mirror fetcher thread: fetcherId = $fetcherId, mirrorName = $mirrorName, srcEndpoint = $srcEndpoint")
-    val threadName = s"MirrorFetcherThread nodeId=${brokerConfig.brokerId} fetcherId=$fetcherId mirrorName=$mirrorName srcNodeId=${srcEndpoint.id}"
-    val logContext = new LogContext(s"[" + threadName + "] ")
+    val threadName = s"MirrorFetcherThread-$fetcherId-${srcEndpoint.id}-$mirrorName"
+    val logContext = new LogContext(s"[MirrorFetcher id=${brokerConfig.brokerId}, fetcherId=$fetcherId, leaderId=${srcEndpoint.id}, mirrorName=$mirrorName] ")
 
     val sender = if (mirrorName.nonEmpty) {
       val mirrorProperties = metadataCache.config(new ConfigResource(ConfigResource.Type.MIRROR, mirrorName))
@@ -163,30 +163,32 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     fetchStates
   }
 
+  // collect idle fetchers under lock, shut down outside to avoid deadlock
   override def shutdownIdleFetcherThreads(): Unit = {
-    this.synchronized {
-      val keysToBeRemoved = new mutable.HashSet[FetcherThreadKey]
+    val idleFetchers = this.synchronized {
+      val keysToBeRemoved = new mutable.HashSet[FetcherKey]
+      val fetchersToShutdown = new mutable.ArrayBuffer[MirrorFetcherThread]
       for ((key, fetcher) <- mirrorFetcherThreadMap) {
         if (fetcher.partitionCount <= 0) {
-          fetcher.shutdown()
+          fetchersToShutdown += fetcher
           keysToBeRemoved += key
         }
       }
       mirrorFetcherThreadMap --= keysToBeRemoved
+      fetchersToShutdown
     }
+    idleFetchers.foreach(_.shutdown())
   }
 
+  // initiate shutdown under lock, await termination outside to avoid deadlock
   override def closeAllFetchers(): Unit = {
-    this.synchronized {
-      for ((_, fetcher) <- mirrorFetcherThreadMap) {
-        fetcher.initiateShutdown()
-      }
-
-      for ((_, fetcher) <- mirrorFetcherThreadMap) {
-        fetcher.shutdown()
-      }
+    val fetchers = this.synchronized {
+      val all = mirrorFetcherThreadMap.values.toSeq
+      all.foreach(_.initiateShutdown())
       mirrorFetcherThreadMap.clear()
+      all
     }
+    fetchers.foreach(_.shutdown())
   }
 
   def updatePartitionLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long): Unit = {
@@ -221,10 +223,10 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
   }
 
   def shutdown(): Unit = {
-    info("Shutting down MirrorFetcherManager")
+    info("shutting down")
     closeAllFetchers()
     lagInfo.clear()
-    info("MirrorFetcherManager shutdown completed")
+    info("shutdown completed")
   }
 }
 
@@ -232,32 +234,20 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
  * Three-dimensional key for grouping mirror fetcher threads.
  *
  * Multiple partitions share the same fetcher thread when they have identical keys
- * (source broker, fetcher ID, and mirror name). This key determines thread reuse.
- *
- * Thread creation rules:
- * - Same source broker + same fetcher ID + same mirror -> REUSE thread
- * - Different source broker -> NEW thread (source leader changed)
- * - Different mirror name -> NEW thread (different auth credentials)
- * - Different fetcher ID -> NEW thread (load balancing)
+ * (fetcher ID, source broker, and mirror name). This key determines thread reuse.
  *
  * Example with num.mirror.replica.fetchers = 2:
  *
- * | Partition  | Source Leader | Fetcher ID | Mirror Name | Key                      | Thread Reused? |
- * |------------|---------------|------------|-------------|--------------------------|----------------|
- * | topic1-p0  | broker-1      | 0          | cluster-A   | (broker-1, 0, cluster-A) | New thread     |
- * | topic1-p1  | broker-1      | 1          | cluster-A   | (broker-1, 1, cluster-A) | New thread     |
- * | topic2-p0  | broker-1      | 0          | cluster-A   | (broker-1, 0, cluster-A) | Reuse          |
- * | topic2-p1  | broker-1      | 1          | cluster-A   | (broker-1, 1, cluster-A) | Reuse          |
- * | topic3-p0  | broker-2      | 0          | cluster-A   | (broker-2, 0, cluster-A) | New thread     |
- * | topic4-p0  | broker-1      | 0          | cluster-B   | (broker-1, 0, cluster-B) | New thread     |
- *
- * Result: 4 fetcher threads created, each serving multiple partitions:
- * - MirrorFetcherThread-0-1-cluster-A: [topic1-p0, topic2-p0] --- Same key
- * - MirrorFetcherThread-1-1-cluster-A: [topic1-p1, topic2-p1] --- Same key
- * - MirrorFetcherThread-0-2-cluster-A: [topic3-p0]
- * - MirrorFetcherThread-0-1-cluster-B: [topic4-p0]
+ * | Partition  | Fetcher ID | Source Leader | Mirror Name | Key                 | Thread Reused? |
+ * |------------|------------|---------------|-------------|---------------------|----------------|
+ * | topic1-p0  | 0          | broker-1      | A2B         | (0, broker-1, A2B)  | New thread     |
+ * | topic1-p1  | 1          | broker-1      | A2B         | (1, broker-1, A2B)  | New thread     |
+ * | topic2-p0  | 0          | broker-1      | A2B         | (0, broker-1, A2B)  | Reuse          |
+ * | topic2-p1  | 1          | broker-1      | A2B         | (1, broker-1, A2B)  | Reuse          |
+ * | topic3-p0  | 0          | broker-2      | A2B         | (0, broker-2, A2B)  | New thread     |
+ * | topic4-p0  | 0          | broker-1      | A2C         | (0, broker-1, A2C)  | New thread     |
  */
-case class FetcherThreadKey(sourceBroker: BrokerEndPoint, fetcherId: Int, mirrorName: String)
+case class FetcherKey(fetcherId: Int, sourceBroker: BrokerEndPoint, mirrorName: String)
 
 case class PartitionLagKey(mirrorName: String, topicPartition: TopicPartition)
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -63,9 +63,9 @@ class MirrorFetcherThread(name: String,
     replicaMgr.maybeCreateMirrorFetchers(mirrorName, partitionAndOffsets.keySet.asJava)
   }
 
-  // invalidates cached source leaders and re-resolves them on IOException from the source cluster
+  // invalidates cached source leaders for affected partitions on IOException from the source cluster
   override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
-    replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName))
+    replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName, mirrorPartitions.asJava))
     replicaMgr.maybeCreateMirrorFetchers(mirrorName, mirrorPartitions.asJava)
   }
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.storage.internals.log.{LogAppendInfo, LogStartOffsetIncr
 
 import java.util.Optional
 import scala.collection.{Map, Set}
+import scala.jdk.CollectionConverters._
 
 /**
  * Fetcher thread for cross-cluster mirroring. Unlike ReplicaFetcherThread, this rewrites
@@ -57,6 +58,11 @@ class MirrorFetcherThread(name: String,
 
   override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
+  }
+
+  override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
+    replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName))
+    replicaMgr.maybeCreateMirrorFetchers(mirrorName, mirrorPartitions.asJava)
   }
 
   // process fetched data

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -40,13 +40,14 @@ class MirrorFetcherThread(name: String,
                           replicaMgr: ReplicaManager,
                           quota: ReplicaQuota,
                           logPrefix: String,
-                          mirrorName: String)
+                          mirrorName: String,
+                          mirrorFetchBackoffMs: Int)
   extends AbstractFetcherThread(name = name,
                                 clientId = name,
                                 leader = leader,
                                 failedPartitions,
                                 fetchTierStateMachine = new TierStateMachine(leader, replicaMgr, false),
-                                fetchBackOffMs = brokerConfig.replicaFetchBackoffMs,
+                                fetchBackOffMs = mirrorFetchBackoffMs,
                                 isInterruptible = false,
                                 replicaMgr.brokerTopicStats,
                                 mirrorName) {
@@ -56,12 +57,13 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.removeFetcherForPartitions(partitions)
   }
 
-  // invalidate stale source leaders before creating new fetchers
+  // invalidates stale source leaders before creating new fetchers
   override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
     replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName))
     replicaMgr.maybeCreateMirrorFetchers(mirrorName, partitionAndOffsets.keySet.asJava)
   }
 
+  // invalidates cached source leaders and re-resolves them on IOException from the source cluster
   override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
     replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName))
     replicaMgr.maybeCreateMirrorFetchers(mirrorName, mirrorPartitions.asJava)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -57,9 +57,9 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.removeFetcherForPartitions(partitions)
   }
 
-  // invalidates stale source leaders before creating new fetchers
+  // invalidates stale source leaders for affected partitions before creating new fetchers
   override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
-    replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName))
+    replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName, partitionAndOffsets.keySet.asJava))
     replicaMgr.maybeCreateMirrorFetchers(mirrorName, partitionAndOffsets.keySet.asJava)
   }
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -56,8 +56,10 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.removeFetcherForPartitions(partitions)
   }
 
+  // invalidate stale source leaders before creating new fetchers
   override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
-    replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
+    replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName))
+    replicaMgr.maybeCreateMirrorFetchers(mirrorName, partitionAndOffsets.keySet.asJava)
   }
 
   override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {

--- a/core/src/main/scala/kafka/server/mirror/MirrorSourceSender.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorSourceSender.scala
@@ -38,14 +38,14 @@ import scala.jdk.CollectionConverters._
  * BlockingSend implementation for cross-cluster mirroring. Creates a dedicated NetworkClient
  * configured with cluster-specific security settings (SASL/SSL) from MirrorConfig.
  */
-class MirrorBlockingSender(sourceBroker: BrokerEndPoint,
-                           mirrorConfig: MirrorConfig,
-                           brokerConfig: KafkaConfig,
-                           metrics: Metrics,
-                           time: Time,
-                           fetcherId: Int,
-                           clientId: String,
-                           logContext: LogContext) extends BlockingSend {
+class MirrorSourceSender(sourceBroker: BrokerEndPoint,
+                         mirrorConfig: MirrorConfig,
+                         brokerConfig: KafkaConfig,
+                         metrics: Metrics,
+                         time: Time,
+                         fetcherId: Int,
+                         clientId: String,
+                         logContext: LogContext) extends BlockingSend {
   private val sourceNode = new Node(sourceBroker.id, sourceBroker.host, sourceBroker.port)
   private val socketTimeout: Int = brokerConfig.replicaSocketTimeoutMs
 
@@ -109,8 +109,6 @@ class MirrorBlockingSender(sourceBroker: BrokerEndPoint,
   }
 
   override def initiateClose(): Unit = {
-    // Note: For Cluster Mirror connections, we don't use dynamic reconfiguration
-    // so no need to remove reconfigurable components
     networkClient.initiateClose()
   }
 

--- a/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
@@ -95,6 +95,16 @@ public final class MirrorConfig {
             "The total number of mirror fetcher threads on each broker is this value multiplied by the number of distinct source brokers multiplied by the number of cluster mirrors. " +
             "Increasing this value can increase the degree of I/O parallelism for cross-cluster replication at the cost of higher CPU and memory utilization.";
 
+    public static final String FETCH_BACKOFF_MS_CONFIG = "mirror.fetch.backoff.ms";
+    public static final long FETCH_BACKOFF_MS_DEFAULT = 1000;
+    public static final String FETCH_BACKOFF_MS_DOC = "The amount of time to wait before retrying mirror fetch requests after a failure. " +
+            "This controls the backoff for mirror fetcher threads on connection errors or other exceptions from the source cluster.";
+
+    public static final String TRUNCATION_BACKOFF_MS_CONFIG = "mirror.truncation.backoff.ms";
+    public static final long TRUNCATION_BACKOFF_MS_DEFAULT = 5000L;
+    public static final String TRUNCATION_BACKOFF_MS_DOC = "The amount of time to wait before retrying truncation to last mirrored offsets " +
+            "when the source cluster is unavailable during the PREPARING state.";
+
     // Metadata refresh interval
     public static final String METADATA_REFRESH_INTERVAL_MS_CONFIG = "mirror.metadata.refresh.interval.ms";
     public static final long METADATA_REFRESH_INTERVAL_MS_DEFAULT = 30000L; // 30 seconds
@@ -315,6 +325,14 @@ public final class MirrorConfig {
         return config.getLong(METADATA_REFRESH_INTERVAL_MS_CONFIG);
     }
 
+    public long fetchBackoffMs() {
+        return config.getLong(FETCH_BACKOFF_MS_CONFIG);
+    }
+
+    public long truncationBackoffMs() {
+        return config.getLong(TRUNCATION_BACKOFF_MS_CONFIG);
+    }
+
     /**
      * Returns the underlying AbstractConfig instance.
      * This provides access to all configuration values including those processed by config providers.
@@ -362,7 +380,9 @@ public final class MirrorConfig {
             .define(MIRROR_TOPIC_NUM_PARTITIONS_CONFIG, INT, MIRROR_TOPIC_NUM_PARTITIONS_DEFAULT, atLeast(1), HIGH, MIRROR_TOPIC_NUM_PARTITIONS_DOC)
             .define(MIRROR_TOPIC_REPLICATION_FACTOR_CONFIG, SHORT, MIRROR_TOPIC_REPLICATION_FACTOR_DEFAULT, atLeast(1), HIGH, MIRROR_TOPIC_REPLICATION_FACTOR_DOC)
             .define(NUM_REPLICA_FETCHERS_CONFIG, INT, NUM_REPLICA_FETCHERS_DEFAULT, atLeast(1), HIGH, NUM_REPLICA_FETCHERS_DOC)
-            .define(METADATA_REFRESH_INTERVAL_MS_CONFIG, LONG, METADATA_REFRESH_INTERVAL_MS_DEFAULT, atLeast(0L), MEDIUM, METADATA_REFRESH_INTERVAL_MS_DOC);
+            .define(METADATA_REFRESH_INTERVAL_MS_CONFIG, LONG, METADATA_REFRESH_INTERVAL_MS_DEFAULT, atLeast(0L), MEDIUM, METADATA_REFRESH_INTERVAL_MS_DOC)
+            .define(FETCH_BACKOFF_MS_CONFIG, LONG, FETCH_BACKOFF_MS_DEFAULT, atLeast(0L), MEDIUM, FETCH_BACKOFF_MS_DOC)
+            .define(TRUNCATION_BACKOFF_MS_CONFIG, LONG, TRUNCATION_BACKOFF_MS_DEFAULT, atLeast(0L), MEDIUM, TRUNCATION_BACKOFF_MS_DOC);
     }
 
     /**

--- a/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
@@ -91,8 +91,8 @@ public final class MirrorConfig {
     // Fetcher configuration
     public static final String NUM_REPLICA_FETCHERS_CONFIG = "mirror.num.replica.fetchers";
     public static final int NUM_REPLICA_FETCHERS_DEFAULT = 1;
-    public static final String NUM_REPLICA_FETCHERS_DOC = "Number of fetcher threads used to replicate records from remote clusters via cluster mirror. " +
-            "The total number of remote fetchers on each broker is bound by <code>mirror.num.replica.fetchers</code> multiplied by the number of cluster mirrors. " +
+    public static final String NUM_REPLICA_FETCHERS_DOC = "Number of fetcher threads per source broker per cluster mirror used to replicate records from remote clusters. " +
+            "The total number of mirror fetcher threads on each broker is this value multiplied by the number of distinct source brokers multiplied by the number of cluster mirrors. " +
             "Increasing this value can increase the degree of I/O parallelism for cross-cluster replication at the cost of higher CPU and memory utilization.";
 
     // Metadata refresh interval


### PR DESCRIPTION
This patch does three main changes:

1. Creates a MirrorBlockingSender for each bootstrap address instead of picking one random server, and adds trySendRequest() which iterates through all senders sequentially until one responds.

2. Adds handleMirrorFetchConnectionFailure hook in AbstractFetcherThread to re-resolve source leaders after 3 consecutive fetch IOExceptions, with override in MirrorFetcherThread that invalidates cached source leaders and triggers fetcher reassignment.

3. Fixes a deadlock in AbstractFetcherManager where shutdownIdleFetcherThreads and closeAllFetchers held the manager lock while awaiting thread shutdown, causing a deadlock when the fetcher thread concurrently tried to acquire the same lock from maybeCreateMirrorFetchers.
