### PR TITLE
Allow redefining mirrors?

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/MirrorAlreadyExistsException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/MirrorAlreadyExistsException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class MirrorAlreadyExistsException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MirrorAlreadyExistsException(String message) {
+        super(message);
+    }
+
+    public MirrorAlreadyExistsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -86,6 +86,7 @@ import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.ListenerNotFoundException;
 import org.apache.kafka.common.errors.LogDirNotFoundException;
 import org.apache.kafka.common.errors.MemberIdRequiredException;
+import org.apache.kafka.common.errors.MirrorAlreadyExistsException;
 import org.apache.kafka.common.errors.MirrorAuthorizationException;
 import org.apache.kafka.common.errors.MirrorNotEmptyException;
 import org.apache.kafka.common.errors.MirrorTopicAlreadyPausedException;
@@ -431,14 +432,15 @@ public enum Errors {
     SHARE_SESSION_LIMIT_REACHED(133, "The limit of share sessions has been reached.", ShareSessionLimitReachedException::new),
     READ_ONLY_TOPIC(134, "The topic is read-only.", ReadOnlyTopicException::new),
     INVALID_MIRROR_NAME(135, "The mirror name does not meet the naming rules.", InvalidMirrorNameException::new),
-    UNKNOWN_MIRROR(136, "The mirror does not exist.", UnknownMirrorException::new),
-    TOPIC_ALREADY_IN_MIRROR(137, "The topic is already assigned to a mirror.", TopicAlreadyInMirrorException::new),
-    TOPIC_NOT_IN_MIRROR(138, "The topic does not belong to the specified mirror.", TopicNotInMirrorException::new),
-    MIRROR_TOPIC_ALREADY_PAUSED(139, "The mirror topic is already paused.", MirrorTopicAlreadyPausedException::new),
-    MIRROR_TOPIC_NOT_PAUSED(140, "The mirror topic is not paused.", MirrorTopicNotPausedException::new),
-    MIRROR_TOPIC_BEING_STOPPED(141, "The mirror topic is being stopped.", MirrorTopicBeingStoppedException::new),
-    MIRROR_NOT_EMPTY(142, "The mirror still has active or non-stopped topics.", MirrorNotEmptyException::new),
-    MIRROR_AUTHORIZATION_FAILED(143, "Mirror authorization failed.", MirrorAuthorizationException::new);
+    MIRROR_ALREADY_EXISTS(136, "The mirror already exists.", MirrorAlreadyExistsException::new),
+    UNKNOWN_MIRROR(137, "The mirror does not exist.", UnknownMirrorException::new),
+    TOPIC_ALREADY_IN_MIRROR(138, "The topic is already assigned to a mirror.", TopicAlreadyInMirrorException::new),
+    TOPIC_NOT_IN_MIRROR(139, "The topic does not belong to the specified mirror.", TopicNotInMirrorException::new),
+    MIRROR_TOPIC_ALREADY_PAUSED(140, "The mirror topic is already paused.", MirrorTopicAlreadyPausedException::new),
+    MIRROR_TOPIC_NOT_PAUSED(141, "The mirror topic is not paused.", MirrorTopicNotPausedException::new),
+    MIRROR_TOPIC_BEING_STOPPED(142, "The mirror topic is being stopped.", MirrorTopicBeingStoppedException::new),
+    MIRROR_NOT_EMPTY(143, "The mirror still has active or non-stopped topics.", MirrorNotEmptyException::new),
+    MIRROR_AUTHORIZATION_FAILED(144, "Mirror authorization failed.", MirrorAuthorizationException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -74,6 +74,7 @@ import static org.apache.kafka.common.config.TopicConfig.MIN_IN_SYNC_REPLICAS_CO
 import static org.apache.kafka.common.config.TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG;
 import static org.apache.kafka.common.metadata.MetadataRecordType.CONFIG_RECORD;
 import static org.apache.kafka.common.protocol.Errors.INVALID_CONFIG;
+import static org.apache.kafka.common.protocol.Errors.MIRROR_ALREADY_EXISTS;
 import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_OP;
 
 public class ConfigurationControlManager {
@@ -550,6 +551,14 @@ public class ConfigurationControlManager {
                     + STOPPED_TOPIC_SUFFIX + "' or '" + PAUSED_TOPIC_SUFFIX + "'");
                 return ControllerResult.of(List.of(), data);
             }
+
+            final Map<String, String> existingConfig = getConfigs(resourceEntry.getKey());
+            if (!existingConfig.isEmpty()) {
+                data.setErrorCode(MIRROR_ALREADY_EXISTS.code())
+                    .setErrorMessage("Mirror '" + mirrorName + "' already exists");
+                return ControllerResult.of(List.of(), data);
+            }
+
             ApiError apiError = incrementalAlterConfigResource(resourceEntry.getKey(),
                     resourceEntry.getValue(),
                     newlyCreatedResource,


### PR DESCRIPTION
This is more a question than a PR, but Issues are disabled :)

Currently, it's possible to successfully run
```shell
kafka-mirrors.sh --bootstrap-server localhost:9092 --create --mirror my-mirror --mirror-config my-mirror.properties
```
multiple times. It seems from the code the existing mirror will be updated. Is this expected? As I get from the KIP, `kafka-configs.sh` is supposed to be used to update existing mirrors.
