### PR TITLE
AddTopicsToMirrorResponse: fix api key

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AddTopicsToMirrorResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddTopicsToMirrorResponse.java
@@ -29,7 +29,7 @@ public class AddTopicsToMirrorResponse extends AbstractResponse {
     private final AddTopicsToMirrorResponseData data;
 
     public AddTopicsToMirrorResponse(AddTopicsToMirrorResponseData data) {
-        super(ApiKeys.REMOVE_TOPICS_FROM_MIRROR);
+        super(ApiKeys.ADD_TOPICS_TO_MIRROR);
         this.data = data;
     }
 


### PR DESCRIPTION
This crashed the broker when it handled a forwarded response from the controller with debug logging enabled.

This change fixes the typo.