### PR TITLE
Fix stop/pause issue with mirror.name validator

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -74,7 +74,7 @@ class LogConfigTest {
       case TopicConfig.COMPRESSION_ZSTD_LEVEL_CONFIG => assertPropertyInvalid(name, "not_a_number", "-0.1")
       case TopicConfig.REMOTE_LOG_COPY_DISABLE_CONFIG => assertPropertyInvalid(name, "not_a_number", "remove", "0")
       case TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_CONFIG => assertPropertyInvalid(name, "not_a_number", "remove", "0")
-      case TopicConfig.MIRROR_NAME_CONFIG => assertPropertyInvalid(name, "foo.removed", "bar.paused")
+      case TopicConfig.MIRROR_NAME_CONFIG => // no op
       case LogConfig.INTERNAL_SEGMENT_BYTES_CONFIG => // no op
 
       case _ => assertPropertyInvalid(name, "not_a_number", "-1")

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -258,7 +258,7 @@ public class ConfigurationControlManager {
                     continue;
                 }
 
-                String newMirrorName = curVal.endsWith(STOPPED_TOPIC_SUFFIX) ? "" : curVal + STOPPED_TOPIC_SUFFIX;
+                String newMirrorName = curVal.endsWith(STOPPED_TOPIC_SUFFIX) ? "" : originalName + STOPPED_TOPIC_SUFFIX;
                 Map<String, Entry<OpType, String>> keyToOps = Map.of(mirrorNameConfig, new AbstractMap.SimpleImmutableEntry<>(SET, newMirrorName));
 
                 ControllerResult<ApiError> configResult = incrementalAlterConfig(configResource, keyToOps, true);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -252,7 +252,8 @@ public class LogConfig extends AbstractConfig {
                 .define(TopicConfig.REMOTE_LOG_COPY_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_COPY_DISABLE_DOC)
                 .define(TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_DOC)
                 .define(TopicConfig.MIRROR_SUPPORT_UNCLEAN_LEADER_ELECTION_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.MIRROR_SUPPORT_UNCLEAN_LEADER_ELECTION_DOC)
-                .defineInternal(MIRROR_NAME_CONFIG, STRING, "", new MirrorNameValidator(), MEDIUM, MIRROR_NAME_DOC)
+                // suffix validation (.stopped, .paused) is handled by ConfigurationControlManager
+                .defineInternal(MIRROR_NAME_CONFIG, STRING, "", null, MEDIUM, MIRROR_NAME_DOC)
                 .defineInternal(INTERNAL_SEGMENT_BYTES_CONFIG, INT, null, null, MEDIUM, INTERNAL_SEGMENT_BYTES_DOC);
     }
 
@@ -627,25 +628,6 @@ public class LogConfig extends AbstractConfig {
             combinedConfigs.putAll(props);
             Map<?, ?> valueMaps = CONFIG.parse(combinedConfigs);
             validateTopicLogConfigValues(existingConfigs, valueMaps, isRemoteLogStorageSystemEnabled);
-        }
-    }
-
-    public static class MirrorNameValidator implements ConfigDef.Validator {
-        @Override
-        public void ensureValid(String name, Object value) {
-            if (value == null) {
-                throw new ConfigException(name, null);
-            }
-            String mirrorName = (String) value;
-            if (mirrorName.endsWith(".stopped") || mirrorName.endsWith(".paused")) {
-                throw new ConfigException(name, value, "Invalid value `" + name + "` for configuration " +
-                        name + ". The value must not end with a suffix of `.stopped` or `.paused`.");
-            }
-        }
-
-        @Override
-        public String toString() {
-            return "non-empty list";
         }
     }
 

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -312,19 +312,17 @@ class ClusterMirroringTest(Test):
 
         def send_interleaving_txns(topic):
             """Send interleaved transactional and non-transactional records, leaving 2 txns pending."""
-            kafka = self.source_kafka
-            run_producer(kafka, topic, topic + "-a", "commit", waiting_ms=5000, background=True)
-            run_producer(kafka, topic)
-            run_producer(kafka, topic, topic + "-b", "pending")
-            run_producer(kafka, topic, topic + "-d", "pending")
-            run_producer(kafka, topic, topic + "-c", "abort", waiting_ms=5000, background=True)
-            run_producer(kafka, topic, topic + "-d", "pending")
-            run_producer(kafka, topic)
-
-            ongoing = count_ongoing_txns(kafka, topic)
-            assert ongoing == 2, "Expected 2 ongoing transactions, got %d" % ongoing
+            run_producer(self.source_kafka, topic, topic + "-a", "commit", waiting_ms=5000, background=True)
+            run_producer(self.source_kafka, topic)
+            run_producer(self.source_kafka, topic, topic + "-b", "pending")
+            run_producer(self.source_kafka, topic, topic + "-d", "pending")
+            run_producer(self.source_kafka, topic, topic + "-c", "abort", waiting_ms=5000, background=True)
+            run_producer(self.source_kafka, topic, topic + "-d", "pending")
+            run_producer(self.source_kafka, topic)
 
         send_interleaving_txns(topic)
+        ongoing = count_ongoing_txns(self.source_kafka, topic)
+        assert ongoing == 2, "Expected 2 ongoing transactions, got %d" % ongoing
 
         self.producer.stop()
 

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalTestProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalTestProducer.java
@@ -40,7 +40,6 @@ import java.util.Properties;
  * Non-transactional mode is used when --transactional-id is omitted.
  */
 public class TransactionalTestProducer {
-
     public static void main(String[] args) throws Exception {
         Map<String, String> parsed = parseArgs(args);
 


### PR DESCRIPTION
Two fixes applied:

1. ConfigurationControlManager: use originalName instead of curVal when building the stopped suffix (fixes paused->stopped case producing "my-mirror.paused.stopped")
2. LogConfig: removed MirrorNameValidator (the validator was silently blocking internal config changes from stopMirrorTopics and pauseMirrorTopics)

The controller already guards against users directly setting suffixed mirror names via setMirrorConfig.
