### PR TITLE
Add DeleteMirror API for cluster mirroring

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1734,6 +1734,18 @@ public interface Admin extends AutoCloseable {
     ResumeMirrorTopicsResult resumeMirrorTopics(String mirrorName, Set<String> topics, ResumeMirrorTopicsOptions options);
 
     /**
+     * Delete a cluster mirror including its configuration.
+     *
+     * The mirror must be empty (no topics) or all its topics must have been removed (in STOPPED
+     * state). After deletion, all mirror metadata are tombstoned and failback is no longer possible.
+     *
+     * @param mirrorName The name of the cluster mirror to delete
+     * @param options Options for the delete mirror operation
+     * @return The DeleteMirrorResult
+     */
+    DeleteMirrorResult deleteMirror(String mirrorName, DeleteMirrorOptions options);
+
+    /**
      * List the cluster mirrors available in the cluster with the default options.
      *
      * <p>This is a convenience method for {@link #listMirrors(ListMirrorsOptions)} with default options.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorOptions.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+public class DeleteMirrorOptions extends AbstractOptions<DeleteMirrorOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteMirrorResult.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+
+public class DeleteMirrorResult {
+    private final KafkaFuture<Void> future;
+
+    DeleteMirrorResult(final KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -299,6 +299,12 @@ public class ForwardingAdmin implements Admin {
     public AddTopicsToMirrorResult addTopicsToMirror(String mirrorName, Set<String> topics, AddTopicsToMirrorOptions options) {
         return delegate.addTopicsToMirror(mirrorName, topics, options);
     }
+
+    @Override
+    public DeleteMirrorResult deleteMirror(String mirrorName, DeleteMirrorOptions options) {
+        return delegate.deleteMirror(mirrorName, options);
+    }
+
     public DescribeMirrorsResult describeMirrors(Collection<String> mirrorNames, DescribeMirrorsOptions options) {
         return delegate.describeMirrors(mirrorNames, options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -215,6 +215,8 @@ import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
 import org.apache.kafka.common.requests.DeleteAclsResponse;
+import org.apache.kafka.common.requests.DeleteMirrorRequest;
+import org.apache.kafka.common.requests.DeleteMirrorResponse;
 import org.apache.kafka.common.requests.DeleteTopicsRequest;
 import org.apache.kafka.common.requests.DeleteTopicsResponse;
 import org.apache.kafka.common.requests.DescribeAclsRequest;
@@ -4874,6 +4876,45 @@ public class KafkaAdminClient extends AdminClient {
         };
         runnable.call(call, now);
         return new CreateMirrorResult(future);
+    }
+
+    @Override
+    public DeleteMirrorResult deleteMirror(String mirrorName, DeleteMirrorOptions options) {
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+        final Call call = new Call("deleteMirror", calcDeadlineMs(now, options.timeoutMs()),
+                new LeastLoadedBrokerOrActiveKController()) {
+
+            @Override
+            DeleteMirrorRequest.Builder createRequest(int timeoutMs) {
+                return new DeleteMirrorRequest.Builder(mirrorName);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                final DeleteMirrorResponse response =
+                        (DeleteMirrorResponse) abstractResponse;
+                Errors error = Errors.forCode(response.data().errorCode());
+                switch (error) {
+                    case NONE:
+                        future.complete(null);
+                        break;
+                    case REQUEST_TIMED_OUT:
+                        throw error.exception(response.data().errorMessage());
+                    default:
+                        log.error("Delete mirror {} failed: {}", mirrorName, response.data().errorMessage());
+                        future.completeExceptionally(error.exception(response.data().errorMessage()));
+                        break;
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        };
+        runnable.call(call, now);
+        return new DeleteMirrorResult(future);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/errors/MirrorNotEmptyException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/MirrorNotEmptyException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class MirrorNotEmptyException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MirrorNotEmptyException() {
+        super();
+    }
+
+    public MirrorNotEmptyException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -145,7 +145,8 @@ public enum ApiKeys {
     LIST_MIRRORS(ApiMessageType.LIST_MIRRORS),
     DESCRIBE_MIRRORS(ApiMessageType.DESCRIBE_MIRRORS),
     PAUSE_MIRROR_TOPICS(ApiMessageType.PAUSE_MIRROR_TOPICS, false, true),
-    RESUME_MIRROR_TOPICS(ApiMessageType.RESUME_MIRROR_TOPICS, false, true);
+    RESUME_MIRROR_TOPICS(ApiMessageType.RESUME_MIRROR_TOPICS, false, true),
+    DELETE_MIRROR(ApiMessageType.DELETE_MIRROR, false, true);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -86,6 +86,7 @@ import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.ListenerNotFoundException;
 import org.apache.kafka.common.errors.LogDirNotFoundException;
 import org.apache.kafka.common.errors.MemberIdRequiredException;
+import org.apache.kafka.common.errors.MirrorNotEmptyException;
 import org.apache.kafka.common.errors.MirrorTopicAlreadyPausedException;
 import org.apache.kafka.common.errors.MirrorTopicBeingRemovedException;
 import org.apache.kafka.common.errors.MirrorTopicNotPausedException;
@@ -434,7 +435,8 @@ public enum Errors {
     TOPIC_NOT_IN_MIRROR(138, "The topic does not belong to the specified mirror.", TopicNotInMirrorException::new),
     MIRROR_TOPIC_ALREADY_PAUSED(139, "The mirror topic is already paused.", MirrorTopicAlreadyPausedException::new),
     MIRROR_TOPIC_NOT_PAUSED(140, "The mirror topic is not paused.", MirrorTopicNotPausedException::new),
-    MIRROR_TOPIC_BEING_REMOVED(141, "The mirror topic is being removed.", MirrorTopicBeingRemovedException::new);
+    MIRROR_TOPIC_BEING_REMOVED(141, "The mirror topic is being removed.", MirrorTopicBeingRemovedException::new),
+    MIRROR_NOT_EMPTY(135, "The mirror still has active or non-removed topics.", MirrorNotEmptyException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -436,7 +436,7 @@ public enum Errors {
     MIRROR_TOPIC_ALREADY_PAUSED(139, "The mirror topic is already paused.", MirrorTopicAlreadyPausedException::new),
     MIRROR_TOPIC_NOT_PAUSED(140, "The mirror topic is not paused.", MirrorTopicNotPausedException::new),
     MIRROR_TOPIC_BEING_REMOVED(141, "The mirror topic is being removed.", MirrorTopicBeingRemovedException::new),
-    MIRROR_NOT_EMPTY(135, "The mirror still has active or non-removed topics.", MirrorNotEmptyException::new);
+    MIRROR_NOT_EMPTY(142, "The mirror still has active or non-removed topics.", MirrorNotEmptyException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -376,6 +376,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return PauseMirrorTopicsRequest.parse(readable, apiVersion);
             case RESUME_MIRROR_TOPICS:
                 return ResumeMirrorTopicsRequest.parse(readable, apiVersion);
+            case DELETE_MIRROR:
+                return DeleteMirrorRequest.parse(readable, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -313,6 +313,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return PauseMirrorTopicsResponse.parse(readable, version);
             case RESUME_MIRROR_TOPICS:
                 return ResumeMirrorTopicsResponse.parse(readable, version);
+            case DELETE_MIRROR:
+                return DeleteMirrorResponse.parse(readable, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.DeleteMirrorRequestData;
+import org.apache.kafka.common.message.DeleteMirrorResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+public class DeleteMirrorRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<DeleteMirrorRequest> {
+
+        private final DeleteMirrorRequestData data;
+
+        public Builder(DeleteMirrorRequestData data) {
+            super(ApiKeys.DELETE_MIRROR);
+            this.data = data;
+        }
+
+        public Builder(String mirrorName) {
+            super(ApiKeys.DELETE_MIRROR, ApiKeys.DELETE_MIRROR.oldestVersion(),
+                  ApiKeys.DELETE_MIRROR.latestVersion());
+            this.data = new DeleteMirrorRequestData().setMirrorName(mirrorName);
+        }
+
+        @Override
+        public DeleteMirrorRequest build(short version) {
+            return new DeleteMirrorRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final DeleteMirrorRequestData data;
+
+    public DeleteMirrorRequest(DeleteMirrorRequestData data, short version) {
+        super(ApiKeys.DELETE_MIRROR, version);
+        this.data = data;
+    }
+
+    @Override
+    public DeleteMirrorRequestData data() {
+        return data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
+        DeleteMirrorResponseData responseData = new DeleteMirrorResponseData();
+        responseData.setErrorCode(error.code());
+        return new DeleteMirrorResponse(responseData);
+    }
+
+    public static DeleteMirrorRequest parse(Readable readable, short version) {
+        return new DeleteMirrorRequest(
+                new DeleteMirrorRequestData(readable, version),
+                version
+        );
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteMirrorResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.DeleteMirrorResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DeleteMirrorResponse extends AbstractResponse {
+    private final DeleteMirrorResponseData data;
+
+    public DeleteMirrorResponse(DeleteMirrorResponseData data) {
+        super(ApiKeys.DELETE_MIRROR);
+        this.data = data;
+    }
+
+    @Override
+    public DeleteMirrorResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Map<Errors, Integer> errorCounts = new HashMap<>();
+        updateErrorCounts(errorCounts, Errors.forCode(data.errorCode()));
+        return errorCounts;
+    }
+
+    public static DeleteMirrorResponse parse(Readable readable, short version) {
+        return new DeleteMirrorResponse(new DeleteMirrorResponseData(readable, version));
+    }
+}

--- a/clients/src/main/resources/common/message/DeleteMirrorRequest.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorRequest.json
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 104,
+  "type": "request",
+  "listeners": ["broker", "controller"],
+  "name": "DeleteMirrorRequest",
+  "latestVersionUnstable": true,
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
+      "about": "The cluster mirror name to delete."}
+  ]
+}

--- a/clients/src/main/resources/common/message/DeleteMirrorResponse.json
+++ b/clients/src/main/resources/common/message/DeleteMirrorResponse.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 104,
+  "type": "response",
+  "name": "DeleteMirrorResponse",
+  // Version 0 is the initial version.
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The error message, or null if there was no error." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1403,6 +1403,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public DeleteMirrorResult deleteMirror(String mirrorName, DeleteMirrorOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     public synchronized DescribeMirrorsResult describeMirrors(Collection<String> mirrorNames, DescribeMirrorsOptions options) {
         Map<String, MirrorDescription> descriptions = new HashMap<>();
         for (String mirrorName : mirrorNames) {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -363,7 +363,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             // get all resources containing the non-empty mirror name change
             Map<ConfigResource, ConfigurationDelta> mirrorNameChanged = delta.configsDelta().changes().entrySet().stream().filter(entry ->
                             entry.getValue().changes().containsKey(TopicConfig.MIRROR_NAME_CONFIG) &&
-                                    !entry.getValue().changes().get(TopicConfig.MIRROR_NAME_CONFIG).isEmpty())
+                                    !entry.getValue().changes().get(TopicConfig.MIRROR_NAME_CONFIG).isEmpty()
+                                    && !entry.getValue().changes().get(TopicConfig.MIRROR_NAME_CONFIG).get().isBlank())
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             // get all topics from the resources

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -139,6 +139,7 @@ class ControllerApis(
         case ApiKeys.REMOVE_TOPICS_FROM_MIRROR => handleRemoveTopicsFromMirror(request)
         case ApiKeys.PAUSE_MIRROR_TOPICS => handlePauseMirrorTopics(request)
         case ApiKeys.RESUME_MIRROR_TOPICS => handleResumeMirrorTopics(request)
+        case ApiKeys.DELETE_MIRROR => handleDeleteMirror(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -319,6 +320,32 @@ class ControllerApis(
             new ResumeMirrorTopicsResponse(response.setThrottleTimeMs(throttleMs)))
         }
       }
+    CompletableFuture.completedFuture[Unit](())
+  }
+
+  def handleDeleteMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+
+    val mirrorVersionLevel = apiVersionManager.features.finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort)
+    if (mirrorVersionLevel == 0) {
+      throw new UnsupportedVersionException(
+        "Cluster mirroring requires mirror.version >= 1. Current version: " + mirrorVersionLevel)
+    }
+
+    val deleteMirrorRequest = request.body[DeleteMirrorRequest]
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
+    val mirrorName = deleteMirrorRequest.data().mirrorName()
+    controller.deleteMirror(context, mirrorName)
+      .handle[Unit] { (response, exception) =>
+        if (exception != null) {
+          requestHelper.handleError(request, exception)
+        } else {
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new DeleteMirrorResponse(response.setThrottleTimeMs(throttleMs)))
+        }
+      }
+
     CompletableFuture.completedFuture[Unit](())
   }
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -324,7 +324,10 @@ class ControllerApis(
   }
 
   def handleDeleteMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val deleteMirrorRequest = request.body[DeleteMirrorRequest]
+    val mirrorName = deleteMirrorRequest.data().mirrorName()
+    if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
+      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
 
     val mirrorVersionLevel = apiVersionManager.features.finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort)
     if (mirrorVersionLevel == 0) {
@@ -332,10 +335,8 @@ class ControllerApis(
         "Cluster mirroring requires mirror.version >= 1. Current version: " + mirrorVersionLevel)
     }
 
-    val deleteMirrorRequest = request.body[DeleteMirrorRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
-    val mirrorName = deleteMirrorRequest.data().mirrorName()
     controller.deleteMirror(context, mirrorName)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -257,6 +257,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.REMOVE_TOPICS_FROM_MIRROR => handleRemoveTopicsFromMirror(request)
         case ApiKeys.PAUSE_MIRROR_TOPICS => handlePauseMirrorTopics(request)
         case ApiKeys.RESUME_MIRROR_TOPICS => handleResumeMirrorTopics(request)
+        case ApiKeys.DELETE_MIRROR => handleDeleteMirror(request)
         case ApiKeys.LIST_MIRRORS => handleListMirrorsRequest(request)
         case ApiKeys.DESCRIBE_MIRRORS => handleDescribeMirrorsRequest(request)
         case ApiKeys.LAST_MIRRORED_OFFSETS => handleLastMirroredOffset(request)
@@ -403,6 +404,15 @@ class KafkaApis(val requestChannel: RequestChannel,
     if (!isClusterMirroringEnabled) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring resume mirror topics request")
       requestHelper.sendMaybeThrottle(request, new ResumeMirrorTopicsResponse(new ResumeMirrorTopicsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
+      return
+    }
+    forwardToController(request)
+  }
+
+  def handleDeleteMirror(request: RequestChannel.Request): Unit = {
+    if (!isClusterMirroringEnabled) {
+      logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring delete mirror request")
+      requestHelper.sendMaybeThrottle(request, new DeleteMirrorResponse(new DeleteMirrorResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
       return
     }
     forwardToController(request)

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.message.AddTopicsToMirrorResponseData;
 import org.apache.kafka.common.message.CreateMirrorResponseData;
+import org.apache.kafka.common.message.DeleteMirrorResponseData;
 import org.apache.kafka.common.message.PauseMirrorTopicsResponseData;
 import org.apache.kafka.common.message.RemoveTopicsFromMirrorResponseData;
 import org.apache.kafka.common.message.ResumeMirrorTopicsResponseData;
@@ -61,6 +62,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.APPEND;
+import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.DELETE;
 import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
 import static org.apache.kafka.common.config.ConfigResource.Type.BROKER;
 import static org.apache.kafka.common.config.TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG;
@@ -459,6 +461,65 @@ public class ConfigurationControlManager {
         data.setErrorCode((short) 0);
 
         return ControllerResult.atomicOf(outputRecords, data);
+    }
+
+    ControllerResult<DeleteMirrorResponseData> deleteMirror(String mirrorName) {
+        List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+        DeleteMirrorResponseData data = new DeleteMirrorResponseData();
+
+        // Check mirror existence
+        ConfigResource mirrorResource = new ConfigResource(Type.MIRROR, mirrorName);
+        TimelineHashMap<String, String> mirrorConfigs = configData.get(mirrorResource);
+        if (mirrorConfigs == null || mirrorConfigs.isEmpty()) {
+            data.setErrorCode(Errors.INVALID_REQUEST.code());
+            data.setErrorMessage("Mirror '" + mirrorName + "' not found");
+            return ControllerResult.of(records, data);
+        }
+
+        // Precondition: no active/paused topics
+        String removedSuffix = mirrorName + REMOVED_TOPIC_SUFFIX;
+        for (Entry<ConfigResource, TimelineHashMap<String, String>> entry : configData.entrySet()) {
+            if (entry.getKey().type() != Type.TOPIC) continue;
+            String mirrorNameValue = entry.getValue().get(TopicConfig.MIRROR_NAME_CONFIG);
+            if (mirrorNameValue == null || mirrorNameValue.isBlank()) continue;
+            if (mirrorNameValue.equals(mirrorName) || mirrorNameValue.equals(mirrorName + PAUSED_TOPIC_SUFFIX)) {
+                data.setErrorCode(Errors.MIRROR_NOT_EMPTY.code());
+                data.setErrorMessage("Mirror '" + mirrorName + "' still has active or paused topic '"
+                    + entry.getKey().name() + "'");
+                return ControllerResult.of(records, data);
+            }
+        }
+
+        // Clear removed topic associations
+        for (Entry<ConfigResource, TimelineHashMap<String, String>> entry : configData.entrySet()) {
+            if (entry.getKey().type() != Type.TOPIC) continue;
+            String mirrorNameValue = entry.getValue().get(TopicConfig.MIRROR_NAME_CONFIG);
+            if (removedSuffix.equals(mirrorNameValue)) {
+                Map<String, Entry<OpType, String>> keyToOps = Map.of(
+                    TopicConfig.MIRROR_NAME_CONFIG, new AbstractMap.SimpleImmutableEntry<>(SET, ""));
+                ControllerResult<ApiError> configResult = incrementalAlterConfig(entry.getKey(), keyToOps, true);
+                if (configResult.response().isSuccess()) {
+                    records.addAll(configResult.records());
+                }
+            }
+        }
+
+        // Tombstone the mirror config
+        Map<String, Entry<OpType, String>> deleteOps = new HashMap<>();
+        for (String key : mirrorConfigs.keySet()) {
+            deleteOps.put(key, new AbstractMap.SimpleImmutableEntry<>(DELETE, null));
+        }
+        ControllerResult<ApiError> configResult = incrementalAlterConfig(mirrorResource, deleteOps, false);
+        if (configResult.response().isFailure()) {
+            data.setErrorCode(configResult.response().error().code());
+            data.setErrorMessage("Failed to delete mirror configuration");
+            return ControllerResult.of(records, data);
+        }
+        records.addAll(configResult.records());
+
+        // Topic disassociations and mirror config tombstones are applied as a single atomic batch
+        data.setErrorCode((short) 0);
+        return ControllerResult.atomicOf(records, data);
     }
 
     List<ApiMessageAndVersion> createClearElrRecordsAsNeeded(List<ApiMessageAndVersion> input) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -471,7 +471,7 @@ public class ConfigurationControlManager {
         ConfigResource mirrorResource = new ConfigResource(Type.MIRROR, mirrorName);
         TimelineHashMap<String, String> mirrorConfigs = configData.get(mirrorResource);
         if (mirrorConfigs == null || mirrorConfigs.isEmpty()) {
-            data.setErrorCode(Errors.INVALID_REQUEST.code());
+            data.setErrorCode(Errors.UNKNOWN_MIRROR.code());
             data.setErrorMessage("Mirror '" + mirrorName + "' not found");
             return ControllerResult.of(records, data);
         }
@@ -498,6 +498,7 @@ public class ConfigurationControlManager {
                 Map<String, Entry<OpType, String>> keyToOps = Map.of(
                     TopicConfig.MIRROR_NAME_CONFIG, new AbstractMap.SimpleImmutableEntry<>(SET, ""));
                 ControllerResult<ApiError> configResult = incrementalAlterConfig(entry.getKey(), keyToOps, true);
+                // TODO add failure handling
                 if (configResult.response().isSuccess()) {
                     records.addAll(configResult.records());
                 }

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.DeleteMirrorResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
@@ -190,6 +191,11 @@ public interface Controller extends AclMutator, AutoCloseable {
             ControllerRequestContext context,
             String mirrorName,
             Set<String> topics
+    );
+
+    CompletableFuture<DeleteMirrorResponseData> deleteMirror(
+            ControllerRequestContext context,
+            String mirrorName
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -50,6 +50,7 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.DeleteMirrorResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
@@ -1819,6 +1820,15 @@ public final class QuorumController implements Controller {
     ) {
         return appendWriteEvent("resumeMirrorTopics", context.deadlineNs(),
                 () -> configurationControl.resumeMirrorTopics(mirrorName, topics));
+    }
+
+    @Override
+    public CompletableFuture<DeleteMirrorResponseData> deleteMirror(
+            ControllerRequestContext context,
+            String mirrorName
+    ) {
+        return appendWriteEvent("deleteMirror", context.deadlineNs(),
+                () -> configurationControl.deleteMirror(mirrorName));
     }
 
     @Override

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -59,6 +59,8 @@ import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupsOptions;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
+import org.apache.kafka.clients.admin.DeleteMirrorOptions;
+import org.apache.kafka.clients.admin.DeleteMirrorResult;
 import org.apache.kafka.clients.admin.DeleteRecordsOptions;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
 import org.apache.kafka.clients.admin.DeleteShareGroupOffsetsOptions;
@@ -455,6 +457,11 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     @Override
     public ResumeMirrorTopicsResult resumeMirrorTopics(final String mirrorName, final Set<String> topics, final ResumeMirrorTopicsOptions options) {
         return adminDelegate.resumeMirrorTopics(mirrorName, topics, options);
+    }
+
+    @Override
+    public DeleteMirrorResult deleteMirror(final String mirrorName, final DeleteMirrorOptions options) {
+        return adminDelegate.deleteMirror(mirrorName, options);
     }
 
     @Override

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -47,6 +47,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
+import org.apache.kafka.common.message.DeleteMirrorResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
@@ -147,6 +148,13 @@ public class MockController implements Controller {
             ControllerRequestContext context,
             String mirrorName,
             Set<String> topics) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<DeleteMirrorResponseData> deleteMirror(
+            ControllerRequestContext context,
+            String mirrorName) {
         throw new UnsupportedOperationException();
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -26,6 +26,8 @@ import org.apache.kafka.clients.admin.CreateMirrorOptions;
 import org.apache.kafka.clients.admin.CreateMirrorResult;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteMirrorOptions;
+import org.apache.kafka.clients.admin.DeleteMirrorResult;
 import org.apache.kafka.clients.admin.DescribeMirrorsOptions;
 import org.apache.kafka.clients.admin.DescribeMirrorsResult;
 import org.apache.kafka.clients.admin.ListMirrorsResult;
@@ -94,6 +96,8 @@ public abstract class MirrorCommand {
                 mirrorService.addTopicsToMirror(opts);
             } else if (opts.hasRemoveOption()) {
                 mirrorService.removeTopicsFromMirror(opts);
+            } else if (opts.hasDeleteOption()) {
+                mirrorService.deleteMirror(opts);
             } else if (opts.hasPauseOption()) {
                 mirrorService.pauseMirrorTopics(opts);
             } else if (opts.hasResumeOption()) {
@@ -255,6 +259,14 @@ public abstract class MirrorCommand {
             System.out.printf("Removed %d topic(s) from mirror %s: %s%n", matchingTopics.size(), mirrorName, matchingTopics);
         }
 
+        private void deleteMirror(MirrorCommandOptions opts) throws ExecutionException, InterruptedException {
+            String mirrorName = opts.mirror().get();
+            DeleteMirrorResult result = adminClient.deleteMirror(
+                mirrorName, new DeleteMirrorOptions());
+            result.all().get();
+            System.out.printf("Deleted mirror %s%n", mirrorName);
+        }
+
         private void pauseMirrorTopics(MirrorCommandOptions opts) throws Exception {
             String topicPattern = opts.topic().get();
             String mirrorName = opts.mirror().get();
@@ -400,6 +412,7 @@ public abstract class MirrorCommand {
         private final OptionSpecBuilder alterOpt;
         private final OptionSpecBuilder addOpt;
         private final OptionSpecBuilder removeOpt;
+        private final OptionSpecBuilder deleteOpt;
         private final OptionSpecBuilder pauseOpt;
         private final OptionSpecBuilder resumeOpt;
         private final OptionSpecBuilder listOpt;
@@ -430,6 +443,7 @@ public abstract class MirrorCommand {
             alterOpt = parser.accepts("alter", "Alter the configuration of an existing cluster mirror.");
             addOpt = parser.accepts("add", "Add topic(s) to an existing cluster mirror (supports regex).");
             removeOpt = parser.accepts("remove", "Remove topic(s) from an existing cluster mirror (supports regex).");
+            deleteOpt = parser.accepts("delete", "Delete a cluster mirror.");
             pauseOpt = parser.accepts("pause", "Pause mirroring for topic(s) matching the pattern (supports regex).");
             resumeOpt = parser.accepts("resume", "Resume mirroring for previously paused topic(s) matching the pattern (supports regex).");
             listOpt = parser.accepts("list", "List all cluster mirrors.");
@@ -445,7 +459,8 @@ public abstract class MirrorCommand {
                 .describedAs("topic")
                 .ofType(String.class);
 
-            replicationFactorOpt = parser.accepts("replication-factor", "The replication factor to use for the mirror topic. If not specified, uses the destination cluster's default.")
+            replicationFactorOpt = parser.accepts("replication-factor", "The replication factor to use for the mirror topic. " +
+                            "If not specified, uses the destination cluster's default.")
                 .withRequiredArg()
                 .describedAs("replication-factor")
                 .ofType(Short.class);
@@ -476,6 +491,10 @@ public abstract class MirrorCommand {
 
         private boolean hasRemoveOption() {
             return has(removeOpt);
+        }
+
+        private boolean hasDeleteOption() {
+            return has(deleteOpt);
         }
 
         private boolean hasPauseOption() {
@@ -535,9 +554,10 @@ public abstract class MirrorCommand {
 
             // should have exactly one action
             if ((has(createOpt) ? 1 : 0) + (has(alterOpt) ? 1 : 0) + (has(addOpt) ? 1 : 0) + (has(removeOpt) ? 1 : 0)
-                    + (has(pauseOpt) ? 1 : 0) + (has(resumeOpt) ? 1 : 0)
+                    + (has(deleteOpt) ? 1 : 0) + (has(pauseOpt) ? 1 : 0) + (has(resumeOpt) ? 1 : 0)
                     + (has(listOpt) ? 1 : 0) + (has(describeOpt) ? 1 : 0) != 1)
-                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --alter, --add, --remove, --pause, --resume, --list, or --describe");
+                CommandLineUtils.printUsageAndExit(parser, "Command must include exactly one action: --create, --alter, --add, " +
+                        "--remove, --delete, --pause, --resume, --list, or --describe");
 
             // check required args
             if (!has(bootstrapServerOpt))


### PR DESCRIPTION
Implement the delete mirror operation that permanently removes a mirror and all its metadata. The mirror must be empty or all its topics must have been removed (in STOPPED state). After deletion, all metadata are tombstoned making failback no longer possible.

New MIRROR_NOT_EMPTY error (code 135) provides a clear, actionable error when deletion is rejected because the mirror still has active or paused topics.