### PR TITLE
MirrorFetcherManager: lazy init mirrorFetcherThreadMap

### DIFF
--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -47,7 +47,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
       name = "MirrorFetcherManager id=" + brokerConfig.brokerId,
       clientId = "MirrorReplica",
       numFetchers = brokerConfig.mirrorConfig.numReplicaFetchers) {
-  private val mirrorFetcherThreadMap = new mutable.HashMap[FetcherKey, MirrorFetcherThread]
+  private lazy val mirrorFetcherThreadMap = new mutable.HashMap[FetcherKey, MirrorFetcherThread]
   private val lagInfo = new TrieMap[PartitionLagKey, LagInfo]
 
   override def deadThreadCount: Int = lock synchronized { mirrorFetcherThreadMap.values.count(_.isThreadFailed) }


### PR DESCRIPTION
Ran into a crash while starting the broker.

This is because `AbstractFetcherManager` invokes maxLag which is
overriden in MirrorFetcherManager, prior to its constructor having been
invoked.

The lazy init should initialise that variable on first access instead.

```
2026-05-11 09:55:56,466 [main] ERROR kafka.Kafka$ - Exiting Kafka due to fatal exception during startup.
java.lang.NullPointerException: Cannot invoke "scala.collection.mutable.HashMap.values()" because the return value of "kafka.server.mirror.MirrorFetcherManager.mirrorFetcherThreadMap()" is null
        at kafka.server.mirror.MirrorFetcherManager.maxLag(MirrorFetcherManager.scala:64)
        at kafka.server.AbstractFetcherManager.$anonfun$new$1(AbstractFetcherManager.scala:46)
        at kafka.server.AbstractFetcherManager.$anonfun$new$1$adapted(AbstractFetcherManager.scala:46)
        at org.apache.kafka.server.metrics.KafkaMetricsGroup$1.value(KafkaMetricsGroup.java:94)
        at <redacted>.opentelemetry.common.reporter.DynamicTypeUtils.dynamicTypeMeasurement(DynamicTypeUtils.java:35)
        at <redacted>.opentelemetry.common.reporter.DynamicTypeUtils.dynamicTypeMeasurement(DynamicTypeUtils.java:28)
        at <redacted>.opentelemetry.reporter.yammer.YammerMetricsReporter.buildObservable(YammerMetricsReporter.java:192)
        at <redacted>.opentelemetry.reporter.yammer.YammerMetricsReporter.onMetricAdded(YammerMetricsReporter.java:138)
        at com.yammer.metrics.core.MetricsRegistry.notifyMetricAdded(MetricsRegistry.java:516)
        at com.yammer.metrics.core.MetricsRegistry.getOrAdd(MetricsRegistry.java:491)
        at com.yammer.metrics.core.MetricsRegistry.newGauge(MetricsRegistry.java:79)
        at org.apache.kafka.server.metrics.KafkaMetricsGroup.newGauge(KafkaMetricsGroup.java:91)
        at org.apache.kafka.server.metrics.KafkaMetricsGroup.newGauge(KafkaMetricsGroup.java:83)
        at kafka.server.AbstractFetcherManager.<init>(AbstractFetcherManager.scala:46)
        at kafka.server.mirror.MirrorFetcherManager.<init>(MirrorFetcherManager.scala:49)
        at kafka.server.ReplicaManager.createMirrorFetcherManager(ReplicaManager.scala:2319)
        at kafka.server.ReplicaManager.<init>(ReplicaManager.scala:275)
        at kafka.server.BrokerServer.startup(BrokerServer.scala:371)
        at kafka.server.KafkaRaftServer.$anonfun$startup$2(KafkaRaftServer.scala:96)
        at kafka.server.KafkaRaftServer.$anonfun$startup$2$adapted(KafkaRaftServer.scala:96)
        at scala.Option.foreach(Option.scala:437)
        at kafka.server.KafkaRaftServer.startup(KafkaRaftServer.scala:96)
        at kafka.Kafka$.main(Kafka.scala:97)
        at kafka.Kafka.main(Kafka.scala)
        at <redacted>.KafkaBrokerLauncher.main(KafkaBrokerLauncher.java:48
```