### PR TITLE
tests: add baseline test for cluster mirroring

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -207,7 +207,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                  dynamicRaftQuorum=False,
                  use_transactions_v2=False,
                  use_share_groups=None,
-                 use_streams_groups=False
+                 use_streams_groups=False,
+                 use_cluster_mirroring=False,
                  ):
         """
         :param context: test context
@@ -273,6 +274,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         :param use_transactions_v2: When true, uses transaction.version=2 which utilizes the new transaction protocol introduced in KIP-890
         :param use_share_groups: When true, enables the use of share groups introduced in KIP-932
         :param use_streams_groups: When true, enables the use of streams groups introduced in KIP-1071
+        :param use_cluster_mirroring: When true, enables the use of cluster mirroring introduced in KIP-1279
         """
 
         self.zk = zk
@@ -299,6 +301,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.use_transactions_v2 = use_transactions_v2
         self.use_share_groups = use_share_groups
         self.use_streams_groups = use_streams_groups
+
+        self.use_cluster_mirroring = use_cluster_mirroring
 
         # Set consumer_group_migration_policy based on context and arguments.
         if consumer_group_migration_policy is None:
@@ -358,7 +362,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                     extra_kafka_opts=extra_kafka_opts, tls_version=tls_version,
                     isolated_kafka=self, allow_zk_with_kraft=self.allow_zk_with_kraft,
                     server_prop_overrides=server_prop_overrides, dynamicRaftQuorum=self.dynamicRaftQuorum,
-                    use_streams_groups=self.use_streams_groups
+                    use_streams_groups=self.use_streams_groups, use_cluster_mirroring=self.use_cluster_mirroring
                 )
                 self.controller_quorum = self.isolated_controller_quorum
 
@@ -786,6 +790,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         if self.use_streams_groups is True:
             override_configs[config_property.UNSTABLE_API_VERSIONS_ENABLE] = str(True)
             override_configs[config_property.UNSTABLE_FEATURE_VERSIONS_ENABLE] = str(True)
+
+        if self.use_cluster_mirroring:
+            override_configs[config_property.UNSTABLE_API_VERSIONS_ENABLE] = 'true'
+            override_configs[config_property.UNSTABLE_FEATURE_VERSIONS_ENABLE] = 'true'
 
         #update template configs with test override configs
         configs.update(override_configs)
@@ -2012,3 +2020,83 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     def java_class_name(self):
         return "kafka\.Kafka"
+
+    def create_cluster_mirror(self, node, mirror_name, mirror_config_file):
+        cluster_mirror_script = self.path.script("kafka-mirrors.sh", node)
+
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s --create --mirror %s --mirror-config %s" % \
+               (cluster_mirror_script,
+                self.bootstrap_servers(self.security_protocol),
+                mirror_name,
+                mirror_config_file)
+        return self.run_cli_tool(node, cmd)
+
+    def list_cluster_mirror(self, node):
+        cluster_mirror_script = self.path.script("kafka-mirrors.sh", node)
+
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s --list" % \
+               (cluster_mirror_script,
+                self.bootstrap_servers(self.security_protocol))
+        return self.run_cli_tool(node, cmd)
+
+    def describe_cluster_mirror(self, node):
+        cluster_mirror_script = self.path.script("kafka-mirrors.sh", node)
+
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s --describe --json" % \
+               (cluster_mirror_script,
+                self.bootstrap_servers(self.security_protocol))
+        return self.run_cli_tool(node, cmd)
+
+
+    def _cluster_mirror_action(self, node, mirror_name, topics, action):
+        assert topics is not None and len(topics) > 0
+        cluster_mirror_script = self.path.script("kafka-mirrors.sh", node)
+
+        cmd = fix_opts_for_new_jvm(node)
+        topic_names = ' '.join(['--topic %s' % topic for topic in topics])
+        cmd += "%s --bootstrap-server %s --%s --mirror %s %s" % \
+               (cluster_mirror_script,
+                self.bootstrap_servers(self.security_protocol),
+                action,
+                mirror_name,
+                topic_names)
+        return self.run_cli_tool(node, cmd)
+
+    def add_topics_to_cluster_mirror(self, node, mirror_name, topics):
+        return self._cluster_mirror_action(node, mirror_name, topics, 'add')
+
+    def delete_topics_from_cluster_mirror(self, node, mirror_name, topics):
+        return self._cluster_mirror_action(node, mirror_name, topics, 'delete')
+
+    def delete_topics_from_cluster_mirror(self, node, mirror_name, topics):
+        return self._cluster_mirror_action(node, mirror_name, topics, 'pause')
+
+    def delete_topics_from_cluster_mirror(self, node, mirror_name, topics):
+        return self._cluster_mirror_action(node, mirror_name, topics, 'resume')
+    
+    def parse_describe_cluster_mirror(self, cluster_mirror_description):
+        """Parse output of kafka-mirrors.sh --describe (or describe_cluster_mirror() method above), which is a string of form
+        """
+        parsed = json.loads(cluster_mirror_description)
+        mirrors = {}
+        for item in parsed:
+            mirror = item["mirror"]
+            if mirror not in mirrors:
+                mirrors[mirror] = {}
+            
+            topic = item["topic"]
+            if topic not in mirrors[mirror]:
+                mirrors[mirror][topic] = {}
+            
+            partition = item["partition"]
+            mirrors[mirror][topic][partition] = {
+                "src_offset": item["sourceOffset"],
+                "dst_offset": item["destinationOffset"],
+                "lag": item["lag"],
+                "state": item["state"]
+            }
+
+        return mirrors

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -1,0 +1,225 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ducktape.mark.resource import cluster
+from ducktape.mark import defaults
+from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
+from kafkatest.services.kafka import KafkaService, quorum
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.services.security.security_config import SecurityConfig
+from kafkatest.version import (
+    CLUSTER_MIRRORING_METADATA_VERSION,
+    CLUSTER_MIRRORING_VERSION,
+)
+import itertools
+
+
+class ClusterMirrorConfig:
+    def __init__(
+        self,
+        bootstrap_servers: str,
+        mirror_topic_properties_exclude: str = None,
+        mirror_groups_include: str = None,
+        mirror_acl_include: str = None,
+        security_config: SecurityConfig = None,
+    ):
+        self.properties = {
+            "bootstrap.servers": bootstrap_servers,
+        }
+        if mirror_topic_properties_exclude is not None:
+            self.properties["mirror.topic.properties.exclude"] = (
+                mirror_topic_properties_exclude
+            )
+        if mirror_groups_include is not None:
+            self.properties["mirror.groups.include"] = mirror_groups_include
+        if mirror_acl_include is not None:
+            self.properties["mirror.acl.include"] = (mirror_acl_include,)
+
+        if (
+            security_config is not None
+            and security_config.security_protocol != SecurityConfig.PLAINTEXT
+        ):
+            self.properties |= security_config.properties
+
+    def props(self, prefix=""):
+        config_lines = (
+            prefix + key + "=" + value for key, value in self.properties.items()
+        )
+        return "\n".join(itertools.chain([""], config_lines, [""]))
+
+    def __str__(self):
+        """
+        Return properties as a string with line separators.
+        """
+        return self.props()
+
+
+class ClusterMirroringTest(Test):
+    PERSISTENT_ROOT = "/mnt/cluster_mirroring"
+    MIRROR_CONFIG_FILE = os.path.join(PERSISTENT_ROOT, "cluster_mirror.properties")
+
+    def __init__(self, test_context):
+        """:type test_context: ducktape.tests.test.TestContext"""
+        super(ClusterMirroringTest, self).__init__(test_context)
+        topic = "test"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 3}}
+        self.source_kafka = KafkaService(
+            test_context,
+            num_nodes=3,
+            zk=None,
+            topics=self.topics,
+            use_cluster_mirroring=True,
+        )
+        self.dest_kafka = KafkaService(
+            test_context, num_nodes=3, zk=None, use_cluster_mirroring=True
+        )
+        self.producer = VerifiableProducer(
+            self.test_context,
+            num_nodes=1,
+            kafka=self.source_kafka,
+            topic=topic,
+            throughput=100,
+        )
+
+    def setup(self):
+        self.source_kafka.start()
+        self.dest_kafka.start()
+
+        self.logger.info(
+            "Changing metadata.version in destination to %s"
+            % CLUSTER_MIRRORING_METADATA_VERSION
+        )
+        self.dest_kafka.upgrade_metadata_version(CLUSTER_MIRRORING_METADATA_VERSION)
+        self.logger.info(
+            "Changing mirror.version in destination to %s" % CLUSTER_MIRRORING_VERSION
+        )
+        self.dest_kafka.run_features_command(
+            "upgrade", "mirror.version", CLUSTER_MIRRORING_VERSION
+        )
+
+        self.producer.start()
+
+    def teardown(self):
+        self.dest_kafka.stop()
+        self.source_kafka.stop()
+
+    @cluster(num_nodes=13)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_convergence(self, metadata_quorum):
+        mirror_cfg = {
+            "name": "test-mirror",
+            "cfg": ClusterMirrorConfig(self.source_kafka.bootstrap_servers()),
+        }
+        self.logger.info(
+            "Creating mirror %s with settings %s", mirror_cfg["name"], mirror_cfg["cfg"]
+        )
+        kafka_node = self.dest_kafka.nodes[0]
+
+        prop_file = str(mirror_cfg["cfg"])
+        self.logger.info(prop_file)
+        kafka_node.account.ssh(
+            "mkdir -p %s" % ClusterMirroringTest.PERSISTENT_ROOT, allow_fail=False
+        )
+        kafka_node.account.create_file(
+            ClusterMirroringTest.MIRROR_CONFIG_FILE, prop_file
+        )
+
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                kafka_node, mirror_cfg["name"], ClusterMirroringTest.MIRROR_CONFIG_FILE
+            ),
+            timeout_sec=20,
+            backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+
+        wait_until(
+            lambda: (
+                "Added"
+                in self.dest_kafka.add_topics_to_cluster_mirror(
+                    kafka_node, mirror_cfg["name"], self.topics.keys()
+                )
+            ),
+            timeout_sec=20,
+            backoff_sec=2,
+            err_msg="Failed to add topics cluster mirror",
+        )
+
+        def all_satisfy_in_mirror(mirror_name, per_partition_condition):
+            output = self.dest_kafka.describe_cluster_mirror(kafka_node)
+            if output == "":
+                return False
+
+            mirrors = self.dest_kafka.parse_describe_cluster_mirror(output)
+            if mirror_name not in mirrors:
+                return False
+            mirror = mirrors[mirror_name]
+
+            for topic in self.topics:
+                if topic not in mirror:
+                    return False
+
+                for partition in mirror[topic].values():
+                    if not per_partition_condition(partition):
+                        return False
+            return True
+
+        wait_until(
+            lambda: all_satisfy_in_mirror(
+                mirror_cfg["name"], lambda p: p["state"] == "MIRRORING"
+            ),
+            timeout_sec=20,
+            backoff_sec=2,
+            err_msg="Failed to start mirrors",
+        )
+
+        wait_until(
+            lambda: self.producer.num_acked >= 5,
+            timeout_sec=10,
+            backoff_sec=2,
+            err_msg="Failed to produce to source cluster",
+        )
+
+        acked = self.producer.num_acked
+        self.source_kafka.restart_cluster(clean_shutdown=True)
+        wait_until(
+            lambda: self.producer.num_acked - acked > 1000,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="Failed to produce since source cluster bounced",
+        )
+
+        acked = self.producer.num_acked
+        self.dest_kafka.restart_cluster(clean_shutdown=True)
+
+        wait_until(
+            lambda: self.producer.num_acked - acked > 1000,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="Failed to produce since destination cluster bounced",
+        )
+        self.producer.stop()
+
+        wait_until(
+            lambda: all_satisfy_in_mirror(mirror_cfg["name"], lambda p: p["lag"] == 0),
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="Failed to start mirrors",
+        )
+
+        # TODO: invoke log segment comparision tooling

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -115,6 +115,7 @@ class ClusterMirroringTest(Test):
         self.producer.start()
 
     def teardown(self):
+        self.producer.stop()
         self.dest_kafka.stop()
         self.source_kafka.stop()
 
@@ -216,7 +217,7 @@ class ClusterMirroringTest(Test):
         self.producer.stop()
 
         wait_until(
-            lambda: all_satisfy_in_mirror(mirror_cfg["name"], lambda p: p["lag"] == 0),
+            lambda: all_satisfy_in_mirror(mirror_cfg["name"], lambda p: p["lag"] == 0 and p["state"] == "MIRRORING"),
             timeout_sec=60,
             backoff_sec=2,
             err_msg="Failed to start mirrors",

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -223,3 +223,7 @@ LATEST_4_0 = V_4_0_0
 # 4.1.x version
 V_4_1_0 = KafkaVersion("4.1.0")
 LATEST_4_1 = V_4_1_0
+
+# Cluster Mirroring
+CLUSTER_MIRRORING_METADATA_VERSION = "4.2-IV2"
+CLUSTER_MIRRORING_VERSION = 1

--- a/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MirrorCommand.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.tools;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.admin.AddTopicsToMirrorOptions;
 import org.apache.kafka.clients.admin.AddTopicsToMirrorResult;
 import org.apache.kafka.clients.admin.Admin;
@@ -111,6 +113,8 @@ public abstract class MirrorCommand {
     }
 
     private static class MirrorService implements AutoCloseable {
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
         private final Admin adminClient;
         private final Properties mirrorConfigs;
 
@@ -368,6 +372,15 @@ public abstract class MirrorCommand {
                 .thenComparing(PartitionInfo::topic)
                 .thenComparing(PartitionInfo::partition));
 
+            if (opts.hasJsonOption()) {
+                try {
+                    System.out.printf(OBJECT_MAPPER.writeValueAsString(partitionInfos));
+                    return;
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException("Failed to serialize JSON", e);
+                }
+            }
+
             // Only print header and results if there are partitions to display
             if (!partitionInfos.isEmpty()) {
                 System.out.printf("%-30s %-40s %-10s %-15s %-18s %-10s %-12s%n",
@@ -424,6 +437,7 @@ public abstract class MirrorCommand {
         private final ArgumentAcceptingOptionSpec<String> mirrorOpt;
         private final ArgumentAcceptingOptionSpec<String> topicOpt;
         private final ArgumentAcceptingOptionSpec<Short> replicationFactorOpt;
+        private final OptionSpecBuilder jsonOpt;
 
         MirrorCommandOptions(String[] args) {
             super(args);
@@ -469,6 +483,8 @@ public abstract class MirrorCommand {
                 .describedAs("replication-factor")
                 .ofType(Short.class);
 
+            jsonOpt = parser.accepts("json", "Output description in JSON format");
+
             options = parser.parse(args);
             checkArgs();
         }
@@ -511,6 +527,10 @@ public abstract class MirrorCommand {
 
         private boolean hasListOption() {
             return has(listOpt);
+        }
+
+        private boolean hasJsonOption() {
+            return has(jsonOpt);
         }
 
         private boolean hasDescribeOption() {
@@ -588,6 +608,9 @@ public abstract class MirrorCommand {
 
             if (has(resumeOpt) && !has(topicOpt))
                 throw new IllegalArgumentException("--topic must be specified when resuming mirror topic(s)");
+
+            if (has(jsonOpt) && !has(describeOpt))
+                throw new IllegalArgumentException("--json is only supported for describing mirrors");
         }
     }
 }


### PR DESCRIPTION
Adds a baseline test for cluster mirroring which:

1. Sets up two Kafka clusters
2. Enables mirroring on the destination
3. Starts the producer on the source cluster on topic with RF=3 and 1
   replica
4. Restarts the source and destination cluster brokers
5. Ensures the lag converges to 0

The test depends on parsing `kafka-mirrors.sh --describe` output and I added a `--json` flag to make our lives easier when parsing it.