### PR TITLE
Fix race condition in STOPPING

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -157,7 +157,8 @@ public class MirrorCoordinator {
                     updateLastMirroredEpochsFuture.complete(null);
                 });
                 CompletableFuture.allOf(bumpLeaderEpochFuture, updateLastMirroredEpochsFuture)
-                        .whenComplete((v, ex) -> writeMirrorPidResetBarrier(mirrorName, topicPartitions));
+                        .whenComplete((v, ex) -> writeMirrorPidResetBarrier(mirrorName, topicPartitions))
+                        .thenRun(() -> transitionTo(mirrorName, topicPartitions, MirrorPartitionState.STOPPED));
                 break;
             case STOPPED:
                 log.debug("STOPPED for topics {}.", topicPartitions);
@@ -417,8 +418,7 @@ public class MirrorCoordinator {
                                 log.error("Failed to write PID reset barrier for partition {} in mirror {}: {}",
                                     tp, mirrorName, pr.error.message());
                             } else {
-                                log.info("Wrote mirror PID reset barrier for partition {} in mirror {}. Moving to STOPPED state.", tp, mirrorName);
-                                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED);
+                                log.info("Wrote mirror PID reset barrier for partition {} in mirror {}", tp, mirrorName);
                             }
                             return null;
                         });

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -150,9 +150,14 @@ public class MirrorCoordinator {
             case STOPPING:
                 log.debug("STOPPING for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions);
-                truncateToLastStableOffset(topicPartitions, tp -> updateLastMirroredEpochs(mirrorName, Set.of(tp)));
-                writeMirrorPidResetBarrier(mirrorName, topicPartitions);
+                CompletableFuture<Void> bumpLeaderEpochFuture = metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions);
+                CompletableFuture<Void> updateLastMirroredEpochsFuture = new CompletableFuture<>();
+                truncateToLastStableOffset(topicPartitions, tp -> {
+                    updateLastMirroredEpochs(mirrorName, Set.of(tp));
+                    updateLastMirroredEpochsFuture.complete(null);
+                });
+                CompletableFuture.allOf(bumpLeaderEpochFuture, updateLastMirroredEpochsFuture)
+                        .whenComplete((v, ex) -> writeMirrorPidResetBarrier(mirrorName, topicPartitions));
                 break;
             case STOPPED:
                 log.debug("STOPPED for topics {}.", topicPartitions);
@@ -235,7 +240,7 @@ public class MirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
-        updateLastMirroredEpochs(updatedMirrorName, offsets, false);
+        updateLastMirroredEpochs(updatedMirrorName, offsets);
 
         WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
         List<WriteMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
@@ -273,7 +278,7 @@ public class MirrorCoordinator {
             partitionOffsets.put(topic, offsets);
         });
 
-        updateLastMirroredEpochs(mirrorName, partitionOffsets, true);
+        updateLastMirroredEpochs(mirrorName, partitionOffsets);
     }
 
     private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(String mirrorName,
@@ -412,7 +417,8 @@ public class MirrorCoordinator {
                                 log.error("Failed to write PID reset barrier for partition {} in mirror {}: {}",
                                     tp, mirrorName, pr.error.message());
                             } else {
-                                log.info("Wrote mirror PID reset barrier for partition {} in mirror {}", tp, mirrorName);
+                                log.info("Wrote mirror PID reset barrier for partition {} in mirror {}. Moving to STOPPED state.", tp, mirrorName);
+                                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED);
                             }
                             return null;
                         });
@@ -443,7 +449,7 @@ public class MirrorCoordinator {
     }
 
     /** Persists offsets to local or remote coordinators, optionally transitioning to STOPPED. */
-    public void updateLastMirroredEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets, boolean transitionToStopped) {
+    public void updateLastMirroredEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
         // Separate partitions into local and remote coordinator groups
         Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
         Map<String, Set<MirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
@@ -489,25 +495,11 @@ public class MirrorCoordinator {
                     RequestLocal.noCaching(),
                     CollectionConverters.asScala(Map.of())
             );
-
-            // TODO: now we assume all partitions work without error, we should handle error cases
-            if (transitionToStopped) {
-                tps.forEach(tp ->
-                    transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED));
-            }
         });
 
         // Write to remote coordinator (batched by coordinator node internally)
         if (!remoteTopicMetadata.isEmpty()) {
-            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
-                if (transitionToStopped) {
-                    res.data().topics().forEach(topic ->
-                        topic.partitions().forEach(partition ->
-                            transitionTo(mirrorName,
-                                Set.of(new TopicPartition(topic.name(), partition.partitionIndex())),
-                                MirrorPartitionState.STOPPED)));
-                }
-            });
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> { });
         }
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -944,7 +944,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             BumpLeaderEpochsRequestData.TopicState topicState = new BumpLeaderEpochsRequestData.TopicState();
             List<BumpLeaderEpochsRequestData.LeaderEpochState> topicLeaderEpoch = new ArrayList<>();
             parts.forEach(partitionId -> {
-
                 int epoch = logManager.getLog(new TopicPartition(topic, partitionId), false).get().latestEpoch().orElse(-1);
                 topicLeaderEpoch.add(new BumpLeaderEpochsRequestData.LeaderEpochState().setMinLeaderEpoch(epoch).setPartitionIndex(partitionId));
             });
@@ -955,7 +954,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         channelManager.sendRequest(new BumpLeaderEpochsRequest.Builder(
                 new BumpLeaderEpochsRequestData().setTopics(topicStates)
         ), new ControllerRequestCompletionHandler() {
-
             @Override
             public void onComplete(ClientResponse response) {
                 log.debug("Bump leader epoch response: {}", response);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -121,6 +121,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -932,7 +933,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         metadataRefreshError.incrementAndGet();
     }
 
-    public void sendBumpLeaderEpoch(LogManager logManager, Set<TopicPartition> topicPartitions) {
+    public CompletableFuture<Void> sendBumpLeaderEpoch(LogManager logManager, Set<TopicPartition> topicPartitions) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         List<BumpLeaderEpochsRequestData.TopicState> topicStates = new ArrayList<>();
         Map<String, Set<Integer>> partitions = new HashMap<>();
         topicPartitions.forEach(tp -> {
@@ -952,7 +954,21 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         channelManager.sendRequest(new BumpLeaderEpochsRequest.Builder(
                 new BumpLeaderEpochsRequestData().setTopics(topicStates)
-        ), new TimeoutHandler(log));
+        ), new ControllerRequestCompletionHandler() {
+
+            @Override
+            public void onComplete(ClientResponse response) {
+                log.debug("Bump leader epoch response: {}", response);
+                future.complete(null);
+            }
+
+            @Override
+            public void onTimeout() {
+                log.warn("BumpLeaderEpoch request timed out");
+            }
+        });
+
+        return future;
     }
 
     /**

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -190,7 +190,6 @@ class ControllerApis(
         if (exception != null) {
           requestHelper.handleError(request, exception)
         } else {
-
           requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
             new BumpLeaderEpochsResponse(response.setThrottleTimeMs(throttleMs)))
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -706,7 +706,6 @@ public class ReplicationControlManager {
     }
 
     public ControllerResult<BumpLeaderEpochsResponseData> bumpLeaderEpochs(Map<Uuid, Map<Integer, Integer>> partitionLeaderEpochs) {
-
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         for (Entry<Uuid, Map<Integer, Integer>> partitionLeaderEpoch : partitionLeaderEpochs.entrySet()) {
             Uuid topicId = partitionLeaderEpoch.getKey();


### PR DESCRIPTION
Now, we move to STOPPED state before writePidResetRecord completes. Fix that by explicitly waiting for previous future completes, then write Pid reset records. Then explicitly move to STOPPED state in STOPPING process.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
