### PR TITLE
Protocol and CLI refinements

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AddTopicsToMirrorOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AddTopicsToMirrorOptions.java
@@ -17,10 +17,10 @@
 
 package org.apache.kafka.clients.admin;
 
-import java.util.Map;
+import java.util.Set;
 
 /**
- * Options for {@link Admin#addTopicsToMirror(Map, AddTopicsToMirrorOptions)}.
+ * Options for {@link Admin#addTopicsToMirror(String, Set, AddTopicsToMirrorOptions)}.
  */
 public class AddTopicsToMirrorOptions extends AbstractOptions<AddTopicsToMirrorOptions> {
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AddTopicsToMirrorResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AddTopicsToMirrorResult.java
@@ -19,10 +19,10 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.KafkaFuture;
 
-import java.util.Map;
+import java.util.Set;
 
 /**
- * The result of the {@link Admin#addTopicsToMirror(Map, AddTopicsToMirrorOptions)} call.
+ * The result of the {@link Admin#addTopicsToMirror(String, Set, AddTopicsToMirrorOptions)} call.
  *
  * The API of this class is evolving, see {@link Admin} for details.
  */

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1683,12 +1683,12 @@ public interface Admin extends AutoCloseable {
      * replicating data from the source cluster. This operation marks the specified topics with the
      * mirror name, preventing local writes and enabling the MirrorFetcherThread to begin replication.
      *
-     * @param topicToMirrorName Map of topic names to mirror names, allowing multiple topics to be
-     *                          added to potentially different mirrors in a single operation
+     * @param mirrorName The mirror name to add the topics to
+     * @param topics Set of topic names to add to mirroring
      * @param options Options for the add topics to mirror operation
      * @return The AddTopicsToMirrorResult containing futures for each topic addition
      */
-    AddTopicsToMirrorResult addTopicsToMirror(Map<String, String> topicToMirrorName, AddTopicsToMirrorOptions options);
+    AddTopicsToMirrorResult addTopicsToMirror(String mirrorName, Set<String> topics, AddTopicsToMirrorOptions options);
 
     /**
      * Remove topics from cluster mirror, making them writable on the destination cluster.
@@ -1698,11 +1698,12 @@ public interface Admin extends AutoCloseable {
      * the mirror clears the mirrorName field from partition metadata, which allows producers to write
      * to these partitions.
      *
+     * @param mirrorName The mirror name to remove the topics from
      * @param topics Set of topic names to remove from mirroring
      * @param options Options for the remove topics from mirror operation
      * @return The RemoveTopicsFromMirrorResult containing futures for each topic removal
      */
-    RemoveTopicsFromMirrorResult removeTopicsFromMirror(Set<String> topics, RemoveTopicsFromMirrorOptions options);
+    RemoveTopicsFromMirrorResult removeTopicsFromMirror(String mirrorName, Set<String> topics, RemoveTopicsFromMirrorOptions options);
 
     /**
      * Pause mirroring for the specified topics.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1712,15 +1712,12 @@ public interface Admin extends AutoCloseable {
      * source cluster. The mirror fetcher threads are removed for these partitions, preserving the
      * current replicated state. Mirroring can be resumed later with {@link #resumeMirrorTopics}.
      *
+     * @param mirrorName The mirror name to pause the topics for
      * @param topics Set of topic names to pause mirroring for
      * @param options Options for the pause mirror topics operation
      * @return The PauseMirrorTopicsResult containing futures for each topic
      */
-    PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics, PauseMirrorTopicsOptions options);
-
-    default PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics) {
-        return pauseMirrorTopics(topics, new PauseMirrorTopicsOptions());
-    }
+    PauseMirrorTopicsResult pauseMirrorTopics(String mirrorName, Set<String> topics, PauseMirrorTopicsOptions options);
 
     /**
      * Resume mirroring for previously paused topics.
@@ -1729,15 +1726,12 @@ public interface Admin extends AutoCloseable {
      * left off. New mirror fetcher threads are created and the partitions transition back to the
      * MIRRORING state.
      *
+     * @param mirrorName The mirror name to resume the topics for
      * @param topics Set of topic names to resume mirroring for
      * @param options Options for the resume mirror topics operation
      * @return The ResumeMirrorTopicsResult containing futures for each topic
      */
-    ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics, ResumeMirrorTopicsOptions options);
-
-    default ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics) {
-        return resumeMirrorTopics(topics, new ResumeMirrorTopicsOptions());
-    }
+    ResumeMirrorTopicsResult resumeMirrorTopics(String mirrorName, Set<String> topics, ResumeMirrorTopicsOptions options);
 
     /**
      * List the cluster mirrors available in the cluster with the default options.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -281,8 +281,8 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
-    public RemoveTopicsFromMirrorResult removeTopicsFromMirror(Set<String> topics, RemoveTopicsFromMirrorOptions options) {
-        return delegate.removeTopicsFromMirror(topics, options);
+    public RemoveTopicsFromMirrorResult removeTopicsFromMirror(String mirrorName, Set<String> topics, RemoveTopicsFromMirrorOptions options) {
+        return delegate.removeTopicsFromMirror(mirrorName, topics, options);
     }
 
     @Override
@@ -296,8 +296,8 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
-    public AddTopicsToMirrorResult addTopicsToMirror(Map<String, String> topicToMirrorName, AddTopicsToMirrorOptions options) {
-        return delegate.addTopicsToMirror(topicToMirrorName, options);
+    public AddTopicsToMirrorResult addTopicsToMirror(String mirrorName, Set<String> topics, AddTopicsToMirrorOptions options) {
+        return delegate.addTopicsToMirror(mirrorName, topics, options);
     }
     public DescribeMirrorsResult describeMirrors(Collection<String> mirrorNames, DescribeMirrorsOptions options) {
         return delegate.describeMirrors(mirrorNames, options);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -286,13 +286,13 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
-    public PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics, PauseMirrorTopicsOptions options) {
-        return delegate.pauseMirrorTopics(topics, options);
+    public PauseMirrorTopicsResult pauseMirrorTopics(String mirrorName, Set<String> topics, PauseMirrorTopicsOptions options) {
+        return delegate.pauseMirrorTopics(mirrorName, topics, options);
     }
 
     @Override
-    public ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics, ResumeMirrorTopicsOptions options) {
-        return delegate.resumeMirrorTopics(topics, options);
+    public ResumeMirrorTopicsResult resumeMirrorTopics(String mirrorName, Set<String> topics, ResumeMirrorTopicsOptions options) {
+        return delegate.resumeMirrorTopics(mirrorName, topics, options);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4955,7 +4955,7 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics, PauseMirrorTopicsOptions options) {
+    public PauseMirrorTopicsResult pauseMirrorTopics(String mirrorName, Set<String> topics, PauseMirrorTopicsOptions options) {
         final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
         final Call call = new Call("pauseMirrorTopics", calcDeadlineMs(now, options.timeoutMs()),
@@ -4963,7 +4963,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             PauseMirrorTopicsRequest.Builder createRequest(int timeoutMs) {
-                return new PauseMirrorTopicsRequest.Builder(topics);
+                return new PauseMirrorTopicsRequest.Builder(mirrorName, topics);
             }
 
             @Override
@@ -4994,7 +4994,7 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics, ResumeMirrorTopicsOptions options) {
+    public ResumeMirrorTopicsResult resumeMirrorTopics(String mirrorName, Set<String> topics, ResumeMirrorTopicsOptions options) {
         final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
         final Call call = new Call("resumeMirrorTopics", calcDeadlineMs(now, options.timeoutMs()),
@@ -5002,7 +5002,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             ResumeMirrorTopicsRequest.Builder createRequest(int timeoutMs) {
-                return new ResumeMirrorTopicsRequest.Builder(topics);
+                return new ResumeMirrorTopicsRequest.Builder(mirrorName, topics);
             }
 
             @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4877,7 +4877,7 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public AddTopicsToMirrorResult addTopicsToMirror(Map<String, String> topicToMirrorName, AddTopicsToMirrorOptions options) {
+    public AddTopicsToMirrorResult addTopicsToMirror(String mirrorName, Set<String> topics, AddTopicsToMirrorOptions options) {
         final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
         final Call call = new Call("addTopicsToMirror", calcDeadlineMs(now, options.timeoutMs()),
@@ -4885,7 +4885,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             AddTopicsToMirrorRequest.Builder createRequest(int timeoutMs) {
-                return new AddTopicsToMirrorRequest.Builder(topicToMirrorName);
+                return new AddTopicsToMirrorRequest.Builder(mirrorName, topics);
             }
 
             @Override
@@ -4900,7 +4900,7 @@ public class KafkaAdminClient extends AdminClient {
                     case REQUEST_TIMED_OUT:
                         throw error.exception();
                     default:
-                        log.error("Mirror topics addition failed: ", topicToMirrorName.keySet());
+                        log.error("Mirror topics addition failed: {}", topics);
                         future.completeExceptionally(error.exception());
                         break;
                 }
@@ -4916,7 +4916,7 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public RemoveTopicsFromMirrorResult removeTopicsFromMirror(Set<String> topics, RemoveTopicsFromMirrorOptions options) {
+    public RemoveTopicsFromMirrorResult removeTopicsFromMirror(String mirrorName, Set<String> topics, RemoveTopicsFromMirrorOptions options) {
         final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
         final Call call = new Call("removeTopicsFromMirror", calcDeadlineMs(now, options.timeoutMs()),
@@ -4924,7 +4924,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             RemoveTopicsFromMirrorRequest.Builder createRequest(int timeoutMs) {
-                return new RemoveTopicsFromMirrorRequest.Builder(topics);
+                return new RemoveTopicsFromMirrorRequest.Builder(mirrorName, topics);
             }
 
             @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/RemoveTopicsFromMirrorResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RemoveTopicsFromMirrorResult.java
@@ -29,7 +29,7 @@ import java.util.Set;
 public class RemoveTopicsFromMirrorResult {
     private final KafkaFuture<Void> future;
 
-    RemoveTopicsFromMirrorResult(final KafkaFuture<Void> future) {
+    RemoveTopicsFromMirrorResult(KafkaFuture<Void> future) {
         this.future = future;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddTopicsToMirrorRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddTopicsToMirrorRequest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Map;
+import java.util.Set;
 
 public class AddTopicsToMirrorRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<AddTopicsToMirrorRequest> {
@@ -35,11 +35,12 @@ public class AddTopicsToMirrorRequest extends AbstractRequest {
             this.data = data;
         }
 
-        public Builder(Map<String, String> topicToMirrorName) {
+        public Builder(String mirrorName, Set<String> topics) {
             super(ApiKeys.ADD_TOPICS_TO_MIRROR, ApiKeys.ADD_TOPICS_TO_MIRROR.oldestVersion(),
                     ApiKeys.ADD_TOPICS_TO_MIRROR.latestVersion());
             AddTopicsToMirrorRequestData data = new AddTopicsToMirrorRequestData();
-            topicToMirrorName.forEach((topic, mirrorName) -> data.topics().add(new AddTopicsToMirrorRequestData.TopicData().setTopicName(topic).setMirrorName(mirrorName)));
+            data.setMirrorName(mirrorName);
+            topics.forEach(topic -> data.topics().add(new AddTopicsToMirrorRequestData.TopicData().setTopicName(topic)));
             this.data = data;
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/PauseMirrorTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/PauseMirrorTopicsRequest.java
@@ -35,10 +35,11 @@ public class PauseMirrorTopicsRequest extends AbstractRequest {
             this.data = data;
         }
 
-        public Builder(Set<String> topics) {
+        public Builder(String mirrorName, Set<String> topics) {
             super(ApiKeys.PAUSE_MIRROR_TOPICS, ApiKeys.PAUSE_MIRROR_TOPICS.oldestVersion(),
                     ApiKeys.PAUSE_MIRROR_TOPICS.latestVersion());
             PauseMirrorTopicsRequestData data = new PauseMirrorTopicsRequestData();
+            data.setMirrorName(mirrorName);
             topics.forEach(topic -> data.topics().add(new PauseMirrorTopicsRequestData.TopicData().setTopicName(topic)));
             this.data = data;
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/RemoveTopicsFromMirrorRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RemoveTopicsFromMirrorRequest.java
@@ -35,10 +35,11 @@ public class RemoveTopicsFromMirrorRequest extends AbstractRequest {
             this.data = data;
         }
 
-        public Builder(Set<String> topics) {
+        public Builder(String mirrorName, Set<String> topics) {
             super(ApiKeys.REMOVE_TOPICS_FROM_MIRROR, ApiKeys.REMOVE_TOPICS_FROM_MIRROR.oldestVersion(),
                     ApiKeys.REMOVE_TOPICS_FROM_MIRROR.latestVersion());
             RemoveTopicsFromMirrorRequestData data = new RemoveTopicsFromMirrorRequestData();
+            data.setMirrorName(mirrorName);
             topics.forEach(topic -> data.topics().add(new RemoveTopicsFromMirrorRequestData.TopicData().setTopicName(topic)));
             this.data = data;
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ResumeMirrorTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ResumeMirrorTopicsRequest.java
@@ -35,10 +35,11 @@ public class ResumeMirrorTopicsRequest extends AbstractRequest {
             this.data = data;
         }
 
-        public Builder(Set<String> topics) {
+        public Builder(String mirrorName, Set<String> topics) {
             super(ApiKeys.RESUME_MIRROR_TOPICS, ApiKeys.RESUME_MIRROR_TOPICS.oldestVersion(),
                     ApiKeys.RESUME_MIRROR_TOPICS.latestVersion());
             ResumeMirrorTopicsRequestData data = new ResumeMirrorTopicsRequestData();
+            data.setMirrorName(mirrorName);
             topics.forEach(topic -> data.topics().add(new ResumeMirrorTopicsRequestData.TopicData().setTopicName(topic)));
             this.data = data;
         }

--- a/clients/src/main/resources/common/message/AddTopicsToMirrorRequest.json
+++ b/clients/src/main/resources/common/message/AddTopicsToMirrorRequest.json
@@ -22,13 +22,13 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
+      "about": "The cluster mirror name." },
     { "name": "Topics", "type": "[]TopicData", "versions": "0+", "about": "The data for the topics.",
       "fields": [
         { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
         { "name": "TopicName", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
-          "about": "The topic name." },
-        { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
-          "about": "The cluster mirror name."}
+          "about": "The topic name." }
       ]}
   ]
 }

--- a/clients/src/main/resources/common/message/AddTopicsToMirrorResponse.json
+++ b/clients/src/main/resources/common/message/AddTopicsToMirrorResponse.json
@@ -27,6 +27,8 @@
       "about": "The error code, or 0 if there was no error." },
     { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "The top-level error message, or null if there was no error." },
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
+      "about": "The cluster mirror name." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/AddTopicsToMirrorResponse.json
+++ b/clients/src/main/resources/common/message/AddTopicsToMirrorResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/CreateMirrorResponse.json
+++ b/clients/src/main/resources/common/message/CreateMirrorResponse.json
@@ -25,7 +25,7 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
-    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
       "about": "The error message, or null if there was no error." }
   ]
 }

--- a/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Mirrors", "type": "[]DescribedMirror", "versions": "0+",
       "about": "Each described mirror.", "fields": [
       { "name": "ErrorCode", "type": "int16", "versions": "0+",

--- a/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
@@ -41,12 +41,12 @@
           "about": "Each partition detail.", "fields": [
           { "name": "PartitionIndex", "type": "int32", "versions": "0+",
             "about": "The partition index." },
-          { "name": "SourceOffset", "type": "int64", "versions": "0+",
-            "about": "The high watermark offset from the source cluster leader." },
-          { "name": "DestinationOffset", "type": "int64", "versions": "0+",
-            "about": "The log end offset on the destination cluster." },
-          { "name": "Lag", "type": "int64", "versions": "0+",
-            "about": "The lag (source offset - destination offset)." },
+          { "name": "SourceOffset", "type": "int64", "versions": "0+", "default": "-1",
+            "about": "The high watermark offset from the source cluster leader, or -1 if not yet available." },
+          { "name": "DestinationOffset", "type": "int64", "versions": "0+", "default": "-1",
+            "about": "The log end offset on the destination cluster, or -1 if not yet available." },
+          { "name": "Lag", "type": "int64", "versions": "0+", "default": "-1",
+            "about": "The lag (source offset - destination offset), or -1 if not yet available." },
           { "name": "State", "type": "string", "versions": "0+",
             "about": "The partition state (INITIALIZING, PREPARING, MIRRORING, STOPPING, STOPPED, FAILED)." }
         ]}

--- a/clients/src/main/resources/common/message/LastMirroredOffsetsResponse.json
+++ b/clients/src/main/resources/common/message/LastMirroredOffsetsResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/ListMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/ListMirrorsResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Mirrors", "type": "[]ListedMirror", "versions": "0+",
       "about": "Each mirror in the response.", "fields": [
       { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",

--- a/clients/src/main/resources/common/message/ListMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/ListMirrorsResponse.json
@@ -21,7 +21,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+", "ignorable": true,
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },

--- a/clients/src/main/resources/common/message/PauseMirrorTopicsRequest.json
+++ b/clients/src/main/resources/common/message/PauseMirrorTopicsRequest.json
@@ -22,6 +22,8 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
+    { "name": "MirrorName", "type": "string", "versions": "0+",
+      "about": "The mirror name to pause the topics for." },
     { "name": "Topics", "type": "[]TopicData", "versions": "0+", "about": "The data for the topics.",
       "fields": [
         { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},

--- a/clients/src/main/resources/common/message/PauseMirrorTopicsResponse.json
+++ b/clients/src/main/resources/common/message/PauseMirrorTopicsResponse.json
@@ -27,6 +27,8 @@
       "about": "The error code, or 0 if there was no error." },
     { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "The top-level error message, or null if there was no error." },
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
+      "about": "The cluster mirror name." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/PauseMirrorTopicsResponse.json
+++ b/clients/src/main/resources/common/message/PauseMirrorTopicsResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The read results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/RemoveTopicsFromMirrorRequest.json
+++ b/clients/src/main/resources/common/message/RemoveTopicsFromMirrorRequest.json
@@ -22,6 +22,8 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
+    { "name": "MirrorName", "type": "string", "versions": "0+",
+      "about": "The cluster mirror name." },
     { "name": "Topics", "type": "[]TopicData", "versions": "0+", "about": "The data for the topics.",
       "fields": [
         { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},

--- a/clients/src/main/resources/common/message/RemoveTopicsFromMirrorResponse.json
+++ b/clients/src/main/resources/common/message/RemoveTopicsFromMirrorResponse.json
@@ -27,6 +27,8 @@
       "about": "The error code, or 0 if there was no error." },
     { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "The top-level error message, or null if there was no error." },
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
+      "about": "The cluster mirror name." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/RemoveTopicsFromMirrorResponse.json
+++ b/clients/src/main/resources/common/message/RemoveTopicsFromMirrorResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/ResumeMirrorTopicsRequest.json
+++ b/clients/src/main/resources/common/message/ResumeMirrorTopicsRequest.json
@@ -23,7 +23,7 @@
   "flexibleVersions": "0+",
   "fields": [
     { "name": "MirrorName", "type": "string", "versions": "0+",
-      "about": "The mirror name to resume the topics for." },
+      "about": "The cluster mirror name to." },
     { "name": "Topics", "type": "[]TopicData", "versions": "0+", "about": "The data for the topics.",
       "fields": [
         { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},

--- a/clients/src/main/resources/common/message/ResumeMirrorTopicsRequest.json
+++ b/clients/src/main/resources/common/message/ResumeMirrorTopicsRequest.json
@@ -22,6 +22,8 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
+    { "name": "MirrorName", "type": "string", "versions": "0+",
+      "about": "The mirror name to resume the topics for." },
     { "name": "Topics", "type": "[]TopicData", "versions": "0+", "about": "The data for the topics.",
       "fields": [
         { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},

--- a/clients/src/main/resources/common/message/ResumeMirrorTopicsResponse.json
+++ b/clients/src/main/resources/common/message/ResumeMirrorTopicsResponse.json
@@ -27,6 +27,8 @@
       "about": "The error code, or 0 if there was no error." },
     { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "The top-level error message, or null if there was no error." },
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
+      "about": "The cluster mirror name." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/ResumeMirrorTopicsResponse.json
+++ b/clients/src/main/resources/common/message/ResumeMirrorTopicsResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/main/resources/common/message/WriteMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/WriteMirrorStatesResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Topics", "type": "[]TopicResult", "versions": "0",
       "about": "The write results for the topics.", "fields": [
       { "name": "Name", "type": "string", "versions": "0", "entityType": "topicName",

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1393,12 +1393,12 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
-    public PauseMirrorTopicsResult pauseMirrorTopics(Set<String> topics, PauseMirrorTopicsOptions options) {
+    public PauseMirrorTopicsResult pauseMirrorTopics(String mirrorName, Set<String> topics, PauseMirrorTopicsOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override
-    public ResumeMirrorTopicsResult resumeMirrorTopics(Set<String> topics, ResumeMirrorTopicsOptions options) {
+    public ResumeMirrorTopicsResult resumeMirrorTopics(String mirrorName, Set<String> topics, ResumeMirrorTopicsOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1383,12 +1383,12 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
-    public AddTopicsToMirrorResult addTopicsToMirror(Map<String, String> topicToMirrorName, AddTopicsToMirrorOptions options) {
+    public AddTopicsToMirrorResult addTopicsToMirror(String mirrorName, Set<String> topics, AddTopicsToMirrorOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override
-    public RemoveTopicsFromMirrorResult removeTopicsFromMirror(Set<String> topics, RemoveTopicsFromMirrorOptions options) {
+    public RemoveTopicsFromMirrorResult removeTopicsFromMirror(String mirrorName, Set<String> topics, RemoveTopicsFromMirrorOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -235,11 +235,12 @@ class ControllerApis(
     val addTopicsToMirrorRequest = request.body[AddTopicsToMirrorRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    val topicToMirrorName: util.Map[String, String] = new util.HashMap[String, String]()
+    val mirrorName = addTopicsToMirrorRequest.data().mirrorName()
+    val topics: util.Set[String] = new util.HashSet[String]()
     addTopicsToMirrorRequest.data().topics().forEach( topic => {
-        topicToMirrorName.put(topic.topicName(), topic.mirrorName())
+        topics.add(topic.topicName())
     })
-    controller.addTopicsToMirror(context, topicToMirrorName)
+    controller.addTopicsToMirror(context, mirrorName, topics)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {
           requestHelper.handleError(request, exception)
@@ -257,11 +258,12 @@ class ControllerApis(
     val removeTopicsFromMirrorRequest = request.body[RemoveTopicsFromMirrorRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
+    val mirrorName = removeTopicsFromMirrorRequest.data().mirrorName()
     val topics: util.Set[String] = new util.HashSet[String]()
     removeTopicsFromMirrorRequest.data().topics().forEach( topic => {
         topics.add(topic.topicName())
     })
-    controller.removeTopicsFromMirror(context, topics)
+    controller.removeTopicsFromMirror(context, mirrorName, topics)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {
           requestHelper.handleError(request, exception)

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -281,9 +281,10 @@ class ControllerApis(
     val pauseRequest = request.body[PauseMirrorTopicsRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
+    val mirrorName = pauseRequest.data().mirrorName()
     val topics: util.Set[String] = new util.HashSet[String]()
     pauseRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
-    controller.pauseMirrorTopics(context, topics)
+    controller.pauseMirrorTopics(context, mirrorName, topics)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {
           requestHelper.handleError(request, exception)
@@ -300,9 +301,10 @@ class ControllerApis(
     val resumeRequest = request.body[ResumeMirrorTopicsRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
+    val mirrorName = resumeRequest.data().mirrorName()
     val topics: util.Set[String] = new util.HashSet[String]()
     resumeRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
-    controller.resumeMirrorTopics(context, topics)
+    controller.resumeMirrorTopics(context, mirrorName, topics)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {
           requestHelper.handleError(request, exception)

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.utils.{AppInfoParser, Time}
 import org.apache.kafka.common.{KafkaException, Uuid}
 import org.apache.kafka.metadata.KafkaConfigSchema
+import org.apache.kafka.server.config.MirrorConfig
 import org.apache.kafka.metadata.bootstrap.{BootstrapDirectory, BootstrapMetadata}
 import org.apache.kafka.metadata.properties.MetaPropertiesEnsemble.VerificationFlag.{REQUIRE_AT_LEAST_ONE_VALID, REQUIRE_METADATA_LOG_DIR}
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble}
@@ -189,5 +190,6 @@ object KafkaRaftServer {
   val configSchema = new KafkaConfigSchema(Map(
     ConfigResource.Type.BROKER -> new ConfigDef(KafkaConfig.configDef),
     ConfigResource.Type.TOPIC -> LogConfig.configDefCopy,
+    ConfigResource.Type.MIRROR -> MirrorConfig.CONFIG_DEF,
   ).asJava, ServerTopicConfigSynonyms.ALL_TOPIC_CONFIG_SYNONYMS)
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -223,7 +223,7 @@ public class ConfigurationControlManager {
         return ControllerResult.atomicOf(outputRecords, outputResults);
     }
 
-    ControllerResult<RemoveTopicsFromMirrorResponseData> removeTopicsFromMirror(Set<String> topics) {
+    ControllerResult<RemoveTopicsFromMirrorResponseData> removeTopicsFromMirror(String mirrorName, Set<String> topics) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         RemoveTopicsFromMirrorResponseData data = new RemoveTopicsFromMirrorResponseData();
         List<RemoveTopicsFromMirrorResponseData.TopicResult> topicResList = new ArrayList<>();
@@ -240,14 +240,21 @@ public class ConfigurationControlManager {
                 topicRes.setErrorCode(Errors.INVALID_REQUEST.code());
             } else {
                 curVal = currentConfigs.get(mirrorNameConfig);
-                // Verify the current value should not be empty
                 if (curVal == null || curVal.isBlank()) {
                     topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
                     topicResList.add(topicRes);
                     continue;
                 }
 
-                // decide if we should clear the mirror name or append a stopped symbol
+                String originalName = curVal.endsWith(PAUSED_TOPIC_SUFFIX)
+                    ? curVal.substring(0, curVal.length() - PAUSED_TOPIC_SUFFIX.length())
+                    : curVal;
+                if (!originalName.equals(mirrorName)) {
+                    topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
                 String newMirrorName = curVal.endsWith(REMOVED_TOPIC_SUFFIX) ? "" : curVal + REMOVED_TOPIC_SUFFIX;
                 Map<String, Entry<OpType, String>> keyToOps = Map.of(mirrorNameConfig, new AbstractMap.SimpleImmutableEntry<>(SET, newMirrorName));
 
@@ -367,21 +374,17 @@ public class ConfigurationControlManager {
         return ControllerResult.of(records, data);
     }
 
-    ControllerResult<AddTopicsToMirrorResponseData> addTopicsToMirror(Map<String, String> topicToMirrorName) {
+    ControllerResult<AddTopicsToMirrorResponseData> addTopicsToMirror(String mirrorName, Set<String> topics) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         AddTopicsToMirrorResponseData data = new AddTopicsToMirrorResponseData();
         List<AddTopicsToMirrorResponseData.TopicResult> topicResList = new ArrayList<>();
-        for (Entry<String, String> topicToMirrorNameEntry : topicToMirrorName.entrySet()) {
-            String topic = topicToMirrorNameEntry.getKey();
-            String mirrorName = topicToMirrorNameEntry.getValue();
-
+        for (String topic : topics) {
             AddTopicsToMirrorResponseData.TopicResult topicRes = new AddTopicsToMirrorResponseData.TopicResult();
             ConfigResource configResource = new ConfigResource(Type.TOPIC, topic);
 
             TimelineHashMap<String, String> currentConfigs = configData.get(configResource);
             if (currentConfigs != null) {
                 String currMirrorNameValue = currentConfigs.get(TopicConfig.MIRROR_NAME_CONFIG);
-                // Verify the current value should be empty or ends with removed suffix
                 if (currMirrorNameValue != null && (currMirrorNameValue.isBlank() || !currMirrorNameValue.endsWith(REMOVED_TOPIC_SUFFIX))) {
                     topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
                     topicResList.add(topicRes);

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -275,7 +275,7 @@ public class ConfigurationControlManager {
         return ControllerResult.of(records, data);
     }
 
-    ControllerResult<PauseMirrorTopicsResponseData> pauseMirrorTopics(Set<String> topics) {
+    ControllerResult<PauseMirrorTopicsResponseData> pauseMirrorTopics(String mirrorName, Set<String> topics) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         PauseMirrorTopicsResponseData data = new PauseMirrorTopicsResponseData();
         List<PauseMirrorTopicsResponseData.TopicResult> topicResList = new ArrayList<>();
@@ -295,13 +295,24 @@ public class ConfigurationControlManager {
                 }
 
                 if (curVal.endsWith(PAUSED_TOPIC_SUFFIX)) {
-                    // Already paused, idempotent success
+                    String originalName = curVal.substring(0, curVal.length() - PAUSED_TOPIC_SUFFIX.length());
+                    if (!originalName.equals(mirrorName)) {
+                        topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
+                        topicResList.add(topicRes);
+                        continue;
+                    }
                     topicRes.setName(topic);
                     topicResList.add(topicRes);
                     continue;
                 }
 
                 if (curVal.endsWith(REMOVED_TOPIC_SUFFIX)) {
+                    topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
+                if (!curVal.equals(mirrorName)) {
                     topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
                     topicResList.add(topicRes);
                     continue;
@@ -328,7 +339,7 @@ public class ConfigurationControlManager {
         return ControllerResult.of(records, data);
     }
 
-    ControllerResult<ResumeMirrorTopicsResponseData> resumeMirrorTopics(Set<String> topics) {
+    ControllerResult<ResumeMirrorTopicsResponseData> resumeMirrorTopics(String mirrorName, Set<String> topics) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         ResumeMirrorTopicsResponseData data = new ResumeMirrorTopicsResponseData();
         List<ResumeMirrorTopicsResponseData.TopicResult> topicResList = new ArrayList<>();
@@ -354,6 +365,12 @@ public class ConfigurationControlManager {
                 }
 
                 String originalMirrorName = curVal.substring(0, curVal.length() - PAUSED_TOPIC_SUFFIX.length());
+                if (!originalMirrorName.equals(mirrorName)) {
+                    topicRes.setErrorCode(Errors.INVALID_REQUEST.code()).setName(topic);
+                    topicResList.add(topicRes);
+                    continue;
+                }
+
                 Map<String, Entry<OpType, String>> keyToOps = Map.of(TopicConfig.MIRROR_NAME_CONFIG,
                     new AbstractMap.SimpleImmutableEntry<>(SET, originalMirrorName));
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -226,6 +226,7 @@ public class ConfigurationControlManager {
     ControllerResult<RemoveTopicsFromMirrorResponseData> removeTopicsFromMirror(String mirrorName, Set<String> topics) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         RemoveTopicsFromMirrorResponseData data = new RemoveTopicsFromMirrorResponseData();
+        data.setMirrorName(mirrorName);
         List<RemoveTopicsFromMirrorResponseData.TopicResult> topicResList = new ArrayList<>();
         for (String topic : topics) {
             String mirrorNameConfig = TopicConfig.MIRROR_NAME_CONFIG;
@@ -278,6 +279,7 @@ public class ConfigurationControlManager {
     ControllerResult<PauseMirrorTopicsResponseData> pauseMirrorTopics(String mirrorName, Set<String> topics) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         PauseMirrorTopicsResponseData data = new PauseMirrorTopicsResponseData();
+        data.setMirrorName(mirrorName);
         List<PauseMirrorTopicsResponseData.TopicResult> topicResList = new ArrayList<>();
         for (String topic : topics) {
             PauseMirrorTopicsResponseData.TopicResult topicRes = new PauseMirrorTopicsResponseData.TopicResult();
@@ -342,6 +344,7 @@ public class ConfigurationControlManager {
     ControllerResult<ResumeMirrorTopicsResponseData> resumeMirrorTopics(String mirrorName, Set<String> topics) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         ResumeMirrorTopicsResponseData data = new ResumeMirrorTopicsResponseData();
+        data.setMirrorName(mirrorName);
         List<ResumeMirrorTopicsResponseData.TopicResult> topicResList = new ArrayList<>();
         for (String topic : topics) {
             ResumeMirrorTopicsResponseData.TopicResult topicRes = new ResumeMirrorTopicsResponseData.TopicResult();
@@ -394,6 +397,7 @@ public class ConfigurationControlManager {
     ControllerResult<AddTopicsToMirrorResponseData> addTopicsToMirror(String mirrorName, Set<String> topics) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         AddTopicsToMirrorResponseData data = new AddTopicsToMirrorResponseData();
+        data.setMirrorName(mirrorName);
         List<AddTopicsToMirrorResponseData.TopicResult> topicResList = new ArrayList<>();
         for (String topic : topics) {
             AddTopicsToMirrorResponseData.TopicResult topicRes = new AddTopicsToMirrorResponseData.TopicResult();

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -440,6 +440,13 @@ public class ConfigurationControlManager {
 
         for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> resourceEntry :
                 configChanges.entrySet()) {
+            String mirrorName = resourceEntry.getKey().name();
+            if (mirrorName.endsWith(REMOVED_TOPIC_SUFFIX) || mirrorName.endsWith(PAUSED_TOPIC_SUFFIX)) {
+                data.setErrorCode(Errors.INVALID_REQUEST.code());
+                data.setErrorMessage("Mirror name must not end with '"
+                    + REMOVED_TOPIC_SUFFIX + "' or '" + PAUSED_TOPIC_SUFFIX + "'");
+                return ControllerResult.of(List.of(), data);
+            }
             ApiError apiError = incrementalAlterConfigResource(resourceEntry.getKey(),
                     resourceEntry.getValue(),
                     newlyCreatedResource,

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -170,11 +170,13 @@ public interface Controller extends AclMutator, AutoCloseable {
 
     CompletableFuture<AddTopicsToMirrorResponseData> addTopicsToMirror(
             ControllerRequestContext context,
-            Map<String, String> topicToMirrorName
+            String mirrorName,
+            Set<String> topics
     );
 
     CompletableFuture<RemoveTopicsFromMirrorResponseData> removeTopicsFromMirror(
             ControllerRequestContext context,
+            String mirrorName,
             Set<String> topics
     );
 

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -182,11 +182,13 @@ public interface Controller extends AclMutator, AutoCloseable {
 
     CompletableFuture<PauseMirrorTopicsResponseData> pauseMirrorTopics(
             ControllerRequestContext context,
+            String mirrorName,
             Set<String> topics
     );
 
     CompletableFuture<ResumeMirrorTopicsResponseData> resumeMirrorTopics(
             ControllerRequestContext context,
+            String mirrorName,
             Set<String> topics
     );
 

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1784,19 +1784,21 @@ public final class QuorumController implements Controller {
     @Override
     public CompletableFuture<AddTopicsToMirrorResponseData> addTopicsToMirror(
             ControllerRequestContext context,
-            Map<String, String> topicToMirrorName
+            String mirrorName,
+            Set<String> topics
     ) {
         return appendWriteEvent("addTopicsToMirror", context.deadlineNs(),
-                () -> configurationControl.addTopicsToMirror(topicToMirrorName));
+                () -> configurationControl.addTopicsToMirror(mirrorName, topics));
     }
 
     @Override
     public CompletableFuture<RemoveTopicsFromMirrorResponseData> removeTopicsFromMirror(
             ControllerRequestContext context,
+            String mirrorName,
             Set<String> topics
     ) {
         return appendWriteEvent("removeTopicsFromMirror", context.deadlineNs(),
-                () -> configurationControl.removeTopicsFromMirror(topics));
+                () -> configurationControl.removeTopicsFromMirror(mirrorName, topics));
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1804,19 +1804,21 @@ public final class QuorumController implements Controller {
     @Override
     public CompletableFuture<PauseMirrorTopicsResponseData> pauseMirrorTopics(
             ControllerRequestContext context,
+            String mirrorName,
             Set<String> topics
     ) {
         return appendWriteEvent("pauseMirrorTopics", context.deadlineNs(),
-                () -> configurationControl.pauseMirrorTopics(topics));
+                () -> configurationControl.pauseMirrorTopics(mirrorName, topics));
     }
 
     @Override
     public CompletableFuture<ResumeMirrorTopicsResponseData> resumeMirrorTopics(
             ControllerRequestContext context,
+            String mirrorName,
             Set<String> topics
     ) {
         return appendWriteEvent("resumeMirrorTopics", context.deadlineNs(),
-                () -> configurationControl.resumeMirrorTopics(topics));
+                () -> configurationControl.resumeMirrorTopics(mirrorName, topics));
     }
 
     @Override

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -438,13 +438,13 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     }
 
     @Override
-    public AddTopicsToMirrorResult addTopicsToMirror(final Map<String, String> topicToMirrorName, final AddTopicsToMirrorOptions options) {
-        return adminDelegate.addTopicsToMirror(topicToMirrorName, options);
+    public AddTopicsToMirrorResult addTopicsToMirror(final String mirrorName, final Set<String> topics, final AddTopicsToMirrorOptions options) {
+        return adminDelegate.addTopicsToMirror(mirrorName, topics, options);
     }
 
     @Override
-    public RemoveTopicsFromMirrorResult removeTopicsFromMirror(final Set<String> topics, final RemoveTopicsFromMirrorOptions options) {
-        return adminDelegate.removeTopicsFromMirror(topics, options);
+    public RemoveTopicsFromMirrorResult removeTopicsFromMirror(final String mirrorName, final Set<String> topics, final RemoveTopicsFromMirrorOptions options) {
+        return adminDelegate.removeTopicsFromMirror(mirrorName, topics, options);
     }
 
     @Override

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -448,13 +448,13 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     }
 
     @Override
-    public PauseMirrorTopicsResult pauseMirrorTopics(final Set<String> topics, final PauseMirrorTopicsOptions options) {
-        return adminDelegate.pauseMirrorTopics(topics, options);
+    public PauseMirrorTopicsResult pauseMirrorTopics(final String mirrorName, final Set<String> topics, final PauseMirrorTopicsOptions options) {
+        return adminDelegate.pauseMirrorTopics(mirrorName, topics, options);
     }
 
     @Override
-    public ResumeMirrorTopicsResult resumeMirrorTopics(final Set<String> topics, final ResumeMirrorTopicsOptions options) {
-        return adminDelegate.resumeMirrorTopics(topics, options);
+    public ResumeMirrorTopicsResult resumeMirrorTopics(final String mirrorName, final Set<String> topics, final ResumeMirrorTopicsOptions options) {
+        return adminDelegate.resumeMirrorTopics(mirrorName, topics, options);
     }
 
     @Override

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -137,6 +137,7 @@ public class MockController implements Controller {
     @Override
     public CompletableFuture<PauseMirrorTopicsResponseData> pauseMirrorTopics(
             ControllerRequestContext context,
+            String mirrorName,
             Set<String> topics) {
         throw new UnsupportedOperationException();
     }
@@ -144,6 +145,7 @@ public class MockController implements Controller {
     @Override
     public CompletableFuture<ResumeMirrorTopicsResponseData> resumeMirrorTopics(
             ControllerRequestContext context,
+            String mirrorName,
             Set<String> topics) {
         throw new UnsupportedOperationException();
     }

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -120,6 +120,7 @@ public class MockController implements Controller {
     @Override
     public CompletableFuture<RemoveTopicsFromMirrorResponseData> removeTopicsFromMirror(
             ControllerRequestContext context,
+            String mirrorName,
             Set<String> topics) {
         throw new UnsupportedOperationException();
     }
@@ -127,7 +128,8 @@ public class MockController implements Controller {
     @Override
     public CompletableFuture<AddTopicsToMirrorResponseData> addTopicsToMirror(
             ControllerRequestContext context,
-            Map<String, String> topicToMirrorName
+            String mirrorName,
+            Set<String> topics
     ) {
         throw new UnsupportedOperationException();
     }

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -257,24 +257,26 @@ public abstract class MirrorCommand {
 
         private void pauseMirrorTopics(MirrorCommandOptions opts) throws Exception {
             String topicPattern = opts.topic().get();
+            String mirrorName = opts.mirror().get();
 
             var allTopics = adminClient.listTopics().names().get();
             Set<String> matchingTopics = matchTopics(allTopics, topicPattern);
 
-            PauseMirrorTopicsResult result = adminClient.pauseMirrorTopics(matchingTopics, new PauseMirrorTopicsOptions());
+            PauseMirrorTopicsResult result = adminClient.pauseMirrorTopics(mirrorName, matchingTopics, new PauseMirrorTopicsOptions());
             result.all().get();
-            System.out.printf("Paused mirroring for %d topic(s): %s%n", matchingTopics.size(), matchingTopics);
+            System.out.printf("Paused mirroring for %d topic(s) in mirror %s: %s%n", matchingTopics.size(), mirrorName, matchingTopics);
         }
 
         private void resumeMirrorTopics(MirrorCommandOptions opts) throws Exception {
             String topicPattern = opts.topic().get();
+            String mirrorName = opts.mirror().get();
 
             var allTopics = adminClient.listTopics().names().get();
             Set<String> matchingTopics = matchTopics(allTopics, topicPattern);
 
-            ResumeMirrorTopicsResult result = adminClient.resumeMirrorTopics(matchingTopics, new ResumeMirrorTopicsOptions());
+            ResumeMirrorTopicsResult result = adminClient.resumeMirrorTopics(mirrorName, matchingTopics, new ResumeMirrorTopicsOptions());
             result.all().get();
-            System.out.printf("Resumed mirroring for %d topic(s): %s%n", matchingTopics.size(), matchingTopics);
+            System.out.printf("Resumed mirroring for %d topic(s) in mirror %s: %s%n", matchingTopics.size(), mirrorName, matchingTopics);
         }
 
         private void listMirrors() throws ExecutionException, InterruptedException {
@@ -541,8 +543,8 @@ public abstract class MirrorCommand {
             if (!has(bootstrapServerOpt))
                 throw new IllegalArgumentException("--bootstrap-server must be specified");
 
-            // --mirror is required for create, alter, add, and remove operations, but optional for list, describe, pause, and resume
-            if (!has(listOpt) && !has(describeOpt) && !has(pauseOpt) && !has(resumeOpt) && !has(mirrorOpt))
+            // --mirror is required for create, alter, add, remove, pause, and resume operations, but optional for list and describe
+            if (!has(listOpt) && !has(describeOpt) && !has(mirrorOpt))
                 throw new IllegalArgumentException("--mirror must be specified");
 
             if (has(createOpt) && !has(mirrorConfigOpt))

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -232,7 +232,7 @@ public abstract class MirrorCommand {
             // TODO: We should return error and let the command retry if the topic metadata is not propagated to brokers. Right now, we sleep 1 sec
             Thread.sleep(1000);
             // Ensures the mirror.name config is properly set even when topics already exist
-            AddTopicsToMirrorResult addResult = adminClient.addTopicsToMirror(topics, new AddTopicsToMirrorOptions());
+            AddTopicsToMirrorResult addResult = adminClient.addTopicsToMirror(mirrorName, topics.keySet(), new AddTopicsToMirrorOptions());
             addResult.all().get();
 
             System.out.printf("Added %d topic(s) to mirror %s: %s%n", topics.size(), mirrorName, topics.keySet());
@@ -250,7 +250,7 @@ public abstract class MirrorCommand {
 
             // Remove all matching topics from the mirror
             RemoveTopicsFromMirrorResult removeTopicsFromMirrorResult = adminClient.removeTopicsFromMirror(
-                matchingTopics, new RemoveTopicsFromMirrorOptions());
+                mirrorName, matchingTopics, new RemoveTopicsFromMirrorOptions());
             removeTopicsFromMirrorResult.all().get();
             System.out.printf("Removed %d topic(s) from mirror %s: %s%n", matchingTopics.size(), mirrorName, matchingTopics);
         }


### PR DESCRIPTION
Cluster Mirroring protocol and CLI refinements.

Each commit in this patch addresses some minor refinements and small fixes to the protocol and CLI commands that were raised in the KIP discussion thread. There is no impact on the existing operations, just improvements.

For now, I'm keeping them all here for convenience, as I have to align the KIP. Let me know if we want to break them into smaller PRs and how (each commit or we can group some of them together as they are related).
