### PR TITLE
changing for pending transaction tests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
@@ -146,4 +146,18 @@ public enum ControlRecordType {
         }
         return false;
     }
+
+    public static boolean isAbortTxnBatch(RecordBatch batch) {
+        if (!batch.isControlBatch()) {
+            return false;
+        }
+        Iterator<Record> iterator = batch.iterator();
+        if (iterator.hasNext()) {
+            Record record = iterator.next();
+            if (record.hasKey()) {
+                return parse(record.key()) == ABORT;
+            }
+        }
+        return false;
+    }
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -156,23 +156,32 @@ public class MirrorCoordinator {
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
                 CompletableFuture<Void> bumpLeaderEpochFuture = new CompletableFuture<>();
                 metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions, bumpLeaderEpochFuture);
-                CompletableFuture<Void> updateLastMirrorEpochsFuture = new CompletableFuture<>();
+                CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture = new CompletableFuture<>();
 
+                // Wait until bump leader epoch completes to abort the on-going transaction records.
+                // After the transaction aborting completion, all the txn should be committed or aborted.
+                // So we're safe to update the last mirrored epochs now.
                 bumpLeaderEpochFuture.whenComplete((v, ex) -> {
-                    appendAbortRecordsForOngoingTxns(topicPartitions, tp -> {
-                        updateLastMirrorEpochs(mirrorName, Set.of(tp));
-                        updateLastMirrorEpochsFuture.complete(null);
-                    });
-                });
-                // Wait until (1) bump leader epoch and (2) update last mirror epoch completes, then write mirror pid reset barrier record
-                CompletableFuture.allOf(bumpLeaderEpochFuture, updateLastMirrorEpochsFuture)
-                        .whenComplete((v, ex) -> {
-                            if (ex == null) {
-                                finishStoppingAfterPidBarrierWritten(mirrorName, topicPartitions);
-                            } else {
-                                log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
-                            }
+                    if (ex == null) {
+                        abortOngoingTransactions(topicPartitions, tp -> {
+                            updateLastMirrorEpochs(mirrorName, Set.of(tp), updateLastMirrorEpochsFuture);
                         });
+                    } else {
+                        // TODO: error handling
+                        log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
+                    }
+
+                });
+
+                // After last mirror epoch updated, writing mirror pid reset barrier record
+                updateLastMirrorEpochsFuture
+                    .whenComplete((v, ex) -> {
+                        if (ex == null) {
+                            finishStoppingAfterPidBarrierWritten(mirrorName, topicPartitions);
+                        } else {
+                            log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
+                        }
+                    });
 
                 break;
             case STOPPED:
@@ -239,15 +248,24 @@ public class MirrorCoordinator {
      * otherwise, the LogValidator#getFirstBatchAndMaybeValidateNoMoreBatches will throw exception.
      * So we append in multiple rounds when needed.
      */
-    private void appendAbortRecordsForOngoingTxns(Set<TopicPartition> topicPartitions,
-                                                  Consumer<TopicPartition> callback) {
+    private void abortOngoingTransactions(Set<TopicPartition> topicPartitions,
+                                          Consumer<TopicPartition> callback) {
         Map<TopicPartition, List<MemoryRecords>> recordsByPartition = new HashMap<>();
+        Set<TopicPartition> partitionsWithoutOngoingTxn = new HashSet<>();
         topicPartitions.forEach(tp -> {
             Option<List<MemoryRecords>> record = replicaManager.getLog(tp).map(UnifiedLog::buildEndTransactionRecords);
             if (record.isDefined() && !record.get().isEmpty()) {
                 recordsByPartition.put(tp, record.get());
+            } else {
+                partitionsWithoutOngoingTxn.add(tp);
             }
         });
+
+        // complete the partitions without on-going txn records.
+        if (!partitionsWithoutOngoingTxn.isEmpty()) {
+            topicPartitions.forEach(callback::accept);
+            return;
+        }
 
         log.info("appending abort: {}", recordsByPartition);
         while (!recordsByPartition.isEmpty()) {
@@ -271,13 +289,13 @@ public class MirrorCoordinator {
             });
 
             log.info("run: appending abort: {}", records);
-            appendAbortTxnMarker(records, partitionsToComplete, callback);
+            appendAbortMarkers(records, partitionsToComplete, callback);
         }
     }
 
-    private void appendAbortTxnMarker(Map<TopicIdPartition, MemoryRecords> records,
-                                      Set<TopicPartition> partitionsToComplete,
-                                      Consumer<TopicPartition> callback) {
+    private void appendAbortMarkers(Map<TopicIdPartition, MemoryRecords> records,
+                                    Set<TopicPartition> partitionsToComplete,
+                                    Consumer<TopicPartition> callback) {
         replicaManager.appendRecords(
             // TODO: replace this with Cluster Mirror specific timeout
             Duration.ofSeconds(5).toMillis(),
@@ -290,9 +308,12 @@ public class MirrorCoordinator {
                     TopicPartition tp = partitionRes._1.topicPartition();
                     ProduceResponse.PartitionResponse pr = partitionRes._2;
                     if (pr.error.code() != Errors.NONE.code()) {
+                        // TODO: retry logic
                         log.error("Failed to append end transaction marker for {}: {}", tp, pr.error.message());
                     } else {
-                        partitionsToComplete.forEach(callback::accept);
+                        if (partitionsToComplete.contains(tp)) {
+                            callback.accept(tp);
+                        }
                     }
                     return null;
                 });
@@ -327,7 +348,8 @@ public class MirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
-        updateLastMirrorEpochs(updatedMirrorName, offsets);
+        // do last mirror epochs update in parallel
+        updateLastMirrorEpochs(updatedMirrorName, offsets, new CompletableFuture<>());
 
         WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
         List<WriteMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
@@ -352,7 +374,7 @@ public class MirrorCoordinator {
         metadataManager.getCachedPartitionMetadata(mirrorName, partitions, callback);
     }
 
-    private void updateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
+    private void updateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions, CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture) {
         Map<String, Map<Integer, Integer>> partitionOffsets = new HashMap<>();
         MirrorUtils.groupPartitionsByTopic(topicPartitions).forEach((topic, parts) -> {
             Map<Integer, Integer> offsets = new HashMap<>();
@@ -365,7 +387,7 @@ public class MirrorCoordinator {
             partitionOffsets.put(topic, offsets);
         });
 
-        updateLastMirrorEpochs(mirrorName, partitionOffsets);
+        updateLastMirrorEpochs(mirrorName, partitionOffsets, updateLastMirrorEpochsFuture);
     }
 
     private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(String mirrorName,
@@ -616,7 +638,7 @@ public class MirrorCoordinator {
     }
 
     /** Persists offsets to local or remote coordinators, optionally transitioning to STOPPED. */
-    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
+    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets, CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture) {
         // Separate partitions into local and remote coordinator groups
         Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
         Map<String, Set<MirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
@@ -657,7 +679,21 @@ public class MirrorCoordinator {
                     true,
                     AppendOrigin.COORDINATOR,
                     CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
-                    ignored -> null,
+                    response -> {
+                        response.foreach(res -> {
+                            TopicPartition tp = res._1.topicPartition();
+                            ProduceResponse.PartitionResponse partitionRes = res._2;
+                            if (partitionRes.error.code() != Errors.NONE.code()) {
+                                // TODO: retry logic
+                                log.error("Failed to write last mirrored offsets to coordinator: {}", partitionRes.error.message());
+                                updateLastMirrorEpochsFuture.completeExceptionally(partitionRes.error.exception());
+                            } else {
+                                updateLastMirrorEpochsFuture.complete(tp);
+                            }
+                            return null;
+                        });
+                        return null;
+                    },
                     ignored -> null,
                     RequestLocal.noCaching(),
                     CollectionConverters.asScala(Map.of())
@@ -666,7 +702,20 @@ public class MirrorCoordinator {
 
         // Write to remote coordinator (batched by coordinator node internally)
         if (!remoteTopicMetadata.isEmpty()) {
-            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> { });
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
+                res.data().topics().forEach(topicResult -> {
+                    String name = topicResult.name();
+                    topicResult.partitions().forEach(partitionResult -> {
+                        TopicPartition tp = new TopicPartition(name, partitionResult.partitionIndex());
+                        if (partitionResult.errorCode() != Errors.NONE.code()) {
+                            log.error("Failed to write last mirrored offsets to remote coordinator: {}", partitionResult.errorCode());
+                            updateLastMirrorEpochsFuture.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
+                        } else {
+                            updateLastMirrorEpochsFuture.complete(tp);
+                        }
+                    });
+                });
+            });
         }
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -158,12 +158,11 @@ public class MirrorCoordinator {
                 metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions, bumpLeaderEpochFuture);
                 CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture = new CompletableFuture<>();
 
-                // Wait until bump leader epoch completes to abort the on-going transaction records.
-                // After the transaction aborting completion, all the txn should be committed or aborted.
-                // So we're safe to update the last mirrored epochs now.
+                // Wait until bump leader epoch completes before aborting the ongoing transactions.
                 bumpLeaderEpochFuture.whenComplete((v, ex) -> {
                     if (ex == null) {
                         abortOngoingTransactions(topicPartitions, tp -> {
+                            // When all transactions are decided, we can safely write the LME to the mirror metadata log.
                             updateLastMirrorEpochs(mirrorName, Set.of(tp), updateLastMirrorEpochsFuture);
                         });
                     } else {
@@ -173,11 +172,11 @@ public class MirrorCoordinator {
 
                 });
 
-                // After last mirror epoch updated, writing mirror pid reset barrier record
+                // After LME is stored, we can write the pid reset barrier record to the data logs.
                 updateLastMirrorEpochsFuture
                     .whenComplete((v, ex) -> {
                         if (ex == null) {
-                            finishStoppingAfterPidBarrierWritten(mirrorName, topicPartitions);
+                            writeMirrorPidResetAndStop(mirrorName, topicPartitions);
                         } else {
                             log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
                         }
@@ -186,7 +185,7 @@ public class MirrorCoordinator {
                 break;
             case STOPPED:
                 log.debug("STOPPED for topics {}.", topicPartitions);
-                // topic is writable
+                // Topic is writable.
                 break;
             case FAILED:
                 log.debug("FAILED for topics {}.", topicPartitions);
@@ -261,11 +260,7 @@ public class MirrorCoordinator {
             }
         });
 
-        // complete the partitions without on-going txn records.
-        if (!partitionsWithoutOngoingTxn.isEmpty()) {
-            topicPartitions.forEach(callback::accept);
-            return;
-        }
+        partitionsWithoutOngoingTxn.forEach(callback::accept);
 
         log.info("appending abort: {}", recordsByPartition);
         while (!recordsByPartition.isEmpty()) {
@@ -305,18 +300,14 @@ public class MirrorCoordinator {
             CollectionConverters.asScala(records),
             partitionResponses -> {
                 partitionResponses.foreach(partitionRes -> {
-                    TopicPartition tp = partitionRes._1.topicPartition();
                     ProduceResponse.PartitionResponse pr = partitionRes._2;
                     if (pr.error.code() != Errors.NONE.code()) {
                         // TODO: retry logic
-                        log.error("Failed to append end transaction marker for {}: {}", tp, pr.error.message());
-                    } else {
-                        if (partitionsToComplete.contains(tp)) {
-                            callback.accept(tp);
-                        }
+                        log.error("Failed to append abort marker for {}: {}", partitionRes._1.topicPartition(), pr.error.message());
                     }
                     return null;
                 });
+                partitionsToComplete.forEach(callback::accept);
                 return null;
             },
             ignored -> null,
@@ -532,13 +523,13 @@ public class MirrorCoordinator {
      * Retry the failed partitions until success.
      * TODO: handle failure, we can't retry forever
      */
-    private void finishStoppingAfterPidBarrierWritten(String mirrorName, Set<TopicPartition> topicPartitions) {
+    private void writeMirrorPidResetAndStop(String mirrorName, Set<TopicPartition> topicPartitions) {
         long retryDelayMs = brokerConfig.mirrorConfig().truncationBackoffMs();
         writeMirrorPidResetBarrier(mirrorName, topicPartitions).whenComplete((responses, ex) -> {
             if (ex != null) {
                 log.error("Failed to write PID reset barrier for partitions {} in mirror {}", topicPartitions, mirrorName, ex);
                 scheduler.scheduleOnce("MirrorPidResetBarrierRetry",
-                    () -> finishStoppingAfterPidBarrierWritten(mirrorName, topicPartitions),
+                    () -> writeMirrorPidResetAndStop(mirrorName, topicPartitions),
                     retryDelayMs);
                 return;
             }
@@ -562,7 +553,7 @@ public class MirrorCoordinator {
             }
             if (!failed.isEmpty()) {
                 scheduler.scheduleOnce("MirrorPidResetBarrierRetry",
-                    () -> finishStoppingAfterPidBarrierWritten(mirrorName, failed),
+                    () -> writeMirrorPidResetAndStop(mirrorName, failed),
                     retryDelayMs);
             }
         });

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -154,34 +154,14 @@ public class MirrorCoordinator {
             case STOPPING:
                 log.debug("STOPPING for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                CompletableFuture<Void> bumpLeaderEpochFuture = new CompletableFuture<>();
-                metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions, bumpLeaderEpochFuture);
-                CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture = new CompletableFuture<>();
-
-                // Wait until bump leader epoch completes before aborting the ongoing transactions.
-                bumpLeaderEpochFuture.whenComplete((v, ex) -> {
-                    if (ex == null) {
-                        abortOngoingTransactions(topicPartitions, tp -> {
-                            // When all transactions are decided, we can safely write the LME to the mirror metadata log.
-                            updateLastMirrorEpochs(mirrorName, Set.of(tp), updateLastMirrorEpochsFuture);
-                        });
-                    } else {
-                        // TODO: error handling
-                        log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
-                    }
-
-                });
-
-                // After LME is stored, we can write the pid reset barrier record to the data logs.
-                updateLastMirrorEpochsFuture
-                    .whenComplete((v, ex) -> {
-                        if (ex == null) {
-                            writeMirrorPidResetAndStop(mirrorName, topicPartitions);
-                        } else {
-                            log.error("Failed to complete the STOPPING state for partition: {}", topicPartitions, ex);
-                        }
+                metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions)
+                    .thenCompose(v -> abortOngoingTransactions(topicPartitions))
+                    .thenRun(() -> collectAndUpdateLastMirrorEpochs(mirrorName, topicPartitions))
+                    .thenAccept(v -> writeMirrorPidResetAndStop(mirrorName, topicPartitions))
+                    .exceptionally(ex -> {
+                        log.error("Failed STOPPING transition for {}", topicPartitions, ex);
+                        return null;
                     });
-
                 break;
             case STOPPED:
                 log.debug("STOPPED for topics {}.", topicPartitions);
@@ -247,24 +227,22 @@ public class MirrorCoordinator {
      * otherwise, the LogValidator#getFirstBatchAndMaybeValidateNoMoreBatches will throw exception.
      * So we append in multiple rounds when needed.
      */
-    private void abortOngoingTransactions(Set<TopicPartition> topicPartitions,
-                                          Consumer<TopicPartition> callback) {
+    private CompletableFuture<Void> abortOngoingTransactions(Set<TopicPartition> topicPartitions) {
         Map<TopicPartition, List<MemoryRecords>> recordsByPartition = new HashMap<>();
-        Set<TopicPartition> partitionsWithoutOngoingTxn = new HashSet<>();
         topicPartitions.forEach(tp -> {
             Option<List<MemoryRecords>> record = replicaManager.getLog(tp).map(UnifiedLog::buildEndTransactionRecords);
             if (record.isDefined() && !record.get().isEmpty()) {
                 recordsByPartition.put(tp, record.get());
-            } else {
-                partitionsWithoutOngoingTxn.add(tp);
             }
         });
 
-        partitionsWithoutOngoingTxn.forEach(callback::accept);
+        if (recordsByPartition.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
 
-        log.info("appending abort: {}", recordsByPartition);
+        log.debug("Appending abort markers for partitions: {}", recordsByPartition.keySet());
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
         while (!recordsByPartition.isEmpty()) {
-            Set<TopicPartition> partitionsToComplete = new HashSet<>();
             Map<TopicIdPartition, MemoryRecords> records = new HashMap<>();
             recordsByPartition.entrySet().removeIf(entry -> {
                 TopicPartition tp = entry.getKey();
@@ -275,22 +253,15 @@ public class MirrorCoordinator {
                     records.put(replicaManager.topicIdPartition(tp), record);
                     it.remove();
                 }
-
-                if (recordsList.isEmpty()) {
-                    partitionsToComplete.add(tp);
-                    return true;
-                }
-                return false;
+                return recordsList.isEmpty();
             });
-
-            log.info("run: appending abort: {}", records);
-            appendAbortMarkers(records, partitionsToComplete, callback);
+            futures.add(appendAbortMarkers(records));
         }
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
-    private void appendAbortMarkers(Map<TopicIdPartition, MemoryRecords> records,
-                                    Set<TopicPartition> partitionsToComplete,
-                                    Consumer<TopicPartition> callback) {
+    private CompletableFuture<Void> appendAbortMarkers(Map<TopicIdPartition, MemoryRecords> records) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         replicaManager.appendRecords(
             // TODO: replace this with Cluster Mirror specific timeout
             Duration.ofSeconds(5).toMillis(),
@@ -307,13 +278,14 @@ public class MirrorCoordinator {
                     }
                     return null;
                 });
-                partitionsToComplete.forEach(callback::accept);
+                future.complete(null);
                 return null;
             },
             ignored -> null,
             RequestLocal.noCaching(),
             CollectionConverters.asScala(Map.of())
         );
+        return future;
     }
 
     /** Writes partition state and offset updates to the internal topic. */
@@ -339,8 +311,7 @@ public class MirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
-        // do last mirror epochs update in parallel
-        updateLastMirrorEpochs(updatedMirrorName, offsets, new CompletableFuture<>());
+        updateLastMirrorEpochs(updatedMirrorName, offsets);
 
         WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
         List<WriteMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
@@ -365,7 +336,7 @@ public class MirrorCoordinator {
         metadataManager.getCachedPartitionMetadata(mirrorName, partitions, callback);
     }
 
-    private void updateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions, CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture) {
+    private void collectAndUpdateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
         Map<String, Map<Integer, Integer>> partitionOffsets = new HashMap<>();
         MirrorUtils.groupPartitionsByTopic(topicPartitions).forEach((topic, parts) -> {
             Map<Integer, Integer> offsets = new HashMap<>();
@@ -378,7 +349,7 @@ public class MirrorCoordinator {
             partitionOffsets.put(topic, offsets);
         });
 
-        updateLastMirrorEpochs(mirrorName, partitionOffsets, updateLastMirrorEpochsFuture);
+        updateLastMirrorEpochs(mirrorName, partitionOffsets);
     }
 
     private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(String mirrorName,
@@ -628,8 +599,8 @@ public class MirrorCoordinator {
         return metadataManager.getLastMirrorEpochs(mirrorName);
     }
 
-    /** Persists offsets to local or remote coordinators, optionally transitioning to STOPPED. */
-    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets, CompletableFuture<TopicPartition> updateLastMirrorEpochsFuture) {
+    /** Persists offsets to local or remote coordinators. */
+    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
         // Separate partitions into local and remote coordinator groups
         Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
         Map<String, Set<MirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
@@ -670,21 +641,7 @@ public class MirrorCoordinator {
                     true,
                     AppendOrigin.COORDINATOR,
                     CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
-                    response -> {
-                        response.foreach(res -> {
-                            TopicPartition tp = res._1.topicPartition();
-                            ProduceResponse.PartitionResponse partitionRes = res._2;
-                            if (partitionRes.error.code() != Errors.NONE.code()) {
-                                // TODO: retry logic
-                                log.error("Failed to write last mirrored offsets to coordinator: {}", partitionRes.error.message());
-                                updateLastMirrorEpochsFuture.completeExceptionally(partitionRes.error.exception());
-                            } else {
-                                updateLastMirrorEpochsFuture.complete(tp);
-                            }
-                            return null;
-                        });
-                        return null;
-                    },
+                    ignored -> null,
                     ignored -> null,
                     RequestLocal.noCaching(),
                     CollectionConverters.asScala(Map.of())
@@ -693,20 +650,7 @@ public class MirrorCoordinator {
 
         // Write to remote coordinator (batched by coordinator node internally)
         if (!remoteTopicMetadata.isEmpty()) {
-            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
-                res.data().topics().forEach(topicResult -> {
-                    String name = topicResult.name();
-                    topicResult.partitions().forEach(partitionResult -> {
-                        TopicPartition tp = new TopicPartition(name, partitionResult.partitionIndex());
-                        if (partitionResult.errorCode() != Errors.NONE.code()) {
-                            log.error("Failed to write last mirrored offsets to remote coordinator: {}", partitionResult.errorCode());
-                            updateLastMirrorEpochsFuture.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
-                        } else {
-                            updateLastMirrorEpochsFuture.complete(tp);
-                        }
-                    });
-                });
-            });
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> { });
         }
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -20,6 +20,7 @@ import kafka.server.KafkaConfig;
 import kafka.server.ReplicaManager;
 
 import org.apache.kafka.clients.admin.MirrorDescription;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
@@ -29,6 +30,7 @@ import org.apache.kafka.common.message.WriteMirrorStatesResponseData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordUtils;
 import org.apache.kafka.common.record.DefaultRecordBatch;
 import org.apache.kafka.common.record.FileRecords;
@@ -57,6 +59,7 @@ import org.apache.kafka.server.util.Scheduler;
 import org.apache.kafka.storage.internals.log.AppendOrigin;
 import org.apache.kafka.storage.internals.log.FetchDataInfo;
 
+import org.apache.kafka.storage.internals.log.UnifiedLog;
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
@@ -74,6 +77,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import scala.Option;
 import scala.jdk.javaapi.CollectionConverters;
 
 import static org.apache.kafka.common.utils.Utils.require;
@@ -154,9 +158,12 @@ public class MirrorCoordinator {
                 CompletableFuture<Void> bumpLeaderEpochFuture = new CompletableFuture<>();
                 metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions, bumpLeaderEpochFuture);
                 CompletableFuture<Void> updateLastMirrorEpochsFuture = new CompletableFuture<>();
-                truncateToLastStableOffset(topicPartitions, tp -> {
-                    updateLastMirrorEpochs(mirrorName, Set.of(tp));
-                    updateLastMirrorEpochsFuture.complete(null);
+
+                bumpLeaderEpochFuture.whenComplete((v, ex) -> {
+                    appendAbortRecordsForOngoingTxns(topicPartitions, tp -> {
+                        updateLastMirrorEpochs(mirrorName, Set.of(tp));
+                        updateLastMirrorEpochsFuture.complete(null);
+                    });
                 });
                 // Wait until (1) bump leader epoch and (2) update last mirror epoch completes, then write mirror pid reset barrier record
                 CompletableFuture.allOf(bumpLeaderEpochFuture, updateLastMirrorEpochsFuture)
@@ -228,20 +235,74 @@ public class MirrorCoordinator {
         });
     }
 
-    private void truncateToLastStableOffset(Set<TopicPartition> topicPartitions,
-                                            Consumer<TopicPartition> callback) {
-        Map<TopicPartition, Long> offsets = new HashMap<>();
+    /**
+     * {@link kafka.server.ReplicaManager#appendRecords} allows only one record batch per partition per call,
+     * otherwise, the LogValidator#getFirstBatchAndMaybeValidateNoMoreBatches will throw exception.
+     * So we append in multiple rounds when needed.
+     */
+    private void appendAbortRecordsForOngoingTxns(Set<TopicPartition> topicPartitions,
+                                                  Consumer<TopicPartition> callback) {
+        Map<TopicPartition, List<MemoryRecords>> recordsByPartition = new HashMap<>();
         topicPartitions.forEach(tp -> {
-            if (replicaManager.getLog(tp).isDefined()) {
-                offsets.put(tp, replicaManager.getLog(tp).get().lastStableOffset());
-            } else {
-                log.warn("Cannot get the log for partition: {}. Skipping log truncation.", tp);
-                callback.accept(tp);
+            Option<List<MemoryRecords>> record = replicaManager.getLog(tp).map(UnifiedLog::buildEndTransactionRecords);
+            if (record.isDefined() && !record.get().isEmpty()) {
+                recordsByPartition.put(tp, record.get());
             }
         });
-        if (!offsets.isEmpty()) {
-            replicaManager.maybeTruncate(offsets, callback);
+
+        log.info("appending abort: {}", recordsByPartition);
+        while (!recordsByPartition.isEmpty()) {
+            Set<TopicPartition> partitionsToComplete = new HashSet<>();
+            Map<TopicIdPartition, MemoryRecords> records = new HashMap<>();
+            recordsByPartition.entrySet().removeIf(entry -> {
+               TopicPartition tp = entry.getKey();
+               List<MemoryRecords> recordsList = entry.getValue();
+               Iterator<MemoryRecords> it = recordsList.iterator();
+               if (it.hasNext()) {
+                   MemoryRecords record = it.next();
+                   records.put(replicaManager.topicIdPartition(tp), record);
+                   it.remove();
+               }
+
+               if (recordsList.isEmpty()) {
+                   partitionsToComplete.add(tp);
+                   return true;
+               }
+               return false;
+            });
+
+            log.info("run: appending abort: {}", records);
+            appendAbortTxnMarker(records, partitionsToComplete, callback);
         }
+    }
+
+    private void appendAbortTxnMarker(Map<TopicIdPartition, MemoryRecords> records,
+                                      Set<TopicPartition> partitionsToComplete,
+                                      Consumer<TopicPartition> callback) {
+        replicaManager.appendRecords(
+            // TODO: replace this with Cluster Mirror specific timeout
+            Duration.ofSeconds(5).toMillis(),
+            (short) -1,
+            true,
+            AppendOrigin.COORDINATOR,
+            CollectionConverters.asScala(records),
+            partitionResponses -> {
+                partitionResponses.foreach(partitionRes -> {
+                    TopicPartition tp = partitionRes._1.topicPartition();
+                    ProduceResponse.PartitionResponse pr = partitionRes._2;
+                    if (pr.error.code() != Errors.NONE.code()) {
+                        log.error("Failed to append end transaction marker for {}: {}", tp, pr.error.message());
+                    } else {
+                        partitionsToComplete.forEach(callback::accept);
+                    }
+                    return null;
+                });
+                return null;
+            },
+            ignored -> null,
+            RequestLocal.noCaching(),
+            CollectionConverters.asScala(Map.of())
+        );
     }
 
     /** Writes partition state and offset updates to the internal topic. */

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.message.WriteMirrorStatesResponseData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordUtils;
 import org.apache.kafka.common.record.DefaultRecordBatch;
 import org.apache.kafka.common.record.FileRecords;
@@ -58,8 +57,8 @@ import org.apache.kafka.server.storage.log.FetchIsolation;
 import org.apache.kafka.server.util.Scheduler;
 import org.apache.kafka.storage.internals.log.AppendOrigin;
 import org.apache.kafka.storage.internals.log.FetchDataInfo;
-
 import org.apache.kafka.storage.internals.log.UnifiedLog;
+
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
@@ -255,20 +254,20 @@ public class MirrorCoordinator {
             Set<TopicPartition> partitionsToComplete = new HashSet<>();
             Map<TopicIdPartition, MemoryRecords> records = new HashMap<>();
             recordsByPartition.entrySet().removeIf(entry -> {
-               TopicPartition tp = entry.getKey();
-               List<MemoryRecords> recordsList = entry.getValue();
-               Iterator<MemoryRecords> it = recordsList.iterator();
-               if (it.hasNext()) {
-                   MemoryRecords record = it.next();
-                   records.put(replicaManager.topicIdPartition(tp), record);
-                   it.remove();
-               }
+                TopicPartition tp = entry.getKey();
+                List<MemoryRecords> recordsList = entry.getValue();
+                Iterator<MemoryRecords> it = recordsList.iterator();
+                if (it.hasNext()) {
+                    MemoryRecords record = it.next();
+                    records.put(replicaManager.topicIdPartition(tp), record);
+                    it.remove();
+                }
 
-               if (recordsList.isEmpty()) {
-                   partitionsToComplete.add(tp);
-                   return true;
-               }
-               return false;
+                if (recordsList.isEmpty()) {
+                    partitionsToComplete.add(tp);
+                    return true;
+                }
+                return false;
             });
 
             log.info("run: appending abort: {}", records);

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -135,11 +135,11 @@ public class MirrorCoordinator {
     private void handleStateTransition(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
         switch (newState) {
             case PREPARING:
-                log.debug("PREPARING for topics {}.", topicPartitions);
+                log.info("PREPARING for topics {}.", topicPartitions);
                 scheduleTruncation(mirrorName, topicPartitions);
                 break;
             case MIRRORING:
-                log.debug("MIRRORING topics {}.", topicPartitions);
+                log.info("MIRRORING topics {}.", topicPartitions);
                 replicaManager.maybeCreateMirrorFetchers(mirrorName, topicPartitions);
                 break;
             case PAUSING:
@@ -152,11 +152,19 @@ public class MirrorCoordinator {
                 // topic is still read-only
                 break;
             case STOPPING:
-                log.debug("STOPPING for topics {}.", topicPartitions);
+                log.info("STOPPING for topics {}.", topicPartitions);
+                // The order of STOPPING process:
+                // 1. remove fetcher for mirror fetcher
+                // 2. store LME because that's the last mirrored epoch before bumping leader epoch
+                // 3. bump leader epoch to draw a line for future failback cluster recognize the new added records
+                // 4. abort ongoing transactions using the updated leader epoch
+                // 5. reset pid to expire all existing PIDs, including the new appended records in (4)
+                // 6. move to STOPPED state
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions)
+
+                collectAndUpdateLastMirrorEpochs(mirrorName, topicPartitions)
+                    .thenCompose(v -> metadataManager.sendBumpLeaderEpoch(replicaManager.logManager(), topicPartitions))
                     .thenCompose(v -> abortOngoingTransactions(topicPartitions))
-                    .thenRun(() -> collectAndUpdateLastMirrorEpochs(mirrorName, topicPartitions))
                     .thenAccept(v -> writeMirrorPidResetAndStop(mirrorName, topicPartitions))
                     .exceptionally(ex -> {
                         log.error("Failed STOPPING transition for {}", topicPartitions, ex);
@@ -164,11 +172,11 @@ public class MirrorCoordinator {
                     });
                 break;
             case STOPPED:
-                log.debug("STOPPED for topics {}.", topicPartitions);
+                log.info("STOPPED for topics {}.", topicPartitions);
                 // Topic is writable.
                 break;
             case FAILED:
-                log.debug("FAILED for topics {}.", topicPartitions);
+                log.info("FAILED for topics {}.", topicPartitions);
                 // TODO: implement recovery actions (i.e. exponential backoff retry)
                 break;
             default:
@@ -279,6 +287,7 @@ public class MirrorCoordinator {
                     return null;
                 });
                 future.complete(null);
+
                 return null;
             },
             ignored -> null,
@@ -336,7 +345,8 @@ public class MirrorCoordinator {
         metadataManager.getCachedPartitionMetadata(mirrorName, partitions, callback);
     }
 
-    private void collectAndUpdateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
+    private CompletableFuture<Void> collectAndUpdateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
         Map<String, Map<Integer, Integer>> partitionOffsets = new HashMap<>();
         MirrorUtils.groupPartitionsByTopic(topicPartitions).forEach((topic, parts) -> {
             Map<Integer, Integer> offsets = new HashMap<>();
@@ -349,7 +359,9 @@ public class MirrorCoordinator {
             partitionOffsets.put(topic, offsets);
         });
 
-        updateLastMirrorEpochs(mirrorName, partitionOffsets);
+        futures.add(updateLastMirrorEpochs(mirrorName, partitionOffsets));
+
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
     private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(String mirrorName,
@@ -600,7 +612,8 @@ public class MirrorCoordinator {
     }
 
     /** Persists offsets to local or remote coordinators. */
-    public void updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
+    public CompletableFuture<Void> updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         // Separate partitions into local and remote coordinator groups
         Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
         Map<String, Set<MirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
@@ -641,7 +654,21 @@ public class MirrorCoordinator {
                     true,
                     AppendOrigin.COORDINATOR,
                     CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
-                    ignored -> null,
+                    response -> {
+                        response.foreach(res -> {
+                            TopicPartition tp = res._1.topicPartition();
+                            ProduceResponse.PartitionResponse partitionRes = res._2;
+                            if (partitionRes.error.code() != Errors.NONE.code()) {
+                                // TODO: retry logic
+                                log.error("Failed to write last mirrored offsets to coordinator: {}", partitionRes.error.message());
+                                future.completeExceptionally(partitionRes.error.exception());
+                            } else {
+                                future.complete(null);
+                            }
+                            return null;
+                        });
+                        return null;
+                    },
                     ignored -> null,
                     RequestLocal.noCaching(),
                     CollectionConverters.asScala(Map.of())
@@ -650,8 +677,23 @@ public class MirrorCoordinator {
 
         // Write to remote coordinator (batched by coordinator node internally)
         if (!remoteTopicMetadata.isEmpty()) {
-            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> { });
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
+                res.data().topics().forEach(topicResult -> {
+                    String name = topicResult.name();
+                    topicResult.partitions().forEach(partitionResult -> {
+                        TopicPartition tp = new TopicPartition(name, partitionResult.partitionIndex());
+                        if (partitionResult.errorCode() != Errors.NONE.code()) {
+                            log.error("Failed to write last mirrored offsets to remote coordinator: {}", partitionResult.errorCode());
+                            future.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
+                        } else {
+                            future.complete(null);
+                        }
+                    });
+                });
+            });
         }
+
+        return future;
     }
 
     private static CoordinatorRecord generateMirrorPartitionState(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -985,7 +985,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         metadataRefreshError.incrementAndGet();
     }
 
-    public void sendBumpLeaderEpoch(LogManager logManager, Set<TopicPartition> topicPartitions, CompletableFuture<Void> future) {
+    public CompletableFuture<Void> sendBumpLeaderEpoch(LogManager logManager, Set<TopicPartition> topicPartitions) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         Map<TopicPartition, Integer> partitionEpochs = new HashMap<>();
 
         List<BumpLeaderEpochsRequestData.TopicState> topicStates = new ArrayList<>();
@@ -1020,6 +1021,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 log.warn("BumpLeaderEpoch request timed out");
             }
         });
+        return future;
     }
 
     /**

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -343,7 +343,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             Set<TopicPartition> incompletedTps = bumpLeaderEpoch.partitionToEpoch().entrySet().stream().filter(entry -> {
                 TopicPartition tp = entry.getKey();
                 int epoch = entry.getValue();
-                return metadataImage.topics().getPartition(metadataImage.topics().getTopic(tp.topic()).id(), tp.partition()).leaderEpoch < epoch;
+                return metadataImage.topics().getPartition(metadataImage.topics().getTopic(tp.topic()).id(), tp.partition()).leaderEpoch <= epoch;
             }).map(Map.Entry::getKey).collect(Collectors.toSet());
             if (incompletedTps.isEmpty()) {
                 bumpLeaderEpoch.future().complete(null);

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -243,7 +243,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
       // Use different fetch request types based on whether we're doing cross-cluster mirroring.
       val requestBuilder = if (isClusterMirror) {
         // Cross-cluster mirroring (MirrorFetcherThread): Use consumer fetch to skip ISR logic on source cluster.
-        FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend).isolationLevel(IsolationLevel.READ_COMMITTED)
+        FetchRequest.Builder.forConsumer(version, maxWait, minBytes, fetchData.toSend).isolationLevel(IsolationLevel.READ_UNCOMMITTED)
       } else {
         // Intra-cluster replication (ReplicaFetcherThread): Use replica fetch even when fetching to enable proper epoch validation.
         FetchRequest.Builder.forReplica(version, brokerConfig.brokerId, brokerEpochSupplier(), maxWait, minBytes, fetchData.toSend)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1422,7 +1422,7 @@ class ReplicaManager(val config: KafkaConfig,
         val allowed = state == MirrorPartitionState.STOPPED ||
           (state == MirrorPartitionState.STOPPING &&
             (origin == AppendOrigin.COORDINATOR || origin == AppendOrigin.REPLICATION) &&
-            records.batches().asScala.exists(ControlRecordType.isMirrorPidResetBatch))
+            records.batches().asScala.exists(b => ControlRecordType.isMirrorPidResetBatch(b) || ControlRecordType.isAbortTxnBatch(b)))
         if (!allowed) {
           throw new ReadOnlyTopicException("Cannot append to read-only partition %s on broker %d (mirrorName=%s)"
             .format(partition.topicPartition, localBrokerId, mirrorName))

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -47,8 +47,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -287,6 +289,12 @@ public class ProducerStateManager {
      */
     public Map<Long, ProducerStateEntry> activeProducers() {
         return Collections.unmodifiableMap(producers);
+    }
+
+    public Set<ProducerStateEntry> ongoingTransactionProducers() {
+        return ongoingTxns.values().stream()
+                .map(txn -> producers.get(txn.producerId))
+                .collect(Collectors.toSet());
     }
 
     public boolean isEmpty() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -291,7 +291,7 @@ public class ProducerStateManager {
         return Collections.unmodifiableMap(producers);
     }
 
-    public Set<ProducerStateEntry> ongoingTransactionProducers() {
+    public Set<ProducerStateEntry> producersWithOngoingTxns() {
         return ongoingTxns.values().stream()
                 .map(txn -> producers.get(txn.producerId))
                 .collect(Collectors.toSet());

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -822,14 +822,14 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     public List<MemoryRecords> buildEndTransactionRecords() {
-        Set<ProducerStateEntry> ongoingTxns = producerStateManager.ongoingTransactionProducers();
+        Set<ProducerStateEntry> ongoingTxns = producerStateManager.producersWithOngoingTxns();
         List<MemoryRecords> records = new LinkedList<>();
 
         ongoingTxns.forEach(producerStateEntry -> {
             // coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
             // Setting it to 0 if the coordinator epoch in the leader node has no coordinator epoch info (-1).
             // This could happen when this PID has not committed/aborted yet. Setting it to 0 can pass the validation
-            // and also align with the implementation in TansactionsCommand#buildAbortSpec when we want to force aborting a pending txn record.
+            // and also align with the implementation in TransactionsCommand#buildAbortSpec when we want to force aborting a pending txn record.
             int coordinatorEpoch = producerStateEntry.coordinatorEpoch() < 0 ? 0 : producerStateEntry.coordinatorEpoch();
             records.add(MemoryRecords.withEndTransactionMarker(producerStateEntry.producerId(),
                     producerStateEntry.producerEpoch(),

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -822,11 +822,11 @@ public class UnifiedLog implements AutoCloseable {
     }
 
     public List<MemoryRecords> buildEndTransactionRecords() {
-        Set<ProducerStateEntry> ongoingTxns = producerStateManager.producersWithOngoingTxns();
+        Set<ProducerStateEntry> producers = producerStateManager.producersWithOngoingTxns();
         List<MemoryRecords> records = new LinkedList<>();
 
-        ongoingTxns.forEach(producerStateEntry -> {
-            // coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
+        producers.forEach(producerStateEntry -> {
+            // Coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
             // Setting it to 0 if the coordinator epoch in the leader node has no coordinator epoch info (-1).
             // This could happen when this PID has not committed/aborted yet. Setting it to 0 can pass the validation
             // and also align with the implementation in TransactionsCommand#buildAbortSpec when we want to force aborting a pending txn record.

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -828,9 +828,14 @@ public class UnifiedLog implements AutoCloseable {
         List<MemoryRecords> records = new LinkedList<>();
 
         ongoingTxns.forEach((producerStateEntry) -> {
+            // coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
+            // Setting it to 0 if the coordinator epoch in the leader node has no coordinator epoch info (-1).
+            // This could happen when this PID has not committed/aborted yet. Setting it to 0 can pass the validation
+            // and also align with the implementation in TansactionsCommand#buildAbortSpec when we want to force aborting a pending txn record.
+            int coordinatorEpoch = producerStateEntry.coordinatorEpoch() < 0 ? 0 : producerStateEntry.coordinatorEpoch();
             records.add(MemoryRecords.withEndTransactionMarker(producerStateEntry.producerId(),
                     producerStateEntry.producerEpoch(),
-                new EndTransactionMarker(ControlRecordType.ABORT, producerStateEntry.coordinatorEpoch())));
+                new EndTransactionMarker(ControlRecordType.ABORT, coordinatorEpoch)));
         });
 
         return records;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -33,6 +33,8 @@ import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.DescribeProducersResponseData;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.DefaultRecordBatch;
+import org.apache.kafka.common.record.EndTransactionMarker;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -73,13 +75,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
@@ -816,6 +821,19 @@ public class UnifiedLog implements AutoCloseable {
 
     public int producerIdCount() {
         return producerStateManager.producerIdCount();
+    }
+
+    public List<MemoryRecords> buildEndTransactionRecords() {
+        Set<ProducerStateEntry> ongoingTxns = producerStateManager.ongoingTransactionProducers();
+        List<MemoryRecords> records = new LinkedList<>();
+
+        ongoingTxns.forEach((producerStateEntry) -> {
+            records.add(MemoryRecords.withEndTransactionMarker(producerStateEntry.producerId(),
+                    producerStateEntry.producerEpoch(),
+                new EndTransactionMarker(ControlRecordType.ABORT, producerStateEntry.coordinatorEpoch())));
+        });
+
+        return records;
     }
 
     public List<DescribeProducersResponseData.ProducerState> activeProducers() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -33,7 +33,6 @@ import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.DescribeProducersResponseData;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordType;
-import org.apache.kafka.common.record.DefaultRecordBatch;
 import org.apache.kafka.common.record.EndTransactionMarker;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
@@ -75,7 +74,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -827,7 +825,7 @@ public class UnifiedLog implements AutoCloseable {
         Set<ProducerStateEntry> ongoingTxns = producerStateManager.ongoingTransactionProducers();
         List<MemoryRecords> records = new LinkedList<>();
 
-        ongoingTxns.forEach((producerStateEntry) -> {
+        ongoingTxns.forEach(producerStateEntry -> {
             // coordinator epoch is used to validate if the same producerId is committed/aborted by an epoch >= known epoch in ProducerAppendInfo#checkCoordinatorEpoch.
             // Setting it to 0 if the coordinator epoch in the leader node has no coordinator epoch info (-1).
             // This could happen when this PID has not committed/aborted yet. Setting it to 0 can pass the validation

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -74,7 +74,7 @@ public class ProducerPerformance {
                 payload = new byte[config.recordSize];
             }
             // not thread-safe, do not share with other threads
-            SplittableRandom random = new SplittableRandom(System.currentTimeMillis());
+            SplittableRandom random = new SplittableRandom(0);
             ProducerRecord<byte[], byte[]> record;
 
             if (config.warmupRecords > 0) {

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -74,7 +74,7 @@ public class ProducerPerformance {
                 payload = new byte[config.recordSize];
             }
             // not thread-safe, do not share with other threads
-            SplittableRandom random = new SplittableRandom(0);
+            SplittableRandom random = new SplittableRandom(System.currentTimeMillis());
             ProducerRecord<byte[], byte[]> record;
 
             if (config.warmupRecords > 0) {
@@ -109,7 +109,13 @@ public class ProducerPerformance {
 
                 currentTransactionSize++;
                 if (config.transactionsEnabled && config.transactionDurationMs <= (sendStartMs - transactionStartTime)) {
-                    producer.commitTransaction();
+                    if (!config.pending) {
+                        if (config.abort) {
+                            producer.abortTransaction();
+                        } else {
+                            producer.commitTransaction();
+                        }
+                    }
                     currentTransactionSize = 0;
                 }
 
@@ -118,11 +124,28 @@ public class ProducerPerformance {
                 }
             }
 
-            if (config.transactionsEnabled && currentTransactionSize != 0)
-                producer.commitTransaction();
+            if (config.transactionsEnabled && currentTransactionSize != 0) {
+                if (!config.pending) {
+                    if (config.waiting) {
+                        Thread.sleep(5000);
+                    }
+                    if (config.abort) {
+                        Thread.sleep(500);
+                        producer.abortTransaction();
+                    } else {
+                        producer.commitTransaction();
+                    }
+                }
+            }
 
             if (!config.shouldPrintMetrics) {
-                producer.close();
+                // don't close the producer here to cause pending txn
+                if (!config.pending) {
+                    producer.close();
+                } else {
+                    producer.flush();
+                    System.out.println("Pending transactions, not closing the producer.");
+                }
 
                 /* print final results */
                 stats.printTotal();
@@ -145,7 +168,13 @@ public class ProducerPerformance {
 
                 /* print out metrics */
                 ToolsUtils.printMetrics(producer.metrics());
-                producer.close();
+
+                // don't close the producer here to cause pending txn
+                if (!config.pending) {
+                    producer.close();
+                } else {
+                    System.out.println("Pending transactions, not closing the producer.");
+                }
             }
         } catch (ArgumentParserException e) {
             if (args.length == 0) {
@@ -155,6 +184,8 @@ public class ProducerPerformance {
                 parser.handleError(e);
                 Exit.exit(1);
             }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
 
     }
@@ -336,6 +367,24 @@ public class ProducerPerformance {
                        "specified via --producer.config or --producer-props. Note that if the transactional id " +
                        "is not specified while --transaction-duration-ms is provided, the default value for the " +
                        "transactional id will be performance-producer- followed by a random uuid.");
+
+        parser.addArgument("--abort")
+                .action(storeTrue())
+                .type(Boolean.class)
+                .metavar("ABORT")
+                .dest("abort");
+
+        parser.addArgument("--pending")
+                .action(storeTrue())
+                .type(Boolean.class)
+                .metavar("PENDING")
+                .dest("pending");
+
+        parser.addArgument("--waiting")
+                .action(storeTrue())
+                .type(Boolean.class)
+                .metavar("WAITING")
+                .dest("waiting");
 
         parser.addArgument("--transaction-duration-ms")
                .action(store())
@@ -540,6 +589,9 @@ public class ProducerPerformance {
         final Long transactionDurationMs;
         final boolean transactionsEnabled;
         final List<byte[]> payloadByteList;
+        final boolean abort;
+        final boolean pending;
+        final boolean waiting;
 
         public ConfigPostProcessor(ArgumentParser parser, String[] args) throws IOException, ArgumentParserException {
             Namespace namespace = parser.parseArgs(args);
@@ -577,6 +629,10 @@ public class ProducerPerformance {
                     ? "\n" : namespace.getString("payloadDelimiter");
             this.payloadByteList = readPayloadFile(payloadFilePath, payloadDelimiter);
             this.producerProps = readProps(producerConfigs, producerConfigFile);
+
+            this.abort = namespace.getBoolean("abort");
+            this.pending = namespace.getBoolean("pending");
+            this.waiting = namespace.getBoolean("waiting");
             // setup transaction related configs
             this.transactionsEnabled = transactionDurationMsArg != null
                     || transactionIdArg != null


### PR DESCRIPTION
Adding 3 more options in producer performance command:
1. abort: to abort a txn record
2. pending: to create a txn record without committing/aborting
3. waiting: sending a data record and waiting for 5 seconds before committing/aborting it. This is for creating the interleaving txn records, ex: 
- write a txn record: PID: 0, value: A
- write a txn record without commiting/aborting: PID: 1, value: B
- commit the 1st record for PID 0.

This is tested using `test-abort-txn` method in this [test script](https://gist.github.com/showuon/14d7d87eb3b8a78404b04b0107fab18f).  The goal of test is to make sure the records appended by STOPPING process are the same as the ABORT records appended by `kafka-transactions.sh`.
Test procedure:
1. create a topic `new-topic`
2. write 1 txn record to create the __transaction_state topic
3. restart the brokers to bump the leader epoch, including the coordinatorEpoch
4. Sending interleaving txn records to topic, including committed txn record, aborted txn record, non-txn record, pending record.
5. Verify there are 2 on-going txn records (not committed/aborted)
6. Starting cluster mirrors
7. Failing over
8. Making sure the destination contain 3 more records appended when in STOPPING state: 2 abort records + 1 PID reset record
9. Aborting 2 on-going txn records in source cluster using txn command, so that we can make sure the records appended by the command is the same as the one appended by cluster mirroring feature.
10. Checking log after txn command aborting, the last 2 ABORT records in server1/2 should be the same as the one in server4/5 on producerId/producerEpoch/coordinatorEpoch fields
11. Consume read_committed and read_uncommitted from source and destination cluster to make sure the results are the same
12. writing more txn records, non-txn records, into destination cluster, to make sure after failover, the desitnation cluster can still appending txn and non-txn records.
13. Consume read_committed and read_uncommitted from the destination cluster. Making sure the records appended after failover are able to be read successfully.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
