### PR TITLE
BrokerServer: close MirrorMetadataManager

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -127,6 +127,8 @@ class BrokerServer(
 
   var mirrorCoordinator: MirrorCoordinator = _
 
+  var mirrorMetadataManager: MirrorMetadataManager = _
+
   var shareCoordinator: ShareCoordinator = _
 
   var clientToControllerChannelManager: NodeToControllerChannelManager = _
@@ -339,7 +341,7 @@ class BrokerServer(
        */
       val defaultActionQueue = new DelayedActionQueue
 
-      val mirrorMetadataManager = new MirrorMetadataManager(
+      mirrorMetadataManager = new MirrorMetadataManager(
         config,
         metrics,
         time,
@@ -803,6 +805,9 @@ class BrokerServer(
 
       if (mirrorCoordinator != null)
         CoreUtils.swallow(mirrorCoordinator.shutdown(), this)
+
+      if (mirrorMetadataManager != null)
+        CoreUtils.swallow(mirrorMetadataManager.close(), this)
 
       if (assignmentsManager != null)
         CoreUtils.swallow(assignmentsManager.close(), this)


### PR DESCRIPTION
Found some integration test failures as they leaked `MirrorStateSender` threads. This is likely because of us not closing
`MirrorMetadataManager` on cluster shutdown.