### PR TITLE
Add LeaderEpoch to mirror offset APIs and coordinator records

### DIFF
--- a/clients/src/main/resources/common/message/LastMirroredOffsetsResponse.json
+++ b/clients/src/main/resources/common/message/LastMirroredOffsetsResponse.json
@@ -37,6 +37,8 @@
           "about": "The partition index." },
         { "name": "LastMirroredOffset", "type": "int64", "versions": "0",
           "about": "The last mirrored offset." },
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0", "default": "-1",
+          "about": "The leader epoch of the last mirrored offset." },
         { "name": "ErrorCode", "type": "int16", "versions": "0",
           "about": "The error code, or 0 if there was no error." }
       ]}

--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -37,6 +37,8 @@
           "about": "The partition index." },
         { "name": "LastMirroredOffset", "type": "int64", "versions": "0",
           "about": "The last mirrored offset." },
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0", "default": "-1",
+          "about": "The leader epoch of the last mirrored offset." },
         { "name": "State", "type": "int8", "versions": "0+",
           "about": "The mirror partition state." },
         { "name": "ErrorCode", "type": "int16", "versions": "0",

--- a/clients/src/main/resources/common/message/WriteMirrorStatesRequest.json
+++ b/clients/src/main/resources/common/message/WriteMirrorStatesRequest.json
@@ -34,6 +34,8 @@
           "about": "The partition index." },
         { "name": "LastMirroredOffset", "type": "int64", "versions": "0",
           "about": "The last mirrored offset." },
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0", "default": "-1",
+          "about": "The leader epoch of the last mirrored offset." },
         { "name": "State", "type": "int8", "versions": "0+",
           "about": "The mirror partition state." }
       ]}

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -50,6 +50,7 @@ import org.apache.kafka.coordinator.mirror.generated.MirrorPartitionStateKey;
 import org.apache.kafka.coordinator.mirror.generated.MirrorPartitionStateValue;
 import org.apache.kafka.metadata.MetadataCache;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.OffsetAndEpoch;
 import org.apache.kafka.server.common.RequestLocal;
 import org.apache.kafka.server.storage.log.FetchIsolation;
 import org.apache.kafka.server.util.Scheduler;
@@ -216,11 +217,14 @@ public class MirrorCoordinator {
                                         Map<String, Set<MirrorUtils.PartitionStateInfo>> topicMetadata,
                                         Consumer<WriteMirrorStatesResponse> callback) {
         String updatedMirrorName = MirrorUtils.originalMirrorName(mirrorName);
-        Map<String, Map<Integer, Long>> offsets = new HashMap<>();
+        Map<String, Map<Integer, OffsetAndEpoch>> offsets = new HashMap<>();
         Map<String, Set<Integer>> tps = new HashMap<>();
         topicMetadata.forEach((topic, partitions) -> {
             Set<Integer> partitionIndices = new HashSet<>();
             partitions.forEach(partition -> {
+                if (partition.offset() != -1 && partition.leaderEpoch() < 0) {
+                    throw new IllegalArgumentException("LeaderEpoch must be >= 0 when offset is set for partition " + partition.partition());
+                }
                 TopicPartition tp = new TopicPartition(topic, partition.partition());
                 partitionIndices.add(tp.partition());
                 if (partition.state() != null && partition.state() != MirrorPartitionState.UNKNOWN) {
@@ -228,7 +232,7 @@ public class MirrorCoordinator {
                 }
                 if (partition.offset() != -1) {
                     offsets.putIfAbsent(topic, new HashMap<>());
-                    offsets.get(topic).put(partition.partition(), partition.offset());
+                    offsets.get(topic).put(partition.partition(), new OffsetAndEpoch(partition.offset(), partition.leaderEpoch()));
                 }
             });
             tps.put(topic, partitionIndices);
@@ -260,11 +264,15 @@ public class MirrorCoordinator {
     }
 
     private void updateLastMirroredOffsets(String mirrorName, Set<TopicPartition> topicPartitions) {
-        Map<String, Map<Integer, Long>> partitionOffsets = new HashMap<>();
+        Map<String, Map<Integer, OffsetAndEpoch>> partitionOffsets = new HashMap<>();
         MirrorUtils.groupPartitionsByTopic(topicPartitions).forEach((topic, parts) -> {
-            Map<Integer, Long> offsets = new HashMap<>();
+            Map<Integer, OffsetAndEpoch> offsets = new HashMap<>();
             parts.forEach(i -> replicaManager.getPartitionOrException(
-                    new TopicPartition(topic, i)).log().foreach(log -> offsets.put(i, log.lastStableOffset())));
+                    new TopicPartition(topic, i)).log().foreach(log -> {
+                        int epoch = log.latestEpoch().orElse(-1);
+                        offsets.put(i, new OffsetAndEpoch(log.lastStableOffset(), epoch));
+                        return null;
+                    }));
             partitionOffsets.put(topic, offsets);
         });
 
@@ -315,7 +323,7 @@ public class MirrorCoordinator {
         } else {
             // write state data to remote coordinator (async network operation)
             Map<String, Set<MirrorUtils.PartitionStateInfo>> topicMetadata =
-                    Map.of(topicPartition.topic(), Set.of(new MirrorUtils.PartitionStateInfo(topicPartition.partition(), newState, -1L)));
+                    Map.of(topicPartition.topic(), Set.of(new MirrorUtils.PartitionStateInfo(topicPartition.partition(), newState, -1L, -1)));
             metadataManager.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
                     res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
                         if (par.errorCode() == Errors.NONE.code()) {
@@ -423,28 +431,28 @@ public class MirrorCoordinator {
         }
     }
 
-    private Map<String, Map<Integer, Long>> lastMirroredOffsetsToCoordinatorRecords(Map<MirrorUtils.PartitionKey, Long> offsets) {
-        Map<String, Map<Integer, Long>> results = new HashMap<>();
+    private Map<String, Map<Integer, OffsetAndEpoch>> lastMirroredOffsetsToCoordinatorRecords(Map<MirrorUtils.PartitionKey, OffsetAndEpoch> offsets) {
+        Map<String, Map<Integer, OffsetAndEpoch>> results = new HashMap<>();
         offsets.forEach((key, value) -> {
-            Map<Integer, Long> partitionOffsets = results.getOrDefault(key.topic(), new HashMap<>());
+            Map<Integer, OffsetAndEpoch> partitionOffsets = results.getOrDefault(key.topic(), new HashMap<>());
             partitionOffsets.put(key.partition(), value);
             results.put(key.topic(), partitionOffsets);
         });
         return results;
     }
 
-    public long getLastMirroredOffset(String mirrorName, TopicPartition topicPartition) {
+    public OffsetAndEpoch getLastMirroredOffset(String mirrorName, TopicPartition topicPartition) {
         return metadataManager.getLastMirroredOffset(mirrorName, topicPartition);
     }
 
     /** Persists offsets to local or remote coordinators, optionally transitioning to STOPPED. */
-    public void updateLastMirroredOffsets(String mirrorName, Map<String, Map<Integer, Long>> partitionOffsets, boolean transitionToStopped) {
+    public void updateLastMirroredOffsets(String mirrorName, Map<String, Map<Integer, OffsetAndEpoch>> partitionOffsets, boolean transitionToStopped) {
         // Separate partitions into local and remote coordinator groups
         Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
         Map<String, Set<MirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
 
         partitionOffsets.forEach((topic, offsetMap) -> {
-            offsetMap.forEach((par, off) -> {
+            offsetMap.forEach((par, offsetAndEpoch) -> {
                 if (isLocalCoordinator(mirrorName, topic, par)) {
                     int coordPartition = getCoordinatorPartitionByKey(
                         new MirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), par));
@@ -454,7 +462,7 @@ public class MirrorCoordinator {
                 } else {
                     remoteTopicMetadata
                         .computeIfAbsent(topic, k -> new HashSet<>())
-                        .add(new MirrorUtils.PartitionStateInfo(par, null, off));
+                        .add(new MirrorUtils.PartitionStateInfo(par, null, offsetAndEpoch.offset(), offsetAndEpoch.epoch()));
                 }
             });
         });
@@ -513,15 +521,18 @@ public class MirrorCoordinator {
         return CoordinatorRecord.record(key, apiVersion);
     }
 
-    private static CoordinatorRecord generateLastMirroredOffsets(String mirrorName, Map<String, Map<Integer, Long>> offsets) {
+    private static CoordinatorRecord generateLastMirroredOffsets(String mirrorName, Map<String, Map<Integer, OffsetAndEpoch>> offsets) {
         var key = new LastMirroredOffsetsKey().setMirrorName(mirrorName);
         var val = new LastMirroredOffsetsValue();
         var topics = new ArrayList<LastMirroredOffsetsValue.Topic>();
         offsets.forEach((topic, partitionOffsets) -> {
             var top = new LastMirroredOffsetsValue.Topic();
             List<LastMirroredOffsetsValue.Partition> partitions = new ArrayList<>();
-            partitionOffsets.forEach((partition, offset) ->
-                    partitions.add(new LastMirroredOffsetsValue.Partition().setPartitionIndex(partition).setLastMirroredOffset(offset)));
+            partitionOffsets.forEach((partition, offsetAndEpoch) ->
+                    partitions.add(new LastMirroredOffsetsValue.Partition()
+                            .setPartitionIndex(partition)
+                            .setLastMirroredOffset(offsetAndEpoch.offset())
+                            .setLeaderEpoch(offsetAndEpoch.epoch())));
             top.setPartitions(partitions);
             topics.add(top);
         });
@@ -541,14 +552,14 @@ public class MirrorCoordinator {
         }
     }
 
-    private Map<String, Map<Integer, Long>> readLastMirroredOffsetsValue(ByteBuffer buffer) {
-        Map<String, Map<Integer, Long>> offsets = new HashMap<>();
+    private Map<String, Map<Integer, OffsetAndEpoch>> readLastMirroredOffsetsValue(ByteBuffer buffer) {
+        Map<String, Map<Integer, OffsetAndEpoch>> offsets = new HashMap<>();
         short version = buffer.getShort();
         if (version <= LastMirroredOffsetsValue.HIGHEST_SUPPORTED_VERSION && version >= LastMirroredOffsetsValue.LOWEST_SUPPORTED_VERSION) {
             LastMirroredOffsetsValue value = new LastMirroredOffsetsValue(new ByteBufferAccessor(buffer), version);
             value.topics().forEach(t -> {
-                Map<Integer, Long> partitions = new HashMap<>();
-                t.partitions().forEach(p -> partitions.put(p.partitionIndex(), p.lastMirroredOffset()));
+                Map<Integer, OffsetAndEpoch> partitions = new HashMap<>();
+                t.partitions().forEach(p -> partitions.put(p.partitionIndex(), new OffsetAndEpoch(p.lastMirroredOffset(), p.leaderEpoch())));
                 offsets.put(t.name(), partitions);
             });
         } else {
@@ -620,7 +631,7 @@ public class MirrorCoordinator {
                             short version = record.key().getShort();
                             if (version == CoordinatorRecordType.LAST_MIRRORED_OFFSETS.id()) {
                                 String clusterName = readMirrorNameFromKey(record.key());
-                                Map<String, Map<Integer, Long>> offsets = readLastMirroredOffsetsValue(record.value());
+                                Map<String, Map<Integer, OffsetAndEpoch>> offsets = readLastMirroredOffsetsValue(record.value());
                                 metadataManager.updateLastMirroredOffsets(clusterName, offsets, Map.of());
                             } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
                                 String clusterName = readMirrorNameFromKey(record.key());

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -98,6 +98,7 @@ import org.apache.kafka.metadata.MetadataCache;
 import org.apache.kafka.metadata.authorizer.StandardAcl;
 import org.apache.kafka.server.common.ControllerRequestCompletionHandler;
 import org.apache.kafka.server.common.NodeToControllerChannelManager;
+import org.apache.kafka.server.common.OffsetAndEpoch;
 import org.apache.kafka.server.common.RequestLocal;
 import org.apache.kafka.server.config.MirrorConfig;
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;
@@ -178,7 +179,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
     private final Map<MirrorPartitionState, AtomicLong> partitionStateCounts = new ConcurrentHashMap<>();
-    private final Map<MirrorUtils.PartitionKey, Long> lastMirroredOffsets = new ConcurrentHashMap<>();
+    private final Map<MirrorUtils.PartitionKey, OffsetAndEpoch> lastMirroredOffsets = new ConcurrentHashMap<>();
 
     // metrics
     private KafkaMetricsGroup metricsGroup;
@@ -539,6 +540,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 WriteMirrorStatesRequestData.PartitionData partitionData = new WriteMirrorStatesRequestData.PartitionData();
                 partitionData.setState(m.state() == null ? MirrorPartitionState.UNKNOWN.value() : m.state().value());
                 partitionData.setLastMirroredOffset(m.offset());
+                partitionData.setLeaderEpoch(m.leaderEpoch());
                 partitionData.setPartitionIndex(m.partition());
 
                 nodeToTopicPartitions
@@ -631,7 +633,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                             topic.partitions().forEach(partition -> {
                                 if (partition.lastMirroredOffset() != -1) {
                                     lastMirroredOffsets.put(new MirrorUtils.PartitionKey(mirrorName, topic.name(), partition.partitionIndex()),
-                                            partition.lastMirroredOffset());
+                                            new OffsetAndEpoch(partition.lastMirroredOffset(), partition.leaderEpoch()));
                                 }
                                 if (partition.state() != -1) {
                                     partitionStates.put(new MirrorUtils.PartitionKey(mirrorName, topic.name(), partition.partitionIndex()),
@@ -659,7 +661,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             parts.forEach(part -> {
                 ReadMirrorStatesResponseData.PartitionResult partitionResult = new ReadMirrorStatesResponseData.PartitionResult();
                 partitionResult.setPartitionIndex(part);
-                partitionResult.setLastMirroredOffset(lastMirroredOffsets.getOrDefault(new MirrorUtils.PartitionKey(mirrorName, tp, part), -1L));
+                OffsetAndEpoch offsetAndEpoch = lastMirroredOffsets.getOrDefault(
+                        new MirrorUtils.PartitionKey(mirrorName, tp, part), new OffsetAndEpoch(-1L, -1));
+                partitionResult.setLastMirroredOffset(offsetAndEpoch.offset());
+                partitionResult.setLeaderEpoch(offsetAndEpoch.epoch());
                 partitionResult.setState(partitionStates.getOrDefault(
                         new MirrorUtils.PartitionKey(mirrorName, tp, part), MirrorPartitionState.UNKNOWN).value());
                 partitionResults.add(partitionResult);
@@ -829,25 +834,22 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    long getLastMirroredOffset(String clusterName, TopicPartition topicPartition) {
+    OffsetAndEpoch getLastMirroredOffset(String clusterName, TopicPartition topicPartition) {
         MirrorUtils.PartitionKey key = new MirrorUtils.PartitionKey(clusterName, topicPartition.topic(), topicPartition.partition());
-        if (lastMirroredOffsets.containsKey(key)) {
-            return lastMirroredOffsets.get(key);
-        }
-        return 0L;
+        return lastMirroredOffsets.getOrDefault(key, new OffsetAndEpoch(0L, -1));
     }
 
-    Map<MirrorUtils.PartitionKey, Long> updateLastMirroredOffsets(String clusterName,
-                                                                  Map<String, Map<Integer, Long>> addedOffsets,
-                                                                  Map<String, Map<Integer, Long>> removedOffsets) {
+    Map<MirrorUtils.PartitionKey, OffsetAndEpoch> updateLastMirroredOffsets(String clusterName,
+                                                                            Map<String, Map<Integer, OffsetAndEpoch>> addedOffsets,
+                                                                            Map<String, Map<Integer, OffsetAndEpoch>> removedOffsets) {
         removedOffsets.forEach((topic, partitionOffsets) -> {
-            partitionOffsets.forEach((partition, offset) -> {
+            partitionOffsets.forEach((partition, offsetAndEpoch) -> {
                 lastMirroredOffsets.remove(new MirrorUtils.PartitionKey(clusterName, topic, partition));
             });
         });
         addedOffsets.forEach((topic, partitionOffsets) -> {
-            partitionOffsets.forEach((partition, offset) -> {
-                lastMirroredOffsets.put(new MirrorUtils.PartitionKey(clusterName, topic, partition), offset);
+            partitionOffsets.forEach((partition, offsetAndEpoch) -> {
+                lastMirroredOffsets.put(new MirrorUtils.PartitionKey(clusterName, topic, partition), offsetAndEpoch);
             });
         });
         return lastMirroredOffsets;

--- a/core/src/main/java/kafka/server/mirror/MirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorUtils.java
@@ -82,7 +82,7 @@ public final class MirrorUtils {
         return mirrorName;
     }
 
-    public record PartitionStateInfo(int partition, MirrorPartitionState state, Long offset) { }
+    public record PartitionStateInfo(int partition, MirrorPartitionState state, long offset, int leaderEpoch) { }
 
     public record PartitionStateLogEntry(String topic, int partition, MirrorPartitionState state) { }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -300,7 +300,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       writeMirrorStatesRequest.data().topics().forEach(topic => {
         val partMetadata = new util.HashSet[PartitionStateInfo]()
         topic.partitions().forEach(part => {
-          partMetadata.add(new PartitionStateInfo(part.partitionIndex(), MirrorPartitionState.fromValue(part.state()), part.lastMirroredOffset()))
+          partMetadata.add(new PartitionStateInfo(part.partitionIndex(), MirrorPartitionState.fromValue(part.state()), part.lastMirroredOffset(), part.leaderEpoch()))
         })
         partitionMetadata.put(topic.name(), partMetadata)
       })
@@ -343,8 +343,10 @@ class KafkaApis(val requestChannel: RequestChannel,
         topic.partitions().forEach(par => {
           val partition = new TopicPartition(topic.name(), par.partitionIndex())
           val partitionResult = new LastMirroredOffsetsResponseData.PartitionResult()
+          val offsetAndEpoch = mirrorCoordinator.getLastMirroredOffset(mirrorName, partition)
           partitionResult.setPartitionIndex(par.partitionIndex())
-            .setLastMirroredOffset(mirrorCoordinator.getLastMirroredOffset(mirrorName, partition))
+            .setLastMirroredOffset(offsetAndEpoch.offset())
+            .setLeaderEpoch(offsetAndEpoch.epoch())
           partitionResults.add(partitionResult)
         })
         topicResult.setName(topic.name())

--- a/mirror-coordinator/src/main/resources/common/message/LastMirroredOffsetsValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/LastMirroredOffsetsValue.json
@@ -33,7 +33,9 @@
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
         { "name": "LastMirroredOffset", "type": "int64", "versions": "0+",
-          "about": "The last mirrored offset for this partition." }
+          "about": "The last mirrored offset for this partition." },
+        { "name": "LeaderEpoch", "type": "int32", "versions": "0+", "default": "-1",
+          "about": "The leader epoch of the last mirrored offset." }
       ]}
     ]}
   ]


### PR DESCRIPTION
Include LeaderEpoch in WriteMirrorStatesRequest, ReadMirrorStatesResponse, LastMirroredOffsetsResponse and the LastMirroredOffsetsValue coordinator record. Track epoch alongside offset in the in-memory cache using OffsetAndEpoch. Validate that leaderEpoch is set when offset is provided.

Skipping truncation validation as we will replace that with LMLE.
