### PR TITLE
Add bit-field PID mapping with collision detection

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -348,7 +348,7 @@ public class MirrorCoordinator {
 
         // periodically query source cluster to get the metadata
         long metadataRefreshIntervalMs = brokerConfig.mirrorConfig().metadataRefreshIntervalMs();
-        scheduler.schedule("MirrorMetadataRefresh", metadataManager::syncMetadata, metadataRefreshIntervalMs, metadataRefreshIntervalMs);
+        scheduler.schedule("MirrorMetadataRefresh", metadataManager::syncMetadata, 0, metadataRefreshIntervalMs);
 
         log.info("Startup complete.");
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AccessControlEntryFilter;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
@@ -172,6 +173,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     // cache
     // thread-safe maps for concurrent access from metadata, scheduler, and fetcher threads
+    private final Map<String, Uuid> sourceClusterIds = new ConcurrentHashMap<>();
     private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
@@ -682,22 +684,23 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         log.info("Mirror config for '{}': {}", mirrorName, props);
 
         var addresses = ClientUtils.parseAndValidateAddresses(Arrays.stream(bootstrapServers.split(",")).toList(), "use_all_dns_ips");
-        // Use random node id here because we don't know node id of remote brokers
-        int rand = random.nextInt(addresses.size());
-        var brokerEndpoint = new BrokerEndPoint(random.nextInt(), addresses.get(rand).getHostString(), addresses.get(rand).getPort());
-        var logContext = new LogContext("[" + MirrorMetadataManager.class.getName() + " replicaId=" + nodeId + ", mirrorName=" + mirrorName + "] ");
-
-        MirrorSourceSender sender = new MirrorSourceSender(
-                brokerEndpoint,
-                MirrorConfig.fromProperties(props),
-                brokerConfig,
-                metrics,
-                time,
-                brokerEndpoint.id(),
-                "broker-" + nodeId + "-mirror-metadata-manager-" + mirrorName,
-                logContext
-        );
-        sourceSenders.put(mirrorName, List.of(sender));
+        MirrorConfig mirrorConfig = MirrorConfig.fromProperties(props);
+        List<MirrorSourceSender> senders = new ArrayList<>();
+        for (var address : addresses) {
+            var brokerEndpoint = new BrokerEndPoint(random.nextInt(), address.getHostString(), address.getPort());
+            var logContext = new LogContext("[" + MirrorMetadataManager.class.getName() + " replicaId=" + nodeId + ", mirrorName=" + mirrorName + "] ");
+            senders.add(new MirrorSourceSender(
+                    brokerEndpoint,
+                    mirrorConfig,
+                    brokerConfig,
+                    metrics,
+                    time,
+                    brokerEndpoint.id(),
+                    "broker-" + nodeId + "-mirror-metadata-manager-" + mirrorName,
+                    logContext
+            ));
+        }
+        sourceSenders.put(mirrorName, senders);
     }
 
     /** Sends a request to the source cluster, iterating available senders with fallback on failure. */
@@ -933,6 +936,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         var response = trySendRequest(mirrorName, MetadataRequest.Builder.allTopics());
         if (!(response.responseBody() instanceof MetadataResponse metadataResponse)) {
             return;
+        }
+
+        String clusterId = metadataResponse.clusterId();
+        if (clusterId != null && !clusterId.isEmpty()) {
+            sourceClusterIds.put(mirrorName, Uuid.fromString(clusterId));
         }
 
         Collection<Node> discoveredBrokers = metadataResponse.brokers();
@@ -1428,10 +1436,34 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return result;
     }
 
+    Uuid getSourceClusterId(String mirrorName) {
+        Uuid cached = sourceClusterIds.get(mirrorName);
+        if (cached != null) {
+            return cached;
+        }
+        // fallback: resolve lazily on cache miss by sending a metadata request synchronously
+        ensureConnection(mirrorName);
+        try {
+            var response = trySendRequest(mirrorName, MetadataRequest.Builder.allTopics());
+            if (response.responseBody() instanceof MetadataResponse metadataResponse) {
+                String clusterId = metadataResponse.clusterId();
+                if (clusterId != null && !clusterId.isEmpty()) {
+                    cached = Uuid.fromString(clusterId);
+                    sourceClusterIds.put(mirrorName, cached);
+                    return cached;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to resolve source cluster ID for mirror {}", mirrorName, e);
+        }
+        return null;
+    }
+
     void clear() {
         partitionStates.clear();
         partitionStateCounts.clear();
         lastMirroredOffsets.clear();
+        sourceClusterIds.clear();
         closeSourceSenders();
         sourceLeaders.clear();
     }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1392,7 +1392,8 @@ class Partition(val topicPartition: TopicPartition,
   private def doAppendRecordsToFollowerOrFutureReplica(
     records: MemoryRecords,
     isFuture: Boolean,
-    partitionLeaderEpoch: Int
+    partitionLeaderEpoch: Int,
+    sourceClusterId: Uuid
   ): Option[LogAppendInfo] = {
     if (isFuture) {
       // The read lock is needed to handle race condition if request handler thread tries to
@@ -1400,13 +1401,13 @@ class Partition(val topicPartition: TopicPartition,
       inReadLock(leaderIsrUpdateLock) {
         // Note the replica may be undefined if it is removed by a non-ReplicaAlterLogDirsThread before
         // this method is called
-        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, getMirrorName().nonEmpty && isLeader) }
+        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, sourceClusterId) }
       }
     } else {
       // The lock is needed to prevent the follower replica from being updated while ReplicaAlterDirThread
       // is executing maybeReplaceCurrentWithFutureReplica() to replace follower replica with the future replica.
       futureLogLock.synchronized {
-        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, getMirrorName().nonEmpty && isLeader))
+        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, sourceClusterId))
       }
     }
   }
@@ -1414,10 +1415,11 @@ class Partition(val topicPartition: TopicPartition,
   def appendRecordsToFollowerOrFutureReplica(
     records: MemoryRecords,
     isFuture: Boolean,
-    partitionLeaderEpoch: Int
+    partitionLeaderEpoch: Int,
+    sourceClusterId: Uuid = null
   ): Option[LogAppendInfo] = {
     try {
-      doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch)
+      doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch, sourceClusterId)
     } catch {
       case e: UnexpectedAppendOffsetException =>
         val log = if (isFuture) futureLocalLogOrException else localLogOrException
@@ -1435,7 +1437,7 @@ class Partition(val topicPartition: TopicPartition,
           info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset} is less than log start offset ${log.logStartOffset}." +
                s" Since this is the first record to be appended to the $replicaName's log, will start the log from offset ${e.firstOffset}.")
           truncateFullyAndStartAt(e.firstOffset, isFuture)
-          doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch)
+          doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch, sourceClusterId)
         } else
           throw e
     }

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -94,9 +94,9 @@ class MirrorFetcherThread(name: String,
       trace("Mirror follower has replica log end offset %d for partition %s. Received %d bytes of messages and leader hw %d"
         .format(log.logEndOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
 
-    // Append batches from the source cluster to the destination partition's log. Leader epochs
-    // are rewritten to the destination's local epoch and producer IDs to negative space before append.
-    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch)
+    // Append batches from the source cluster to the destination partition's log.
+    val sourceClusterId = replicaMgr.mirrorMetadataManager.map(_.getSourceClusterId(mirrorName)).orNull
+    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch, sourceClusterId)
 
     if (logTrace)
       trace("Mirror follower has replica log end offset %d after appending %d bytes of messages for partition %s"

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -132,7 +132,7 @@ public class PartitionMakeFollowerBenchmark {
             int initialOffSet = 0;
             while (true) {
                 MemoryRecords memoryRecords =  MemoryRecords.withRecords(initialOffSet, Compression.NONE, 0, simpleRecords);
-                partition.appendRecordsToFollowerOrFutureReplica(memoryRecords, false, Integer.MAX_VALUE);
+                partition.appendRecordsToFollowerOrFutureReplica(memoryRecords, false, Integer.MAX_VALUE, null);
                 initialOffSet = initialOffSet + 2;
             }
         });

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateEntry.java
@@ -41,6 +41,7 @@ public class ProducerStateEntry {
     private int coordinatorEpoch;
     private long lastTimestamp;
     private OptionalLong currentTxnFirstOffset;
+    private String sourceClusterId;
 
     public static ProducerStateEntry empty(long producerId) {
         return new ProducerStateEntry(producerId, RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty(), Optional.empty());
@@ -110,21 +111,22 @@ public class ProducerStateEntry {
     }
 
     public void update(ProducerStateEntry nextEntry) {
-        update(nextEntry.producerEpoch, nextEntry.coordinatorEpoch, nextEntry.lastTimestamp, nextEntry.batchMetadata, nextEntry.currentTxnFirstOffset);
+        update(nextEntry.producerEpoch, nextEntry.coordinatorEpoch, nextEntry.lastTimestamp, nextEntry.batchMetadata, nextEntry.currentTxnFirstOffset, nextEntry.sourceClusterId);
     }
 
     public void update(short producerEpoch, int coordinatorEpoch, long lastTimestamp) {
-        update(producerEpoch, coordinatorEpoch, lastTimestamp, new ArrayDeque<>(0), OptionalLong.empty());
+        update(producerEpoch, coordinatorEpoch, lastTimestamp, new ArrayDeque<>(0), OptionalLong.empty(), null);
     }
 
     private void update(short producerEpoch, int coordinatorEpoch, long lastTimestamp, Deque<BatchMetadata> batchMetadata,
-                        OptionalLong currentTxnFirstOffset) {
+                        OptionalLong currentTxnFirstOffset, String sourceClusterId) {
         maybeUpdateProducerEpoch(producerEpoch);
         while (!batchMetadata.isEmpty())
             addBatchMetadata(batchMetadata.removeFirst());
         this.coordinatorEpoch = coordinatorEpoch;
         this.currentTxnFirstOffset = currentTxnFirstOffset;
         this.lastTimestamp = lastTimestamp;
+        this.sourceClusterId = sourceClusterId;
     }
 
     public void setCurrentTxnFirstOffset(long firstOffset) {
@@ -166,6 +168,14 @@ public class ProducerStateEntry {
         return currentTxnFirstOffset;
     }
 
+    public String sourceClusterId() {
+        return sourceClusterId;
+    }
+
+    public void setSourceClusterId(String sourceClusterId) {
+        this.sourceClusterId = sourceClusterId;
+    }
+
     @Override
     public String toString() {
         return "ProducerStateEntry(" +
@@ -175,6 +185,7 @@ public class ProducerStateEntry {
                 ", coordinatorEpoch=" + coordinatorEpoch +
                 ", lastTimestamp=" + lastTimestamp +
                 ", batchMetadata=" + batchMetadata +
+                ", sourceClusterId=" + sourceClusterId +
                 ')';
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -651,7 +651,11 @@ public class ProducerStateManager {
             OptionalLong currentTxnFirstOffsetVal = currentTxnFirstOffset >= 0 ? OptionalLong.of(currentTxnFirstOffset) : OptionalLong.empty();
             Optional<BatchMetadata> batchMetadata =
                     (lastOffset >= 0) ? Optional.of(new BatchMetadata(lastSequence, lastOffset, offsetDelta, timestamp)) : Optional.empty();
-            entries.add(new ProducerStateEntry(producerId, producerEpoch, coordinatorEpoch, timestamp, currentTxnFirstOffsetVal, batchMetadata));
+            ProducerStateEntry entry = new ProducerStateEntry(producerId, producerEpoch, coordinatorEpoch, timestamp, currentTxnFirstOffsetVal, batchMetadata);
+            if (version >= 2) {
+                entry.setSourceClusterId(producerEntry.sourceClusterId());
+            }
+            entries.add(entry);
         }
 
         return entries;
@@ -659,6 +663,9 @@ public class ProducerStateManager {
 
     // visible for testing
     public static void writeSnapshot(File file, Map<Long, ProducerStateEntry> entries, boolean sync) throws IOException {
+        boolean hasMirroredEntries = entries.values().stream().anyMatch(e -> e.sourceClusterId() != null);
+        short snapshotVersion = hasMirroredEntries ? (short) 2 : (short) 1;
+
         ProducerSnapshot producerSnapshot = new ProducerSnapshot();
         List<ProducerSnapshot.ProducerEntry> producerEntries = new ArrayList<>(entries.size());
         for (Map.Entry<Long, ProducerStateEntry> producerIdEntry : entries.entrySet()) {
@@ -673,11 +680,14 @@ public class ProducerStateManager {
                     .setTimestamp(entry.lastTimestamp())
                     .setCoordinatorEpoch(entry.coordinatorEpoch())
                     .setCurrentTxnFirstOffset(entry.currentTxnFirstOffset().orElse(-1L));
+            if (snapshotVersion >= 2) {
+                producerEntry.setSourceClusterId(entry.sourceClusterId());
+            }
             producerEntries.add(producerEntry);
         }
 
         producerSnapshot.setProducerEntries(producerEntries);
-        ByteBuffer buffer = MessageUtil.toVersionPrefixedByteBuffer(ProducerSnapshot.HIGHEST_SUPPORTED_VERSION, producerSnapshot);
+        ByteBuffer buffer = MessageUtil.toVersionPrefixedByteBuffer(snapshotVersion, producerSnapshot);
 
         // now fill in the CRC
         long crc = Crc32C.compute(buffer, PRODUCER_ENTRIES_OFFSET, buffer.limit() - PRODUCER_ENTRIES_OFFSET);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1297,6 +1297,7 @@ public class UnifiedLog implements AutoCloseable {
      */
     private void maybeOverrideProducerIdAndLeaderEpoch(MemoryRecords records, Uuid sourceClusterId) {
         if (sourceClusterId != null) {
+            // XOR-fold the source cluster UUID's most and least significant 64-bit halves, masked to 32 bits
             long clusterHash = (sourceClusterId.getMostSignificantBits() ^ sourceClusterId.getLeastSignificantBits()) & 0xFFFFFFFFL;
             String sourceClusterIdStr = sourceClusterId.toString();
             boolean collisionDetected = false;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -79,6 +79,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
@@ -1043,7 +1044,7 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch) {
-        return appendAsFollower(records, leaderEpoch, false);
+        return appendAsFollower(records, leaderEpoch, null);
     }
 
     /**
@@ -1051,10 +1052,11 @@ public class UnifiedLog implements AutoCloseable {
      *
      * @param records The records to append
      * @param leaderEpoch the epoch of the replica appending
+     * @param sourceClusterId The source cluster UUID for mirror leaders, or null if not mirroring
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @return Information about the appended messages including the first and last offset.
      */
-    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, boolean isMirroredTopic) {
+    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, Uuid sourceClusterId) {
         return append(records,
                       AppendOrigin.REPLICATION,
                       false,
@@ -1063,7 +1065,7 @@ public class UnifiedLog implements AutoCloseable {
                       VerificationGuard.SENTINEL,
                       true,
                       RecordBatch.CURRENT_MAGIC_VALUE,
-                      isMirroredTopic);
+                      sourceClusterId);
     }
 
     private LogAppendInfo append(MemoryRecords records,
@@ -1074,7 +1076,7 @@ public class UnifiedLog implements AutoCloseable {
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
                                  byte toMagic) {
-        return append(records, origin, validateAndAssignOffsets, leaderEpoch, requestLocal, verificationGuard, ignoreRecordSize, toMagic, false);
+        return append(records, origin, validateAndAssignOffsets, leaderEpoch, requestLocal, verificationGuard, ignoreRecordSize, toMagic, null);
     }
 
     /**
@@ -1090,7 +1092,7 @@ public class UnifiedLog implements AutoCloseable {
      * @param requestLocal The request local instance if validateAndAssignOffsets is true
      * @param ignoreRecordSize True to skip validation of record size
      * @param toMagic Current Magic value
-     * @param isMirrorLeader True if this is a read-only leader fetching from source cluster
+     * @param sourceClusterId The source cluster UUID for mirror leaders, or null if not mirroring
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @throws OffsetsOutOfOrderException If out of order offsets found in 'records'
      * @throws UnexpectedAppendOffsetException If the first or last offset in append is less than next offset
@@ -1104,7 +1106,7 @@ public class UnifiedLog implements AutoCloseable {
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
                                  byte toMagic,
-                                 boolean isMirrorLeader) {
+                                 Uuid sourceClusterId) {
         // We want to ensure the partition metadata file is written to the log dir before any log data is written to disk.
         // This will ensure that any log data can be recovered with the correct topic ID in the case of failure.
         maybeFlushMetadataFile();
@@ -1170,7 +1172,7 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                maybeOverrideProducerIdAndLeaderEpoch(records, isMirrorLeader);
+                                maybeOverrideProducerIdAndLeaderEpoch(records, sourceClusterId);
                                 // we are taking the offsets we are given
                                 if (appendInfo.firstOrLastOffsetOfFirstBatch() < localLog.logEndOffset()) {
                                     // we may still be able to recover if the log is empty
@@ -1246,6 +1248,7 @@ public class UnifiedLog implements AutoCloseable {
 
                                 // update the producer state
                                 result.updatedProducers.values().forEach(producerStateManager::update);
+                                maybeTagMirroredProducers(result.updatedProducers.keySet(), sourceClusterId);
 
                                 // update the transaction index with the true last stable offset. The last offset visible
                                 // to consumers using READ_COMMITTED will be limited by this value and the high watermark.
@@ -1274,21 +1277,76 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     /**
-     * Override producer IDs and leader epochs for records being mirrored from a source cluster.
-     * This is only applied to read-only leaders (partition leader with mirrorName set)
-     * to ensure producer IDs from source cluster don't conflict with local producer IDs,
-     * and local epoch-based partition replication can work without changes.
+     * Rewrites leader epochs and producer IDs for mirrored records. Leader epochs are set to
+     * the local epoch. Producer IDs are mapped into the negative space using a bit-field layout
+     * that encodes the source cluster identity, making the transformation idempotent and safe
+     * for chained mirroring (A -> B -> C). Each source cluster gets its own region of the
+     * negative ID space (~2 billion IDs per region, ~4 billion regions), so producer IDs from
+     * different source clusters never collide. Already-transformed IDs (negative) and
+     * non-transactional batches (pid -1) are left unchanged.
      *
-     * @param records The records being appended
-     * @param isMirrorLeader True if this is a read-only leader fetching from source cluster
+     * <pre>
+     * Bit 63:     1 (sign bit, marks as mirrored)
+     * Bits 62-31: 32-bit hash of source cluster ID (region selector)
+     * Bits 30-0:  31 bits of original producer ID (producer identity within region)
+     * </pre>
+     *
+     * Collision detection: if the computed mapped PID already exists in the producer state
+     * with a different source cluster ID, the hash is rehashed with an incrementing salt
+     * until a free slot is found. A PSM snapshot is forced after collision resolution.
      */
-    private void maybeOverrideProducerIdAndLeaderEpoch(MemoryRecords records, boolean isMirrorLeader) {
-        if (isMirrorLeader) {
+    private void maybeOverrideProducerIdAndLeaderEpoch(MemoryRecords records, Uuid sourceClusterId) {
+        if (sourceClusterId != null) {
+            long clusterHash = (sourceClusterId.getMostSignificantBits() ^ sourceClusterId.getLeastSignificantBits()) & 0xFFFFFFFFL;
+            String sourceClusterIdStr = sourceClusterId.toString();
+            boolean collisionDetected = false;
             for (MutableRecordBatch batch : records.batches()) {
-                // Keep using local leader epochs
                 batch.setPartitionLeaderEpoch(latestEpoch().orElse(0));
-                // Mirrored producer IDs occupy the negative space to avoid any conflict
-                batch.setProducerId(-(batch.producerId() + 2));
+                long pid = batch.producerId();
+                if (pid >= 0) {
+                    // map the producer into the source cluster's region
+                    long mappedPid = Long.MIN_VALUE | (clusterHash << 31) | (pid & 0x7FFFFFFFL);
+                    Optional<ProducerStateEntry> existing = producerStateManager.lastEntry(mappedPid);
+                    if (existing.isPresent()) {
+                        String existingClusterId = existing.get().sourceClusterId();
+                        if (existingClusterId != null && !existingClusterId.equals(sourceClusterIdStr)) {
+                            long salt = 1;
+                            while (salt <= 0xFFFFFFFFL) {
+                                // shift the producer into a different region
+                                long rehashed = ((clusterHash + salt) & 0xFFFFFFFFL);
+                                mappedPid = Long.MIN_VALUE | (rehashed << 31) | (pid & 0x7FFFFFFFL);
+                                Optional<ProducerStateEntry> recheck = producerStateManager.lastEntry(mappedPid);
+                                if (recheck.isEmpty() || sourceClusterIdStr.equals(recheck.get().sourceClusterId())) {
+                                    break;
+                                }
+                                salt++;
+                            }
+                            collisionDetected = true;
+                            logger.warn("PID collision detected for producer {} from cluster {} (existing cluster: {}). " +
+                                "Rehashed with salt {} to mapped PID {}", pid, sourceClusterIdStr, existingClusterId, salt, mappedPid);
+                        }
+                    }
+                    batch.setProducerId(mappedPid);
+                }
+            }
+            if (collisionDetected) {
+                try {
+                    producerStateManager.takeSnapshot();
+                } catch (IOException e) {
+                    logger.error("Failed to force PSM snapshot after collision resolution", e);
+                }
+            }
+        }
+    }
+
+    private void maybeTagMirroredProducers(Set<Long> producerIds, Uuid sourceClusterId) {
+        if (sourceClusterId != null) {
+            String sourceClusterIdStr = sourceClusterId.toString();
+            for (long pid : producerIds) {
+                if (pid < 0) {
+                    producerStateManager.lastEntry(pid).ifPresent(
+                        entry -> entry.setSourceClusterId(sourceClusterIdStr));
+                }
             }
         }
     }

--- a/storage/src/main/resources/message/ProducerSnapshot.json
+++ b/storage/src/main/resources/message/ProducerSnapshot.json
@@ -16,68 +16,76 @@
 {
   "type": "data",
   "name": "ProducerSnapshot",
-  "validVersions": "1",
+  "validVersions": "1-2",
   "flexibleVersions":  "none",
   "fields": [
     {
       "name": "Crc",
       "type": "uint32",
-      "versions": "1",
+      "versions": "1+",
       "about": "CRC of the snapshot data"
     },
     {
       "name": "ProducerEntries",
       "type": "[]ProducerEntry",
-      "versions": "1",
+      "versions": "1+",
       "about": "The entries in the producer table",
       "fields": [
         {
           "name": "ProducerId",
           "type": "int64",
-          "versions": "1",
+          "versions": "1+",
           "about": "The producer ID"
         },
         {
           "name": "Epoch",
           "type": "int16",
-          "versions": "1",
+          "versions": "1+",
           "about": "Current epoch of the producer"
         },
         {
           "name": "LastSequence",
           "type": "int32",
-          "versions": "1",
+          "versions": "1+",
           "about": "Last written sequence of the producer"
         },
         {
           "name": "LastOffset",
           "type": "int64",
-          "versions": "1",
+          "versions": "1+",
           "about": "Last written offset of the producer"
         },
         {
           "name": "OffsetDelta",
           "type": "int32",
-          "versions": "1",
+          "versions": "1+",
           "about": "The difference of the last sequence and first sequence in the last written batch"
         },
         {
           "name": "Timestamp",
           "type": "int64",
-          "versions": "1",
+          "versions": "1+",
           "about": "Max timestamp from the last written entry"
         },
         {
           "name": "CoordinatorEpoch",
           "type": "int32",
-          "versions": "1",
+          "versions": "1+",
           "about": "The epoch of the last transaction coordinator to send an end transaction marker"
         },
         {
           "name": "CurrentTxnFirstOffset",
           "type": "int64",
-          "versions": "1",
+          "versions": "1+",
           "about": "The first offset of the on-going transaction (-1 if there is none)"
+        },
+        {
+          "name": "SourceClusterId",
+          "type": "string",
+          "versions": "2+",
+          "nullableVersions": "2+",
+          "default": "null",
+          "about": "The source cluster ID for mirrored producer IDs, null for local producers"
         }
       ]
     }


### PR DESCRIPTION
Implement producer ID transformation for mirrored records using a bit-field layout that encodes the source cluster identity into the negative PID space, making the mapping idempotent and safe for chained mirroring (A -> B -> C).

Bit layout: sign bit (63) | 32-bit cluster hash (62-31) | 31-bit PID (30-0)

The source cluster ID is resolved from MetadataResponse and cached in MirrorMetadataManager. Collision detection checks the PID cache for existing entries with a different source cluster ID, rehashing with an incrementing salt on conflict and forcing a cache snapshot.

The source cluster ID is persisted in PID cache snapshots via a new v2 schema, used only when mirrored entries exist.
