### PR TITLE
fix deadlock in mirrorFetcherManager

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -39,6 +39,7 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
   private var numFetchersPerBroker = numFetchers
   val failedPartitions = new FailedPartitions
   this.logIdent = "[" + name + "] "
+  @volatile var isClosed = false
 
   private val tags = Map("clientId" -> clientId).asJava
 
@@ -130,7 +131,14 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
   def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): T
 
   def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
+    if (isClosed) {
+      return
+    }
+
     lock synchronized {
+      if (isClosed) {
+        return
+      }
       val partitionsPerFetcher = partitionAndOffsets.groupBy { case (topicPartition, brokerAndInitialFetchOffset) =>
         BrokerAndFetcherId(brokerAndInitialFetchOffset.leader, getFetcherId(topicPartition))
       }
@@ -205,30 +213,33 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
     fetchStates
   }
 
+  // collect idle fetchers under lock, shut down outside to avoid deadlock
   def shutdownIdleFetcherThreads(): Unit = {
-    lock synchronized {
+    val idleFetchers = lock synchronized {
       val keysToBeRemoved = new mutable.HashSet[BrokerIdAndFetcherId]
+      val fetchersToShutdown = new mutable.ArrayBuffer[AbstractFetcherThread]
       for ((key, fetcher) <- fetcherThreadMap) {
         if (fetcher.partitionCount <= 0) {
-          fetcher.shutdown()
+          fetchersToShutdown += fetcher
           keysToBeRemoved += key
         }
       }
       fetcherThreadMap --= keysToBeRemoved
+      fetchersToShutdown
     }
+    idleFetchers.foreach(_.shutdown())
   }
 
+  // initiate shutdown under lock, await termination outside to avoid deadlock
   def closeAllFetchers(): Unit = {
-    lock synchronized {
-      for ((_, fetcher) <- fetcherThreadMap) {
-        fetcher.initiateShutdown()
-      }
-
-      for ((_, fetcher) <- fetcherThreadMap) {
-        fetcher.shutdown()
-      }
+    val fetchers = lock synchronized {
+      isClosed = true
+      val all = fetcherThreadMap.values.toSeq
+      all.foreach(_.initiateShutdown())
       fetcherThreadMap.clear()
+      all
     }
+    fetchers.foreach(_.shutdown())
   }
 }
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -71,6 +71,10 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
   }
 
   override def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
+    if (isClosed) {
+      return
+    }
+
     logger.debug("Adding fetcher for partitions, existing fetchers: {}", mirrorFetcherThreadMap.keys)
     // Ensures partitions with different cluster mirrors get separate fetcher threads.
     // This is crucial because different cluster mirrors may require different authentication credentials.
@@ -83,6 +87,10 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     }
 
     this.synchronized {
+      if (isClosed) {
+        return
+      }
+
       def addAndStartFetcherThread(fetcherKey: FetcherKey): MirrorFetcherThread = {
         val fetcherThread = createFetcherThread(fetcherKey.fetcherId, fetcherKey.mirrorName, fetcherKey.sourceBroker)
         mirrorFetcherThreadMap.put(fetcherKey, fetcherThread)
@@ -163,30 +171,32 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     fetchStates
   }
 
+  // collect idle fetchers under lock, shut down outside to avoid deadlock
   override def shutdownIdleFetcherThreads(): Unit = {
-    this.synchronized {
+    val idleFetchers = this.synchronized {
       val keysToBeRemoved = new mutable.HashSet[FetcherKey]
+      val fetchersToShutdown = new mutable.ArrayBuffer[MirrorFetcherThread]
       for ((key, fetcher) <- mirrorFetcherThreadMap) {
         if (fetcher.partitionCount <= 0) {
-          fetcher.shutdown()
+          fetchersToShutdown += fetcher
           keysToBeRemoved += key
         }
       }
       mirrorFetcherThreadMap --= keysToBeRemoved
+      fetchersToShutdown
     }
+    idleFetchers.foreach(_.shutdown())
   }
 
   override def closeAllFetchers(): Unit = {
-    this.synchronized {
-      for ((_, fetcher) <- mirrorFetcherThreadMap) {
-        fetcher.initiateShutdown()
-      }
-
-      for ((_, fetcher) <- mirrorFetcherThreadMap) {
-        fetcher.shutdown()
-      }
+    val fetchers = this.synchronized {
+      isClosed = true
+      val all = mirrorFetcherThreadMap.values.toSeq
+      all.foreach(_.initiateShutdown())
       mirrorFetcherThreadMap.clear()
+      all
     }
+    fetchers.foreach(_.shutdown())
   }
 
   def updatePartitionLag(mirrorName: String, topicPartition: TopicPartition, sourceOffset: Long, destinationOffset: Long): Unit = {


### PR DESCRIPTION
Fixes a deadlock in AbstractFetcherManager where shutdownIdleFetcherThreads and closeAllFetchers held the manager lock while awaiting thread shutdown, causing a deadlock when the fetcher thread concurrently tried to acquire the same lock from maybeCreateMirrorFetchers.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
