### PR TITLE
Fix checkstyle

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -335,6 +335,7 @@
     <allow pkg="scala.jdk.javaapi" />
     <allow pkg="org.apache.kafka.coordinator.transaction" />
     <allow pkg="org.apache.kafka.coordinator.group" />
+    <allow pkg="org.apache.kafka.coordinator.mirror" />
     <allow pkg="org.apache.kafka.tools" />
     <allow pkg="org.apache.kafka.tools.api" />
     <allow pkg="org.apache.kafka.tools.filter" />


### PR DESCRIPTION
Fixes:

```sh
[ant:checkstyle] [ERROR] /home/fvaleri/Documents/kafka/tools/src/main/java/org/apache/kafka/tools/consumer/MirrorStateMessageFormatter.java:20:1: Disallowed import - org.apache.kafka.coordinator.mirror.MirrorRecordSerde. [ImportControl]                                             
[ant:checkstyle] [ERROR] /home/fvaleri/Documents/kafka/tools/src/main/java/org/apache/kafka/tools/consumer/MirrorStateMessageFormatter.java:21:1: Disallowed import - org.apache.kafka.coordinator.mirror.generated.CoordinatorRecordJsonConverters. [ImportControl]  
```