### PR TITLE
Add mirror state message formatter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2515,6 +2515,7 @@ project(':tools') {
     implementation project(':group-coordinator')
     implementation project(':coordinator-common')
     implementation project(':share-coordinator')
+    implementation project(':mirror-coordinator')
     implementation project(':raft')
     implementation libs.argparse4j
     implementation libs.jacksonDatabind

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/CoordinatorRecordMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/CoordinatorRecordMessageFormatter.java
@@ -82,6 +82,7 @@ public abstract class CoordinatorRecordMessageFormatter implements MessageFormat
 
         try {
             output.write(json.toString().getBytes(UTF_8));
+            output.write('\n');
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/MirrorStateMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/MirrorStateMessageFormatter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.consumer;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.coordinator.mirror.MirrorRecordSerde;
+import org.apache.kafka.coordinator.mirror.generated.CoordinatorRecordJsonConverters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class MirrorStateMessageFormatter extends CoordinatorRecordMessageFormatter {
+
+    public MirrorStateMessageFormatter() {
+        super(new MirrorRecordSerde());
+    }
+
+    @Override
+    protected boolean isRecordTypeAllowed(short recordType) {
+        return true;
+    }
+
+    @Override
+    protected JsonNode keyAsJson(ApiMessage message) {
+        return CoordinatorRecordJsonConverters.writeRecordKeyAsJson(message);
+    }
+
+    @Override
+    protected JsonNode valueAsJson(ApiMessage message, short version) {
+        return CoordinatorRecordJsonConverters.writeRecordValueAsJson(message, version);
+    }
+}


### PR DESCRIPTION
```sh
$ bin/kafka-console-consumer.sh --bootstrap-server :9094 --topic __mirror_state --from-beginning \
  --formatter org.apache.kafka.tools.consumer.MirrorStateMessageFormatter
{"key":{"type":2,"data":{"mirrorName":"my-mirror"}},"value":{"version":0,"data":{"topicName":"my-topic","partition":0,"state":0}}}
{"key":{"type":2,"data":{"mirrorName":"my-mirror"}},"value":{"version":0,"data":{"topicName":"my-topic","partition":0,"state":2}}}
```