### PR TITLE
Add source cluster ID in list mirror

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5060,6 +5060,7 @@ public class KafkaAdminClient extends AdminClient {
                         listings.add(new MirrorListing(
                                 mirror.mirrorName(),
                                 mirror.sourceBootstrap(),
+                                mirror.sourceClusterId(),
                                 mirror.topicCount()
                         ));
                     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MirrorListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MirrorListing.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 public class MirrorListing {
     private final String mirrorName;
     private final String sourceBootstrap;
+    private final String sourceClusterId;
     private final int topicCount;
 
     /**
@@ -35,12 +36,25 @@ public class MirrorListing {
      *
      * @param mirrorName Mirror name
      * @param sourceBootstrap Source cluster bootstrap servers
+     * @param sourceClusterId Source cluster ID
+     * @param topicCount Number of topics configured for this mirror
+     */
+    public MirrorListing(String mirrorName, String sourceBootstrap, String sourceClusterId, int topicCount) {
+        this.mirrorName = mirrorName;
+        this.sourceBootstrap = sourceBootstrap;
+        this.sourceClusterId = sourceClusterId;
+        this.topicCount = topicCount;
+    }
+
+    /**
+     * Create an instance with the specified parameters (backwards compatibility).
+     *
+     * @param mirrorName Mirror name
+     * @param sourceBootstrap Source cluster bootstrap servers
      * @param topicCount Number of topics configured for this mirror
      */
     public MirrorListing(String mirrorName, String sourceBootstrap, int topicCount) {
-        this.mirrorName = mirrorName;
-        this.sourceBootstrap = sourceBootstrap;
-        this.topicCount = topicCount;
+        this(mirrorName, sourceBootstrap, "", topicCount);
     }
 
     /**
@@ -50,7 +64,7 @@ public class MirrorListing {
      * @param sourceBootstrap Source cluster bootstrap servers
      */
     public MirrorListing(String mirrorName, String sourceBootstrap) {
-        this(mirrorName, sourceBootstrap, 0);
+        this(mirrorName, sourceBootstrap, "", 0);
     }
 
     /**
@@ -72,6 +86,15 @@ public class MirrorListing {
     }
 
     /**
+     * The source cluster ID.
+     *
+     * @return Source cluster ID, or empty string if not yet resolved
+     */
+    public String sourceClusterId() {
+        return sourceClusterId;
+    }
+
+    /**
      * The number of topics configured for this mirror.
      *
      * @return Number of topics, or 0 if mirror has no topics configured
@@ -82,12 +105,12 @@ public class MirrorListing {
 
     @Override
     public String toString() {
-        return "MirrorListing(mirrorName='" + mirrorName + "', sourceBootstrap='" + sourceBootstrap + "', topicCount=" + topicCount + ")";
+        return "MirrorListing(mirrorName='" + mirrorName + "', sourceBootstrap='" + sourceBootstrap + "', sourceClusterId='" + sourceClusterId + "', topicCount=" + topicCount + ")";
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mirrorName, sourceBootstrap, topicCount);
+        return Objects.hash(mirrorName, sourceBootstrap, sourceClusterId, topicCount);
     }
 
     @Override
@@ -97,6 +120,7 @@ public class MirrorListing {
         MirrorListing that = (MirrorListing) o;
         return topicCount == that.topicCount &&
                Objects.equals(mirrorName, that.mirrorName) &&
-               Objects.equals(sourceBootstrap, that.sourceBootstrap);
+               Objects.equals(sourceBootstrap, that.sourceBootstrap) &&
+               Objects.equals(sourceClusterId, that.sourceClusterId);
     }
 }

--- a/clients/src/main/resources/common/message/ListMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/ListMirrorsResponse.json
@@ -33,6 +33,8 @@
         "about": "The cluster mirror name." },
       { "name": "SourceBootstrap", "type": "string", "versions": "0+",
         "about": "The source cluster bootstrap servers." },
+      { "name": "SourceClusterId", "type": "string", "versions": "0+", "default": "",
+        "about": "The source cluster ID, or empty if not yet resolved." },
       { "name": "TopicCount", "type": "int32", "versions": "0+", "default": "0",
         "about": "The number of topics configured for this mirror. 0 indicates an empty mirror with no topics." }
     ]}

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -677,6 +677,10 @@ public class MirrorCoordinator {
         return metadataManager.getSourceBootstrap(mirrorName);
     }
 
+    public Uuid getSourceClusterId(String mirrorName) {
+        return metadataManager.getSourceClusterId(mirrorName);
+    }
+
     public Map<TopicPartition, MirrorPartitionState> getMirrorStates(String mirrorName) {
         return metadataManager.getMirrorStates(mirrorName);
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -938,9 +938,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
 
+        // Cross-cluster identity validation
         String clusterId = metadataResponse.clusterId();
         if (clusterId != null && !clusterId.isEmpty()) {
-            sourceClusterIds.put(mirrorName, Uuid.fromString(clusterId));
+            Uuid newClusterId = Uuid.fromString(clusterId);
+            Uuid previousClusterId = sourceClusterIds.put(mirrorName, newClusterId);
+            if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
+                throw new IllegalStateException("Source cluster ID changed for mirror " + mirrorName
+                    + ": expected " + previousClusterId + ", got " + newClusterId
+                    + ". This may indicate a misconfiguration or that the source cluster has been replaced.");
+            }
         }
 
         Collection<Node> discoveredBrokers = metadataResponse.brokers();

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -416,6 +416,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       val authorizedMirrors = mirrorCoordinator.getConfiguredMirrors().asScala
         .filter(mirrorName => authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = false))
       authorizedMirrors.foreach(mirrorName => {
+        val sourceClusterId = mirrorCoordinator.getSourceClusterId(mirrorName)
         mirrors.add(new ListMirrorsResponseData.ListedMirror()
           .setMirrorName(mirrorName)
           .setSourceBootstrap(if (mirrorCoordinator.getSourceBootstrap(mirrorName) != null)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -420,6 +420,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           .setMirrorName(mirrorName)
           .setSourceBootstrap(if (mirrorCoordinator.getSourceBootstrap(mirrorName) != null)
             mirrorCoordinator.getSourceBootstrap(mirrorName) else "")
+          .setSourceClusterId(if (sourceClusterId != null) sourceClusterId.toString else "")
           .setTopicCount(mirrorCoordinator.getConfiguredTopics(mirrorName).size()))
       })
       responseData.setMirrors(mirrors)

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -710,10 +710,10 @@ public class ReplicationControlManager {
                                  List<ApiMessageAndVersion> configRecords,
                                  boolean authorizedToReturnConfigs) {
         Map<String, String> creationConfigs = translateCreationConfigs(topic.configs());
-        boolean useProvidedTopicId = false;
+        boolean useMirrorTopicId = false;
         // should keep source topicId for mirror topics
         if (topic.mirrorInfo() != null && !topic.mirrorInfo().topicId().equals(Uuid.ZERO_UUID)) {
-            useProvidedTopicId = true;
+            useMirrorTopicId = true;
         }
 
         Map<Integer, PartitionRegistration> newParts = new HashMap<>();
@@ -746,7 +746,7 @@ public class ReplicationControlManager {
                         "partition " + assignment.partitionIndex() + " are fenced or in controlled shutdown.");
                 }
 
-                if (useProvidedTopicId && isr.size() < assignment.brokerIds().size()) {
+                if (useMirrorTopicId && isr.size() < assignment.brokerIds().size()) {
                     return new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
                         "Some brokers specified in the manual partition assignment for " +
                         "partition " + assignment.partitionIndex() + " are fenced or in controlled shutdown. " +
@@ -800,7 +800,7 @@ public class ReplicationControlManager {
                             "Unable to replicate the partition " + replicationFactor +
                                 " time(s): All brokers are currently fenced or in controlled shutdown.");
                     }
-                    if (useProvidedTopicId && isr.size() < partitionAssignment.replicas().size()) {
+                    if (useMirrorTopicId && isr.size() < partitionAssignment.replicas().size()) {
                         return new ApiError(Errors.INVALID_REPLICATION_FACTOR,
                             "Unable to replicate the partition " + replicationFactor +
                                 " time(s): Some brokers are currently fenced or in controlled shutdown. " +
@@ -830,7 +830,8 @@ public class ReplicationControlManager {
             return ApiError.fromThrowable(e);
         }
 
-        Uuid topicId = useProvidedTopicId ? topic.mirrorInfo().topicId() : Uuid.randomUuid();
+        // Preserve topic ID for mirror topics
+        Uuid topicId = useMirrorTopicId ? topic.mirrorInfo().topicId() : Uuid.randomUuid();
 
         CreatableTopicResult result = new CreatableTopicResult().
             setName(topic.name()).

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -292,16 +292,20 @@ public abstract class MirrorCommand {
             listings.sort(Comparator.comparing(MirrorListing::mirrorName));
 
             // Print header
-            System.out.printf("%-30s %-10s %-50s%n", "MIRROR", "TOPICS", "SOURCE-BOOTSTRAP");
+            System.out.printf("%-30s %-10s %-26s %-50s%n", "MIRROR", "TOPICS", "SOURCE-CLUSTER-ID", "SOURCE-BOOTSTRAP");
 
             // Print each mirror
             for (MirrorListing listing : listings) {
                 String sourceBootstrap = listing.sourceBootstrap() != null && !listing.sourceBootstrap().isEmpty()
                     ? listing.sourceBootstrap()
                     : "-";
-                System.out.printf("%-30s %-10d %-50s%n",
+                String sourceClusterId = listing.sourceClusterId() != null && !listing.sourceClusterId().isEmpty()
+                    ? listing.sourceClusterId()
+                    : "-";
+                System.out.printf("%-30s %-10d %-26s %-50s%n",
                     truncateLeft(listing.mirrorName(), 30),
                     listing.topicCount(),
+                    sourceClusterId,
                     truncateLeft(sourceBootstrap, 50));
             }
         }


### PR DESCRIPTION
Add a fail-fast check in MirrorMetadataManager.discoverSourceBrokers that detects when the source cluster ID changes unexpectedly during metadata refresh. This prevents silent data corruption from mirroring records from a wrong source cluster.

Expose the source cluster ID in the list mirror command output by adding SourceClusterId to the ListMirrorsResponse protocol, propagating it through MirrorCoordinator, KafkaApis, MirrorListing, KafkaAdminClient, and the MirrorCommand CLI formatter.