### PR TITLE
Cl3 authz

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5217,13 +5217,11 @@ public class KafkaAdminClient extends AdminClient {
         private static class PartialMirrorDescription {
             final String mirrorName;
             final Map<String, Set<MirrorDescription.LeaderState>> topicPartitions;
-            final Set<Integer> authorizedOps;
             Throwable error;
 
             PartialMirrorDescription(String mirrorName) {
                 this.mirrorName = mirrorName;
                 this.topicPartitions = new HashMap<>();
-                this.authorizedOps = new HashSet<>();
                 this.error = null;
             }
 
@@ -5255,17 +5253,12 @@ public class KafkaAdminClient extends AdminClient {
                     }
                 }
 
-                // Merge authorized operations
-                if (mirror.authorizedOperations() != -2147483648) {
-                    authorizedOps.add(mirror.authorizedOperations());
-                }
             }
 
             MirrorDescription toMirrorDescription() {
                 return new MirrorDescription(
                         mirrorName,
-                        topicPartitions,
-                        authorizedOps.isEmpty() ? Collections.emptySet() : authorizedOps
+                        topicPartitions
                 );
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MirrorDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MirrorDescription.java
@@ -32,14 +32,11 @@ import java.util.Set;
 public class MirrorDescription {
     private final String mirrorName;
     private final Map<String, Set<LeaderState>> topics;
-    private final Set<Integer> authorizedOperations;
 
     public MirrorDescription(String mirrorName,
-                             Map<String, Set<LeaderState>> topics,
-                             Set<Integer> authorizedOperations) {
+                             Map<String, Set<LeaderState>> topics) {
         this.mirrorName = mirrorName;
         this.topics = Collections.unmodifiableMap(topics);
-        this.authorizedOperations = authorizedOperations;
     }
 
     public String mirrorName() {
@@ -50,23 +47,18 @@ public class MirrorDescription {
         return topics;
     }
 
-    public Set<Integer> authorizedOperations() {
-        return authorizedOperations;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MirrorDescription that = (MirrorDescription) o;
         return Objects.equals(mirrorName, that.mirrorName) &&
-               Objects.equals(topics, that.topics) &&
-               Objects.equals(authorizedOperations, that.authorizedOperations);
+               Objects.equals(topics, that.topics);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mirrorName, topics, authorizedOperations);
+        return Objects.hash(mirrorName, topics);
     }
 
     @Override
@@ -74,7 +66,6 @@ public class MirrorDescription {
         return "MirrorDescription{" +
                "mirrorName='" + mirrorName + '\'' +
                ", topics=" + topics +
-               ", authorizedOperations=" + authorizedOperations +
                '}';
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
@@ -63,7 +63,12 @@ public enum ResourceType {
     /**
      * A user principal
      */
-    USER((byte) 7);
+    USER((byte) 7),
+
+    /**
+     * A cluster mirror.
+     */
+    CLUSTER_MIRROR((byte) 8);
 
     private static final HashMap<Byte, ResourceType> CODE_TO_VALUE = new HashMap<>();
 

--- a/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
@@ -48,11 +48,9 @@
           { "name": "Lag", "type": "int64", "versions": "0+", "default": "-1",
             "about": "The lag (source offset - destination offset), or -1 if not yet available." },
           { "name": "State", "type": "string", "versions": "0+",
-            "about": "The partition state (INITIALIZING, PREPARING, MIRRORING, STOPPING, STOPPED, FAILED)." }
+            "about": "The partition state." }
         ]}
-      ]},
-      { "name": "AuthorizedOperations", "type": "int32", "versions": "0+", "default": "-2147483648",
-        "about": "32-bit bitfield to represent authorized operations for this mirror." }
+      ]}
     ]}
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1409,8 +1409,7 @@ public class MockAdminClient extends AdminClient {
             // Return empty description for mock
             MirrorDescription description = new MirrorDescription(
                 mirrorName,
-                Collections.emptyMap(),
-                Collections.emptySet()
+                Collections.emptyMap()
             );
             descriptions.put(mirrorName, description);
         }

--- a/core/src/main/scala/kafka/server/ConfigHelper.scala
+++ b/core/src/main/scala/kafka/server/ConfigHelper.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{ApiError, DescribeConfigsRequest, DescribeConfigsResponse}
 import org.apache.kafka.common.requests.DescribeConfigsResponse.ConfigSource
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
-import org.apache.kafka.common.resource.ResourceType.{CLUSTER, GROUP, TOPIC}
+import org.apache.kafka.common.resource.ResourceType.{CLUSTER, CLUSTER_MIRROR, GROUP, TOPIC}
 import org.apache.kafka.coordinator.group.GroupConfig
 import org.apache.kafka.metadata.{ConfigRepository, MetadataCache}
 import org.apache.kafka.server.ConfigHelperUtils.createResponseConfig
@@ -54,8 +54,10 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
     val describeConfigsRequest = request.body[DescribeConfigsRequest]
     val (authorizedResources, unauthorizedResources) = describeConfigsRequest.data.resources.asScala.partition { resource =>
       ConfigResource.Type.forId(resource.resourceType) match {
-        case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER | ConfigResource.Type.CLIENT_METRICS | ConfigResource.Type.MIRROR =>
+        case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER | ConfigResource.Type.CLIENT_METRICS =>
           authHelper.authorize(request.context, DESCRIBE_CONFIGS, CLUSTER, CLUSTER_NAME)
+        case ConfigResource.Type.MIRROR =>
+          authHelper.authorize(request.context, DESCRIBE_CONFIGS, CLUSTER_MIRROR, resource.resourceName)
         case ConfigResource.Type.TOPIC =>
           authHelper.authorize(request.context, DESCRIBE_CONFIGS, TOPIC, resource.resourceName)
         case ConfigResource.Type.GROUP =>
@@ -66,7 +68,8 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
     val authorizedConfigs = describeConfigs(authorizedResources.toList, describeConfigsRequest.data.includeSynonyms, describeConfigsRequest.data.includeDocumentation)
     val unauthorizedConfigs = unauthorizedResources.map { resource =>
       val error = ConfigResource.Type.forId(resource.resourceType) match {
-        case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER | ConfigResource.Type.CLIENT_METRICS | ConfigResource.Type.MIRROR => Errors.CLUSTER_AUTHORIZATION_FAILED
+        case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER | ConfigResource.Type.CLIENT_METRICS => Errors.CLUSTER_AUTHORIZATION_FAILED
+        case ConfigResource.Type.MIRROR => Errors.CLUSTER_AUTHORIZATION_FAILED
         case ConfigResource.Type.TOPIC => Errors.TOPIC_AUTHORIZATION_FAILED
         case ConfigResource.Type.GROUP => Errors.GROUP_AUTHORIZATION_FAILED
         case rt => throw new InvalidRequestException(s"Unexpected resource type $rt for resource ${resource.resourceName}")

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -168,7 +168,7 @@ class ControllerApis(
   }
 
   def handleCreateMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    authHelper.authorizeClusterOperation(request, ALTER)
 
     // Check if cluster mirroring is supported by the mirror.version feature
     val mirrorVersionLevel = apiVersionManager.features.finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort)
@@ -231,7 +231,7 @@ class ControllerApis(
   }
 
   def handleAddTopicsToMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    authHelper.authorizeClusterOperation(request, ALTER)
     val addTopicsToMirrorRequest = request.body[AddTopicsToMirrorRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
@@ -254,7 +254,7 @@ class ControllerApis(
   }
 
   def handleRemoveTopicsFromMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    authHelper.authorizeClusterOperation(request, ALTER)
     val removeTopicsFromMirrorRequest = request.body[RemoveTopicsFromMirrorRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
@@ -277,7 +277,7 @@ class ControllerApis(
   }
 
   def handlePauseMirrorTopics(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    authHelper.authorizeClusterOperation(request, ALTER)
     val pauseRequest = request.body[PauseMirrorTopicsRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
@@ -297,7 +297,7 @@ class ControllerApis(
   }
 
   def handleResumeMirrorTopics(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    authHelper.authorizeClusterOperation(request, ALTER)
     val resumeRequest = request.body[ResumeMirrorTopicsRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -45,7 +45,7 @@ import org.apache.kafka.common.protocol.Errors._
 import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
-import org.apache.kafka.common.resource.ResourceType.{CLUSTER, GROUP, TOPIC, USER}
+import org.apache.kafka.common.resource.ResourceType.{CLUSTER, CLUSTER_MIRROR, GROUP, TOPIC, USER}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME
@@ -168,7 +168,9 @@ class ControllerApis(
   }
 
   def handleCreateMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, ALTER)
+    val mirrorName = request.body[CreateMirrorRequest].data().mirrorName()
+    if (!authHelper.authorize(request.context, CREATE, CLUSTER_MIRROR, mirrorName))
+      throw new ClusterAuthorizationException(s"Request $request needs CREATE permission on ClusterMirror:$mirrorName.")
 
     // Check if cluster mirroring is supported by the mirror.version feature
     val mirrorVersionLevel = apiVersionManager.features.finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort)
@@ -231,11 +233,12 @@ class ControllerApis(
   }
 
   def handleAddTopicsToMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, ALTER)
     val addTopicsToMirrorRequest = request.body[AddTopicsToMirrorRequest]
+    val mirrorName = addTopicsToMirrorRequest.data().mirrorName()
+    if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
+      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    val mirrorName = addTopicsToMirrorRequest.data().mirrorName()
     val topics: util.Set[String] = new util.HashSet[String]()
     addTopicsToMirrorRequest.data().topics().forEach( topic => {
         topics.add(topic.topicName())
@@ -254,11 +257,12 @@ class ControllerApis(
   }
 
   def handleRemoveTopicsFromMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, ALTER)
     val removeTopicsFromMirrorRequest = request.body[RemoveTopicsFromMirrorRequest]
+    val mirrorName = removeTopicsFromMirrorRequest.data().mirrorName()
+    if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
+      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    val mirrorName = removeTopicsFromMirrorRequest.data().mirrorName()
     val topics: util.Set[String] = new util.HashSet[String]()
     removeTopicsFromMirrorRequest.data().topics().forEach( topic => {
         topics.add(topic.topicName())
@@ -277,11 +281,12 @@ class ControllerApis(
   }
 
   def handlePauseMirrorTopics(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, ALTER)
     val pauseRequest = request.body[PauseMirrorTopicsRequest]
+    val mirrorName = pauseRequest.data().mirrorName()
+    if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
+      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    val mirrorName = pauseRequest.data().mirrorName()
     val topics: util.Set[String] = new util.HashSet[String]()
     pauseRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
     controller.pauseMirrorTopics(context, mirrorName, topics)
@@ -297,11 +302,12 @@ class ControllerApis(
   }
 
   def handleResumeMirrorTopics(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, ALTER)
     val resumeRequest = request.body[ResumeMirrorTopicsRequest]
+    val mirrorName = resumeRequest.data().mirrorName()
+    if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
+      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    val mirrorName = resumeRequest.data().mirrorName()
     val topics: util.Set[String] = new util.HashSet[String]()
     resumeRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
     controller.resumeMirrorTopics(context, mirrorName, topics)
@@ -631,11 +637,17 @@ class ControllerApis(
         } else {
           new ApiError(CLUSTER_AUTHORIZATION_FAILED)
         }
-      case ConfigResource.Type.TOPIC | ConfigResource.Type.MIRROR =>
+      case ConfigResource.Type.TOPIC =>
         if (authHelper.authorize(requestContext, ALTER_CONFIGS, TOPIC, resource.name)) {
           new ApiError(NONE)
         } else {
           new ApiError(TOPIC_AUTHORIZATION_FAILED)
+        }
+      case ConfigResource.Type.MIRROR =>
+        if (authHelper.authorize(requestContext, ALTER_CONFIGS, CLUSTER_MIRROR, resource.name)) {
+          new ApiError(NONE)
+        } else {
+          new ApiError(CLUSTER_AUTHORIZATION_FAILED)
         }
       case ConfigResource.Type.GROUP =>
         if (authHelper.authorize(requestContext, ALTER_CONFIGS, GROUP, resource.name)) {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -412,20 +412,18 @@ class KafkaApis(val requestChannel: RequestChannel,
     val responseData = new ListMirrorsResponseData()
 
     if (isClusterMirroringEnabled) {
-      if (authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
-        val mirrors = new util.ArrayList[ListMirrorsResponseData.ListedMirror]()
-        mirrorCoordinator.getConfiguredMirrors().forEach(mirrorName => {
-          mirrors.add(new ListMirrorsResponseData.ListedMirror()
-            .setMirrorName(mirrorName)
-            .setSourceBootstrap(if (mirrorCoordinator.getSourceBootstrap(mirrorName) != null)
-              mirrorCoordinator.getSourceBootstrap(mirrorName) else "")
-            .setTopicCount(mirrorCoordinator.getConfiguredTopics(mirrorName).size()))
-        })
-        responseData.setMirrors(mirrors)
-        responseData.setErrorCode(Errors.NONE.code)
-      } else {
-        responseData.setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)
-      }
+      val mirrors = new util.ArrayList[ListMirrorsResponseData.ListedMirror]()
+      val authorizedMirrors = mirrorCoordinator.getConfiguredMirrors().asScala
+        .filter(mirrorName => authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = false))
+      authorizedMirrors.foreach(mirrorName => {
+        mirrors.add(new ListMirrorsResponseData.ListedMirror()
+          .setMirrorName(mirrorName)
+          .setSourceBootstrap(if (mirrorCoordinator.getSourceBootstrap(mirrorName) != null)
+            mirrorCoordinator.getSourceBootstrap(mirrorName) else "")
+          .setTopicCount(mirrorCoordinator.getConfiguredTopics(mirrorName).size()))
+      })
+      responseData.setMirrors(mirrors)
+      responseData.setErrorCode(Errors.NONE.code)
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), returning empty mirror list")
     }
@@ -438,15 +436,16 @@ class KafkaApis(val requestChannel: RequestChannel,
     val responseData = new DescribeMirrorsResponseData()
 
     if (isClusterMirroringEnabled) {
-      if (authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
-        val requestedMirrors = if (describeMirrorsRequest.data.mirrorNames.isEmpty) {
-          mirrorCoordinator.getConfiguredMirrors().asScala.toSeq // get all mirror partitions
-        } else {
-          describeMirrorsRequest.data.mirrorNames.asScala.toSeq
-        }
+      val requestedMirrors = if (describeMirrorsRequest.data.mirrorNames.isEmpty) {
+        mirrorCoordinator.getConfiguredMirrors().asScala.toSeq
+      } else {
+        describeMirrorsRequest.data.mirrorNames.asScala.toSeq
+      }
+      val authorizedMirrors = requestedMirrors
+        .filter(mirrorName => authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = false))
 
-        requestedMirrors.foreach { mirrorName =>
-          // Each broker reports partitions it's responsible for to avoid duplicates
+      authorizedMirrors.foreach { mirrorName =>
+        // Each broker reports partitions it's responsible for to avoid duplicates
           val lagInfoMap = replicaManager.getMirrorLagInfo(mirrorName)
           val partitionStates = mirrorCoordinator.getMirrorStates(mirrorName).asScala
 
@@ -487,10 +486,6 @@ class KafkaApis(val requestChannel: RequestChannel,
             responseData.mirrors().add(describedMirror)
           }
         }
-      } else {
-        // Authorization failed - return empty list with no error
-        // Individual mirror errors would be set per mirror if needed
-      }
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), returning empty mirror list")
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -294,6 +294,10 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleWriteMirrorStates(request: RequestChannel.Request): Unit = {
     if (isClusterMirroringEnabled) {
+      if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
+        requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData().setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)))
+        return
+      }
       val writeMirrorStatesRequest = request.body[WriteMirrorStatesRequest]
       val mirrorName = writeMirrorStatesRequest.data().mirrorName()
       val partitionMetadata = new util.HashMap[String, util.Set[PartitionStateInfo]]()
@@ -313,6 +317,10 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleReadMirrorStates(request: RequestChannel.Request): Unit = {
     if (isClusterMirroringEnabled) {
+      if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
+        requestHelper.sendMaybeThrottle(request, new ReadMirrorStatesResponse(new ReadMirrorStatesResponseData().setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)))
+        return
+      }
       val readMirrorStatesRequest = request.body[ReadMirrorStatesRequest]
       val mirrorName = readMirrorStatesRequest.data().mirrorName()
       val partitionMetadata = new util.HashMap[String, util.Set[Integer]]()
@@ -333,6 +341,10 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleLastMirroredOffset(request: RequestChannel.Request): Unit = {
     if (isClusterMirroringEnabled) {
+      if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
+        requestHelper.sendMaybeThrottle(request, new LastMirroredOffsetsResponse(new LastMirroredOffsetsResponseData().setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)))
+        return
+      }
       val lastMirroredOffsetRequest = request.body[LastMirroredOffsetsRequest]
       val responseData = new LastMirroredOffsetsResponseData()
       val mirrorName = lastMirroredOffsetRequest.data().mirrorName()
@@ -1561,6 +1573,7 @@ class KafkaApis(val requestChannel: RequestChannel,
             return (Errors.INVALID_REQUEST, Node.noNode)
         }
       } else if (keyType == CoordinatorType.MIRROR.id) {
+        authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
         try {
           MirrorRecordKey.validate(key)
         } catch {

--- a/server/src/main/java/org/apache/kafka/security/authorizer/AclEntry.java
+++ b/server/src/main/java/org/apache/kafka/security/authorizer/AclEntry.java
@@ -64,6 +64,8 @@ public class AclEntry {
                 return Set.of(DESCRIBE);
             case USER:
                 return Set.of(CREATE_TOKENS, DESCRIBE_TOKENS);
+            case CLUSTER_MIRROR:
+                return Set.of(CREATE, ALTER, DESCRIBE, DELETE, ALTER_CONFIGS, DESCRIBE_CONFIGS);
             default:
                 throw new IllegalArgumentException("Not a concrete resource type");
         }
@@ -76,6 +78,7 @@ public class AclEntry {
             case GROUP:
                 return Errors.GROUP_AUTHORIZATION_FAILED;
             case CLUSTER:
+            case CLUSTER_MIRROR:
                 return Errors.CLUSTER_AUTHORIZATION_FAILED;
             case TRANSACTIONAL_ID:
                 return Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED;

--- a/tools/src/main/java/org/apache/kafka/tools/AclCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/AclCommand.java
@@ -366,11 +366,14 @@ public class AclCommand {
         if (opts.options.has(opts.delegationTokenOpt)) {
             opts.options.valuesOf(opts.delegationTokenOpt).forEach(token -> resourceFilters.add(new ResourcePatternFilter(ResourceType.DELEGATION_TOKEN, token.trim(), patternType)));
         }
+        if (opts.options.has(opts.clusterMirrorOpt)) {
+            opts.options.valuesOf(opts.clusterMirrorOpt).forEach(mirror -> resourceFilters.add(new ResourcePatternFilter(ResourceType.CLUSTER_MIRROR, mirror.trim(), patternType)));
+        }
         if (opts.options.has(opts.userPrincipalOpt)) {
             opts.options.valuesOf(opts.userPrincipalOpt).forEach(user -> resourceFilters.add(new ResourcePatternFilter(ResourceType.USER, user.trim(), patternType)));
         }
         if (resourceFilters.isEmpty() && dieIfNoResourceFound) {
-            CommandLineUtils.printUsageAndExit(opts.parser, "You must provide at least one resource: --topic <topic> or --cluster or --group <group> or --delegation-token <Delegation Token ID>");
+            CommandLineUtils.printUsageAndExit(opts.parser, "You must provide at least one resource: --topic <topic> or --cluster or --group <group> or --cluster-mirror <mirror> or --delegation-token <Delegation Token ID>");
         }
         return resourceFilters;
     }
@@ -426,6 +429,7 @@ public class AclCommand {
         private final OptionSpecBuilder producerOpt;
         private final OptionSpecBuilder consumerOpt;
         private final OptionSpecBuilder forceOpt;
+        private final OptionSpec<String> clusterMirrorOpt;
         private final OptionSpec<String> userPrincipalOpt;
 
         public AclCommandOptions(String[] args) {
@@ -522,6 +526,11 @@ public class AclCommand {
             consumerOpt = parser.accepts("consumer", "Convenience option to add/remove ACLs for consumer role. " +
                     "This will generate ACLs that allows READ,DESCRIBE on topic and READ on group.");
             forceOpt = parser.accepts("force", "Assume Yes to all queries and do not prompt.");
+            clusterMirrorOpt = parser.accepts("cluster-mirror", "Cluster mirror to which ACLs should be added or removed. " +
+                            "A value of '*' indicates ACL should apply to all cluster mirrors.")
+                    .withRequiredArg()
+                    .describedAs("cluster-mirror")
+                    .ofType(String.class);
             userPrincipalOpt = parser.accepts("user-principal", "Specifies a user principal as a resource in relation with the operation. For instance " +
                             "one could grant CreateTokens or DescribeTokens permission on a given user principal.")
                     .withRequiredArg()


### PR DESCRIPTION
This is coming out from security feedback of discussion thread.

- Adds missing CLUSTER_ACTION authorization checks to WriteMirrorStates, ReadMirrorStates, LastMirroredOffsets, and FindCoordinator(MIRROR) in KafkaApis, matching the pattern used by share group coordinator RPCs.
- Introduces CLUSTER_MIRROR as a new ResourceType, enabling per-mirror ACLs with CREATE, ALTER, DESCRIBE, DELETE, ALTER_CONFIGS, DESCRIBE_CONFIGS.
