### PR TITLE
Add PID mapping with MirrorPidResetRecord on failover

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
@@ -54,6 +54,9 @@ public enum ControlRecordType {
     KRAFT_VERSION((short) 5),
     KRAFT_VOTERS((short) 6),
 
+    // Cluster mirroring control messages
+    MIRROR_PID_RESET((short) 7),
+
     // UNKNOWN is used to indicate a control type which the client is not aware of and should be ignored
     UNKNOWN((short) -1);
 
@@ -117,6 +120,8 @@ public enum ControlRecordType {
                 return KRAFT_VERSION;
             case 6:
                 return KRAFT_VOTERS;
+            case 7:
+                return MIRROR_PID_RESET;
 
             default:
                 return UNKNOWN;

--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 
 /**
  * Control records specify a schema for the record key which includes a version and type:
@@ -130,5 +131,19 @@ public enum ControlRecordType {
 
     public static ControlRecordType parse(ByteBuffer key) {
         return fromTypeId(parseTypeId(key));
+    }
+
+    public static boolean isMirrorPidResetBatch(RecordBatch batch) {
+        if (!batch.isControlBatch()) {
+            return false;
+        }
+        Iterator<Record> iterator = batch.iterator();
+        if (iterator.hasNext()) {
+            Record record = iterator.next();
+            if (record.hasKey()) {
+                return parse(record.key()) == MIRROR_PID_RESET;
+            }
+        }
+        return false;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordUtils.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.message.KRaftVersionRecord;
 import org.apache.kafka.common.message.LeaderChangeMessage;
+import org.apache.kafka.common.message.MirrorPidResetRecord;
 import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.message.VotersRecord;
@@ -34,6 +35,7 @@ public class ControlRecordUtils {
     public static final short SNAPSHOT_FOOTER_CURRENT_VERSION = 0;
     public static final short SNAPSHOT_HEADER_CURRENT_VERSION = 0;
     public static final short KRAFT_VOTERS_CURRENT_VERSION = 0;
+    public static final short MIRROR_PID_RESET_CURRENT_VERSION = 0;
 
     public static LeaderChangeMessage deserializeLeaderChangeMessage(Record record) {
         ControlRecordType recordType = ControlRecordType.parse(record.key());
@@ -88,6 +90,13 @@ public class ControlRecordUtils {
 
     public static VotersRecord deserializeVotersRecord(ByteBuffer data) {
         return new VotersRecord(new ByteBufferAccessor(data.slice()), KRAFT_VOTERS_CURRENT_VERSION);
+    }
+
+    public static MirrorPidResetRecord deserializeMirrorPidResetRecord(Record record) {
+        ControlRecordType recordType = ControlRecordType.parse(record.key());
+        validateControlRecordType(ControlRecordType.MIRROR_PID_RESET, recordType);
+
+        return new MirrorPidResetRecord(new ByteBufferAccessor(record.value().slice()), MIRROR_PID_RESET_CURRENT_VERSION);
     }
 
     private static void validateControlRecordType(ControlRecordType expected, ControlRecordType actual) {

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.message.KRaftVersionRecord;
 import org.apache.kafka.common.message.LeaderChangeMessage;
+import org.apache.kafka.common.message.MirrorPidResetRecord;
 import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.message.VotersRecord;
@@ -815,6 +816,25 @@ public class MemoryRecords extends AbstractRecords {
             )
         ) {
             builder.appendVotersMessage(timestamp, votersRecord);
+            return builder.build();
+        }
+    }
+
+    public static MemoryRecords withMirrorPidResetRecord(
+        long initialOffset,
+        long timestamp,
+        int leaderEpoch,
+        ByteBuffer buffer,
+        MirrorPidResetRecord mirrorPidResetRecord
+    ) {
+        try (MemoryRecordsBuilder builder = createKraftControlRecordBuilder(
+                initialOffset,
+                timestamp,
+                leaderEpoch,
+                buffer
+            )
+        ) {
+            builder.appendMirrorPidResetMessage(timestamp, mirrorPidResetRecord);
             return builder.build();
         }
     }

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.message.KRaftVersionRecord;
 import org.apache.kafka.common.message.LeaderChangeMessage;
+import org.apache.kafka.common.message.MirrorPidResetRecord;
 import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.message.VotersRecord;
@@ -667,6 +668,14 @@ public class MemoryRecordsBuilder implements AutoCloseable {
             timestamp,
             ControlRecordType.KRAFT_VOTERS,
             MessageUtil.toByteBufferAccessor(votersRecord, ControlRecordUtils.KRAFT_VOTERS_CURRENT_VERSION).buffer()
+        );
+    }
+
+    public void appendMirrorPidResetMessage(long timestamp, MirrorPidResetRecord mirrorPidResetRecord) {
+        appendControlRecord(
+            timestamp,
+            ControlRecordType.MIRROR_PID_RESET,
+            MessageUtil.toByteBufferAccessor(mirrorPidResetRecord, ControlRecordUtils.MIRROR_PID_RESET_CURRENT_VERSION).buffer()
         );
     }
 

--- a/clients/src/main/resources/common/message/MirrorPidResetRecord.json
+++ b/clients/src/main/resources/common/message/MirrorPidResetRecord.json
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Cluster Mirror is in development. This schema is subject to non-backwards-compatible changes.
+{
+  "type": "data",
+  "name": "MirrorPidResetRecord",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Version", "type": "int16", "versions": "0",
+      "about": "The version of the mirror PID reset record."},
+    { "name": "SourceClusterId", "type": "string", "versions": "0",
+      "about": "The source cluster UUID for verification."}
+  ]
+}

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -20,6 +20,7 @@ import kafka.server.KafkaConfig;
 import kafka.server.ReplicaManager;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.WriteMirrorStatesResponseData;
@@ -132,7 +133,6 @@ public class MirrorCoordinator {
                 break;
             case MIRRORING:
                 log.debug("MIRRORING topics {}.", topicPartitions);
-                // start mirroring
                 replicaManager.maybeCreateMirrorFetchers(mirrorName, topicPartitions);
                 break;
             case PAUSING:
@@ -151,6 +151,7 @@ public class MirrorCoordinator {
                 break;
             case STOPPED:
                 log.debug("STOPPED for topics {}.", topicPartitions);
+                writeMirrorPidResetBarrier(mirrorName, topicPartitions);
                 // topic is writable
                 break;
             case FAILED:
@@ -158,7 +159,7 @@ public class MirrorCoordinator {
                 // TODO: implement recovery actions (i.e. exponential backoff retry)
                 break;
             default:
-                log.error("Illegal state transition to " + newState);
+                log.error("Illegal state transition to {}", newState);
                 throw new IllegalArgumentException("Illegal state transition to " + newState);
         }
     }
@@ -348,7 +349,7 @@ public class MirrorCoordinator {
 
         // periodically query source cluster to get the metadata
         long metadataRefreshIntervalMs = brokerConfig.mirrorConfig().metadataRefreshIntervalMs();
-        scheduler.schedule("MirrorMetadataRefresh", metadataManager::syncMetadata, metadataRefreshIntervalMs, metadataRefreshIntervalMs);
+        scheduler.schedule("MirrorMetadataRefresh", metadataManager::syncMetadata, 0, metadataRefreshIntervalMs);
 
         log.info("Startup complete.");
     }
@@ -371,6 +372,21 @@ public class MirrorCoordinator {
                     scheduleTruncation(mirrorName, topicPartitions, retryDelayMs);
                 }
             }, delayMs);
+    }
+
+    private void writeMirrorPidResetBarrier(String mirrorName, Set<TopicPartition> topicPartitions) {
+        Uuid sourceClusterId = metadataManager.getSourceClusterId(mirrorName);
+        if (sourceClusterId == null) {
+            log.warn("Source cluster ID not available for mirror {}. Skipping PID reset barrier.", mirrorName);
+            return;
+        }
+        for (TopicPartition tp : topicPartitions) {
+            try {
+                replicaManager.getPartitionOrException(tp).appendMirrorPidResetBarrier(sourceClusterId);
+            } catch (Exception e) {
+                log.error("Failed to write PID reset barrier for partition {} in mirror {}", tp, mirrorName, e);
+            }
+        }
     }
 
     private Map<String, Map<Integer, Long>> lastMirroredOffsetsToCoordinatorRecords(Map<MirrorUtils.PartitionKey, Long> offsets) {

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -23,10 +23,13 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.internals.Topic;
+import org.apache.kafka.common.message.MirrorPidResetRecord;
 import org.apache.kafka.common.message.WriteMirrorStatesResponseData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.ControlRecordUtils;
+import org.apache.kafka.common.record.DefaultRecordBatch;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -148,10 +151,10 @@ public class MirrorCoordinator {
                 log.debug("STOPPING for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
                 truncateToLastStableOffset(topicPartitions, tp -> updateLastMirroredOffsets(mirrorName, Set.of(tp)));
+                writeMirrorPidResetBarrier(mirrorName, topicPartitions);
                 break;
             case STOPPED:
                 log.debug("STOPPED for topics {}.", topicPartitions);
-                writeMirrorPidResetBarrier(mirrorName, topicPartitions);
                 // topic is writable
                 break;
             case FAILED:
@@ -380,9 +383,40 @@ public class MirrorCoordinator {
             log.warn("Source cluster ID not available for mirror {}. Skipping PID reset barrier.", mirrorName);
             return;
         }
+        MirrorPidResetRecord record = new MirrorPidResetRecord()
+            .setVersion(ControlRecordUtils.MIRROR_PID_RESET_CURRENT_VERSION)
+            .setSourceClusterId(sourceClusterId.toString());
+        long timestamp = time.milliseconds();
         for (TopicPartition tp : topicPartitions) {
             try {
-                replicaManager.getPartitionOrException(tp).appendMirrorPidResetBarrier(sourceClusterId);
+                var topicIdPartition = replicaManager.topicIdPartition(tp);
+                int bufferSize = DefaultRecordBatch.RECORD_BATCH_OVERHEAD + 256;
+                ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+                MemoryRecords records = MemoryRecords.withMirrorPidResetRecord(0, timestamp, 0, buffer, record);
+                replicaManager.appendRecords(
+                    // TODO: replace this with Cluster Mirror specific timeout
+                    Duration.ofSeconds(5).toMillis(),
+                    (short) -1,
+                    true,
+                    AppendOrigin.COORDINATOR,
+                    CollectionConverters.asScala(Map.of(topicIdPartition, records)),
+                    partitionResponses -> {
+                        partitionResponses.foreach(partitionRes -> {
+                            ProduceResponse.PartitionResponse pr = partitionRes._2;
+                            if (pr.error.code() != Errors.NONE.code()) {
+                                log.error("Failed to write PID reset barrier for partition {} in mirror {}: {}",
+                                    tp, mirrorName, pr.error.message());
+                            } else {
+                                log.info("Wrote mirror PID reset barrier for partition {} in mirror {}", tp, mirrorName);
+                            }
+                            return null;
+                        });
+                        return null;
+                    },
+                    ignored -> null,
+                    RequestLocal.noCaching(),
+                    CollectionConverters.asScala(Map.of())
+                );
             } catch (Exception e) {
                 log.error("Failed to write PID reset barrier for partition {} in mirror {}", tp, mirrorName, e);
             }

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -396,7 +396,7 @@ public class MirrorCoordinator {
                 replicaManager.appendRecords(
                     // TODO: replace this with Cluster Mirror specific timeout
                     Duration.ofSeconds(5).toMillis(),
-                    (short) -1,
+                    (short) -1, // request ack from all ISR
                     true,
                     AppendOrigin.COORDINATOR,
                     CollectionConverters.asScala(Map.of(topicIdPartition, records)),
@@ -475,7 +475,7 @@ public class MirrorCoordinator {
             replicaManager.appendRecords(
                     // TODO: replace this with Cluster Mirror specific timeout
                     Duration.ofSeconds(5).toMillis(),
-                    (short) -1,
+                    (short) -1, // request ack from all ISR
                     true,
                     AppendOrigin.COORDINATOR,
                     CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AccessControlEntryFilter;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
@@ -172,6 +173,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     // cache
     // thread-safe maps for concurrent access from metadata, scheduler, and fetcher threads
+    private final Map<String, Uuid> sourceClusterIds = new ConcurrentHashMap<>();
     private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
@@ -936,6 +938,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
 
+        String clusterId = metadataResponse.clusterId();
+        if (clusterId != null && !clusterId.isEmpty()) {
+            sourceClusterIds.put(mirrorName, Uuid.fromString(clusterId));
+        }
+
         Collection<Node> discoveredBrokers = metadataResponse.brokers();
         if (discoveredBrokers.isEmpty()) {
             return;
@@ -1429,10 +1436,34 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return result;
     }
 
+    Uuid getSourceClusterId(String mirrorName) {
+        Uuid cached = sourceClusterIds.get(mirrorName);
+        if (cached != null) {
+            return cached;
+        }
+        // cache miss: resolve by sending a synchronous metadata request
+        ensureConnection(mirrorName);
+        try {
+            var response = trySendRequest(mirrorName, MetadataRequest.Builder.allTopics());
+            if (response.responseBody() instanceof MetadataResponse metadataResponse) {
+                String clusterId = metadataResponse.clusterId();
+                if (clusterId != null && !clusterId.isEmpty()) {
+                    cached = Uuid.fromString(clusterId);
+                    sourceClusterIds.put(mirrorName, cached);
+                    return cached;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to resolve source cluster ID for mirror {}", mirrorName, e);
+        }
+        return null;
+    }
+
     void clear() {
         partitionStates.clear();
         partitionStateCounts.clear();
         lastMirroredOffsets.clear();
+        sourceClusterIds.clear();
         closeSourceSenders();
         sourceLeaders.clear();
     }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1392,7 +1392,8 @@ class Partition(val topicPartition: TopicPartition,
   private def doAppendRecordsToFollowerOrFutureReplica(
     records: MemoryRecords,
     isFuture: Boolean,
-    partitionLeaderEpoch: Int
+    partitionLeaderEpoch: Int,
+    sourceClusterId: Uuid
   ): Option[LogAppendInfo] = {
     if (isFuture) {
       // The read lock is needed to handle race condition if request handler thread tries to
@@ -1400,13 +1401,13 @@ class Partition(val topicPartition: TopicPartition,
       inReadLock(leaderIsrUpdateLock) {
         // Note the replica may be undefined if it is removed by a non-ReplicaAlterLogDirsThread before
         // this method is called
-        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, getMirrorName().nonEmpty && isLeader) }
+        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, sourceClusterId) }
       }
     } else {
       // The lock is needed to prevent the follower replica from being updated while ReplicaAlterDirThread
       // is executing maybeReplaceCurrentWithFutureReplica() to replace follower replica with the future replica.
       futureLogLock.synchronized {
-        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, getMirrorName().nonEmpty && isLeader))
+        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, sourceClusterId))
       }
     }
   }
@@ -1414,10 +1415,11 @@ class Partition(val topicPartition: TopicPartition,
   def appendRecordsToFollowerOrFutureReplica(
     records: MemoryRecords,
     isFuture: Boolean,
-    partitionLeaderEpoch: Int
+    partitionLeaderEpoch: Int,
+    sourceClusterId: Uuid = null
   ): Option[LogAppendInfo] = {
     try {
-      doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch)
+      doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch, sourceClusterId)
     } catch {
       case e: UnexpectedAppendOffsetException =>
         val log = if (isFuture) futureLocalLogOrException else localLogOrException
@@ -1435,10 +1437,14 @@ class Partition(val topicPartition: TopicPartition,
           info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset} is less than log start offset ${log.logStartOffset}." +
                s" Since this is the first record to be appended to the $replicaName's log, will start the log from offset ${e.firstOffset}.")
           truncateFullyAndStartAt(e.firstOffset, isFuture)
-          doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch)
+          doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch, sourceClusterId)
         } else
           throw e
     }
+  }
+
+  def appendMirrorPidResetBarrier(sourceClusterId: Uuid): Unit = {
+    localLogOrException.appendMirrorPidResetBarrier(sourceClusterId)
   }
 
   def appendRecordsToLeader(records: MemoryRecords, origin: AppendOrigin, requiredAcks: Int,

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1393,7 +1393,7 @@ class Partition(val topicPartition: TopicPartition,
     records: MemoryRecords,
     isFuture: Boolean,
     partitionLeaderEpoch: Int,
-    sourceClusterId: Uuid
+    isMirrorLeader: Boolean
   ): Option[LogAppendInfo] = {
     if (isFuture) {
       // The read lock is needed to handle race condition if request handler thread tries to
@@ -1401,13 +1401,13 @@ class Partition(val topicPartition: TopicPartition,
       inReadLock(leaderIsrUpdateLock) {
         // Note the replica may be undefined if it is removed by a non-ReplicaAlterLogDirsThread before
         // this method is called
-        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, sourceClusterId) }
+        futureLog.map { _.appendAsFollower(records, partitionLeaderEpoch, isMirrorLeader) }
       }
     } else {
       // The lock is needed to prevent the follower replica from being updated while ReplicaAlterDirThread
       // is executing maybeReplaceCurrentWithFutureReplica() to replace follower replica with the future replica.
       futureLogLock.synchronized {
-        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, sourceClusterId))
+        Some(localLogOrException.appendAsFollower(records, partitionLeaderEpoch, isMirrorLeader))
       }
     }
   }
@@ -1416,10 +1416,10 @@ class Partition(val topicPartition: TopicPartition,
     records: MemoryRecords,
     isFuture: Boolean,
     partitionLeaderEpoch: Int,
-    sourceClusterId: Uuid = null
+    isMirrorLeader: Boolean = false
   ): Option[LogAppendInfo] = {
     try {
-      doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch, sourceClusterId)
+      doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch, isMirrorLeader)
     } catch {
       case e: UnexpectedAppendOffsetException =>
         val log = if (isFuture) futureLocalLogOrException else localLogOrException
@@ -1437,7 +1437,7 @@ class Partition(val topicPartition: TopicPartition,
           info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset} is less than log start offset ${log.logStartOffset}." +
                s" Since this is the first record to be appended to the $replicaName's log, will start the log from offset ${e.firstOffset}.")
           truncateFullyAndStartAt(e.firstOffset, isFuture)
-          doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch, sourceClusterId)
+          doAppendRecordsToFollowerOrFutureReplica(records, isFuture, partitionLeaderEpoch, isMirrorLeader)
         } else
           throw e
     }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1443,10 +1443,6 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  def appendMirrorPidResetBarrier(sourceClusterId: Uuid): Unit = {
-    localLogOrException.appendMirrorPidResetBarrier(sourceClusterId)
-  }
-
   def appendRecordsToLeader(records: MemoryRecords, origin: AppendOrigin, requiredAcks: Int,
                             requestLocal: RequestLocal, verificationGuard: VerificationGuard = VerificationGuard.SENTINEL): LogAppendInfo = {
     val (info, leaderHWIncremented) = inReadLock(leaderIsrUpdateLock) {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1413,7 +1413,8 @@ class ReplicaManager(val config: KafkaConfig,
       // if it's mirrored topic, it will become writable only when in STOPPED state
       val mirrorName = partition.getMirrorName()
       if (mirrorMetadataManager.isDefined && mirrorName.nonEmpty &&
-        mirrorMetadataManager.get.getPartitionState(mirrorName, partition.topicPartition) != MirrorPartitionState.STOPPED) {
+        !Set(MirrorPartitionState.STOPPING, MirrorPartitionState.STOPPED).contains(
+          mirrorMetadataManager.get.getPartitionState(mirrorName, partition.topicPartition))) {
         throw new ReadOnlyTopicException("Cannot append to read-only partition %s on broker %d (mirrorName=%s)"
           .format(partition.topicPartition, localBrokerId, mirrorName))
       }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1384,19 +1384,6 @@ class ReplicaManager(val config: KafkaConfig,
     requiredAcks == -1 || requiredAcks == 1 || requiredAcks == 0
   }
 
-  private def containsMirrorPidResetBatch(records: MemoryRecords): Boolean = {
-    import scala.jdk.CollectionConverters._
-    records.batches().asScala.exists { batch =>
-      batch.isControlBatch && {
-        val iter = batch.iterator()
-        iter.hasNext && {
-          val record = iter.next()
-          record.hasKey && ControlRecordType.parse(record.key()) == ControlRecordType.MIRROR_PID_RESET
-        }
-      }
-    }
-  }
-
   /**
    * Append the messages to the local replica logs
    */
@@ -1427,7 +1414,7 @@ class ReplicaManager(val config: KafkaConfig,
       if (mirrorMetadataManager.isDefined && mirrorName.nonEmpty) {
         val state = mirrorMetadataManager.get.getPartitionState(mirrorName, partition.topicPartition)
         val allowed = state == MirrorPartitionState.STOPPED ||
-          (state == MirrorPartitionState.STOPPING && containsMirrorPidResetBatch(records))
+          (state == MirrorPartitionState.STOPPING && records.batches().asScala.exists(ControlRecordType.isMirrorPidResetBatch))
         if (!allowed) {
           throw new ReadOnlyTopicException("Cannot append to read-only partition %s on broker %d (mirrorName=%s)"
             .format(partition.topicPartition, localBrokerId, mirrorName))

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1384,6 +1384,19 @@ class ReplicaManager(val config: KafkaConfig,
     requiredAcks == -1 || requiredAcks == 1 || requiredAcks == 0
   }
 
+  private def containsMirrorPidResetBatch(records: MemoryRecords): Boolean = {
+    import scala.jdk.CollectionConverters._
+    records.batches().asScala.exists { batch =>
+      batch.isControlBatch && {
+        val iter = batch.iterator()
+        iter.hasNext && {
+          val record = iter.next()
+          record.hasKey && ControlRecordType.parse(record.key()) == ControlRecordType.MIRROR_PID_RESET
+        }
+      }
+    }
+  }
+
   /**
    * Append the messages to the local replica logs
    */
@@ -1409,14 +1422,16 @@ class ReplicaManager(val config: KafkaConfig,
       logStartOffset
     }
 
-    def validateReadOnlyTopic(partition: Partition): Unit = {
-      // if it's mirrored topic, it will become writable only when in STOPPED state
+    def validateReadOnlyTopic(partition: Partition, records: MemoryRecords): Unit = {
       val mirrorName = partition.getMirrorName()
-      if (mirrorMetadataManager.isDefined && mirrorName.nonEmpty &&
-        !Set(MirrorPartitionState.STOPPING, MirrorPartitionState.STOPPED).contains(
-          mirrorMetadataManager.get.getPartitionState(mirrorName, partition.topicPartition))) {
-        throw new ReadOnlyTopicException("Cannot append to read-only partition %s on broker %d (mirrorName=%s)"
-          .format(partition.topicPartition, localBrokerId, mirrorName))
+      if (mirrorMetadataManager.isDefined && mirrorName.nonEmpty) {
+        val state = mirrorMetadataManager.get.getPartitionState(mirrorName, partition.topicPartition)
+        val allowed = state == MirrorPartitionState.STOPPED ||
+          (state == MirrorPartitionState.STOPPING && containsMirrorPidResetBatch(records))
+        if (!allowed) {
+          throw new ReadOnlyTopicException("Cannot append to read-only partition %s on broker %d (mirrorName=%s)"
+            .format(partition.topicPartition, localBrokerId, mirrorName))
+        }
       }
     }
 
@@ -1436,7 +1451,7 @@ class ReplicaManager(val config: KafkaConfig,
       } else {
         try {
           val partition = getPartitionOrException(topicIdPartition)
-          validateReadOnlyTopic(partition)
+          validateReadOnlyTopic(partition, records)
           val info = partition.appendRecordsToLeader(records, origin, requiredAcks, requestLocal,
             verificationGuards.getOrElse(topicIdPartition.topicPartition(), VerificationGuard.SENTINEL))
           val numAppendedMessages = info.numMessages

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -96,7 +96,11 @@ class MirrorFetcherThread(name: String,
 
     // Append batches from the source cluster to the destination partition's log. Leader epochs
     // are rewritten to the destination's local epoch and producer IDs to negative space before append.
-    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch)
+    val sourceClusterId = replicaMgr.mirrorMetadataManager.map(_.getSourceClusterId(mirrorName)).orNull
+    if (sourceClusterId == null) {
+      warn(s"Source cluster ID not yet available for mirror $mirrorName. Producer IDs will not be mapped for $topicPartition.")
+    }
+    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch, sourceClusterId)
 
     if (logTrace)
       trace("Mirror follower has replica log end offset %d after appending %d bytes of messages for partition %s"

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -94,13 +94,8 @@ class MirrorFetcherThread(name: String,
       trace("Mirror follower has replica log end offset %d for partition %s. Received %d bytes of messages and leader hw %d"
         .format(log.logEndOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
 
-    // Append batches from the source cluster to the destination partition's log. Leader epochs
-    // are rewritten to the destination's local epoch and producer IDs to negative space before append.
-    val sourceClusterId = replicaMgr.mirrorMetadataManager.map(_.getSourceClusterId(mirrorName)).orNull
-    if (sourceClusterId == null) {
-      warn(s"Source cluster ID not yet available for mirror $mirrorName. Producer IDs will not be mapped for $topicPartition.")
-    }
-    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch, sourceClusterId)
+    // Append batches from the source cluster to the destination partition's log.
+    val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch, isMirrorLeader = true)
 
     if (logTrace)
       trace("Mirror follower has replica log end offset %d after appending %d bytes of messages for partition %s"

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.message.KRaftVersionRecordJsonConverter
 import org.apache.kafka.common.message.LeaderChangeMessageJsonConverter
 import org.apache.kafka.common.message.SnapshotFooterRecordJsonConverter
 import org.apache.kafka.common.message.SnapshotHeaderRecordJsonConverter
+import org.apache.kafka.common.message.MirrorPidResetRecordJsonConverter
 import org.apache.kafka.common.message.VotersRecordJsonConverter
 import org.apache.kafka.common.metadata.{MetadataJsonConverters, MetadataRecordType}
 import org.apache.kafka.common.protocol.{ApiMessage, ByteBufferAccessor}
@@ -356,6 +357,9 @@ object DumpLogSegments {
       case ControlRecordType.KRAFT_VOTERS=>
         val voters = ControlRecordUtils.deserializeVotersRecord(record)
         print(s" KRaftVoters ${VotersRecordJsonConverter.write(voters, voters.version())}")
+      case ControlRecordType.MIRROR_PID_RESET =>
+        val mirrorPidReset = ControlRecordUtils.deserializeMirrorPidResetRecord(record)
+        print(s" MirrorPidReset ${MirrorPidResetRecordJsonConverter.write(mirrorPidReset, mirrorPidReset.version())}")
       case controlType =>
         print(s" controlType: $controlType($controlTypeId)")
     }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -132,7 +132,7 @@ public class PartitionMakeFollowerBenchmark {
             int initialOffSet = 0;
             while (true) {
                 MemoryRecords memoryRecords =  MemoryRecords.withRecords(initialOffSet, Compression.NONE, 0, simpleRecords);
-                partition.appendRecordsToFollowerOrFutureReplica(memoryRecords, false, Integer.MAX_VALUE);
+                partition.appendRecordsToFollowerOrFutureReplica(memoryRecords, false, Integer.MAX_VALUE, null);
                 initialOffSet = initialOffSet + 2;
             }
         });

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -132,7 +132,7 @@ public class PartitionMakeFollowerBenchmark {
             int initialOffSet = 0;
             while (true) {
                 MemoryRecords memoryRecords =  MemoryRecords.withRecords(initialOffSet, Compression.NONE, 0, simpleRecords);
-                partition.appendRecordsToFollowerOrFutureReplica(memoryRecords, false, Integer.MAX_VALUE, null);
+                partition.appendRecordsToFollowerOrFutureReplica(memoryRecords, false, Integer.MAX_VALUE, false);
                 initialOffSet = initialOffSet + 2;
             }
         });

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -412,16 +412,10 @@ public class ProducerStateManager {
     }
 
     public void expireMirroredProducers() {
-        int count = 0;
-        var it = producers.entrySet().iterator();
-        while (it.hasNext()) {
-            if (it.next().getKey() < 0) {
-                it.remove();
-                count++;
-            }
-        }
+        int count = producers.size();
         if (count > 0) {
-            producerIdCount = producers.size();
+            producers.clear();
+            producerIdCount = 0;
             log.info("Expired {} mirrored producer(s) from {}", count, topicPartition);
         }
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -411,6 +411,21 @@ public class ProducerStateManager {
         }
     }
 
+    public void expireMirroredProducers() {
+        int count = 0;
+        var it = producers.entrySet().iterator();
+        while (it.hasNext()) {
+            if (it.next().getKey() < 0) {
+                it.remove();
+                count++;
+            }
+        }
+        if (count > 0) {
+            producerIdCount = producers.size();
+            log.info("Expired {} mirrored producer(s) from {}", count, topicPartition);
+        }
+    }
+
     public void updateMapEndOffset(long lastOffset) {
         lastMapOffset = lastOffset;
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -31,7 +31,10 @@ import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.DescribeProducersResponseData;
+import org.apache.kafka.common.message.MirrorPidResetRecord;
 import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.ControlRecordUtils;
+import org.apache.kafka.common.record.DefaultRecordBatch;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -1043,7 +1046,7 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch) {
-        return appendAsFollower(records, leaderEpoch, false);
+        return appendAsFollower(records, leaderEpoch, null);
     }
 
     /**
@@ -1051,10 +1054,11 @@ public class UnifiedLog implements AutoCloseable {
      *
      * @param records The records to append
      * @param leaderEpoch the epoch of the replica appending
+     * @param sourceClusterId The source cluster UUID for mirror leaders, or null if not mirroring
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @return Information about the appended messages including the first and last offset.
      */
-    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, boolean isMirroredTopic) {
+    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, Uuid sourceClusterId) {
         return append(records,
                       AppendOrigin.REPLICATION,
                       false,
@@ -1063,7 +1067,7 @@ public class UnifiedLog implements AutoCloseable {
                       VerificationGuard.SENTINEL,
                       true,
                       RecordBatch.CURRENT_MAGIC_VALUE,
-                      isMirroredTopic);
+                      sourceClusterId);
     }
 
     private LogAppendInfo append(MemoryRecords records,
@@ -1074,7 +1078,7 @@ public class UnifiedLog implements AutoCloseable {
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
                                  byte toMagic) {
-        return append(records, origin, validateAndAssignOffsets, leaderEpoch, requestLocal, verificationGuard, ignoreRecordSize, toMagic, false);
+        return append(records, origin, validateAndAssignOffsets, leaderEpoch, requestLocal, verificationGuard, ignoreRecordSize, toMagic, null);
     }
 
     /**
@@ -1090,7 +1094,7 @@ public class UnifiedLog implements AutoCloseable {
      * @param requestLocal The request local instance if validateAndAssignOffsets is true
      * @param ignoreRecordSize True to skip validation of record size
      * @param toMagic Current Magic value
-     * @param isMirrorLeader True if this is a read-only leader fetching from source cluster
+     * @param sourceClusterId The source cluster UUID for mirror leaders, or null if not mirroring
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @throws OffsetsOutOfOrderException If out of order offsets found in 'records'
      * @throws UnexpectedAppendOffsetException If the first or last offset in append is less than next offset
@@ -1104,7 +1108,7 @@ public class UnifiedLog implements AutoCloseable {
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
                                  byte toMagic,
-                                 boolean isMirrorLeader) {
+                                 Uuid sourceClusterId) {
         // We want to ensure the partition metadata file is written to the log dir before any log data is written to disk.
         // This will ensure that any log data can be recovered with the correct topic ID in the case of failure.
         maybeFlushMetadataFile();
@@ -1170,7 +1174,7 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                maybeOverrideProducerIdAndLeaderEpoch(records, isMirrorLeader);
+                                maybeOverrideProducerIdAndLeaderEpoch(records, sourceClusterId);
                                 // we are taking the offsets we are given
                                 if (appendInfo.firstOrLastOffsetOfFirstBatch() < localLog.logEndOffset()) {
                                     // we may still be able to recover if the log is empty
@@ -1274,22 +1278,44 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     /**
-     * Override producer IDs and leader epochs for records being mirrored from a source cluster.
-     * This is only applied to read-only leaders (partition leader with mirrorName set)
-     * to ensure producer IDs from source cluster don't conflict with local producer IDs,
-     * and local epoch-based partition replication can work without changes.
-     *
-     * @param records The records being appended
-     * @param isMirrorLeader True if this is a read-only leader fetching from source cluster
+     * Rewrites leader epochs and producer IDs for mirrored records. Leader epochs are set to
+     * the local epoch. Producer IDs are mapped into the negative space using -(PID + 2) to
+     * avoid conflicts with local producers, while preserving -1 (NO_PRODUCER_ID) for
+     * non-idempotent batches. Already-negative PIDs (from chained mirroring) pass through
+     * unchanged, making the transformation idempotent.
      */
-    private void maybeOverrideProducerIdAndLeaderEpoch(MemoryRecords records, boolean isMirrorLeader) {
-        if (isMirrorLeader) {
+    private void maybeOverrideProducerIdAndLeaderEpoch(MemoryRecords records, Uuid sourceClusterId) {
+        if (sourceClusterId != null) {
             for (MutableRecordBatch batch : records.batches()) {
-                // Keep using local leader epochs
                 batch.setPartitionLeaderEpoch(latestEpoch().orElse(0));
-                // Mirrored producer IDs occupy the negative space to avoid any conflict
-                batch.setProducerId(-(batch.producerId() + 2));
+                long pid = batch.producerId();
+                if (pid >= 0) {
+                    batch.setProducerId(-(pid + 2));
+                }
             }
+        }
+    }
+
+    public void appendMirrorPidResetBarrier(Uuid sourceClusterId) {
+        try {
+            synchronized (lock) {
+                MirrorPidResetRecord record = new MirrorPidResetRecord()
+                    .setVersion(ControlRecordUtils.MIRROR_PID_RESET_CURRENT_VERSION)
+                    .setSourceClusterId(sourceClusterId.toString());
+                int bufferSize = DefaultRecordBatch.RECORD_BATCH_OVERHEAD + 256;
+                ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+                long offset = localLog.logEndOffset();
+                int leaderEpoch = latestEpoch().orElse(0);
+                MemoryRecords records = MemoryRecords.withMirrorPidResetRecord(
+                    offset, time().milliseconds(), leaderEpoch, buffer, record);
+                localLog.append(offset, records);
+                producerStateManager.expireMirroredProducers();
+                producerStateManager.updateMapEndOffset(offset + 1);
+                updateHighWatermarkWithLogEndOffset();
+                logger.info("Wrote mirror PID reset barrier at offset {} for source cluster {}", offset, sourceClusterId);
+            }
+        } catch (IOException e) {
+            throw new KafkaStorageException("Failed to append mirror PID reset barrier", e);
         }
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -31,10 +31,8 @@ import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.DescribeProducersResponseData;
-import org.apache.kafka.common.message.MirrorPidResetRecord;
 import org.apache.kafka.common.record.CompressionType;
-import org.apache.kafka.common.record.ControlRecordUtils;
-import org.apache.kafka.common.record.DefaultRecordBatch;
+import org.apache.kafka.common.record.ControlRecordType;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -1296,27 +1294,15 @@ public class UnifiedLog implements AutoCloseable {
         }
     }
 
-    public void appendMirrorPidResetBarrier(Uuid sourceClusterId) {
-        try {
-            synchronized (lock) {
-                MirrorPidResetRecord record = new MirrorPidResetRecord()
-                    .setVersion(ControlRecordUtils.MIRROR_PID_RESET_CURRENT_VERSION)
-                    .setSourceClusterId(sourceClusterId.toString());
-                int bufferSize = DefaultRecordBatch.RECORD_BATCH_OVERHEAD + 256;
-                ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
-                long offset = localLog.logEndOffset();
-                int leaderEpoch = latestEpoch().orElse(0);
-                MemoryRecords records = MemoryRecords.withMirrorPidResetRecord(
-                    offset, time().milliseconds(), leaderEpoch, buffer, record);
-                localLog.append(offset, records);
-                producerStateManager.expireMirroredProducers();
-                producerStateManager.updateMapEndOffset(offset + 1);
-                updateHighWatermarkWithLogEndOffset();
-                logger.info("Wrote mirror PID reset barrier at offset {} for source cluster {}", offset, sourceClusterId);
+    private static boolean isMirrorPidResetBatch(RecordBatch batch) {
+        Iterator<Record> iterator = batch.iterator();
+        if (iterator.hasNext()) {
+            Record record = iterator.next();
+            if (record.hasKey()) {
+                return ControlRecordType.parse(record.key()) == ControlRecordType.MIRROR_PID_RESET;
             }
-        } catch (IOException e) {
-            throw new KafkaStorageException("Failed to append mirror PID reset barrier", e);
         }
+        return false;
     }
 
     public void assignEpochStartOffset(int leaderEpoch, long startOffset) {
@@ -1430,7 +1416,9 @@ public class UnifiedLog implements AutoCloseable {
         int relativePositionInSegment = appendOffsetMetadata.relativePositionInSegment;
 
         for (MutableRecordBatch batch : records.batches()) {
-            if (batch.hasProducerId()) {
+            if (batch.isControlBatch() && isMirrorPidResetBatch(batch)) {
+                producerStateManager.expireMirroredProducers();
+            } else if (batch.hasProducerId()) {
                 // if this is a client produce request, there will be up to 5 batches which could have been duplicated.
                 // If we find a duplicate, we return the metadata of the appended batch to the client.
                 if (origin == AppendOrigin.CLIENT) {
@@ -2619,7 +2607,9 @@ public class UnifiedLog implements AutoCloseable {
         Map<Long, ProducerAppendInfo> loadedProducers = new HashMap<>();
         final List<CompletedTxn> completedTxns = new ArrayList<>();
         records.batches().forEach(batch -> {
-            if (batch.hasProducerId()) {
+            if (batch.isControlBatch() && isMirrorPidResetBatch(batch)) {
+                producerStateManager.expireMirroredProducers();
+            } else if (batch.hasProducerId()) {
                 Optional<CompletedTxn> maybeCompletedTxn = updateProducers(
                         producerStateManager,
                         batch,

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1044,7 +1044,7 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch) {
-        return appendAsFollower(records, leaderEpoch, null);
+        return appendAsFollower(records, leaderEpoch, false);
     }
 
     /**
@@ -1052,11 +1052,11 @@ public class UnifiedLog implements AutoCloseable {
      *
      * @param records The records to append
      * @param leaderEpoch the epoch of the replica appending
-     * @param sourceClusterId The source cluster UUID for mirror leaders, or null if not mirroring
+     * @param isMirrorLeader true if this is a mirror leader appending from a source cluster
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @return Information about the appended messages including the first and last offset.
      */
-    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, Uuid sourceClusterId) {
+    public LogAppendInfo appendAsFollower(MemoryRecords records, int leaderEpoch, boolean isMirrorLeader) {
         return append(records,
                       AppendOrigin.REPLICATION,
                       false,
@@ -1065,7 +1065,7 @@ public class UnifiedLog implements AutoCloseable {
                       VerificationGuard.SENTINEL,
                       true,
                       RecordBatch.CURRENT_MAGIC_VALUE,
-                      sourceClusterId);
+                      isMirrorLeader);
     }
 
     private LogAppendInfo append(MemoryRecords records,
@@ -1076,7 +1076,7 @@ public class UnifiedLog implements AutoCloseable {
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
                                  byte toMagic) {
-        return append(records, origin, validateAndAssignOffsets, leaderEpoch, requestLocal, verificationGuard, ignoreRecordSize, toMagic, null);
+        return append(records, origin, validateAndAssignOffsets, leaderEpoch, requestLocal, verificationGuard, ignoreRecordSize, toMagic, false);
     }
 
     /**
@@ -1092,7 +1092,7 @@ public class UnifiedLog implements AutoCloseable {
      * @param requestLocal The request local instance if validateAndAssignOffsets is true
      * @param ignoreRecordSize True to skip validation of record size
      * @param toMagic Current Magic value
-     * @param sourceClusterId The source cluster UUID for mirror leaders, or null if not mirroring
+     * @param isMirrorLeader true if this is a mirror leader appending from a source cluster
      * @throws KafkaStorageException If the append fails due to an I/O error.
      * @throws OffsetsOutOfOrderException If out of order offsets found in 'records'
      * @throws UnexpectedAppendOffsetException If the first or last offset in append is less than next offset
@@ -1106,7 +1106,7 @@ public class UnifiedLog implements AutoCloseable {
                                  VerificationGuard verificationGuard,
                                  boolean ignoreRecordSize,
                                  byte toMagic,
-                                 Uuid sourceClusterId) {
+                                 boolean isMirrorLeader) {
         // We want to ensure the partition metadata file is written to the log dir before any log data is written to disk.
         // This will ensure that any log data can be recovered with the correct topic ID in the case of failure.
         maybeFlushMetadataFile();
@@ -1172,7 +1172,7 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                maybeOverrideLeaderEpoch(records, sourceClusterId);
+                                maybeOverrideLeaderEpoch(records, isMirrorLeader);
                                 // we are taking the offsets we are given
                                 if (appendInfo.firstOrLastOffsetOfFirstBatch() < localLog.logEndOffset()) {
                                     // we may still be able to recover if the log is empty
@@ -1277,13 +1277,10 @@ public class UnifiedLog implements AutoCloseable {
 
     /**
      * Rewrites leader epochs and producer IDs for mirrored records. Leader epochs are set to
-     * the local epoch. Producer IDs are mapped into the negative space using -(PID + 2) to
-     * avoid conflicts with local producers, while preserving -1 (NO_PRODUCER_ID) for
-     * non-idempotent batches. Already-negative PIDs (from chained mirroring) pass through
-     * unchanged, making the transformation idempotent.
+     * the local epoch to maintain epoch monotonicity on the destination log.
      */
-    private void maybeOverrideLeaderEpoch(MemoryRecords records, Uuid sourceClusterId) {
-        if (sourceClusterId != null) {
+    private void maybeOverrideLeaderEpoch(MemoryRecords records, boolean isMirrorLeader) {
+        if (isMirrorLeader) {
             for (MutableRecordBatch batch : records.batches()) {
                 batch.setPartitionLeaderEpoch(latestEpoch().orElse(0));
             }
@@ -1414,7 +1411,9 @@ public class UnifiedLog implements AutoCloseable {
         for (MutableRecordBatch batch : records.batches()) {
             if (batch.isControlBatch() && isMirrorPidResetBatch(batch)) {
                 producerStateManager.expireMirroredProducers();
-            } else if (batch.hasProducerId()) {
+            }
+
+            if (batch.hasProducerId()) {
                 // if this is a client produce request, there will be up to 5 batches which could have been duplicated.
                 // If we find a duplicate, we return the metadata of the appended batch to the client.
                 if (origin == AppendOrigin.CLIENT) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1172,7 +1172,7 @@ public class UnifiedLog implements AutoCloseable {
                                     });
                                 }
                             } else {
-                                maybeOverrideProducerIdAndLeaderEpoch(records, sourceClusterId);
+                                maybeOverrideLeaderEpoch(records, sourceClusterId);
                                 // we are taking the offsets we are given
                                 if (appendInfo.firstOrLastOffsetOfFirstBatch() < localLog.logEndOffset()) {
                                     // we may still be able to recover if the log is empty
@@ -1282,14 +1282,10 @@ public class UnifiedLog implements AutoCloseable {
      * non-idempotent batches. Already-negative PIDs (from chained mirroring) pass through
      * unchanged, making the transformation idempotent.
      */
-    private void maybeOverrideProducerIdAndLeaderEpoch(MemoryRecords records, Uuid sourceClusterId) {
+    private void maybeOverrideLeaderEpoch(MemoryRecords records, Uuid sourceClusterId) {
         if (sourceClusterId != null) {
             for (MutableRecordBatch batch : records.batches()) {
                 batch.setPartitionLeaderEpoch(latestEpoch().orElse(0));
-                long pid = batch.producerId();
-                if (pid >= 0) {
-                    batch.setProducerId(-(pid + 2));
-                }
             }
         }
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1287,17 +1287,6 @@ public class UnifiedLog implements AutoCloseable {
         }
     }
 
-    private static boolean isMirrorPidResetBatch(RecordBatch batch) {
-        Iterator<Record> iterator = batch.iterator();
-        if (iterator.hasNext()) {
-            Record record = iterator.next();
-            if (record.hasKey()) {
-                return ControlRecordType.parse(record.key()) == ControlRecordType.MIRROR_PID_RESET;
-            }
-        }
-        return false;
-    }
-
     public void assignEpochStartOffset(int leaderEpoch, long startOffset) {
         leaderEpochCache.assign(leaderEpoch, startOffset);
     }
@@ -1409,7 +1398,7 @@ public class UnifiedLog implements AutoCloseable {
         int relativePositionInSegment = appendOffsetMetadata.relativePositionInSegment;
 
         for (MutableRecordBatch batch : records.batches()) {
-            if (batch.isControlBatch() && isMirrorPidResetBatch(batch)) {
+            if (ControlRecordType.isMirrorPidResetBatch(batch)) {
                 producerStateManager.expireMirroredProducers();
             }
 
@@ -2602,9 +2591,11 @@ public class UnifiedLog implements AutoCloseable {
         Map<Long, ProducerAppendInfo> loadedProducers = new HashMap<>();
         final List<CompletedTxn> completedTxns = new ArrayList<>();
         records.batches().forEach(batch -> {
-            if (batch.isControlBatch() && isMirrorPidResetBatch(batch)) {
+            if (ControlRecordType.isMirrorPidResetBatch(batch)) {
                 producerStateManager.expireMirroredProducers();
-            } else if (batch.hasProducerId()) {
+            }
+
+            if (batch.hasProducerId()) {
                 Optional<CompletedTxn> maybeCompletedTxn = updateProducers(
                         producerStateManager,
                         batch,


### PR DESCRIPTION
This patch implements the design that is described here: 
https://cwiki.apache.org/confluence/x/9ZM8G
