### PR TITLE
Remove unclean leader election warning

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1204,31 +1204,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         var describeConfigResponse = trySendRequest(mirrorName, describeConfigsRequest);
         if (describeConfigResponse.responseBody() instanceof DescribeConfigsResponse describeConfigsRes) {
             log.debug("Periodic describe config response: {}", describeConfigsRes);
-            warnIfUncleanLeaderElection(describeConfigsRes);
             Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(describeConfigsRes, mirrorConfig);
             applyConfigurationChanges(configsToChange);
         }
-    }
-
-    private void warnIfUncleanLeaderElection(DescribeConfigsResponse describeConfigsRes) {
-        describeConfigsRes.data().results().forEach(describeConfigResult -> {
-            if (describeConfigResult.resourceType() == ConfigResource.Type.TOPIC.id()) {
-                describeConfigResult.configs().stream()
-                    .filter(con -> con.name().equals(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG) && "true".equals(con.value()))
-                    .findFirst()
-                    .ifPresent(con -> {
-                        if (con.configSource() == DescribeConfigsResponse.ConfigSource.TOPIC_CONFIG.id()) {
-                            log.warn("Mirror topic '{}' has unclean.leader.election.enable=true set at topic level. " +
-                                    "This is not supported as log divergence cannot be reconciled across clusters.",
-                                    describeConfigResult.resourceName());
-                        } else {
-                            log.warn("Mirror topic '{}' has unclean.leader.election.enable=true (inherited from broker or cluster default). " +
-                                    "This is not supported as log divergence cannot be reconciled across clusters.",
-                                    describeConfigResult.resourceName());
-                        }
-                    });
-            }
-        });
     }
 
     private Map<String, Map<String, String>> detectConfigurationChanges(


### PR DESCRIPTION
Now that we support ULE in Cluster Mirroring, we don't need any use case specific warning.