### PR TITLE
avoid unnecessary batch traversing for mirror pid reset batch

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1409,12 +1409,14 @@ class ReplicaManager(val config: KafkaConfig,
       logStartOffset
     }
 
-    def validateReadOnlyTopic(partition: Partition, records: MemoryRecords): Unit = {
+    def validateReadOnlyTopic(partition: Partition, records: MemoryRecords, origin: AppendOrigin): Unit = {
       val mirrorName = partition.getMirrorName()
       if (mirrorMetadataManager.isDefined && mirrorName.nonEmpty) {
         val state = mirrorMetadataManager.get.getPartitionState(mirrorName, partition.topicPartition)
         val allowed = state == MirrorPartitionState.STOPPED ||
-          (state == MirrorPartitionState.STOPPING && records.batches().asScala.exists(ControlRecordType.isMirrorPidResetBatch))
+          (state == MirrorPartitionState.STOPPING &&
+            (origin == AppendOrigin.COORDINATOR || origin == AppendOrigin.REPLICATION) &&
+            records.batches().asScala.exists(ControlRecordType.isMirrorPidResetBatch))
         if (!allowed) {
           throw new ReadOnlyTopicException("Cannot append to read-only partition %s on broker %d (mirrorName=%s)"
             .format(partition.topicPartition, localBrokerId, mirrorName))
@@ -1438,7 +1440,7 @@ class ReplicaManager(val config: KafkaConfig,
       } else {
         try {
           val partition = getPartitionOrException(topicIdPartition)
-          validateReadOnlyTopic(partition, records)
+          validateReadOnlyTopic(partition, records, origin)
           val info = partition.appendRecordsToLeader(records, origin, requiredAcks, requestLocal,
             verificationGuards.getOrElse(topicIdPartition.topicPartition(), VerificationGuard.SENTINEL))
           val numAppendedMessages = info.numMessages

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1398,7 +1398,8 @@ public class UnifiedLog implements AutoCloseable {
         int relativePositionInSegment = appendOffsetMetadata.relativePositionInSegment;
 
         for (MutableRecordBatch batch : records.batches()) {
-            if (ControlRecordType.isMirrorPidResetBatch(batch)) {
+            if ((origin == AppendOrigin.COORDINATOR || origin == AppendOrigin.REPLICATION)
+                    && ControlRecordType.isMirrorPidResetBatch(batch)) {
                 producerStateManager.expireMirroredProducers();
             }
 


### PR DESCRIPTION
A minor improvement to avoid unnecessary batch traversing for mirror pid reset batch if the origin is not COORDINATOR/REPLICATION because the batch will never be produced by CLIENT or RAFT_LEADER.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
