### PR TITLE
Skip proactive epoch bump on mirror start

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -527,7 +527,8 @@ public class MirrorCoordinator {
                                 });
                             }
 
-                            replicaManager.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
+                            replicaManager.maybeTruncateForLeaderEpoch(epochs,
+                                    partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING));
                         });
                 } catch (Exception e) {
                     log.warn("Failed to truncate to last mirrored offsets for mirror {}, retrying in {} ms", mirrorName, retryDelayMs, e);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -537,8 +537,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     t.transitionTo(mirrorName, tp, MirrorPartitionState.PAUSED);
                 }
             } else if (curState == MirrorPartitionState.PAUSED) {
-                // during PAUSED, the source leader epoch might jump a lot, moving to EPOCH_FENCING first.
-                t.transitionTo(mirrorName, tp, MirrorPartitionState.EPOCH_FENCING);
+                t.transitionTo(mirrorName, tp, MirrorPartitionState.MIRRORING);
             } else if (curState == MirrorPartitionState.UNKNOWN
                     || curState == MirrorPartitionState.STOPPED) {
                 t.transitionTo(mirrorName, tp, MirrorPartitionState.PREPARING);

--- a/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
@@ -128,12 +128,10 @@ public enum MirrorPartitionState {
                         || source == MirrorPartitionState.STOPPED
                         || source == MirrorPartitionState.FAILED;
             case EPOCH_FENCING:
-                return source == MirrorPartitionState.PREPARING
-                        || source == MirrorPartitionState.MIRRORING
-                        || source == MirrorPartitionState.STOPPED
-                        || source == MirrorPartitionState.FAILED;
+                return source == MirrorPartitionState.MIRRORING;
             case MIRRORING:
-                return source == MirrorPartitionState.EPOCH_FENCING
+                return source == MirrorPartitionState.PREPARING
+                        || source == MirrorPartitionState.EPOCH_FENCING
                         || source == MirrorPartitionState.PAUSED;
             case PAUSING:
                 return source == MirrorPartitionState.MIRRORING;


### PR DESCRIPTION
Skip proactive epoch bump on mirror start, let fetcher trigger it when SLE > DLE. When a mirror is starting there is no thread to stop, so there is no penalty and it simplifies the state transition diagram.