### PR TITLE
Add __mirror_state tombstones

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -345,6 +345,7 @@ public class MirrorCoordinator {
         log.info("Starting up.");
         numPartitions = brokerConfig.mirrorConfig().topicNumPartitions();
         metadataManager.setStateTransitioner((mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state));
+        metadataManager.setMirrorDeletionHandler(this::tombstoneMirrorRecords);
         metadataManager.setCoordinatorPartitionByKeyFinder(key -> getCoordinatorPartitionByKey(key));
         metadataManager.setCoordinatorPartitionByNameFinder(mirrorName -> getCoordinatorPartitionByName(mirrorName));
 
@@ -528,6 +529,50 @@ public class MirrorCoordinator {
         val.setTopics(topics);
         var apiVersion = new ApiMessageAndVersion(val, LastMirroredOffsetsValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);
+    }
+
+    private void tombstoneMirrorRecords(String mirrorName) {
+        Map<TopicPartition, MirrorPartitionState> states = metadataManager.getMirrorStates(mirrorName);
+        // Collect local coordinator partitions that need tombstones
+        Set<Integer> localCoordPartitions = new HashSet<>();
+        states.forEach((tp, state) -> {
+            if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
+                localCoordPartitions.add(getCoordinatorPartitionByKey(
+                    new MirrorRecordKey(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition())));
+            }
+        });
+
+        // Write one partition state tombstone and one offset tombstone per coordinator partition
+        var timestamp = time.milliseconds();
+        var stateTombstone = CoordinatorRecord.tombstone(new MirrorPartitionStateKey().setMirrorName(mirrorName));
+        var offsetTombstone = CoordinatorRecord.tombstone(new LastMirroredOffsetsKey().setMirrorName(mirrorName));
+        var stateKeyBytes = serde.serializeKey(stateTombstone);
+        var offsetKeyBytes = serde.serializeKey(offsetTombstone);
+
+        for (int coordPartition : localCoordPartitions) {
+            var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, coordPartition);
+            var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
+            var memRecord = MemoryRecords.withRecords(Compression.NONE,
+                new SimpleRecord(timestamp, stateKeyBytes, null),
+                new SimpleRecord(timestamp, offsetKeyBytes, null));
+            replicaManager.appendRecords(
+                Duration.ofSeconds(5).toMillis(),
+                (short) -1,
+                true,
+                AppendOrigin.COORDINATOR,
+                CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
+                partitionResponses -> null,
+                ignored -> null,
+                RequestLocal.noCaching(),
+                CollectionConverters.asScala(Map.of())
+            );
+        }
+
+        // Clean up in-memory caches
+        states.keySet().forEach(tp ->
+            metadataManager.removePartitionState(
+                new MirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition())));
+        metadataManager.removeLastMirroredOffsets(mirrorName);
     }
 
     private String readMirrorNameFromKey(ByteBuffer buffer) {

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -546,15 +546,14 @@ public class MirrorCoordinator {
         var timestamp = time.milliseconds();
         var stateTombstone = CoordinatorRecord.tombstone(new MirrorPartitionStateKey().setMirrorName(mirrorName));
         var offsetTombstone = CoordinatorRecord.tombstone(new LastMirroredOffsetsKey().setMirrorName(mirrorName));
-        var stateKeyBytes = serde.serializeKey(stateTombstone);
-        var offsetKeyBytes = serde.serializeKey(offsetTombstone);
 
         for (int coordPartition : localCoordPartitions) {
             var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, coordPartition);
             var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
             var memRecord = MemoryRecords.withRecords(Compression.NONE,
-                new SimpleRecord(timestamp, stateKeyBytes, null),
-                new SimpleRecord(timestamp, offsetKeyBytes, null));
+                new SimpleRecord(timestamp, serde.serializeKey(stateTombstone), serde.serializeValue(stateTombstone)),
+                new SimpleRecord(timestamp, serde.serializeKey(offsetTombstone), serde.serializeValue(offsetTombstone))
+            );
             replicaManager.appendRecords(
                 Duration.ofSeconds(5).toMillis(),
                 (short) -1,

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -168,6 +168,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Supplier<GroupCoordinator> groupCoordinatorSupplier;
     private final Supplier<MirrorFetcherManager> mirrorFetcherManagerSupplier;
     private Optional<MirrorUtils.StateTransitioner> stateTransitioner = Optional.empty();
+    private Optional<Consumer<String>> mirrorDeletionHandler = Optional.empty();
     private Optional<Function<MirrorRecordKey, Integer>> coordinatorPartitionFinder = Optional.empty();
     private Optional<Function<String, Integer>> coordinatorPartitionByNameFinder = Optional.empty();
 
@@ -259,6 +260,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .filter(e -> e.getKey().type() == ConfigResource.Type.MIRROR)
                 .forEach(e -> {
                     String mirrorName = e.getKey().name();
+                    boolean mirrorDeleted = newImage.configs()
+                        .configProperties(e.getKey()).isEmpty();
+                    if (mirrorDeleted) {
+                        log.info("Mirror '{}' has been deleted. Writing tombstone records.", mirrorName);
+                        mirrorDeletionHandler.ifPresent(h -> h.accept(mirrorName));
+                    }
                     sourceLeaders.remove(mirrorName);
                     List<MirrorSourceSender> senders = sourceSenders.remove(mirrorName);
                     if (senders != null) {
@@ -508,6 +515,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     void setStateTransitioner(MirrorUtils.StateTransitioner function) {
         this.stateTransitioner = Optional.of(function);
+    }
+
+    void setMirrorDeletionHandler(Consumer<String> handler) {
+        this.mirrorDeletionHandler = Optional.of(handler);
     }
 
     void setCoordinatorPartitionByKeyFinder(Function<MirrorRecordKey, Integer> function) {
@@ -775,11 +786,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     // atomic remove + counter decrement to keep partition state counts consistent
-    private void removePartitionState(MirrorUtils.PartitionKey key) {
+    void removePartitionState(MirrorUtils.PartitionKey key) {
         partitionStates.computeIfPresent(key, (k, oldState) -> {
             partitionStateCounts.computeIfAbsent(oldState, s -> new AtomicLong()).decrementAndGet();
             return null;
         });
+    }
+
+    void removeLastMirroredOffsets(String mirrorName) {
+        lastMirroredOffsets.keySet().removeIf(key -> key.mirrorName().equals(mirrorName));
     }
 
     private long partitionStateCount(MirrorPartitionState state) {

--- a/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
@@ -53,7 +53,7 @@ public enum MirrorPartitionState {
     /**
      * Triggered by RemoveTopicsFromMirror API (fail over) or topic deletion on the source.
      * The system records the last mirrored offset to the internal topic.
-     * Valid from: PREPARING, MIRRORING, PAUSING (race guard), PAUSED.
+     * Valid from: PREPARING, MIRRORING, PAUSING (race guard), PAUSED, FAILED.
      */
     STOPPING((byte) 4),
 
@@ -130,7 +130,8 @@ public enum MirrorPartitionState {
                 return source == MirrorPartitionState.PREPARING
                         || source == MirrorPartitionState.MIRRORING
                         || source == MirrorPartitionState.PAUSING
-                        || source == MirrorPartitionState.PAUSED;
+                        || source == MirrorPartitionState.PAUSED
+                        || source == MirrorPartitionState.FAILED;
             case STOPPED:
                 return source == MirrorPartitionState.STOPPING;
             case FAILED:

--- a/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
@@ -108,6 +108,7 @@ public enum MirrorPartitionState {
         throw new IllegalArgumentException("Illegal mirror state: " + value);
     }
 
+    @SuppressWarnings("checkstyle:cyclomaticComplexity")
     public static boolean isValidTransition(MirrorPartitionState source, MirrorPartitionState target) {
         if (source == target) {
             return true;

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -496,12 +496,14 @@ public class ConfigurationControlManager {
             String mirrorNameValue = entry.getValue().get(TopicConfig.MIRROR_NAME_CONFIG);
             if (removedSuffix.equals(mirrorNameValue)) {
                 Map<String, Entry<OpType, String>> keyToOps = Map.of(
-                    TopicConfig.MIRROR_NAME_CONFIG, new AbstractMap.SimpleImmutableEntry<>(SET, ""));
+                    TopicConfig.MIRROR_NAME_CONFIG, new AbstractMap.SimpleImmutableEntry<>(DELETE, null));
                 ControllerResult<ApiError> configResult = incrementalAlterConfig(entry.getKey(), keyToOps, true);
-                // TODO add failure handling
-                if (configResult.response().isSuccess()) {
-                    records.addAll(configResult.records());
+                if (configResult.response().isFailure()) {
+                    data.setErrorCode(configResult.response().error().code());
+                    data.setErrorMessage("Failed to clear mirror association for topic '" + entry.getKey().name() + "'");
+                    return ControllerResult.of(records, data);
                 }
+                records.addAll(configResult.records());
             }
         }
 


### PR DESCRIPTION
When deleting a mirror, in addition to adding mirror config and mirror.name topic config tombstones, we also need to add mirror state and LMO tombstones.

```
# cluster metadata
| offset: 205 CreateTime: 1774879273427 keySize: -1 valueSize: 27 sequence: -1 headerKeys: [] payload: {"type":"CONFIG_RECORD","version":0,"data":{"resourceType":2,"resourceName":"my-topic","name":"mirror.name","value":null}}
| offset: 206 CreateTime: 1774879273427 keySize: -1 valueSize: 34 sequence: -1 headerKeys: [] payload: {"type":"CONFIG_RECORD","version":0,"data":{"resourceType":64,"resourceName":"my-mirror","name":"bootstrap.servers","value":null}}

# mirror state
| offset: 5 CreateTime: 1774879273458 keySize: 13 valueSize: -1 sequence: -1 headerKeys: [] key: {"type":"2","data":{"mirrorName":"my-mirror"}} payload: <DELETE>
| offset: 6 CreateTime: 1774879273458 keySize: 13 valueSize: -1 sequence: -1 headerKeys: [] key: {"type":"1","data":{"mirrorName":"my-mirror"}} payload: <DELETE>
```