### PR TITLE
Fix concurrent issue in MirrorFetcherManager

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -727,9 +727,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    /** Resolves source partition leader from cache, refreshing metadata synchronously if needed. */
+    /** Updates cached source leader for a specific partition. */
+    public void updateSourceLeader(String mirrorName, TopicPartition tp, Node leader) {
+        sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>()).put(tp, leader);
+    }
+
+    /** Resolves source partition leader from cache, falling back to bootstrap server if not cached. */
     public Node resolveSourceLeader(String mirrorName, TopicPartition tp) {
-        // Try to use cached metadata.
         var partitionLeaders = sourceLeaders.get(mirrorName);
         if (partitionLeaders != null) {
             Node leader = partitionLeaders.get(tp);
@@ -738,30 +742,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
         }
 
-        // No cached metadata. Refresh synchronously before creating fetcher threads.
-        log.info("No cached metadata for mirror {} partition {}. Refreshing metadata from remote cluster.", mirrorName, tp);
+        // No cached metadata. Fall back to the bootstrap server instead of blocking on a
+        // synchronous metadata refresh, which can stall the metadata event queue thread when
+        // the source broker is down. The periodic metadata refresh will populate the cache,
+        // and the fetcher thread will handle leader rediscovery via maybeCreateMirrorFetchers.
         ensureConnection(mirrorName);
-        try {
-            syncTopicMetadata(mirrorName);
-        } catch (Exception e) {
-            log.error("Failed to refresh topic metadata for mirror {}", mirrorName, e);
-        }
-
-        // Try to resolve source leader broker.
-        partitionLeaders = sourceLeaders.get(mirrorName);
-        if (partitionLeaders != null) {
-            Node leader = partitionLeaders.get(tp);
-            if (leader != null) {
-                log.debug("Successfully fetched leader for {} from mirror {}: broker {}", tp, mirrorName, leader.id());
-                return leader;
-            }
-        }
-
-        // Metadata refresh failed or partition not found. Fall back to first bootstrap server.
-        // This should rarely happen and indicates a configuration or connectivity issue.
-        log.warn("Unable to resolve source leader for mirror {} partition {} after refresh. Falling back to bootstrap server.", mirrorName, tp);
         List<MirrorSourceSender> senders = sourceSenders.get(mirrorName);
         if (senders != null && !senders.isEmpty()) {
+            log.info("No cached leader for mirror {} partition {}. Using bootstrap server as initial target.", mirrorName, tp);
             BrokerEndPoint ep = senders.get(0).brokerEndPoint();
             return new Node(ep.id(), ep.host(), ep.port());
         }

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -287,22 +287,24 @@ abstract class AbstractFetcherThread(name: String,
   private def maybeCreateMirrorFetchers(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
     var newStates: Map[TopicPartition, InitialFetchState] = scala.collection.mutable.Map.empty[TopicPartition, InitialFetchState]
       // snapshot under lock to avoid ConcurrentModificationException from concurrent addFetcherForPartitions
-      inLock(partitionMapLock) { partitionStates.partitionStateMap.asScala.toMap }
-      .foreach { case (topicPartition, currentFetchState) =>
-        partitionToData.get(topicPartition) match {
-          case Some(partitionData) =>
-            val leaderNode = if (leader.lastSeenEndpoints().isEmpty) Optional.empty()
-              else Optional.of(leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId()))
-            // If leader node change, we need to update it.
-            // Note: we can't compare the node id because it might be different from the original node id (ex: replied as consumer id -1).
-            if (leaderNode.isPresent && (!leaderNode.get().host.equals(leader.brokerEndPoint().host()) ||
-              leaderNode.get().port != leader.brokerEndPoint().port)) {
-                val brokerEndpoint = new BrokerEndPoint(leaderNode.get.id(), leaderNode.get.host, leaderNode.get.port)
-                newStates += topicPartition -> InitialFetchState(currentFetchState.topicId().toScala, brokerEndpoint,
-                  partitionData.currentLeader().leaderEpoch(), currentFetchState.fetchOffset(), mirrorName)
+      inLock(partitionMapLock) {
+        partitionStates.partitionStateMap.asScala
+          .foreach { case (topicPartition, currentFetchState) =>
+            partitionToData.get(topicPartition) match {
+              case Some(partitionData) =>
+                val leaderNode = if (leader.lastSeenEndpoints().isEmpty) Optional.empty()
+                else Optional.of(leader.lastSeenEndpoints().get(partitionData.currentLeader().leaderId()))
+                // If leader node change, we need to update it.
+                // Note: we can't compare the node id because it might be different from the original node id (ex: replied as consumer id -1).
+                if (leaderNode.isPresent && (!leaderNode.get().host.equals(leader.brokerEndPoint().host()) ||
+                  leaderNode.get().port != leader.brokerEndPoint().port)) {
+                  val brokerEndpoint = new BrokerEndPoint(leaderNode.get.id(), leaderNode.get.host, leaderNode.get.port)
+                  newStates += topicPartition -> InitialFetchState(currentFetchState.topicId().toScala, brokerEndpoint,
+                    partitionData.currentLeader().leaderEpoch(), currentFetchState.fetchOffset(), mirrorName)
+                }
+              case _ =>
             }
-          case _ =>
-        }
+          }
       }
     if (newStates.nonEmpty) {
       info("!!! maybeCreateMirrorFetchers: " + newStates)

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -286,8 +286,8 @@ abstract class AbstractFetcherThread(name: String,
   /** Reassigns mirrored partitions to new fetcher threads after source leader change. */
   private def maybeCreateMirrorFetchers(partitionToData: Map[TopicPartition, PartitionData]): Unit = {
     var newStates: Map[TopicPartition, InitialFetchState] = scala.collection.mutable.Map.empty[TopicPartition, InitialFetchState]
-      // snapshot to avoid ConcurrentModificationException from concurrent addFetcherForPartitions
-      partitionStates.partitionStateMap.asScala.toMap
+      // snapshot under lock to avoid ConcurrentModificationException from concurrent addFetcherForPartitions
+      inLock(partitionMapLock) { partitionStates.partitionStateMap.asScala.toMap }
       .foreach { case (topicPartition, currentFetchState) =>
         partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
@@ -569,9 +569,9 @@ abstract class AbstractFetcherThread(name: String,
       truncateOnFetchResponse(divergingEndOffsets)
     if (mirrorPartitionsWithNewEpoch.nonEmpty)
       updateMirrorFetchEpoch(mirrorPartitionsWithNewEpoch)
-    if (mirrorPartitionsWithNewLeader.nonEmpty)
+    if (mirrorPartitionsWithNewLeader.nonEmpty && isRunning)
       maybeCreateMirrorFetchers(mirrorPartitionsWithNewLeader)
-    if (fetchException.exists(_.isInstanceOf[IOException]) && partitionsWithError.nonEmpty && mirrorName.nonEmpty) {
+    if (fetchException.exists(_.isInstanceOf[IOException]) && partitionsWithError.nonEmpty && mirrorName.nonEmpty && isRunning) {
       try {
         handleMirrorFetchConnectionFailure(partitionsWithError.toSet)
       } catch {

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -100,9 +100,6 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
 
       for ((remoteFetcherKey, initialFetchOffsets) <- partitionsPerFetcher) {
         val fetcherThread = mirrorFetcherThreadMap.get(remoteFetcherKey) match {
-          case Some(currentFetcherThread) if currentFetcherThread.isThreadFailed =>
-            logger.warn("Recreating failed mirror fetcher for {}", remoteFetcherKey)
-            addAndStartFetcherThread(remoteFetcherKey)
           case Some(currentFetcherThread) if currentFetcherThread.leader.brokerEndPoint() == remoteFetcherKey.sourceBroker =>
             // reuse the fetcher thread
             logger.debug("Reusing mirror fetcher for {}", remoteFetcherKey)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -100,6 +100,9 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
 
       for ((remoteFetcherKey, initialFetchOffsets) <- partitionsPerFetcher) {
         val fetcherThread = mirrorFetcherThreadMap.get(remoteFetcherKey) match {
+          case Some(currentFetcherThread) if currentFetcherThread.isThreadFailed =>
+            logger.warn("Recreating failed mirror fetcher for {}", remoteFetcherKey)
+            addAndStartFetcherThread(remoteFetcherKey)
           case Some(currentFetcherThread) if currentFetcherThread.leader.brokerEndPoint() == remoteFetcherKey.sourceBroker =>
             // reuse the fetcher thread
             logger.debug("Reusing mirror fetcher for {}", remoteFetcherKey)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -17,7 +17,7 @@
 package kafka.server.mirror
 
 import kafka.server._
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.requests.FetchResponse
 import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState}
@@ -57,13 +57,18 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.removeFetcherForPartitions(partitions)
   }
 
-  // invalidates stale source leaders for affected partitions before creating new fetchers
+  // uses leader info from fetch response to update cache and create new fetchers directly
   override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
-    replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName, partitionAndOffsets.keySet.asJava))
-    replicaMgr.maybeCreateMirrorFetchers(mirrorName, partitionAndOffsets.keySet.asJava)
+    replicaMgr.mirrorMetadataManager.foreach { mmm =>
+      partitionAndOffsets.foreach { case (tp, state) =>
+        mmm.updateSourceLeader(mirrorName, tp,
+          new Node(state.leader.id(), state.leader.host(), state.leader.port()))
+      }
+    }
+    replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
-  // invalidates cached source leaders for affected partitions on IOException from the source cluster
+  // invalidates cached source leaders for affected partitions when source connection is broken
   override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
     replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName, mirrorPartitions.asJava))
     replicaMgr.maybeCreateMirrorFetchers(mirrorName, mirrorPartitions.asJava)


### PR DESCRIPTION
As I suspected, there was another concurrency bug:

    In AbstractFetcherThread.maybeCreateMirrorFetchers, the code iterates partitionStates.partitionStateMap without holding partitionMapLock. The .toMap call iterates the underlying LinkedHashMap which can be modified concurrently by addPartitions/removePartitions from other threads. This ConcurrentModificationException is an unhandled exception that kills the fetcher thread.

    In MirrorFetcherManager.addFetcherForPartitions, when a thread exists in the map with a matching key, it's reused without checking if the thread is still alive. After Bug 1 kills the thread, subsequent addFetcherForPartitions calls add partitions to the dead thread. Those partitions are never fetched.

Fixing that brought in another bug present:

When the source broker is down, the metadata event queue thread is blocked by the following operation (connection timeout is typically 30s). This prevents mirrorMetadataManager.onMetadataUpdate from ever being reached.

BrokerMetadataPublisher.onMetadataUpdate
  -> updateCoordinator for __mirror_state
  -> mirrorCoordinator.onElection 
  -> loadMirrorMetadata
  -> applyLoadedPartitionStates 
  -> handleStateTransition(MIRRORING)
  -> replicaManager.maybeCreateMirrorFetchers
  -> resolveSourceLeader
  -> syncTopicMetadata
  -> trySendRequest
  -> sender.sendRequest

Fix changes:

    Remove synchronous syncTopicMetadata call that blocks the metadata event queue thread when source broker is down. Falls back to bootstrap server immediately. The periodic metadata refresh populates the cache.

    Update the source leader cache with the correct leader info from the fetch response in AbstractFetcherThread.addFetcherForPartitions, instead of invalidating and re-resolving via maybeCreateMirrorFetchers which causes infinite thrashing.

    Add isRunning guards on maybeCreateMirrorFetchers and handleMirrorFetchConnectionFailure to prevent shutting-down threads from invalidating the source leader cache and creating new fetchers when their in-flight requests are cancelled.

Hopefully we are good for now. Let me know if you have any comment or test result to share, otherwise I guess we can merge and move on.


==
Rebase with the latest cl3 branch based on #95. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
