### PR TITLE
append abort records for ongoing txns

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
@@ -146,4 +146,18 @@ public enum ControlRecordType {
         }
         return false;
     }
+
+    public static boolean isAbortTxnBatch(RecordBatch batch) {
+        if (!batch.isControlBatch()) {
+            return false;
+        }
+        Iterator<Record> iterator = batch.iterator();
+        if (iterator.hasNext()) {
+            Record record = iterator.next();
+            if (record.hasKey()) {
+                return parse(record.key()) == ABORT;
+            }
+        }
+        return false;
+    }
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -156,23 +156,32 @@ public class MirrorCoordinator {
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
                 CompletableFuture<Void> bumpLeaderEpochFuture = new CompletableFuture<>();
                 metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions, bumpLeaderEpochFuture);
-                CompletableFuture<Void> updateLastMirrorEpochsFuture = new CompletableFuture<>();
+                CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture = new CompletableFuture<>();
 
+                // Wait until bump leader epoch completes to abort the on-going transaction records.
+                // After the transaction aborting completion, all the txn should be committed or aborted.
+                // So we're safe to update the last mirrored epochs now.
                 bumpLeaderEpochFuture.whenComplete((v, ex) -> {
-                    appendAbortRecordsForOngoingTxns(topicPartitions, tp -> {
-                        updateLastMirrorEpochs(mirrorName, Set.of(tp));
-                        updateLastMirrorEpochsFuture.complete(null);
-                    });
-                });
-                // Wait until (1) bump leader epoch and (2) update last mirror epoch completes, then write mirror pid reset barrier record
-                CompletableFuture.allOf(bumpLeaderEpochFuture, updateLastMirrorEpochsFuture)
-                        .whenComplete((v, ex) -> {
-                            if (ex == null) {
-                                finishStoppingAfterPidBarrierWritten(mirrorName, topicPartitions);
-                            } else {
-                                log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
-                            }
+                    if (ex == null) {
+                        abortOngoingTransactions(topicPartitions, tp -> {
+                            updateLastMirrorEpochs(mirrorName, Set.of(tp), updateLastMirrorEpochsFuture);
                         });
+                    } else {
+                        // TODO: error handling
+                        log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
+                    }
+
+                });
+
+                // After last mirror epoch updated, writing mirror pid reset barrier record
+                updateLastMirrorEpochsFuture
+                    .whenComplete((v, ex) -> {
+                        if (ex == null) {
+                            finishStoppingAfterPidBarrierWritten(mirrorName, topicPartitions);
+                        } else {
+                            log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
+                        }
+                    });
 
                 break;
             case STOPPED:
@@ -239,15 +248,24 @@ public class MirrorCoordinator {
      * otherwise, the LogValidator#getFirstBatchAndMaybeValidateNoMoreBatches will throw exception.
      * So we append in multiple rounds when needed.
      */
-    private void appendAbortRecordsForOngoingTxns(Set<TopicPartition> topicPartitions,
-                                                  Consumer<TopicPartition> callback) {
+    private void abortOngoingTransactions(Set<TopicPartition> topicPartitions,
+                                          Consumer<TopicPartition> callback) {
         Map<TopicPartition, List<MemoryRecords>> recordsByPartition = new HashMap<>();
+        Set<TopicPartition> partitionsWithoutOngoingTxn = new HashSet<>();
         topicPartitions.forEach(tp -> {
             Option<List<MemoryRecords>> record = replicaManager.getLog(tp).map(UnifiedLog::buildEndTransactionRecords);
             if (record.isDefined() && !record.get().isEmpty()) {
                 recordsByPartition.put(tp, record.get());
+            } else {
+                partitionsWithoutOngoingTxn.add(tp);
             }
         });
+
+        // complete the partitions without on-going txn records.
+        if (!partitionsWithoutOngoingTxn.isEmpty()) {
+            topicPartitions.forEach(callback::accept);
+            return;
+        }
 
         log.info("appending abort: {}", recordsByPartition);
         while (!recordsByPartition.isEmpty()) {
@@ -271,13 +289,13 @@ public class MirrorCoordinator {
             });
 
             log.info("run: appending abort: {}", records);
-            appendAbortTxnMarker(records, partitionsToComplete, callback);
+            appendAbortMarkers(records, partitionsToComplete, callback);
         }
     }
 
-    private void appendAbortTxnMarker(Map<TopicIdPartition, MemoryRecords> records,
-                                      Set<TopicPartition> partitionsToComplete,
-                                      Consumer<TopicPartition> callback) {
+    private void appendAbortMarkers(Map<TopicIdPartition, MemoryRecords> records,
+                                    Set<TopicPartition> partitionsToComplete,
+                                    Consumer<TopicPartition> callback) {
         replicaManager.appendRecords(
             // TODO: replace this with Cluster Mirror specific timeout
             Duration.ofSeconds(5).toMillis(),
@@ -290,9 +308,12 @@ public class MirrorCoordinator {
                     TopicPartition tp = partitionRes._1.topicPartition();
                     ProduceResponse.PartitionResponse pr = partitionRes._2;
                     if (pr.error.code() != Errors.NONE.code()) {
+                        // TODO: retry logic
                         log.error("Failed to append end transaction marker for {}: {}", tp, pr.error.message());
                     } else {
-                        partitionsToComplete.forEach(callback::accept);
+                        if (partitionsToComplete.contains(tp)) {
+                            callback.accept(tp);
+                        }
                     }
                     return null;
                 });
@@ -327,7 +348,8 @@ public class MirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
-        updateLastMirrorEpochs(updatedMirrorName, offsets);
+        // do last mirror epochs update in parallel
+        updateLastMirrorEpochs(updatedMirrorName, offsets, new CompletableFuture<>());
 
         WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
         List<WriteMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
@@ -352,7 +374,7 @@ public class MirrorCoordinator {
         metadataManager.getCachedPartitionMetadata(mirrorName, partitions, callback);
     }
 
-    private void updateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
+    private void updateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions, CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture) {
         Map<String, Map<Integer, Integer>> partitionOffsets = new HashMap<>();
         MirrorUtils.groupPartitionsByTopic(topicPartitions).forEach((topic, parts) -> {
             Map<Integer, Integer> offsets = new HashMap<>();
@@ -365,7 +387,7 @@ public class MirrorCoordinator {
             partitionOffsets.put(topic, offsets);
         });
 
-        updateLastMirrorEpochs(mirrorName, partitionOffsets);
+        updateLastMirrorEpochs(mirrorName, partitionOffsets, updateLastMirrorEpochsFuture);
     }
 
     private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(String mirrorName,
@@ -616,7 +638,7 @@ public class MirrorCoordinator {
     }
 
     /** Persists offsets to local or remote coordinators, optionally transitioning to STOPPED. */
-    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
+    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets, CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture) {
         // Separate partitions into local and remote coordinator groups
         Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
         Map<String, Set<MirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
@@ -657,7 +679,21 @@ public class MirrorCoordinator {
                     true,
                     AppendOrigin.COORDINATOR,
                     CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
-                    ignored -> null,
+                    response -> {
+                        response.foreach(res -> {
+                            TopicPartition tp = res._1.topicPartition();
+                            ProduceResponse.PartitionResponse partitionRes = res._2;
+                            if (partitionRes.error.code() != Errors.NONE.code()) {
+                                // TODO: retry logic
+                                log.error("Failed to write last mirrored offsets to coordinator: {}", partitionRes.error.message());
+                                updateLastMirrorEpochsFuture.completeExceptionally(partitionRes.error.exception());
+                            } else {
+                                updateLastMirrorEpochsFuture.complete(tp);
+                            }
+                            return null;
+                        });
+                        return null;
+                    },
                     ignored -> null,
                     RequestLocal.noCaching(),
                     CollectionConverters.asScala(Map.of())
@@ -666,7 +702,20 @@ public class MirrorCoordinator {
 
         // Write to remote coordinator (batched by coordinator node internally)
         if (!remoteTopicMetadata.isEmpty()) {
-            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> { });
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
+                res.data().topics().forEach(topicResult -> {
+                    String name = topicResult.name();
+                    topicResult.partitions().forEach(partitionResult -> {
+                        TopicPartition tp = new TopicPartition(name, partitionResult.partitionIndex());
+                        if (partitionResult.errorCode() != Errors.NONE.code()) {
+                            log.error("Failed to write last mirrored offsets to remote coordinator: {}", partitionResult.errorCode());
+                            updateLastMirrorEpochsFuture.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
+                        } else {
+                            updateLastMirrorEpochsFuture.complete(tp);
+                        }
+                    });
+                });
+            });
         }
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -158,12 +158,11 @@ public class MirrorCoordinator {
                 metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions, bumpLeaderEpochFuture);
                 CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture = new CompletableFuture<>();
 
-                // Wait until bump leader epoch completes to abort the on-going transaction records.
-                // After the transaction aborting completion, all the txn should be committed or aborted.
-                // So we're safe to update the last mirrored epochs now.
+                // Wait until bump leader epoch completes before aborting the ongoing transactions.
                 bumpLeaderEpochFuture.whenComplete((v, ex) -> {
                     if (ex == null) {
                         abortOngoingTransactions(topicPartitions, tp -> {
+                            // When all transactions are decided, we can safely write the LME to the mirror metadata log.
                             updateLastMirrorEpochs(mirrorName, Set.of(tp), updateLastMirrorEpochsFuture);
                         });
                     } else {
@@ -173,11 +172,11 @@ public class MirrorCoordinator {
 
                 });
 
-                // After last mirror epoch updated, writing mirror pid reset barrier record
+                // After LME is stored, we can write the pid reset barrier record to the data logs.
                 updateLastMirrorEpochsFuture
                     .whenComplete((v, ex) -> {
                         if (ex == null) {
-                            finishStoppingAfterPidBarrierWritten(mirrorName, topicPartitions);
+                            writeMirrorPidResetAndStop(mirrorName, topicPartitions);
                         } else {
                             log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
                         }
@@ -186,7 +185,7 @@ public class MirrorCoordinator {
                 break;
             case STOPPED:
                 log.debug("STOPPED for topics {}.", topicPartitions);
-                // topic is writable
+                // Topic is writable.
                 break;
             case FAILED:
                 log.debug("FAILED for topics {}.", topicPartitions);
@@ -261,11 +260,7 @@ public class MirrorCoordinator {
             }
         });
 
-        // complete the partitions without on-going txn records.
-        if (!partitionsWithoutOngoingTxn.isEmpty()) {
-            topicPartitions.forEach(callback::accept);
-            return;
-        }
+        partitionsWithoutOngoingTxn.forEach(callback::accept);
 
         log.info("appending abort: {}", recordsByPartition);
         while (!recordsByPartition.isEmpty()) {
@@ -305,18 +300,14 @@ public class MirrorCoordinator {
             CollectionConverters.asScala(records),
             partitionResponses -> {
                 partitionResponses.foreach(partitionRes -> {
-                    TopicPartition tp = partitionRes._1.topicPartition();
                     ProduceResponse.PartitionResponse pr = partitionRes._2;
                     if (pr.error.code() != Errors.NONE.code()) {
                         // TODO: retry logic
-                        log.error("Failed to append end transaction marker for {}: {}", tp, pr.error.message());
-                    } else {
-                        if (partitionsToComplete.contains(tp)) {
-                            callback.accept(tp);
-                        }
+                        log.error("Failed to append abort marker for {}: {}", partitionRes._1.topicPartition(), pr.error.message());
                     }
                     return null;
                 });
+                partitionsToComplete.forEach(callback::accept);
                 return null;
             },
             ignored -> null,
@@ -532,13 +523,13 @@ public class MirrorCoordinator {
      * Retry the failed partitions until success.
      * TODO: handle failure, we can't retry forever
      */
-    private void finishStoppingAfterPidBarrierWritten(String mirrorName, Set<TopicPartition> topicPartitions) {
+    private void writeMirrorPidResetAndStop(String mirrorName, Set<TopicPartition> topicPartitions) {
         long retryDelayMs = brokerConfig.mirrorConfig().truncationBackoffMs();
         writeMirrorPidResetBarrier(mirrorName, topicPartitions).whenComplete((responses, ex) -> {
             if (ex != null) {
                 log.error("Failed to write PID reset barrier for partitions {} in mirror {}", topicPartitions, mirrorName, ex);
                 scheduler.scheduleOnce("MirrorPidResetBarrierRetry",
-                    () -> finishStoppingAfterPidBarrierWritten(mirrorName, topicPartitions),
+                    () -> writeMirrorPidResetAndStop(mirrorName, topicPartitions),
                     retryDelayMs);
                 return;
             }
@@ -562,7 +553,7 @@ public class MirrorCoordinator {
             }
             if (!failed.isEmpty()) {
                 scheduler.scheduleOnce("MirrorPidResetBarrierRetry",
-                    () -> finishStoppingAfterPidBarrierWritten(mirrorName, failed),
+                    () -> writeMirrorPidResetAndStop(mirrorName, failed),
                     retryDelayMs);
             }
         });

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -154,34 +154,14 @@ public class MirrorCoordinator {
             case STOPPING:
                 log.debug("STOPPING for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                CompletableFuture<Void> bumpLeaderEpochFuture = new CompletableFuture<>();
-                metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions, bumpLeaderEpochFuture);
-                CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture = new CompletableFuture<>();
-
-                // Wait until bump leader epoch completes before aborting the ongoing transactions.
-                bumpLeaderEpochFuture.whenComplete((v, ex) -> {
-                    if (ex == null) {
-                        abortOngoingTransactions(topicPartitions, tp -> {
-                            // When all transactions are decided, we can safely write the LME to the mirror metadata log.
-                            updateLastMirrorEpochs(mirrorName, Set.of(tp), updateLastMirrorEpochsFuture);
-                        });
-                    } else {
-                        // TODO: error handling
-                        log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
-                    }
-
-                });
-
-                // After LME is stored, we can write the pid reset barrier record to the data logs.
-                updateLastMirrorEpochsFuture
-                    .whenComplete((v, ex) -> {
-                        if (ex == null) {
-                            writeMirrorPidResetAndStop(mirrorName, topicPartitions);
-                        } else {
-                            log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
-                        }
+                metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions)
+                    .thenCompose(v -> abortOngoingTransactions(topicPartitions))
+                    .thenRun(() -> collectAndUpdateLastMirrorEpochs(mirrorName, topicPartitions))
+                    .thenAccept(v -> writeMirrorPidResetAndStop(mirrorName, topicPartitions))
+                    .exceptionally(ex -> {
+                        log.error("Failed STOPPING transition for {}", topicPartitions, ex);
+                        return null;
                     });
-
                 break;
             case STOPPED:
                 log.debug("STOPPED for topics {}.", topicPartitions);
@@ -247,24 +227,22 @@ public class MirrorCoordinator {
      * otherwise, the LogValidator#getFirstBatchAndMaybeValidateNoMoreBatches will throw exception.
      * So we append in multiple rounds when needed.
      */
-    private void abortOngoingTransactions(Set<TopicPartition> topicPartitions,
-                                          Consumer<TopicPartition> callback) {
+    private CompletableFuture<Void> abortOngoingTransactions(Set<TopicPartition> topicPartitions) {
         Map<TopicPartition, List<MemoryRecords>> recordsByPartition = new HashMap<>();
-        Set<TopicPartition> partitionsWithoutOngoingTxn = new HashSet<>();
         topicPartitions.forEach(tp -> {
             Option<List<MemoryRecords>> record = replicaManager.getLog(tp).map(UnifiedLog::buildEndTransactionRecords);
             if (record.isDefined() && !record.get().isEmpty()) {
                 recordsByPartition.put(tp, record.get());
-            } else {
-                partitionsWithoutOngoingTxn.add(tp);
             }
         });
 
-        partitionsWithoutOngoingTxn.forEach(callback::accept);
+        if (recordsByPartition.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
 
-        log.info("appending abort: {}", recordsByPartition);
+        log.debug("Appending abort markers for partitions: {}", recordsByPartition.keySet());
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
         while (!recordsByPartition.isEmpty()) {
-            Set<TopicPartition> partitionsToComplete = new HashSet<>();
             Map<TopicIdPartition, MemoryRecords> records = new HashMap<>();
             recordsByPartition.entrySet().removeIf(entry -> {
                 TopicPartition tp = entry.getKey();
@@ -275,22 +253,15 @@ public class MirrorCoordinator {
                     records.put(replicaManager.topicIdPartition(tp), record);
                     it.remove();
                 }
-
-                if (recordsList.isEmpty()) {
-                    partitionsToComplete.add(tp);
-                    return true;
-                }
-                return false;
+                return recordsList.isEmpty();
             });
-
-            log.info("run: appending abort: {}", records);
-            appendAbortMarkers(records, partitionsToComplete, callback);
+            futures.add(appendAbortMarkers(records));
         }
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
-    private void appendAbortMarkers(Map<TopicIdPartition, MemoryRecords> records,
-                                    Set<TopicPartition> partitionsToComplete,
-                                    Consumer<TopicPartition> callback) {
+    private CompletableFuture<Void> appendAbortMarkers(Map<TopicIdPartition, MemoryRecords> records) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         replicaManager.appendRecords(
             // TODO: replace this with Cluster Mirror specific timeout
             Duration.ofSeconds(5).toMillis(),
@@ -307,13 +278,14 @@ public class MirrorCoordinator {
                     }
                     return null;
                 });
-                partitionsToComplete.forEach(callback::accept);
+                future.complete(null);
                 return null;
             },
             ignored -> null,
             RequestLocal.noCaching(),
             CollectionConverters.asScala(Map.of())
         );
+        return future;
     }
 
     /** Writes partition state and offset updates to the internal topic. */
@@ -339,8 +311,7 @@ public class MirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
-        // do last mirror epochs update in parallel
-        updateLastMirrorEpochs(updatedMirrorName, offsets, new CompletableFuture<>());
+        updateLastMirrorEpochs(updatedMirrorName, offsets);
 
         WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
         List<WriteMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
@@ -365,7 +336,7 @@ public class MirrorCoordinator {
         metadataManager.getCachedPartitionMetadata(mirrorName, partitions, callback);
     }
 
-    private void updateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions, CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture) {
+    private void collectAndUpdateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
         Map<String, Map<Integer, Integer>> partitionOffsets = new HashMap<>();
         MirrorUtils.groupPartitionsByTopic(topicPartitions).forEach((topic, parts) -> {
             Map<Integer, Integer> offsets = new HashMap<>();
@@ -378,7 +349,7 @@ public class MirrorCoordinator {
             partitionOffsets.put(topic, offsets);
         });
 
-        updateLastMirrorEpochs(mirrorName, partitionOffsets, updateLastMirrorEpochsFuture);
+        updateLastMirrorEpochs(mirrorName, partitionOffsets);
     }
 
     private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(String mirrorName,
@@ -628,8 +599,8 @@ public class MirrorCoordinator {
         return metadataManager.getLastMirrorEpochs(mirrorName);
     }
 
-    /** Persists offsets to local or remote coordinators, optionally transitioning to STOPPED. */
-    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets, CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture) {
+    /** Persists offsets to local or remote coordinators. */
+    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
         // Separate partitions into local and remote coordinator groups
         Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
         Map<String, Set<MirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
@@ -670,21 +641,7 @@ public class MirrorCoordinator {
                     true,
                     AppendOrigin.COORDINATOR,
                     CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
-                    response -> {
-                        response.foreach(res -> {
-                            TopicPartition tp = res._1.topicPartition();
-                            ProduceResponse.PartitionResponse partitionRes = res._2;
-                            if (partitionRes.error.code() != Errors.NONE.code()) {
-                                // TODO: retry logic
-                                log.error("Failed to write last mirrored offsets to coordinator: {}", partitionRes.error.message());
-                                updateLastMirrorEpochsFuture.completeExceptionally(partitionRes.error.exception());
-                            } else {
-                                updateLastMirrorEpochsFuture.complete(tp);
-                            }
-                            return null;
-                        });
-                        return null;
-                    },
+                    ignored -> null,
                     ignored -> null,
                     RequestLocal.noCaching(),
                     CollectionConverters.asScala(Map.of())
@@ -693,20 +650,7 @@ public class MirrorCoordinator {
 
         // Write to remote coordinator (batched by coordinator node internally)
         if (!remoteTopicMetadata.isEmpty()) {
-            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
-                res.data().topics().forEach(topicResult -> {
-                    String name = topicResult.name();
-                    topicResult.partitions().forEach(partitionResult -> {
-                        TopicPartition tp = new TopicPartition(name, partitionResult.partitionIndex());
-                        if (partitionResult.errorCode() != Errors.NONE.code()) {
-                            log.error("Failed to write last mirrored offsets to remote coordinator: {}", partitionResult.errorCode());
-                            updateLastMirrorEpochsFuture.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
-                        } else {
-                            updateLastMirrorEpochsFuture.complete(tp);
-                        }
-                    });
-                });
-            });
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> { });
         }
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -20,6 +20,7 @@ import kafka.server.KafkaConfig;
 import kafka.server.ReplicaManager;
 
 import org.apache.kafka.clients.admin.MirrorDescription;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
@@ -29,6 +30,7 @@ import org.apache.kafka.common.message.WriteMirrorStatesResponseData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordUtils;
 import org.apache.kafka.common.record.DefaultRecordBatch;
 import org.apache.kafka.common.record.FileRecords;
@@ -57,6 +59,7 @@ import org.apache.kafka.server.util.Scheduler;
 import org.apache.kafka.storage.internals.log.AppendOrigin;
 import org.apache.kafka.storage.internals.log.FetchDataInfo;
 
+import org.apache.kafka.storage.internals.log.UnifiedLog;
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
@@ -74,6 +77,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import scala.Option;
 import scala.jdk.javaapi.CollectionConverters;
 
 import static org.apache.kafka.common.utils.Utils.require;
@@ -154,9 +158,12 @@ public class MirrorCoordinator {
                 CompletableFuture<Void> bumpLeaderEpochFuture = new CompletableFuture<>();
                 metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions, bumpLeaderEpochFuture);
                 CompletableFuture<Void> updateLastMirrorEpochsFuture = new CompletableFuture<>();
-                truncateToLastStableOffset(topicPartitions, tp -> {
-                    updateLastMirrorEpochs(mirrorName, Set.of(tp));
-                    updateLastMirrorEpochsFuture.complete(null);
+
+                bumpLeaderEpochFuture.whenComplete((v, ex) -> {
+                    appendAbortRecordsForOngoingTxns(topicPartitions, tp -> {
+                        updateLastMirrorEpochs(mirrorName, Set.of(tp));
+                        updateLastMirrorEpochsFuture.complete(null);
+                    });
                 });
                 // Wait until (1) bump leader epoch and (2) update last mirror epoch completes, then write mirror pid reset barrier record
                 CompletableFuture.allOf(bumpLeaderEpochFuture, updateLastMirrorEpochsFuture)
@@ -228,20 +235,74 @@ public class MirrorCoordinator {
         });
     }
 
-    private void truncateToLastStableOffset(Set<TopicPartition> topicPartitions,
-                                            Consumer<TopicPartition> callback) {
-        Map<TopicPartition, Long> offsets = new HashMap<>();
+    /**
+     * {@link kafka.server.ReplicaManager#appendRecords} allows only one record batch per partition per call,
+     * otherwise, the LogValidator#getFirstBatchAndMaybeValidateNoMoreBatches will throw exception.
+     * So we append in multiple rounds when needed.
+     */
+    private void appendAbortRecordsForOngoingTxns(Set<TopicPartition> topicPartitions,
+                                                  Consumer<TopicPartition> callback) {
+        Map<TopicPartition, List<MemoryRecords>> recordsByPartition = new HashMap<>();
         topicPartitions.forEach(tp -> {
-            if (replicaManager.getLog(tp).isDefined()) {
-                offsets.put(tp, replicaManager.getLog(tp).get().lastStableOffset());
-            } else {
-                log.warn("Cannot get the log for partition: {}. Skipping log truncation.", tp);
-                callback.accept(tp);
+            Option<List<MemoryRecords>> record = replicaManager.getLog(tp).map(UnifiedLog::buildEndTransactionRecords);
+            if (record.isDefined() && !record.get().isEmpty()) {
+                recordsByPartition.put(tp, record.get());
             }
         });
-        if (!offsets.isEmpty()) {
-            replicaManager.maybeTruncate(offsets, callback);
+
+        log.info("appending abort: {}", recordsByPartition);
+        while (!recordsByPartition.isEmpty()) {
+            Set<TopicPartition> partitionsToComplete = new HashSet<>();
+            Map<TopicIdPartition, MemoryRecords> records = new HashMap<>();
+            recordsByPartition.entrySet().removeIf(entry -> {
+               TopicPartition tp = entry.getKey();
+               List<MemoryRecords> recordsList = entry.getValue();
+               Iterator<MemoryRecords> it = recordsList.iterator();
+               if (it.hasNext()) {
+                   MemoryRecords record = it.next();
+                   records.put(replicaManager.topicIdPartition(tp), record);
+                   it.remove();
+               }
+
+               if (recordsList.isEmpty()) {
+                   partitionsToComplete.add(tp);
+                   return true;
+               }
+               return false;
+            });
+
+            log.info("run: appending abort: {}", records);
+            appendAbortTxnMarker(records, partitionsToComplete, callback);
         }
+    }
+
+    private void appendAbortTxnMarker(Map<TopicIdPartition, MemoryRecords> records,
+                                      Set<TopicPartition> partitionsToComplete,
+                                      Consumer<TopicPartition> callback) {
+        replicaManager.appendRecords(
+            // TODO: replace this with Cluster Mirror specific timeout
+            Duration.ofSeconds(5).toMillis(),
+            (short) -1,
+            true,
+            AppendOrigin.COORDINATOR,
+            CollectionConverters.asScala(records),
+            partitionResponses -> {
+                partitionResponses.foreach(partitionRes -> {
+                    TopicPartition tp = partitionRes._1.topicPartition();
+                    ProduceResponse.PartitionResponse pr = partitionRes._2;
+                    if (pr.error.code() != Errors.NONE.code()) {
+                        log.error("Failed to append end transaction marker for {}: {}", tp, pr.error.message());
+                    } else {
+                        partitionsToComplete.forEach(callback::accept);
+                    }
+                    return null;
+                });
+                return null;
+            },
+            ignored -> null,
+            RequestLocal.noCaching(),
+            CollectionConverters.asScala(Map.of())
+        );
     }
 
     /** Writes partition state and offset updates to the internal topic. */

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -656,7 +656,6 @@ public class MirrorCoordinator {
                     CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
                     response -> {
                         response.foreach(res -> {
-                            TopicPartition tp = res._1.topicPartition();
                             ProduceResponse.PartitionResponse partitionRes = res._2;
                             if (partitionRes.error.code() != Errors.NONE.code()) {
                                 // TODO: retry logic
@@ -679,9 +678,7 @@ public class MirrorCoordinator {
         if (!remoteTopicMetadata.isEmpty()) {
             metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
                 res.data().topics().forEach(topicResult -> {
-                    String name = topicResult.name();
                     topicResult.partitions().forEach(partitionResult -> {
-                        TopicPartition tp = new TopicPartition(name, partitionResult.partitionIndex());
                         if (partitionResult.errorCode() != Errors.NONE.code()) {
                             log.error("Failed to write last mirrored offsets to remote coordinator: {}", partitionResult.errorCode());
                             future.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.message.WriteMirrorStatesResponseData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordUtils;
 import org.apache.kafka.common.record.DefaultRecordBatch;
 import org.apache.kafka.common.record.FileRecords;
@@ -58,8 +57,8 @@ import org.apache.kafka.server.storage.log.FetchIsolation;
 import org.apache.kafka.server.util.Scheduler;
 import org.apache.kafka.storage.internals.log.AppendOrigin;
 import org.apache.kafka.storage.internals.log.FetchDataInfo;
-
 import org.apache.kafka.storage.internals.log.UnifiedLog;
+
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
@@ -255,20 +254,20 @@ public class MirrorCoordinator {
             Set<TopicPartition> partitionsToComplete = new HashSet<>();
             Map<TopicIdPartition, MemoryRecords> records = new HashMap<>();
             recordsByPartition.entrySet().removeIf(entry -> {
-               TopicPartition tp = entry.getKey();
-               List<MemoryRecords> recordsList = entry.getValue();
-               Iterator<MemoryRecords> it = recordsList.iterator();
-               if (it.hasNext()) {
-                   MemoryRecords record = it.next();
-                   records.put(replicaManager.topicIdPartition(tp), record);
-                   it.remove();
-               }
+                TopicPartition tp = entry.getKey();
+                List<MemoryRecords> recordsList = entry.getValue();
+                Iterator<MemoryRecords> it = recordsList.iterator();
+                if (it.hasNext()) {
+                    MemoryRecords record = it.next();
+                    records.put(replicaManager.topicIdPartition(tp), record);
+                    it.remove();
+                }
 
-               if (recordsList.isEmpty()) {
-                   partitionsToComplete.add(tp);
-                   return true;
-               }
-               return false;
+                if (recordsList.isEmpty()) {
+                    partitionsToComplete.add(tp);
+                    return true;
+                }
+                return false;
             });
 
             log.info("run: appending abort: {}", records);

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -135,11 +135,11 @@ public class MirrorCoordinator {
     private void handleStateTransition(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
         switch (newState) {
             case PREPARING:
-                log.debug("PREPARING for topics {}.", topicPartitions);
+                log.info("PREPARING for topics {}.", topicPartitions);
                 scheduleTruncation(mirrorName, topicPartitions);
                 break;
             case MIRRORING:
-                log.debug("MIRRORING topics {}.", topicPartitions);
+                log.info("MIRRORING topics {}.", topicPartitions);
                 replicaManager.maybeCreateMirrorFetchers(mirrorName, topicPartitions);
                 break;
             case PAUSING:
@@ -152,11 +152,19 @@ public class MirrorCoordinator {
                 // topic is still read-only
                 break;
             case STOPPING:
-                log.debug("STOPPING for topics {}.", topicPartitions);
+                log.info("STOPPING for topics {}.", topicPartitions);
+                // The order of STOPPING process:
+                // 1. remove fetcher for mirror fetcher
+                // 2. store LME because that's the last mirrored epoch before bumping leader epoch
+                // 3. bump leader epoch to draw a line for future failback cluster recognize the new added records
+                // 4. abort ongoing transactions using the updated leader epoch
+                // 5. reset pid to expire all existing PIDs, including the new appended records in (4)
+                // 6. move to STOPPED state
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions)
+
+                collectAndUpdateLastMirrorEpochs(mirrorName, topicPartitions)
+                    .thenCompose(v -> metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions))
                     .thenCompose(v -> abortOngoingTransactions(topicPartitions))
-                    .thenRun(() -> collectAndUpdateLastMirrorEpochs(mirrorName, topicPartitions))
                     .thenAccept(v -> writeMirrorPidResetAndStop(mirrorName, topicPartitions))
                     .exceptionally(ex -> {
                         log.error("Failed STOPPING transition for {}", topicPartitions, ex);
@@ -164,11 +172,11 @@ public class MirrorCoordinator {
                     });
                 break;
             case STOPPED:
-                log.debug("STOPPED for topics {}.", topicPartitions);
+                log.info("STOPPED for topics {}.", topicPartitions);
                 // Topic is writable.
                 break;
             case FAILED:
-                log.debug("FAILED for topics {}.", topicPartitions);
+                log.info("FAILED for topics {}.", topicPartitions);
                 // TODO: implement recovery actions (i.e. exponential backoff retry)
                 break;
             default:
@@ -279,6 +287,7 @@ public class MirrorCoordinator {
                     return null;
                 });
                 future.complete(null);
+
                 return null;
             },
             ignored -> null,
@@ -336,7 +345,8 @@ public class MirrorCoordinator {
         metadataManager.getCachedPartitionMetadata(mirrorName, partitions, callback);
     }
 
-    private void collectAndUpdateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
+    private CompletableFuture<Void> collectAndUpdateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
         Map<String, Map<Integer, Integer>> partitionOffsets = new HashMap<>();
         MirrorUtils.groupPartitionsByTopic(topicPartitions).forEach((topic, parts) -> {
             Map<Integer, Integer> offsets = new HashMap<>();
@@ -349,7 +359,9 @@ public class MirrorCoordinator {
             partitionOffsets.put(topic, offsets);
         });
 
-        updateLastMirrorEpochs(mirrorName, partitionOffsets);
+        futures.add(updateLastMirrorEpochs(mirrorName, partitionOffsets));
+
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
     private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(String mirrorName,
@@ -600,7 +612,8 @@ public class MirrorCoordinator {
     }
 
     /** Persists offsets to local or remote coordinators. */
-    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
+    public CompletableFuture<Void> updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         // Separate partitions into local and remote coordinator groups
         Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
         Map<String, Set<MirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
@@ -641,7 +654,21 @@ public class MirrorCoordinator {
                     true,
                     AppendOrigin.COORDINATOR,
                     CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
-                    ignored -> null,
+                    response -> {
+                        response.foreach(res -> {
+                            TopicPartition tp = res._1.topicPartition();
+                            ProduceResponse.PartitionResponse partitionRes = res._2;
+                            if (partitionRes.error.code() != Errors.NONE.code()) {
+                                // TODO: retry logic
+                                log.error("Failed to write last mirrored offsets to coordinator: {}", partitionRes.error.message());
+                                future.completeExceptionally(partitionRes.error.exception());
+                            } else {
+                                future.complete(null);
+                            }
+                            return null;
+                        });
+                        return null;
+                    },
                     ignored -> null,
                     RequestLocal.noCaching(),
                     CollectionConverters.asScala(Map.of())
@@ -650,8 +677,23 @@ public class MirrorCoordinator {
 
         // Write to remote coordinator (batched by coordinator node internally)
         if (!remoteTopicMetadata.isEmpty()) {
-            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> { });
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
+                res.data().topics().forEach(topicResult -> {
+                    String name = topicResult.name();
+                    topicResult.partitions().forEach(partitionResult -> {
+                        TopicPartition tp = new TopicPartition(name, partitionResult.partitionIndex());
+                        if (partitionResult.errorCode() != Errors.NONE.code()) {
+                            log.error("Failed to write last mirrored offsets to remote coordinator: {}", partitionResult.errorCode());
+                            future.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
+                        } else {
+                            future.complete(null);
+                        }
+                    });
+                });
+            });
         }
+
+        return future;
     }
 
     private static CoordinatorRecord generateMirrorPartitionState(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -985,7 +985,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         metadataRefreshError.incrementAndGet();
     }
 
-    public void sendBumpLeaderEpoch(LogManager logManager, Set<TopicPartition> topicPartitions, CompletableFuture<Void> future) {
+    public CompletableFuture<Void> sendBumpLeaderEpoch(LogManager logManager, Set<TopicPartition> topicPartitions) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         Map<TopicPartition, Integer> partitionEpochs = new HashMap<>();
 
         List<BumpLeaderEpochsRequestData.TopicState> topicStates = new ArrayList<>();
@@ -1020,6 +1021,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 log.warn("BumpLeaderEpoch request timed out");
             }
         });
+        return future;
     }
 
     /**

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -343,7 +343,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             Set<TopicPartition> incompletedTps = bumpLeaderEpoch.partitionToEpoch().entrySet().stream().filter(entry -> {
                 TopicPartition tp = entry.getKey();
                 int epoch = entry.getValue();
-                return metadataImage.topics().getPartition(metadataImage.topics().getTopic(tp.topic()).id(), tp.partition()).leaderEpoch < epoch;
+                return metadataImage.topics().getPartition(metadataImage.topics().getTopic(tp.topic()).id(), tp.partition()).leaderEpoch <= epoch;
             }).map(Map.Entry::getKey).collect(Collectors.toSet());
             if (incompletedTps.isEmpty()) {
                 bumpLeaderEpoch.future().complete(null);

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -243,7 +243,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
       // Use different fetch request types based on whether we're doing cross-cluster mirroring.
       val requestBuilder = if (isClusterMirror) {
         // Cross-cluster mirroring (MirrorFetcherThread): Use consumer fetch to skip ISR logic on source cluster.
-        FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend).isolationLevel(IsolationLevel.READ_COMMITTED)
+        FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend).isolationLevel(IsolationLevel.READ_UNCOMMITTED)
       } else {
         // Intra-cluster replication (ReplicaFetcherThread): Use replica fetch even when fetching to enable proper epoch validation.
         FetchRequest.Builder.forReplica(version, brokerConfig.brokerId, brokerEpochSupplier(), maxWait, minBytes, fetchData.toSend)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1422,7 +1422,7 @@ class ReplicaManager(val config: KafkaConfig,
         val allowed = state == MirrorPartitionState.STOPPED ||
           (state == MirrorPartitionState.STOPPING &&
             (origin == AppendOrigin.COORDINATOR || origin == AppendOrigin.REPLICATION) &&
-            records.batches().asScala.exists(ControlRecordType.isMirrorPidResetBatch))
+            records.batches().asScala.exists(b => ControlRecordType.isMirrorPidResetBatch(b) || ControlRecordType.isAbortTxnBatch(b)))
         if (!allowed) {
           throw new ReadOnlyTopicException("Cannot append to read-only partition %s on broker %d (mirrorName=%s)"
             .format(partition.topicPartition, localBrokerId, mirrorName))

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -47,8 +47,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -287,6 +289,12 @@ public class ProducerStateManager {
      */
     public Map<Long, ProducerStateEntry> activeProducers() {
         return Collections.unmodifiableMap(producers);
+    }
+
+    public Set<ProducerStateEntry> ongoingTransactionProducers() {
+        return ongoingTxns.values().stream()
+                .map(txn -> producers.get(txn.producerId))
+                .collect(Collectors.toSet());
     }
 
     public boolean isEmpty() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -291,7 +291,7 @@ public class ProducerStateManager {
         return Collections.unmodifiableMap(producers);
     }
 
-    public Set<ProducerStateEntry> ongoingTransactionProducers() {
+    public Set<ProducerStateEntry> producersWithOngoingTxns() {
         return ongoingTxns.values().stream()
                 .map(txn -> producers.get(txn.producerId))
                 .collect(Collectors.toSet());

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -822,14 +822,14 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     public List<MemoryRecords> buildEndTransactionRecords() {
-        Set<ProducerStateEntry> ongoingTxns = producerStateManager.ongoingTransactionProducers();
+        Set<ProducerStateEntry> ongoingTxns = producerStateManager.producersWithOngoingTxns();
         List<MemoryRecords> records = new LinkedList<>();
 
         ongoingTxns.forEach(producerStateEntry -> {
             // coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
             // Setting it to 0 if the coordinator epoch in the leader node has no coordinator epoch info (-1).
             // This could happen when this PID has not committed/aborted yet. Setting it to 0 can pass the validation
-            // and also align with the implementation in TansactionsCommand#buildAbortSpec when we want to force aborting a pending txn record.
+            // and also align with the implementation in TransactionsCommand#buildAbortSpec when we want to force aborting a pending txn record.
             int coordinatorEpoch = producerStateEntry.coordinatorEpoch() < 0 ? 0 : producerStateEntry.coordinatorEpoch();
             records.add(MemoryRecords.withEndTransactionMarker(producerStateEntry.producerId(),
                     producerStateEntry.producerEpoch(),

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -822,11 +822,11 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     public List<MemoryRecords> buildEndTransactionRecords() {
-        Set<ProducerStateEntry> ongoingTxns = producerStateManager.producersWithOngoingTxns();
+        Set<ProducerStateEntry> producers = producerStateManager.producersWithOngoingTxns();
         List<MemoryRecords> records = new LinkedList<>();
 
-        ongoingTxns.forEach(producerStateEntry -> {
-            // coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
+        producers.forEach(producerStateEntry -> {
+            // Coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
             // Setting it to 0 if the coordinator epoch in the leader node has no coordinator epoch info (-1).
             // This could happen when this PID has not committed/aborted yet. Setting it to 0 can pass the validation
             // and also align with the implementation in TransactionsCommand#buildAbortSpec when we want to force aborting a pending txn record.

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -828,9 +828,14 @@ public class UnifiedLog implements AutoCloseable {
         List<MemoryRecords> records = new LinkedList<>();
 
         ongoingTxns.forEach((producerStateEntry) -> {
+            // coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
+            // Setting it to 0 if the coordinator epoch in the leader node has no coordinator epoch info (-1).
+            // This could happen when this PID has not committed/aborted yet. Setting it to 0 can pass the validation
+            // and also align with the implementation in TansactionsCommand#buildAbortSpec when we want to force aborting a pending txn record.
+            int coordinatorEpoch = producerStateEntry.coordinatorEpoch() < 0 ? 0 : producerStateEntry.coordinatorEpoch();
             records.add(MemoryRecords.withEndTransactionMarker(producerStateEntry.producerId(),
                     producerStateEntry.producerEpoch(),
-                new EndTransactionMarker(ControlRecordType.ABORT, producerStateEntry.coordinatorEpoch())));
+                new EndTransactionMarker(ControlRecordType.ABORT, coordinatorEpoch)));
         });
 
         return records;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -33,6 +33,8 @@ import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.DescribeProducersResponseData;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.DefaultRecordBatch;
+import org.apache.kafka.common.record.EndTransactionMarker;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -73,13 +75,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
@@ -816,6 +821,19 @@ public class UnifiedLog implements AutoCloseable {
 
     public int producerIdCount() {
         return producerStateManager.producerIdCount();
+    }
+
+    public List<MemoryRecords> buildEndTransactionRecords() {
+        Set<ProducerStateEntry> ongoingTxns = producerStateManager.ongoingTransactionProducers();
+        List<MemoryRecords> records = new LinkedList<>();
+
+        ongoingTxns.forEach((producerStateEntry) -> {
+            records.add(MemoryRecords.withEndTransactionMarker(producerStateEntry.producerId(),
+                    producerStateEntry.producerEpoch(),
+                new EndTransactionMarker(ControlRecordType.ABORT, producerStateEntry.coordinatorEpoch())));
+        });
+
+        return records;
     }
 
     public List<DescribeProducersResponseData.ProducerState> activeProducers() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -33,7 +33,6 @@ import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.DescribeProducersResponseData;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordType;
-import org.apache.kafka.common.record.DefaultRecordBatch;
 import org.apache.kafka.common.record.EndTransactionMarker;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
@@ -75,7 +74,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -827,7 +825,7 @@ public class UnifiedLog implements AutoCloseable {
         Set<ProducerStateEntry> ongoingTxns = producerStateManager.ongoingTransactionProducers();
         List<MemoryRecords> records = new LinkedList<>();
 
-        ongoingTxns.forEach((producerStateEntry) -> {
+        ongoingTxns.forEach(producerStateEntry -> {
             // coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
             // Setting it to 0 if the coordinator epoch in the leader node has no coordinator epoch info (-1).
             // This could happen when this PID has not committed/aborted yet. Setting it to 0 can pass the validation

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -2076,7 +2076,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     def delete_topics_from_cluster_mirror(self, node, mirror_name, topics):
         return self._cluster_mirror_action(node, mirror_name, topics, 'resume')
-    
+
+    def stop_cluster_mirror_topics(self, node, mirror_name, topics):
+        return self._cluster_mirror_action(node, mirror_name, topics, 'stop')
+
     def parse_describe_cluster_mirror(self, cluster_mirror_description):
         """Parse output of kafka-mirrors.sh --describe (or describe_cluster_mirror() method above), which is a string of form
         """

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -67,7 +67,6 @@ class ClusterMirrorConfig:
         """
         return self.props()
 
-
 class ClusterMirroringTest(Test):
     PERSISTENT_ROOT = "/mnt/cluster_mirroring"
     MIRROR_CONFIG_FILE = os.path.join(PERSISTENT_ROOT, "cluster_mirror.properties")
@@ -75,17 +74,19 @@ class ClusterMirroringTest(Test):
     def __init__(self, test_context):
         """:type test_context: ducktape.tests.test.TestContext"""
         super(ClusterMirroringTest, self).__init__(test_context)
-        topic = "test"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 3}}
+        topic = "my-topic"
+        self.topics = {topic: {"partitions": 3, "replication-factor": 3}}
         self.source_kafka = KafkaService(
             test_context,
             num_nodes=3,
             zk=None,
             topics=self.topics,
             use_cluster_mirroring=True,
+            controller_num_nodes_override=1,
         )
         self.dest_kafka = KafkaService(
-            test_context, num_nodes=3, zk=None, use_cluster_mirroring=True
+            test_context, num_nodes=3, zk=None, use_cluster_mirroring=True,
+            controller_num_nodes_override=1,
         )
         self.producer = VerifiableProducer(
             self.test_context,
@@ -114,15 +115,45 @@ class ClusterMirroringTest(Test):
         self.producer.start()
 
     def teardown(self):
-        self.producer.stop()
-        self.dest_kafka.stop()
-        self.source_kafka.stop()
+        if any(self.producer.alive(node) for node in self.producer.nodes):
+            try:
+                self.producer.stop()
+            except Exception as e:
+                self.logger.warning("Error stopping producer: %s" % str(e))
+        for kafka in [self.dest_kafka, self.source_kafka]:
+            try:
+                kafka.stop()
+            except Exception:
+                self.logger.warning("Graceful stop failed for %s, forcing SIGKILL" % str(kafka))
+                for node in kafka.nodes:
+                    kafka.stop_node(node, clean_shutdown=False)
 
-    @cluster(num_nodes=13)
+    def all_satisfy_in_mirror(self, kafka_node, mirror_name, per_partition_condition):
+        """Check that all partitions of all mirrored topics satisfy the given condition."""
+        output = self.dest_kafka.describe_cluster_mirror(kafka_node)
+        if output == "":
+            return False
+
+        mirrors = self.dest_kafka.parse_describe_cluster_mirror(output)
+        if mirror_name not in mirrors:
+            return False
+        mirror = mirrors[mirror_name]
+
+        for topic in self.topics:
+            if topic not in mirror:
+                return False
+
+            for partition in mirror[topic].values():
+                if not per_partition_condition(partition):
+                    return False
+        return True
+
+    @cluster(num_nodes=9)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
-    def test_convergence(self, metadata_quorum):
+    def test_log_convergence(self, metadata_quorum):
+        """Verify that mirrored log segments are byte identical to source after bouncing both clusters."""
         mirror_cfg = {
-            "name": "test-mirror",
+            "name": "my-mirror",
             "cfg": ClusterMirrorConfig(self.source_kafka.bootstrap_servers()),
         }
         self.logger.info(
@@ -160,28 +191,9 @@ class ClusterMirroringTest(Test):
             err_msg="Failed to start mirror topics",
         )
 
-        def all_satisfy_in_mirror(mirror_name, per_partition_condition):
-            output = self.dest_kafka.describe_cluster_mirror(kafka_node)
-            if output == "":
-                return False
-
-            mirrors = self.dest_kafka.parse_describe_cluster_mirror(output)
-            if mirror_name not in mirrors:
-                return False
-            mirror = mirrors[mirror_name]
-
-            for topic in self.topics:
-                if topic not in mirror:
-                    return False
-
-                for partition in mirror[topic].values():
-                    if not per_partition_condition(partition):
-                        return False
-            return True
-
         wait_until(
-            lambda: all_satisfy_in_mirror(
-                mirror_cfg["name"], lambda p: p["state"] == "MIRRORING"
+            lambda: self.all_satisfy_in_mirror(
+                kafka_node, mirror_cfg["name"], lambda p: p["state"] == "MIRRORING"
             ),
             timeout_sec=20,
             backoff_sec=2,
@@ -216,10 +228,215 @@ class ClusterMirroringTest(Test):
         self.producer.stop()
 
         wait_until(
-            lambda: all_satisfy_in_mirror(mirror_cfg["name"], lambda p: p["lag"] == 0 and p["state"] == "MIRRORING"),
+            lambda: self.all_satisfy_in_mirror(
+                kafka_node, mirror_cfg["name"],
+                lambda p: p["lag"] == 0 and p["state"] == "MIRRORING"
+            ),
             timeout_sec=60,
             backoff_sec=2,
             err_msg="Failed to start mirrors",
         )
 
-        # TODO: invoke log segment comparision tooling
+        def log_segment_hashes(kafka, topic, partition=0):
+            """Return a dict mapping segment file names to their MD5 hashes."""
+            leader_node = kafka.leader(topic, partition)
+            cmd = "md5sum %s*/%s-%d/*.log 2>/dev/null" % (
+                KafkaService.DATA_LOG_DIR_PREFIX, topic, partition)
+            hashes = {}
+            for line in leader_node.account.ssh_capture(cmd, allow_fail=True):
+                parts = line.strip().split()
+                if len(parts) == 2:
+                    hashes[os.path.basename(parts[1])] = parts[0]
+            return hashes
+
+        # Check log segments convergence by comparing md5 hashes
+        for topic, cfg in self.topics.items():
+            for partition in range(cfg["partitions"]):
+                source_hashes = log_segment_hashes(self.source_kafka, topic, partition)
+                dest_hashes = log_segment_hashes(self.dest_kafka, topic, partition)
+                assert source_hashes.keys() == dest_hashes.keys(), \
+                    "Segment files differ for %s-%d: source=%s, dest=%s" % (
+                        topic, partition, sorted(source_hashes.keys()), sorted(dest_hashes.keys()))
+                mismatches = []
+                for seg in source_hashes:
+                    if source_hashes[seg] != dest_hashes[seg]:
+                        mismatches.append("%s: source=%s, dest=%s" % (
+                            seg, source_hashes[seg], dest_hashes[seg]))
+                assert not mismatches, \
+                    "Log segment mismatch for %s-%d:\n  %s" % (topic, partition, "\n  ".join(mismatches))
+
+    @cluster(num_nodes=9)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_stop_with_txns(self, metadata_quorum):
+        """Verify that STOPPING transition aborts pending transactions and allows committed reads."""
+        mirror_name = "my-mirror"
+        kafka_node = self.dest_kafka.nodes[0]
+        topic = list(self.topics.keys())[0]
+
+        def run_producer(kafka, topic, transactional_id=None, mode="commit",
+                         num_records=1, waiting_ms=0, background=False):
+            """Run TransactionalTestProducer via SSH on the first broker node."""
+            node = kafka.nodes[0]
+            cmd = kafka.path.script("kafka-run-class.sh", node)
+            cmd += " org.apache.kafka.tools.TransactionalTestProducer"
+            cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
+            cmd += " --topic %s" % topic
+            if transactional_id is not None:
+                cmd += " --transactional-id %s" % transactional_id
+                cmd += " --mode %s" % mode
+                if waiting_ms > 0:
+                    cmd += " --waiting-ms %s" % str(waiting_ms)
+            cmd += " --num-records %s" % str(num_records)
+            if background:
+                cmd += " &"
+            node.account.ssh(cmd, allow_fail=False)
+
+        run_producer(self.source_kafka, topic, topic + "-a", "commit")
+
+        self.logger.info("Restarting source brokers to bump leader epoch")
+        self.source_kafka.restart_cluster(clean_shutdown=True)
+
+        def count_ongoing_txns(kafka, topic):
+            """Count ongoing transactions across all partitions using describe-producers."""
+            node = kafka.nodes[0]
+            count = 0
+            for partition in range(self.topics[topic]["partitions"]):
+                cmd = kafka.path.script("kafka-transactions.sh", node)
+                cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
+                cmd += " describe-producers --topic %s --partition %d" % (topic, partition)
+                for line in node.account.ssh_capture(cmd, allow_fail=True):
+                    fields = line.strip().split()
+                    if fields and fields[-1] != "None" and fields[-1] != "CurrentTransactionStartOffset":
+                        count += 1
+            return count
+
+        def send_interleaving_txns(topic):
+            """Send interleaved transactional and non-transactional records, leaving 2 txns pending."""
+            kafka = self.source_kafka
+            run_producer(kafka, topic, topic + "-a", "commit", waiting_ms=5000, background=True)
+            run_producer(kafka, topic)
+            run_producer(kafka, topic, topic + "-b", "pending")
+            run_producer(kafka, topic, topic + "-d", "pending")
+            run_producer(kafka, topic, topic + "-c", "abort", waiting_ms=5000, background=True)
+            run_producer(kafka, topic, topic + "-d", "pending")
+            run_producer(kafka, topic)
+
+            ongoing = count_ongoing_txns(kafka, topic)
+            assert ongoing == 2, "Expected 2 ongoing transactions, got %d" % ongoing
+
+        send_interleaving_txns(topic)
+
+        self.producer.stop()
+
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+        self.logger.info(
+            "Creating mirror %s with settings %s", mirror_name, mirror_cfg
+        )
+        prop_file = str(mirror_cfg)
+        kafka_node.account.ssh(
+            "mkdir -p %s" % ClusterMirroringTest.PERSISTENT_ROOT, allow_fail=False
+        )
+        kafka_node.account.create_file(
+            ClusterMirroringTest.MIRROR_CONFIG_FILE, prop_file
+        )
+
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                kafka_node, mirror_name, ClusterMirroringTest.MIRROR_CONFIG_FILE
+            ),
+            timeout_sec=20,
+            backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+
+        wait_until(
+            lambda: (
+                "Started"
+                in self.dest_kafka.start_cluster_mirror_topics(
+                    kafka_node, mirror_name, self.topics.keys()
+                )
+            ),
+            timeout_sec=20,
+            backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+
+        wait_until(
+            lambda: self.all_satisfy_in_mirror(
+                kafka_node, mirror_name,
+                lambda p: p["lag"] == 0 and p["state"] == "MIRRORING"
+            ),
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="Mirror did not catch up",
+        )
+
+        self.logger.info("Stopping mirror topics for %s", mirror_name)
+        self.dest_kafka.stop_cluster_mirror_topics(
+            kafka_node, mirror_name, self.topics.keys()
+        )
+
+        def check_stopped():
+            output = self.dest_kafka.describe_cluster_mirror(kafka_node)
+            self.logger.info("describe_cluster_mirror: %s", output)
+            return self.all_satisfy_in_mirror(
+                kafka_node, mirror_name, lambda p: p["state"] == "STOPPED"
+            )
+
+        wait_until(
+            check_stopped,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="Mirror topics did not reach STOPPED state",
+        )
+
+        def parse_end_offsets(output):
+            """Parse get_offset_shell output into a {partition: offset} dict."""
+            offsets = {}
+            for line in output.strip().splitlines():
+                parts = line.strip().split(":")
+                if len(parts) == 3:
+                    offsets[int(parts[1])] = int(parts[2])
+            return offsets
+
+        source_offsets = parse_end_offsets(
+            self.source_kafka.get_offset_shell(topic=topic, time=-1))
+        dest_offsets = parse_end_offsets(
+            self.dest_kafka.get_offset_shell(topic=topic, time=-1))
+        extra = sum(dest_offsets.values()) - sum(source_offsets.values())
+        # 2 abort markers (one per pending txn) + 1 PID reset barrier per partition
+        num_partitions = self.topics[topic]["partitions"]
+        expected_extra = 2 + num_partitions
+        assert extra == expected_extra, \
+            "Expected %d extra records (2 abort + %d PID reset) on destination, got %d. " \
+            "source=%s, dest=%s" % (expected_extra, num_partitions, extra, source_offsets, dest_offsets)
+
+        run_producer(self.dest_kafka, topic, topic + "-b", "commit")
+        run_producer(self.dest_kafka, topic, topic + "-d", "commit")
+
+        def run_consumer(kafka, topic, isolation_level="read_uncommitted"):
+            """Run console consumer and return the record count."""
+            node = kafka.nodes[0]
+            cmd = kafka.path.script("kafka-console-consumer.sh", node)
+            cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
+            cmd += " --topic %s --from-beginning" % topic
+            cmd += " --isolation-level %s" % isolation_level
+            cmd += " --timeout-ms 10000"
+            count = 0
+            for line in node.account.ssh_capture(cmd, allow_fail=True):
+                if line.strip():
+                    count += 1
+            return count
+
+        # checking raw number of records
+        source_count = run_consumer(self.source_kafka, topic)
+        dest_count = run_consumer(self.dest_kafka, topic)
+        assert dest_count == source_count + 2, \
+            "Expected dest to have exactly 2 more records than source, " \
+            "got source=%d, dest=%d" % (source_count, dest_count)
+
+        # checking read_committed consumer can make progress
+        # 4 aborted data records are filtered out: txn-b, txn-c, txn-d fenced, txn-d pending
+        dest_committed = run_consumer(self.dest_kafka, topic, "read_committed")
+        assert dest_committed == dest_count - 4, \
+            "Expected dest_committed=%d, got %d" % (dest_count - 4, dest_committed)

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalTestProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalTestProducer.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Exit;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Test-only producer that supports three transaction modes:
+ *   commit  - sends records, commits the transaction, then exits.
+ *   abort   - sends records, aborts the transaction, then exits.
+ *   pending - sends records, flushes, then exits without committing
+ *             or aborting, leaving the transaction open on the broker.
+ *
+ * The --waiting-ms option adds a delay (in milliseconds) before
+ * committing or aborting, allowing other producers to interleave
+ * records in between.
+ *
+ * Non-transactional mode is used when --transactional-id is omitted.
+ */
+public class TransactionalTestProducer {
+
+    public static void main(String[] args) throws Exception {
+        Map<String, String> parsed = parseArgs(args);
+
+        String bootstrapServers = parsed.get("bootstrap-server");
+        String topic = parsed.get("topic");
+        if (bootstrapServers == null || topic == null) {
+            System.err.println("Usage: TransactionalTestProducer --bootstrap-server <servers> --topic <topic>"
+                + " [--transactional-id <id>] [--mode commit|abort|pending] [--num-records <n>] [--waiting-ms <ms>]");
+            Exit.exit(1);
+        }
+
+        String transactionalId = parsed.get("transactional-id");
+        String mode = parsed.getOrDefault("mode", "commit");
+        int numRecords = Integer.parseInt(parsed.getOrDefault("num-records", "1"));
+        long waitingMs = Long.parseLong(parsed.getOrDefault("waiting-ms", "0"));
+
+        produce(bootstrapServers, topic, transactionalId, mode, numRecords, waitingMs);
+    }
+
+    static Map<String, String> parseArgs(String[] args) {
+        Map<String, String> parsed = new HashMap<>();
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "--bootstrap-server":
+                case "--topic":
+                case "--transactional-id":
+                case "--mode":
+                case "--num-records":
+                case "--waiting-ms":
+                    parsed.put(args[i].substring(2), args[++i]);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown argument: " + args[i]);
+            }
+        }
+        return parsed;
+    }
+
+    static void produce(String bootstrapServers, String topic, String transactionalId,
+                        String mode, int numRecords, long waitingMs) throws Exception {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        if (transactionalId != null) {
+            props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+            props.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, "900000");
+        }
+
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(props)) {
+            if (transactionalId != null) {
+                producer.initTransactions();
+                producer.beginTransaction();
+            }
+
+            for (int i = 0; i < numRecords; i++) {
+                producer.send(new ProducerRecord<>(topic, "key-" + i, "value-" + i));
+            }
+            producer.flush();
+
+            if (transactionalId != null) {
+                if (waitingMs > 0) {
+                    Thread.sleep(waitingMs);
+                }
+                switch (mode) {
+                    case "commit":
+                        producer.commitTransaction();
+                        break;
+                    case "abort":
+                        producer.abortTransaction();
+                        break;
+                    case "pending":
+                        // halt to bypass producer.close() which would abort the open transaction
+                        System.out.println("DONE");
+                        System.out.flush();
+                        Exit.halt(0);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unknown mode: " + mode);
+                }
+            }
+
+            System.out.println("DONE");
+        }
+    }
+}


### PR DESCRIPTION
This PR replaces the LSO truncation approach (remove uncommitted transaction tails) with explicit ABORT marker appending during the STOPPING transition. It also switches the mirror fetch isolation level from READ_COMMITTED to READ_UNCOMMITTED so transaction data records are replicated before they are committed/aborted at the source.

Testing done with the source cluster log:
```
offset    pid    content
0         100    record1
1         200    record2
2         100    commit 
3         300    record3
4         200    abort
```
And in the destination cluster after STOPPING, it'll be:
```
0         100    record1
1         200    record2
2         100    commit 
3         300    record3
4         200    abort
--- new ---
5         300    abort
6.        -1     MirrorPidReset
```

When building the abortTxnRecord, we need:
1. producerId
2. producerEpoch
3. coordinatorEpoch

All of them are stored in producerStateManager. 
For (3), the `coordinatorEpoch` is not a field in a normal recordBatch, it will only be set in a committed/aborted record. So, when the producerId had not committed/aborted before, the `coordinatorEpoch` stored in the leader node is -1. The validation in the leader node is that when appending the record, we check if the epoch is >= previous known coordinatorEpoch [here](https://github.com/apache/kafka/blob/trunk/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java#L246). So if the coordinatorEpoch is -1 in the leaderNode cache, we'll use 0. This aligns with the implemntaion in the TransactionsCommand abort command. The abort command goes with this flow:
a. Using describeProducer to the leader node to get the producerState. The producerState is coming from the ProducerStateManager#ProducerStateEntry [here](https://github.com/apache/kafka/blob/trunk/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java#L841). This is the state we get in this PR.
b. Use the returned producerState to abort the txn records [here](https://github.com/apache/kafka/blob/trunk/tools/src/main/java/org/apache/kafka/tools/TransactionsCommand.java#L185).


Will add another PR for bash script testing.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
