### PR TITLE
auto create share group when alter offset

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -800,7 +800,8 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Map.Entry<AlterShareGroupOffsetsResponseData, InitializeShareGroupStateParameters> response = groupMetadataManager.completeAlterShareGroupOffsets(
             groupId,
             alterShareGroupOffsetsRequestData,
-            records
+            records,
+            group
         );
         return new CoordinatorResult<>(
             records,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1171,10 +1171,11 @@ public class GroupMetadataManager {
         String groupId,
         long committedOffset
     ) throws GroupIdNotFoundException {
-        Group group = group(groupId, committedOffset);
+        // Get or create the share group. If the group exists, check that it's empty. If it is created, it is empty.
+        final ShareGroup group = getOrMaybeCreateShareGroup(groupId, true);
 
         if (group.type() == SHARE) {
-            return (ShareGroup) group;
+            return group;
         } else {
             // We don't support upgrading/downgrading between protocols at the moment so
             // we throw an exception if a group exists with the wrong type.
@@ -8190,10 +8191,10 @@ public class GroupMetadataManager {
     public Map.Entry<AlterShareGroupOffsetsResponseData, InitializeShareGroupStateParameters> completeAlterShareGroupOffsets(
         String groupId,
         AlterShareGroupOffsetsRequestData alterShareGroupOffsetsRequest,
-        List<CoordinatorRecord> records
+        List<CoordinatorRecord> records,
+        ShareGroup group
     ) {
         final long currentTimeMs = time.milliseconds();
-        Group group = groups.get(groupId);
         AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection alterShareGroupOffsetsResponseTopics = new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection();
 
         Map<Uuid, InitMapValue> initializingTopics = new HashMap<>();
@@ -8256,7 +8257,7 @@ public class GroupMetadataManager {
         return Map.entry(
             new AlterShareGroupOffsetsResponseData()
                 .setResponses(alterShareGroupOffsetsResponseTopics),
-            buildInitializeShareGroupState(groupId, ((ShareGroup) group).groupEpoch(), offsetByTopicPartitions)
+            buildInitializeShareGroupState(groupId, group.groupEpoch(), offsetByTopicPartitions)
         );
     }
 


### PR DESCRIPTION
Based on [this commit](https://github.com/apache/kafka/pull/20708/changes#diff-00f0f81cf13e66781777d94f7d2e68a581663385c37e98792507f2294c91bb09R8310) in v4.2, create the non-existed share group when alter offsets. Only change the necessary part for test offset sync up functionality only.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
