### PR TITLE
Add authorizedOperations to DescribeMirrors and fix ACL sync deleting CLUSTER_MIRROR ACLs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5236,16 +5236,22 @@ public class KafkaAdminClient extends AdminClient {
         private synchronized void tryComplete() {
             if (remaining.isEmpty()) {
                 Map<String, MirrorDescription> descriptions = new HashMap<>(partialDescriptions.size());
+                Throwable firstError = null;
                 for (Map.Entry<String, PartialMirrorDescription> entry : partialDescriptions.entrySet()) {
                     PartialMirrorDescription partial = entry.getValue();
                     if (partial.error != null) {
-                        // If there was an error for this mirror, we could either skip it or throw
-                        // For now, we'll skip mirrors with errors
+                        if (firstError == null) {
+                            firstError = partial.error;
+                        }
                         continue;
                     }
                     descriptions.put(entry.getKey(), partial.toMirrorDescription());
                 }
-                allFuture.complete(descriptions);
+                if (descriptions.isEmpty() && firstError != null) {
+                    allFuture.completeExceptionally(firstError);
+                } else {
+                    allFuture.complete(descriptions);
+                }
             }
         }
 
@@ -5259,21 +5265,35 @@ public class KafkaAdminClient extends AdminClient {
         private static class PartialMirrorDescription {
             final String mirrorName;
             final Map<String, Set<MirrorDescription.LeaderState>> topicPartitions;
+            int authorizedOperations;
+            boolean hasSuccess;
             Throwable error;
 
             PartialMirrorDescription(String mirrorName) {
                 this.mirrorName = mirrorName;
                 this.topicPartitions = new HashMap<>();
+                this.authorizedOperations = MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED;
+                this.hasSuccess = false;
                 this.error = null;
             }
 
+            // DescribeMirrors fans out to all brokers. During ACL propagation, some brokers
+            // may deny while others allow. A success from any broker is authoritative, so we
+            // only retain the error if no broker has returned a successful response.
             void merge(DescribeMirrorsResponseData.DescribedMirror mirror) {
                 Errors errorCode = Errors.forCode(mirror.errorCode());
                 if (errorCode != Errors.NONE) {
-                    if (this.error == null) {
+                    if (!this.hasSuccess && this.error == null) {
                         this.error = errorCode.exception();
                     }
                     return;
+                }
+
+                this.hasSuccess = true;
+                this.error = null;
+
+                if (mirror.authorizedOperations() != MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED) {
+                    this.authorizedOperations = mirror.authorizedOperations();
                 }
 
                 // Merge topic partitions
@@ -5301,7 +5321,8 @@ public class KafkaAdminClient extends AdminClient {
             MirrorDescription toMirrorDescription() {
                 return new MirrorDescription(
                         mirrorName,
-                        topicPartitions
+                        topicPartitions,
+                        validAclOperations(authorizedOperations)
                 );
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MirrorDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MirrorDescription.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Collections;
@@ -32,11 +33,14 @@ import java.util.Set;
 public class MirrorDescription {
     private final String mirrorName;
     private final Map<String, Set<LeaderState>> topics;
+    private final Set<AclOperation> authorizedOperations;
 
     public MirrorDescription(String mirrorName,
-                             Map<String, Set<LeaderState>> topics) {
+                             Map<String, Set<LeaderState>> topics,
+                             Set<AclOperation> authorizedOperations) {
         this.mirrorName = mirrorName;
         this.topics = Collections.unmodifiableMap(topics);
+        this.authorizedOperations = authorizedOperations;
     }
 
     public String mirrorName() {
@@ -47,18 +51,26 @@ public class MirrorDescription {
         return topics;
     }
 
+    /**
+     * Returns the authorized operations for this mirror, or null if not requested.
+     */
+    public Set<AclOperation> authorizedOperations() {
+        return authorizedOperations;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MirrorDescription that = (MirrorDescription) o;
         return Objects.equals(mirrorName, that.mirrorName) &&
-               Objects.equals(topics, that.topics);
+               Objects.equals(topics, that.topics) &&
+               Objects.equals(authorizedOperations, that.authorizedOperations);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mirrorName, topics);
+        return Objects.hash(mirrorName, topics, authorizedOperations);
     }
 
     @Override
@@ -66,6 +78,7 @@ public class MirrorDescription {
         return "MirrorDescription{" +
                "mirrorName='" + mirrorName + '\'' +
                ", topics=" + topics +
+               ", authorizedOperations=" + authorizedOperations +
                '}';
     }
 

--- a/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeMirrorsResponse.json
@@ -33,6 +33,8 @@
         "about": "The error code, or 0 if there was no error." },
       { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
         "about": "The cluster mirror name." },
+      { "name": "AuthorizedOperations", "type": "int32", "versions": "0+", "default": "-2147483648",
+        "about": "32-bit bitfield to represent authorized operations for this mirror." },
       { "name": "Topics", "type": "[]TopicPartitions", "versions": "0+",
         "about": "Each topic in the mirror.", "fields": [
         { "name": "TopicName", "type": "string", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1414,7 +1414,8 @@ public class MockAdminClient extends AdminClient {
             // Return empty description for mock
             MirrorDescription description = new MirrorDescription(
                 mirrorName,
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                null
             );
             descriptions.put(mirrorName, description);
         }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1469,9 +1469,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
         });
 
-        // collect remove acls list
+        // collect remove acls list (skip CLUSTER_MIRROR ACLs as they are destination-specific)
         metadataImage.acls().acls().values().forEach(acl -> {
-            if (!allRemoteAcls.contains(acl.toBinding())) {
+            if (acl.resourceType() != ResourceType.CLUSTER_MIRROR && !allRemoteAcls.contains(acl.toBinding())) {
                 deleteACLsList.add(acl.toBinding());
             }
         });

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -416,16 +416,31 @@ class KafkaApis(val requestChannel: RequestChannel,
     val responseData = new DescribeMirrorsResponseData()
 
     if (MirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
-      val requestedMirrors = if (describeMirrorsRequest.data.mirrorNames.isEmpty) {
+      val describeAll = describeMirrorsRequest.data.mirrorNames.isEmpty
+      val requestedMirrors = if (describeAll) {
         mirrorCoordinator.getConfiguredMirrors().asScala.toSeq
       } else {
         describeMirrorsRequest.data.mirrorNames.asScala.toSeq
       }
-      val authorizedMirrors = requestedMirrors
-        .filter(mirrorName => authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = false))
 
-      authorizedMirrors.foreach { mirrorName =>
-        // Each broker reports partitions it's responsible for to avoid duplicates
+      requestedMirrors.foreach { mirrorName =>
+        if (!authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = !describeAll)) {
+          if (!describeAll) {
+            responseData.mirrors().add(new DescribeMirrorsResponseData.DescribedMirror()
+              .setMirrorName(mirrorName)
+              .setErrorCode(Errors.MIRROR_AUTHORIZATION_FAILED.code))
+          }
+        } else {
+          val describedMirror = new DescribeMirrorsResponseData.DescribedMirror()
+            .setMirrorName(mirrorName)
+            .setErrorCode(Errors.NONE.code)
+
+          if (describeMirrorsRequest.data.includeAuthorizedOperations) {
+            describedMirror.setAuthorizedOperations(authHelper.authorizedOperations(
+              request, new Resource(ResourceType.CLUSTER_MIRROR, mirrorName)))
+          }
+
+          // Each broker reports partitions it's responsible for to avoid duplicates
           val lagInfoMap = replicaManager.getMirrorLagInfo(mirrorName)
           val partitionStates = mirrorCoordinator.getMirrorStates(mirrorName).asScala
           val lastMirrorEpoch = mirrorCoordinator.getLastMirrorEpochs(mirrorName)
@@ -436,10 +451,6 @@ class KafkaApis(val requestChannel: RequestChannel,
           }).toSeq
 
           if (partitionsToReport.nonEmpty) {
-            val describedMirror = new DescribeMirrorsResponseData.DescribedMirror()
-              .setMirrorName(mirrorName)
-              .setErrorCode(Errors.NONE.code)
-
             // Group partitions by topic
             val topicsMap = scala.collection.mutable.Map[String, DescribeMirrorsResponseData.TopicPartitions]()
 
@@ -465,9 +476,11 @@ class KafkaApis(val requestChannel: RequestChannel,
             val topicsList = new util.ArrayList[DescribeMirrorsResponseData.TopicPartitions]()
             topicsMap.values.foreach(tp => topicsList.add(tp))
             describedMirror.setTopics(topicsList)
-            responseData.mirrors().add(describedMirror)
           }
+
+          responseData.mirrors().add(describedMirror)
         }
+      }
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring describe mirrors request")
       responseData.setErrorCode(Errors.UNSUPPORTED_VERSION.code)

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
@@ -729,4 +729,29 @@ public class StandardAuthorizerTest {
         // StandardAuthorizer has 4 metrics
         assertEquals(5, metrics.metrics().size());
     }
+
+    @Test
+    public void testClusterMirrorAuthorization() throws Exception {
+        StandardAuthorizer authorizer = createAndInitializeStandardAuthorizer();
+        StandardAcl mirrorAcl = new StandardAcl(
+            ResourceType.CLUSTER_MIRROR, "my-mirror", LITERAL,
+            "User:alice", WILDCARD, DESCRIBE, ALLOW);
+        StandardAclWithId aclWithId = withId(mirrorAcl);
+        authorizer.addAcl(aclWithId.id(), aclWithId.acl());
+
+        // alice should be allowed DESCRIBE on CLUSTER_MIRROR my-mirror
+        assertEquals(List.of(ALLOWED),
+            authorizer.authorize(newRequestContext("alice"),
+                List.of(newAction(DESCRIBE, ResourceType.CLUSTER_MIRROR, "my-mirror"))));
+
+        // bob should be denied (no ACL for bob)
+        assertEquals(List.of(DENIED),
+            authorizer.authorize(newRequestContext("bob"),
+                List.of(newAction(DESCRIBE, ResourceType.CLUSTER_MIRROR, "my-mirror"))));
+
+        // alice should be denied for a different mirror
+        assertEquals(List.of(DENIED),
+            authorizer.authorize(newRequestContext("alice"),
+                List.of(newAction(DESCRIBE, ResourceType.CLUSTER_MIRROR, "other-mirror"))));
+    }
 }


### PR DESCRIPTION
DescribeMirrors now supports includeAuthorizedOperations. When requested, each broker returns a 32-bit bitfield where bit N is set if AclOperation with code N is allowed for the requesting principal on that CLUSTER_MIRROR resource. For example, bit 7 = DESCRIBE (code 7), bit 3 = READ (code 3). The client ORs the bitfields from all brokers and converts the result to a Set<AclOperation> exposed via MirrorDescription.authorizedOperations().

The DescribeMirrors handler now also returns per-mirror authorization errors (MIRROR_AUTHORIZATION_FAILED) instead of silently filtering unauthorized mirrors, and the client-side merge treats a success from any broker as authoritative over authorization errors from others.

The ACL sync in MirrorMetadataManager.detectACLChanges() was comparing all local ACLs against source cluster ACLs and deleting any local ACL not present on the source. This caused CLUSTER_MIRROR ACLs (which are destination-specific) to be removed on the next sync cycle. Fixed by skipping CLUSTER_MIRROR ACLs when building the delete list.

Added StandardAuthorizerTest.testClusterMirrorAuthorization to verify that the StandardAuthorizer correctly handles CLUSTER_MIRROR ACLs.
