### PR TITLE
Fix renaming of LastMirroredOffset to LastMirroredEpoch

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -377,7 +377,7 @@ public class MirrorCoordinator {
     /** Schedules truncation with retry on failure, using mirror.truncation.backoff.ms as retry delay. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions, long delayMs) {
         long retryDelayMs = brokerConfig.mirrorConfig().truncationBackoffMs();
-        scheduler.scheduleOnce("LastMirroredEpochTruncation",
+        scheduler.scheduleOnce("LastMirroredEpochsTruncation",
             () -> {
                 try {
                     metadataManager.truncateToLastMirroredEpochs(replicaManager, mirrorName, topicPartitions,

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -377,7 +377,7 @@ public class MirrorCoordinator {
     /** Schedules truncation with retry on failure, using mirror.truncation.backoff.ms as retry delay. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions, long delayMs) {
         long retryDelayMs = brokerConfig.mirrorConfig().truncationBackoffMs();
-        scheduler.scheduleOnce("LastMirroredOffsetTruncation",
+        scheduler.scheduleOnce("LastMirroredEpochTruncation",
             () -> {
                 try {
                     metadataManager.truncateToLastMirroredEpochs(replicaManager, mirrorName, topicPartitions,
@@ -542,7 +542,7 @@ public class MirrorCoordinator {
         // Write one partition state tombstone and one offset tombstone per coordinator partition
         var timestamp = time.milliseconds();
         var stateTombstone = CoordinatorRecord.tombstone(new MirrorPartitionStateKey().setMirrorName(mirrorName));
-        var offsetTombstone = CoordinatorRecord.tombstone(new LastMirroredOffsetsKey().setMirrorName(mirrorName));
+        var offsetTombstone = CoordinatorRecord.tombstone(new LastMirroredEpochsKey().setMirrorName(mirrorName));
 
         for (int coordPartition : localCoordPartitions) {
             var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, coordPartition);
@@ -568,7 +568,7 @@ public class MirrorCoordinator {
         states.keySet().forEach(tp ->
             metadataManager.removePartitionState(
                 new MirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition())));
-        metadataManager.removeLastMirroredOffsets(mirrorName);
+        metadataManager.removeLastMirroredEpochs(mirrorName);
     }
 
     private String readMirrorNameFromKey(ByteBuffer buffer) {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -797,8 +797,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    void removeLastMirroredOffsets(String mirrorName) {
-        lastMirroredOffsets.keySet().removeIf(key -> key.mirrorName().equals(mirrorName));
+    void removeLastMirroredEpochs(String mirrorName) {
+        lastMirroredEpochs.keySet().removeIf(key -> key.mirrorName().equals(mirrorName));
     }
 
     private long partitionStateCount(MirrorPartitionState state) {
@@ -912,10 +912,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         new LastMirroredEpochsRequestData().setMirrorName(mirrorName).setTopics(topicDataList))
         );
 
-        if (response.responseBody() instanceof LastMirroredEpochsResponse lastMirroredOffsetResponse) {
-            log.debug("Received last mirrored epoch response: {}", lastMirroredOffsetResponse);
+        if (response.responseBody() instanceof LastMirroredEpochsResponse lastMirroredEpochResponse) {
+            log.debug("Received last mirrored epoch response: {}", lastMirroredEpochResponse);
             Map<TopicPartition, Integer> epochs = new HashMap<>();
-            lastMirroredOffsetResponse.data().topics().forEach(topic -> {
+            lastMirroredEpochResponse.data().topics().forEach(topic -> {
                 String name = topic.name();
                 topic.partitions().forEach(partition -> {
                     epochs.put(new TopicPartition(name, partition.partitionIndex()), partition.lastMirroredEpoch());

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -912,10 +912,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         new LastMirroredEpochsRequestData().setMirrorName(mirrorName).setTopics(topicDataList))
         );
 
-        if (response.responseBody() instanceof LastMirroredEpochsResponse lastMirroredEpochResponse) {
-            log.debug("Received last mirrored epoch response: {}", lastMirroredEpochResponse);
+        if (response.responseBody() instanceof LastMirroredEpochsResponse lastMirroredEpochsResponse) {
+            log.debug("Received last mirrored epochs response: {}", lastMirroredEpochsResponse);
             Map<TopicPartition, Integer> epochs = new HashMap<>();
-            lastMirroredEpochResponse.data().topics().forEach(topic -> {
+            lastMirroredEpochsResponse.data().topics().forEach(topic -> {
                 String name = topic.name();
                 topic.partitions().forEach(partition -> {
                     epochs.put(new TopicPartition(name, partition.partitionIndex()), partition.lastMirroredEpoch());

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -347,11 +347,11 @@ class KafkaApis(val requestChannel: RequestChannel,
         requestHelper.sendMaybeThrottle(request, new LastMirroredEpochsResponse(new LastMirroredEpochsResponseData().setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)))
         return
       }
-      val lastMirroredOffsetRequest = request.body[LastMirroredEpochsRequest]
+      val lastMirroredEpochsRequest = request.body[LastMirroredEpochsRequest]
       val responseData = new LastMirroredEpochsResponseData()
-      val mirrorName = lastMirroredOffsetRequest.data().mirrorName()
+      val mirrorName = lastMirroredEpochsRequest.data().mirrorName()
       val topicResults = new util.ArrayList[LastMirroredEpochsResponseData.TopicResult]()
-      lastMirroredOffsetRequest.data().topics().forEach(topic => {
+      lastMirroredEpochsRequest.data().topics().forEach(topic => {
         val topicResult = new LastMirroredEpochsResponseData.TopicResult()
         val partitionResults = new util.ArrayList[LastMirroredEpochsResponseData.PartitionResult]()
         topic.partitions().forEach(par => {


### PR DESCRIPTION
Compilation of core was failing due to references to `LastMirroredOffset` which has been renamed in
21513df1c7f2882d26e956b53756ff56ce75c038.

This PR fixes the compilation and updates naming to reflect the change.