### PR TITLE
Add security improvements

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/MirrorAuthorizationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/MirrorAuthorizationException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class MirrorAuthorizationException extends AuthorizationException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MirrorAuthorizationException(String message) {
+        super(message);
+    }
+
+    public MirrorAuthorizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -86,6 +86,7 @@ import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.ListenerNotFoundException;
 import org.apache.kafka.common.errors.LogDirNotFoundException;
 import org.apache.kafka.common.errors.MemberIdRequiredException;
+import org.apache.kafka.common.errors.MirrorAuthorizationException;
 import org.apache.kafka.common.errors.MirrorNotEmptyException;
 import org.apache.kafka.common.errors.MirrorTopicAlreadyPausedException;
 import org.apache.kafka.common.errors.MirrorTopicBeingRemovedException;
@@ -436,7 +437,8 @@ public enum Errors {
     MIRROR_TOPIC_ALREADY_PAUSED(139, "The mirror topic is already paused.", MirrorTopicAlreadyPausedException::new),
     MIRROR_TOPIC_NOT_PAUSED(140, "The mirror topic is not paused.", MirrorTopicNotPausedException::new),
     MIRROR_TOPIC_BEING_REMOVED(141, "The mirror topic is being removed.", MirrorTopicBeingRemovedException::new),
-    MIRROR_NOT_EMPTY(142, "The mirror still has active or non-removed topics.", MirrorNotEmptyException::new);
+    MIRROR_NOT_EMPTY(142, "The mirror still has active or non-removed topics.", MirrorNotEmptyException::new),
+    MIRROR_AUTHORIZATION_FAILED(143, "Mirror authorization failed.", MirrorAuthorizationException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/core/src/main/java/kafka/server/mirror/MirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorUtils.java
@@ -25,6 +25,8 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.config.MirrorConfig;
 import org.apache.kafka.server.network.BrokerEndPoint;
 
+import org.apache.kafka.server.common.MirrorVersion;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -39,6 +41,11 @@ import static org.apache.kafka.controller.ConfigurationControlManager.REMOVED_TO
  */
 public final class MirrorUtils {
     private MirrorUtils() {}
+
+    public static boolean isClusterMirroringEnabled(Map<String, Short> finalizedFeatures) {
+        short featureLevel = finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, (short) 0);
+        return MirrorVersion.fromFeatureLevel(featureLevel).isClusterMirroringSupported();
+    }
 
     public static MirrorSourceSender createSender(BrokerEndPoint brokerEndpoint,
                                                   MirrorConfig mirrorConfig,

--- a/core/src/main/java/kafka/server/mirror/MirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorUtils.java
@@ -22,10 +22,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.common.MirrorVersion;
 import org.apache.kafka.server.config.MirrorConfig;
 import org.apache.kafka.server.network.BrokerEndPoint;
-
-import org.apache.kafka.server.common.MirrorVersion;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/core/src/main/scala/kafka/server/ConfigHelper.scala
+++ b/core/src/main/scala/kafka/server/ConfigHelper.scala
@@ -69,7 +69,7 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
     val unauthorizedConfigs = unauthorizedResources.map { resource =>
       val error = ConfigResource.Type.forId(resource.resourceType) match {
         case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER | ConfigResource.Type.CLIENT_METRICS => Errors.CLUSTER_AUTHORIZATION_FAILED
-        case ConfigResource.Type.MIRROR => Errors.CLUSTER_AUTHORIZATION_FAILED
+        case ConfigResource.Type.MIRROR => Errors.MIRROR_AUTHORIZATION_FAILED
         case ConfigResource.Type.TOPIC => Errors.TOPIC_AUTHORIZATION_FAILED
         case ConfigResource.Type.GROUP => Errors.GROUP_AUTHORIZATION_FAILED
         case rt => throw new InvalidRequestException(s"Unexpected resource type $rt for resource ${resource.resourceName}")

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -27,12 +27,13 @@ import kafka.raft.RaftManager
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.logger.RuntimeLoggerManager
 import kafka.server.metadata.KRaftMetadataCache
+import kafka.server.mirror.MirrorUtils
 import kafka.utils.Logging
 import org.apache.kafka.clients.admin.{AlterConfigOp, EndpointType}
 import org.apache.kafka.common.Uuid.ZERO_UUID
-import org.apache.kafka.common.acl.AclOperation.{ALTER, ALTER_CONFIGS, CLUSTER_ACTION, CREATE, CREATE_TOKENS, DELETE, DESCRIBE, DESCRIBE_CONFIGS}
+import org.apache.kafka.common.acl.AclOperation.{ALTER, ALTER_CONFIGS, CLUSTER_ACTION, CREATE, CREATE_TOKENS, DELETE, DESCRIBE, DESCRIBE_CONFIGS, READ}
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
-import org.apache.kafka.common.errors.{ApiException, ClusterAuthorizationException, InvalidRequestException, TopicDeletionDisabledException, UnsupportedVersionException}
+import org.apache.kafka.common.errors.{ApiException, ClusterAuthorizationException, InvalidRequestException, MirrorAuthorizationException, TopicAuthorizationException, TopicDeletionDisabledException, UnsupportedVersionException}
 import org.apache.kafka.common.internals.{FatalExitError, Plugin, Topic}
 import org.apache.kafka.common.message.AlterConfigsResponseData.{AlterConfigsResourceResponse => OldAlterConfigsResourceResponse}
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic
@@ -58,7 +59,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.server.{ApiVersionManager, DelegationTokenManager, ProcessRole}
 import org.apache.kafka.server.authorizer.Authorizer
-import org.apache.kafka.server.common.{ApiMessageAndVersion, MirrorVersion, RequestLocal}
+import org.apache.kafka.server.common.{ApiMessageAndVersion, RequestLocal}
 import org.apache.kafka.server.quota.ControllerMutationQuota
 import org.apache.kafka.server.record.BrokerCompressionType
 
@@ -200,15 +201,9 @@ class ControllerApis(
   def handleCreateMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
     val mirrorName = request.body[CreateMirrorRequest].data().mirrorName()
     if (!authHelper.authorize(request.context, CREATE, CLUSTER_MIRROR, mirrorName))
-      throw new ClusterAuthorizationException(s"Request $request needs CREATE permission on ClusterMirror:$mirrorName.")
-
-    // Check if cluster mirroring is supported by the mirror.version feature
-    val mirrorVersionLevel = apiVersionManager.features.finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort)
-    if (mirrorVersionLevel == 0) {
-      throw new UnsupportedVersionException(
-        "Cluster mirroring requires mirror.version >= 1. Current version: " + mirrorVersionLevel)
-    }
-
+      throw new MirrorAuthorizationException(s"Request $request needs CREATE permission on ClusterMirror:$mirrorName.")
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
+      throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
     val createMirrorRequest = request.body[CreateMirrorRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal, OptionalLong.empty())
     val altersByName = new util.HashMap[String, Entry[AlterConfigOp.OpType, String]]()
@@ -266,13 +261,19 @@ class ControllerApis(
     val addTopicsToMirrorRequest = request.body[AddTopicsToMirrorRequest]
     val mirrorName = addTopicsToMirrorRequest.data().mirrorName()
     if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
-      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
-    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
-      OptionalLong.empty())
+      throw new MirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
+      throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
     val topics: util.Set[String] = new util.HashSet[String]()
     addTopicsToMirrorRequest.data().topics().forEach( topic => {
         topics.add(topic.topicName())
     })
+    val unauthorizedTopics = topics.asScala.filterNot(topic =>
+      authHelper.authorize(request.context, READ, TOPIC, topic, logIfDenied = false))
+    if (unauthorizedTopics.nonEmpty)
+      throw new TopicAuthorizationException(unauthorizedTopics.asJava)
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
     controller.addTopicsToMirror(context, mirrorName, topics)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {
@@ -290,13 +291,19 @@ class ControllerApis(
     val removeTopicsFromMirrorRequest = request.body[RemoveTopicsFromMirrorRequest]
     val mirrorName = removeTopicsFromMirrorRequest.data().mirrorName()
     if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
-      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
-    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
-      OptionalLong.empty())
+      throw new MirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
+      throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
     val topics: util.Set[String] = new util.HashSet[String]()
     removeTopicsFromMirrorRequest.data().topics().forEach( topic => {
         topics.add(topic.topicName())
     })
+    val unauthorizedTopics = topics.asScala.filterNot(topic =>
+      authHelper.authorize(request.context, READ, TOPIC, topic, logIfDenied = false))
+    if (unauthorizedTopics.nonEmpty)
+      throw new TopicAuthorizationException(unauthorizedTopics.asJava)
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
     controller.removeTopicsFromMirror(context, mirrorName, topics)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {
@@ -314,11 +321,17 @@ class ControllerApis(
     val pauseRequest = request.body[PauseMirrorTopicsRequest]
     val mirrorName = pauseRequest.data().mirrorName()
     if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
-      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
-    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
-      OptionalLong.empty())
+      throw new MirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
+      throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
     val topics: util.Set[String] = new util.HashSet[String]()
     pauseRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
+    val unauthorizedTopics = topics.asScala.filterNot(topic =>
+      authHelper.authorize(request.context, READ, TOPIC, topic, logIfDenied = false))
+    if (unauthorizedTopics.nonEmpty)
+      throw new TopicAuthorizationException(unauthorizedTopics.asJava)
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
     controller.pauseMirrorTopics(context, mirrorName, topics)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {
@@ -335,11 +348,17 @@ class ControllerApis(
     val resumeRequest = request.body[ResumeMirrorTopicsRequest]
     val mirrorName = resumeRequest.data().mirrorName()
     if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
-      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
-    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
-      OptionalLong.empty())
+      throw new MirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
+      throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
     val topics: util.Set[String] = new util.HashSet[String]()
     resumeRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
+    val unauthorizedTopics = topics.asScala.filterNot(topic =>
+      authHelper.authorize(request.context, READ, TOPIC, topic, logIfDenied = false))
+    if (unauthorizedTopics.nonEmpty)
+      throw new TopicAuthorizationException(unauthorizedTopics.asJava)
+    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
+      OptionalLong.empty())
     controller.resumeMirrorTopics(context, mirrorName, topics)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {
@@ -356,14 +375,9 @@ class ControllerApis(
     val deleteMirrorRequest = request.body[DeleteMirrorRequest]
     val mirrorName = deleteMirrorRequest.data().mirrorName()
     if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
-      throw new ClusterAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
-
-    val mirrorVersionLevel = apiVersionManager.features.finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort)
-    if (mirrorVersionLevel == 0) {
-      throw new UnsupportedVersionException(
-        "Cluster mirroring requires mirror.version >= 1. Current version: " + mirrorVersionLevel)
-    }
-
+      throw new MirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
+      throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
     controller.deleteMirror(context, mirrorName)
@@ -704,7 +718,7 @@ class ControllerApis(
         if (authHelper.authorize(requestContext, ALTER_CONFIGS, CLUSTER_MIRROR, resource.name)) {
           new ApiError(NONE)
         } else {
-          new ApiError(CLUSTER_AUTHORIZATION_FAILED)
+          new ApiError(MIRROR_AUTHORIZATION_FAILED)
         }
       case ConfigResource.Type.GROUP =>
         if (authHelper.authorize(requestContext, ALTER_CONFIGS, GROUP, resource.name)) {

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -31,7 +31,7 @@ import kafka.server.mirror.MirrorUtils
 import kafka.utils.Logging
 import org.apache.kafka.clients.admin.{AlterConfigOp, EndpointType}
 import org.apache.kafka.common.Uuid.ZERO_UUID
-import org.apache.kafka.common.acl.AclOperation.{ALTER, ALTER_CONFIGS, CLUSTER_ACTION, CREATE, CREATE_TOKENS, DELETE, DESCRIBE, DESCRIBE_CONFIGS, READ}
+import org.apache.kafka.common.acl.AclOperation.{ALTER, ALTER_CONFIGS, CLUSTER_ACTION, CREATE, CREATE_TOKENS, DELETE, DESCRIBE, DESCRIBE_CONFIGS}
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.{ApiException, ClusterAuthorizationException, InvalidRequestException, MirrorAuthorizationException, TopicAuthorizationException, TopicDeletionDisabledException, UnsupportedVersionException}
 import org.apache.kafka.common.internals.{FatalExitError, Plugin, Topic}
@@ -269,7 +269,7 @@ class ControllerApis(
         topics.add(topic.topicName())
     })
     val unauthorizedTopics = topics.asScala.filterNot(topic =>
-      authHelper.authorize(request.context, READ, TOPIC, topic, logIfDenied = false))
+      authHelper.authorize(request.context, ALTER_CONFIGS, TOPIC, topic, logIfDenied = false))
     if (unauthorizedTopics.nonEmpty)
       throw new TopicAuthorizationException(unauthorizedTopics.asJava)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
@@ -299,7 +299,7 @@ class ControllerApis(
         topics.add(topic.topicName())
     })
     val unauthorizedTopics = topics.asScala.filterNot(topic =>
-      authHelper.authorize(request.context, READ, TOPIC, topic, logIfDenied = false))
+      authHelper.authorize(request.context, ALTER_CONFIGS, TOPIC, topic, logIfDenied = false))
     if (unauthorizedTopics.nonEmpty)
       throw new TopicAuthorizationException(unauthorizedTopics.asJava)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
@@ -327,7 +327,7 @@ class ControllerApis(
     val topics: util.Set[String] = new util.HashSet[String]()
     pauseRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
     val unauthorizedTopics = topics.asScala.filterNot(topic =>
-      authHelper.authorize(request.context, READ, TOPIC, topic, logIfDenied = false))
+      authHelper.authorize(request.context, ALTER_CONFIGS, TOPIC, topic, logIfDenied = false))
     if (unauthorizedTopics.nonEmpty)
       throw new TopicAuthorizationException(unauthorizedTopics.asJava)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
@@ -354,7 +354,7 @@ class ControllerApis(
     val topics: util.Set[String] = new util.HashSet[String]()
     resumeRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
     val unauthorizedTopics = topics.asScala.filterNot(topic =>
-      authHelper.authorize(request.context, READ, TOPIC, topic, logIfDenied = false))
+      authHelper.authorize(request.context, ALTER_CONFIGS, TOPIC, topic, logIfDenied = false))
     if (unauthorizedTopics.nonEmpty)
       throw new TopicAuthorizationException(unauthorizedTopics.asJava)
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -22,7 +22,7 @@ import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.{QuotaManagers, UNBOUNDED_QUOTA}
 import kafka.server.handlers.DescribeTopicPartitionsRequestHandler
 import kafka.server.mirror.MirrorUtils.PartitionStateInfo
-import kafka.server.mirror.{MirrorCoordinator, MirrorPartitionState}
+import kafka.server.mirror.{MirrorCoordinator, MirrorPartitionState, MirrorUtils}
 import kafka.server.share.{ShareFetchUtils, SharePartitionManager}
 import kafka.utils.Logging
 import org.apache.kafka.clients.CommonClientConfigs
@@ -65,7 +65,7 @@ import org.apache.kafka.coordinator.share.ShareCoordinator
 import org.apache.kafka.metadata.{ConfigRepository, MetadataCache}
 import org.apache.kafka.server.{ApiVersionManager, ClientMetricsManager, DelegationTokenManager, ProcessRole}
 import org.apache.kafka.server.authorizer._
-import org.apache.kafka.server.common.{GroupVersion, MirrorVersion, RequestLocal, ShareVersion, StreamsVersion, TransactionVersion}
+import org.apache.kafka.server.common.{GroupVersion, RequestLocal, ShareVersion, StreamsVersion, TransactionVersion}
 import org.apache.kafka.server.config.DelegationTokenManagerConfigs
 import org.apache.kafka.server.share.context.ShareFetchContext
 import org.apache.kafka.server.share.{ErroneousAndValidPartitionData, SharePartitionKey}
@@ -293,7 +293,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleWriteMirrorStates(request: RequestChannel.Request): Unit = {
-    if (isClusterMirroringEnabled) {
+    if (MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
         requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData().setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)))
         return
@@ -316,7 +316,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleReadMirrorStates(request: RequestChannel.Request): Unit = {
-    if (isClusterMirroringEnabled) {
+    if (MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
         requestHelper.sendMaybeThrottle(request, new ReadMirrorStatesResponse(new ReadMirrorStatesResponseData().setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)))
         return
@@ -341,7 +341,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleAddTopicsToMirror(request: RequestChannel.Request): Unit = {
     // TODO: do the mirror partition state validation before forwarding to controller
-    if (!isClusterMirroringEnabled) {
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring add topics to mirror request")
       requestHelper.sendMaybeThrottle(request, new AddTopicsToMirrorResponse(new AddTopicsToMirrorResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
       return
@@ -350,7 +350,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleRemoveTopicsFromMirror(request: RequestChannel.Request): Unit = {
-    if (!isClusterMirroringEnabled) {
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring remove topics from mirror request")
       requestHelper.sendMaybeThrottle(request, new RemoveTopicsFromMirrorResponse(new RemoveTopicsFromMirrorResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
       return
@@ -359,7 +359,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handlePauseMirrorTopics(request: RequestChannel.Request): Unit = {
-    if (!isClusterMirroringEnabled) {
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring pause mirror topics request")
       requestHelper.sendMaybeThrottle(request, new PauseMirrorTopicsResponse(new PauseMirrorTopicsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
       return
@@ -368,7 +368,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleResumeMirrorTopics(request: RequestChannel.Request): Unit = {
-    if (!isClusterMirroringEnabled) {
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring resume mirror topics request")
       requestHelper.sendMaybeThrottle(request, new ResumeMirrorTopicsResponse(new ResumeMirrorTopicsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
       return
@@ -377,7 +377,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleDeleteMirror(request: RequestChannel.Request): Unit = {
-    if (!isClusterMirroringEnabled) {
+    if (!MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring delete mirror request")
       requestHelper.sendMaybeThrottle(request, new DeleteMirrorResponse(new DeleteMirrorResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
       return
@@ -388,7 +388,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleListMirrorsRequest(request: RequestChannel.Request): Unit = {
     val responseData = new ListMirrorsResponseData()
 
-    if (isClusterMirroringEnabled) {
+    if (MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       val mirrors = new util.ArrayList[ListMirrorsResponseData.ListedMirror]()
       val authorizedMirrors = mirrorCoordinator.getConfiguredMirrors().asScala
         .filter(mirrorName => authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = false))
@@ -415,7 +415,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val describeMirrorsRequest = request.body[DescribeMirrorsRequest]
     val responseData = new DescribeMirrorsResponseData()
 
-    if (isClusterMirroringEnabled) {
+    if (MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       val requestedMirrors = if (describeMirrorsRequest.data.mirrorNames.isEmpty) {
         mirrorCoordinator.getConfiguredMirrors().asScala.toSeq
       } else {
@@ -4428,14 +4428,6 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   private def isShareGroupProtocolEnabled: Boolean = {
     config.shareGroupConfig.isShareGroupEnabled || shareVersion().supportsShareGroups
-  }
-
-  private def mirrorVersion(): MirrorVersion = {
-    MirrorVersion.fromFeatureLevel(metadataCache.features.finalizedFeatures.getOrDefault(MirrorVersion.FEATURE_NAME, 0.toShort))
-  }
-
-  private def isClusterMirroringEnabled: Boolean = {
-    mirrorVersion().isClusterMirroringSupported
   }
 
   private def updateRecordConversionStats(request: RequestChannel.Request,

--- a/server/src/main/java/org/apache/kafka/security/authorizer/AclEntry.java
+++ b/server/src/main/java/org/apache/kafka/security/authorizer/AclEntry.java
@@ -78,8 +78,9 @@ public class AclEntry {
             case GROUP:
                 return Errors.GROUP_AUTHORIZATION_FAILED;
             case CLUSTER:
-            case CLUSTER_MIRROR:
                 return Errors.CLUSTER_AUTHORIZATION_FAILED;
+            case CLUSTER_MIRROR:
+                return Errors.MIRROR_AUTHORIZATION_FAILED;
             case TRANSACTIONAL_ID:
                 return Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED;
             case DELEGATION_TOKEN:

--- a/server/src/main/java/org/apache/kafka/server/PartitionFetchState.java
+++ b/server/src/main/java/org/apache/kafka/server/PartitionFetchState.java
@@ -120,8 +120,7 @@ public record PartitionFetchState(
                 ", state=" + state +
                 ", lag=" + lag +
                 ", delay=" + delay.orElse(0L) + "ms)" +
-                ", mirrorName=" + mirrorName +
-                ", mirrorLeaderEpoch=" + mirrorLeaderEpoch + ")";
+                ", mirrorName=" + mirrorName + ")";
     }
 
     public PartitionFetchState updateTopicId(Optional<Uuid> newTopicId) {


### PR DESCRIPTION
- Add MIRROR_AUTHORIZATION_FAILED error code (143) with dedicated
  MirrorAuthorizationException, replacing the reuse of
  CLUSTER_AUTHORIZATION_FAILED for CLUSTER_MIRROR resource type
- Add READ on TOPIC authorization check to AddTopicsToMirror,
  RemoveTopicsFromMirror, PauseMirrorTopics, and ResumeMirrorTopics
  controller handlers, following Kafka's convention for
  cross-resource operations
- Add mirror.version feature check to all controller-side mirror
  handlers that were missing it (AddTopicsToMirror,
  RemoveTopicsFromMirror, PauseMirrorTopics, ResumeMirrorTopics)
