### PR TITLE
Add exponential backoff retry for FAILED mirror partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1783,8 +1783,8 @@ public interface Admin extends AutoCloseable {
      *
      * This operation retrieves detailed information about cluster mirrors including:
      * - Topics being mirrored
-     * - Partition-level lag information (source offset vs destination offset)
-     * - Mirroring state for each partition (INITIALIZING, PREPARING, MIRRORING, etc.)
+     * - Partition-level lag information
+     * - Mirroring state for each partition
      *
      * @param mirrorNames The names of the mirrors to describe
      * @param options The options to use when describing mirrors

--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -40,7 +40,11 @@
         { "name": "State", "type": "int8", "versions": "0+",
           "about": "The mirror partition state." },
         { "name": "ErrorCode", "type": "int16", "versions": "0",
-          "about": "The error code, or 0 if there was no error." }
+          "about": "The error code, or 0 if there was no error." },
+        { "name": "PreviousState", "type": "int8", "taggedVersions": "0+", "tag": 0, "default": 16,
+          "about": "The mirror partition state before the last transition; UNKNOWN if not recorded." },
+        { "name": "RetryAttempt", "type": "int16", "taggedVersions": "0+", "tag": 1, "default": 0,
+          "about": "The number of automatic retry attempts while in FAILED state." }
       ]}
     ]}
   ]

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -106,7 +106,6 @@ public class MirrorCoordinator {
     private final Time time;
     private final MirrorRecordSerde serde;
 
-    private final Map<TopicPartition, Integer> failedRetryAttempts = new ConcurrentHashMap<>();
     // Exponential backoff for FAILED state retries with 20% jitter.
     // With defaults (initial=1s, max=300s): attempt 0 ~1s, attempt 1 ~2s, attempt 2 ~4s, ..., attempt 8+ ~300s.
     private ExponentialBackoff failedRetryBackoff;
@@ -208,26 +207,29 @@ public class MirrorCoordinator {
         }
     }
 
-    private void updateRetryAttempts(TopicPartition tp, MirrorPartitionState newState) {
+    private void updateRetryAttemptsAndPrevState(TopicPartition tp, MirrorPartitionState newState) {
         if (newState == MirrorPartitionState.FAILED) {
-            failedRetryAttempts.merge(tp, 1, Integer::sum);
+            metadataManager.failedRetryAttempts().merge(tp, 1, Integer::sum);
+            metadataManager.prevStateBeforeFailure().put(tp, newState);
         } else {
-            failedRetryAttempts.remove(tp);
+            metadataManager.failedRetryAttempts().remove(tp);
+            metadataManager.prevStateBeforeFailure().remove(tp);
         }
     }
 
     private void scheduleFailedRetries(String mirrorName, Set<TopicPartition> topicPartitions) {
         int maxAttempts = brokerConfig.mirrorConfig().failedRetryMaxAttempts();
         topicPartitions.forEach(tp -> {
-            int attempt = failedRetryAttempts.getOrDefault(tp, 0);
+            int attempt = metadataManager.failedRetryAttempts().getOrDefault(tp, 0);
             if (maxAttempts > 0 && attempt >= maxAttempts) {
                 log.error("Partition {} exceeded max retry attempts ({}), requires manual intervention.", tp, maxAttempts);
                 return;
             }
             long delay = failedRetryBackoff.backoff(attempt);
+            MirrorPartitionState prevState = metadataManager.prevStateBeforeFailure().getOrDefault(tp, MirrorPartitionState.PREPARING);
             log.info("Scheduling retry #{} for partition {} in {} ms.", attempt + 1, tp, delay);
             scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
-                () -> transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PREPARING), delay);
+                () -> transitionTo(mirrorName, Set.of(tp), prevState), delay);
         });
     }
 
@@ -237,7 +239,7 @@ public class MirrorCoordinator {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
-                updateRetryAttempts(tp, newState);
+                updateRetryAttemptsAndPrevState(tp, newState);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
@@ -767,14 +769,15 @@ public class MirrorCoordinator {
 
     private CoordinatorRecord generateMirrorPartitionState(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
         short retryAttempt = (state == MirrorPartitionState.FAILED)
-                ? failedRetryAttempts.getOrDefault(topicPartition, 0).shortValue()
+                ? metadataManager.failedRetryAttempts().getOrDefault(topicPartition, 0).shortValue()
                 : 0;
         var key = new MirrorPartitionStateKey().setMirrorName(mirrorName);
         var val = new MirrorPartitionStateValue()
                 .setTopicName(topicPartition.topic())
                 .setPartition(topicPartition.partition())
                 .setState(state.value())
-                .setRetryAttempt(retryAttempt);
+                .setRetryAttempt(retryAttempt)
+                .setPreviousState(metadataManager.prevStateBeforeFailure().getOrDefault(topicPartition, MirrorPartitionState.UNKNOWN).value());
         var apiVersion = new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);
     }
@@ -871,7 +874,8 @@ public class MirrorCoordinator {
         if (version <= MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION && version >= MirrorPartitionStateValue.LOWEST_SUPPORTED_VERSION) {
             MirrorPartitionStateValue value = new MirrorPartitionStateValue(new ByteBufferAccessor(buffer), version);
             return new MirrorUtils.PartitionStateLogEntry(value.topicName(), value.partition(),
-                    MirrorPartitionState.fromValue(value.state()), value.retryAttempt());
+                    MirrorPartitionState.fromValue(value.state()), value.retryAttempt(),
+                    MirrorPartitionState.fromValue(value.previousState()));
         } else {
             throw new IllegalStateException("Unsupported partition state value version: " + version);
         }
@@ -939,9 +943,9 @@ public class MirrorCoordinator {
                                         new MirrorUtils.PartitionKey(clusterName, value.topic(), value.partition()), value.state());
                                 TopicPartition tp = new TopicPartition(value.topic(), value.partition());
                                 if (value.state() == MirrorPartitionState.FAILED && value.retryAttempt() > 0) {
-                                    failedRetryAttempts.put(tp, value.retryAttempt());
+                                    metadataManager.failedRetryAttempts().put(tp, value.retryAttempt());
                                 } else {
-                                    failedRetryAttempts.remove(tp);
+                                    metadataManager.failedRetryAttempts().remove(tp);
                                 }
                             } else {
                                 throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);
@@ -978,7 +982,7 @@ public class MirrorCoordinator {
             OptionalInt partitionLeaderEpoch
     ) {
         sourceSenders.clear();
-        failedRetryAttempts.clear();
+        metadataManager.failedRetryAttempts().clear();
         metadataManager.clear();
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -939,8 +939,10 @@ public class MirrorCoordinator {
                             } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
                                 String clusterName = readMirrorNameFromKey(record.key());
                                 MirrorUtils.PartitionStateLogEntry value = readMirrorPartitionStateValue(record.value());
-                                metadataManager.updatePartitionState(
-                                        new MirrorUtils.PartitionKey(clusterName, value.topic(), value.partition()), value.state());
+                                MirrorUtils.PartitionKey pk = new MirrorUtils.PartitionKey(
+                                        clusterName, value.topic(), value.partition());
+                                metadataManager.updatePartitionState(pk, value.state());
+                                metadataManager.partitionPreviousStates().put(pk, value.previousState());
                                 TopicPartition tp = new TopicPartition(value.topic(), value.partition());
                                 if (value.state() == MirrorPartitionState.FAILED && value.retryAttempt() > 0) {
                                     metadataManager.failedRetryAttempts().put(tp, value.retryAttempt());

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.ReadMirrorStatesResponse;
 import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
+import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -74,6 +75,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -89,6 +91,8 @@ import static org.apache.kafka.common.utils.Utils.require;
  * distributed across brokers by hashing the mirror record key to a partition.
  */
 public class MirrorCoordinator {
+    private static final long RETRY_DELAY_MS = 5000L;
+
     private final String name;
     private final Logger log;
     private final AtomicBoolean isActive = new AtomicBoolean(false);
@@ -101,6 +105,11 @@ public class MirrorCoordinator {
     private final MetadataCache metadataCache;
     private final Time time;
     private final MirrorRecordSerde serde;
+
+    private final Map<TopicPartition, Integer> failedRetryAttempts = new ConcurrentHashMap<>();
+    // Exponential backoff for FAILED state retries with 20% jitter.
+    // With defaults (initial=1s, max=300s): attempt 0 ~1s, attempt 1 ~2s, attempt 2 ~4s, ..., attempt 8+ ~300s.
+    private ExponentialBackoff failedRetryBackoff;
 
     private volatile int numPartitions = -1;
 
@@ -175,7 +184,6 @@ public class MirrorCoordinator {
                 // 5. reset pid to expire all existing PIDs, including the new appended records in (4)
                 // 6. move to STOPPED state
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-
                 collectAndUpdateLastMirrorEpochs(mirrorName, topicPartitions)
                     .thenCompose(v -> metadataManager.sendBumpLeaderEpochs(
                             metadataManager.buildLocalEpochBumpTargets(replicaManager.logManager(), topicPartitions)))
@@ -192,12 +200,35 @@ public class MirrorCoordinator {
                 break;
             case FAILED:
                 log.info("FAILED for topics {}.", topicPartitions);
-                // TODO: implement recovery actions (i.e. exponential backoff retry)
+                scheduleFailedRetries(mirrorName, topicPartitions);
                 break;
             default:
                 log.error("Illegal state transition to {}", newState);
                 throw new IllegalArgumentException("Illegal state transition to " + newState);
         }
+    }
+
+    private void updateRetryAttempts(TopicPartition tp, MirrorPartitionState newState) {
+        if (newState == MirrorPartitionState.FAILED) {
+            failedRetryAttempts.merge(tp, 1, Integer::sum);
+        } else {
+            failedRetryAttempts.remove(tp);
+        }
+    }
+
+    private void scheduleFailedRetries(String mirrorName, Set<TopicPartition> topicPartitions) {
+        int maxAttempts = brokerConfig.mirrorConfig().failedRetryMaxAttempts();
+        topicPartitions.forEach(tp -> {
+            int attempt = failedRetryAttempts.getOrDefault(tp, 0);
+            if (maxAttempts > 0 && attempt >= maxAttempts) {
+                log.error("Partition {} exceeded max retry attempts ({}), requires manual intervention.", tp, maxAttempts);
+                return;
+            }
+            long delay = failedRetryBackoff.backoff(attempt);
+            log.info("Scheduling retry #{} for partition {} in {} ms.", attempt + 1, tp, delay);
+            scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
+                () -> transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PREPARING), delay);
+        });
     }
 
     /** Validates and persists partition state, then executes transition actions. */
@@ -206,6 +237,7 @@ public class MirrorCoordinator {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
+                updateRetryAttempts(tp, newState);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
@@ -457,6 +489,11 @@ public class MirrorCoordinator {
 
         log.info("Starting up.");
         numPartitions = brokerConfig.mirrorConfig().topicNumPartitions();
+        failedRetryBackoff = new ExponentialBackoff(
+                brokerConfig.mirrorConfig().failedRetryInitialBackoffMs(),
+                2,
+                brokerConfig.mirrorConfig().failedRetryMaxBackoffMs(),
+                0.2);
         metadataManager.initialize(
                 (mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state),
                 this::tombstoneMirrorRecords,
@@ -479,7 +516,6 @@ public class MirrorCoordinator {
 
     /** Schedules truncation with retry on failure, using mirror.truncation.backoff.ms as retry delay. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions, long delayMs) {
-        long retryDelayMs = brokerConfig.mirrorConfig().truncationBackoffMs();
         final Consumer<TopicPartition> truncateCallback =
             partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.EPOCH_FENCING);
         scheduler.scheduleOnce("LastMirrorEpochsTruncation",
@@ -496,8 +532,8 @@ public class MirrorCoordinator {
                                     replicaManager.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
                                     return;
                                 } else {
-                                    log.warn("Failed to truncate to last mirrored offsets for mirror {}, retrying in {} ms", mirrorName, retryDelayMs, error);
-                                    scheduleTruncation(mirrorName, topicPartitions, retryDelayMs);
+                                    log.warn("Failed to truncate to last mirrored offsets for mirror {}, retrying in {} ms", mirrorName, RETRY_DELAY_MS, error);
+                                    scheduleTruncation(mirrorName, topicPartitions, RETRY_DELAY_MS);
                                     return;
                                 }
                             }
@@ -532,8 +568,8 @@ public class MirrorCoordinator {
                                     partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING));
                         });
                 } catch (Exception e) {
-                    log.warn("Failed to truncate to last mirrored offsets for mirror {}, retrying in {} ms", mirrorName, retryDelayMs, e);
-                    scheduleTruncation(mirrorName, topicPartitions, retryDelayMs);
+                    log.warn("Failed to truncate to last mirrored offsets for mirror {}, retrying in {} ms", mirrorName, RETRY_DELAY_MS, e);
+                    scheduleTruncation(mirrorName, topicPartitions, RETRY_DELAY_MS);
                 }
             }, delayMs);
     }
@@ -544,13 +580,12 @@ public class MirrorCoordinator {
      * TODO: handle failure, we can't retry forever
      */
     private void writeMirrorPidResetAndStop(String mirrorName, Set<TopicPartition> topicPartitions) {
-        long retryDelayMs = brokerConfig.mirrorConfig().truncationBackoffMs();
         writeMirrorPidResetBarrier(mirrorName, topicPartitions).whenComplete((responses, ex) -> {
             if (ex != null) {
                 log.error("Failed to write PID reset barrier for partitions {} in mirror {}", topicPartitions, mirrorName, ex);
                 scheduler.scheduleOnce("MirrorPidResetBarrierRetry",
                     () -> writeMirrorPidResetAndStop(mirrorName, topicPartitions),
-                    retryDelayMs);
+                        RETRY_DELAY_MS);
                 return;
             }
             Set<TopicPartition> succeeded = new HashSet<>();
@@ -574,7 +609,7 @@ public class MirrorCoordinator {
             if (!failed.isEmpty()) {
                 scheduler.scheduleOnce("MirrorPidResetBarrierRetry",
                     () -> writeMirrorPidResetAndStop(mirrorName, failed),
-                    retryDelayMs);
+                        RETRY_DELAY_MS);
             }
         });
     }
@@ -730,9 +765,16 @@ public class MirrorCoordinator {
         return future;
     }
 
-    private static CoordinatorRecord generateMirrorPartitionState(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
+    private CoordinatorRecord generateMirrorPartitionState(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
+        short retryAttempt = (state == MirrorPartitionState.FAILED)
+                ? failedRetryAttempts.getOrDefault(topicPartition, 0).shortValue()
+                : 0;
         var key = new MirrorPartitionStateKey().setMirrorName(mirrorName);
-        var val = new MirrorPartitionStateValue().setTopicName(topicPartition.topic()).setPartition(topicPartition.partition()).setState(state.value());
+        var val = new MirrorPartitionStateValue()
+                .setTopicName(topicPartition.topic())
+                .setPartition(topicPartition.partition())
+                .setState(state.value())
+                .setRetryAttempt(retryAttempt);
         var apiVersion = new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);
     }
@@ -828,7 +870,8 @@ public class MirrorCoordinator {
         short version = buffer.getShort();
         if (version <= MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION && version >= MirrorPartitionStateValue.LOWEST_SUPPORTED_VERSION) {
             MirrorPartitionStateValue value = new MirrorPartitionStateValue(new ByteBufferAccessor(buffer), version);
-            return new MirrorUtils.PartitionStateLogEntry(value.topicName(), value.partition(), MirrorPartitionState.fromValue(value.state()));
+            return new MirrorUtils.PartitionStateLogEntry(value.topicName(), value.partition(),
+                    MirrorPartitionState.fromValue(value.state()), value.retryAttempt());
         } else {
             throw new IllegalStateException("Unsupported partition state value version: " + version);
         }
@@ -894,6 +937,12 @@ public class MirrorCoordinator {
                                 MirrorUtils.PartitionStateLogEntry value = readMirrorPartitionStateValue(record.value());
                                 metadataManager.updatePartitionState(
                                         new MirrorUtils.PartitionKey(clusterName, value.topic(), value.partition()), value.state());
+                                TopicPartition tp = new TopicPartition(value.topic(), value.partition());
+                                if (value.state() == MirrorPartitionState.FAILED && value.retryAttempt() > 0) {
+                                    failedRetryAttempts.put(tp, value.retryAttempt());
+                                } else {
+                                    failedRetryAttempts.remove(tp);
+                                }
                             } else {
                                 throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);
                             }
@@ -929,6 +978,7 @@ public class MirrorCoordinator {
             OptionalInt partitionLeaderEpoch
     ) {
         sourceSenders.clear();
+        failedRetryAttempts.clear();
         metadataManager.clear();
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -19,6 +19,7 @@ package kafka.server.mirror;
 import kafka.server.KafkaConfig;
 import kafka.server.ReplicaManager;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.MirrorDescription;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
@@ -491,9 +492,9 @@ public class MirrorCoordinator {
         numPartitions = brokerConfig.mirrorConfig().topicNumPartitions();
         failedRetryBackoff = new ExponentialBackoff(
                 brokerConfig.mirrorConfig().failedRetryInitialBackoffMs(),
-                2,
+                CommonClientConfigs.RETRY_BACKOFF_EXP_BASE,
                 brokerConfig.mirrorConfig().failedRetryMaxBackoffMs(),
-                0.2);
+                CommonClientConfigs.RETRY_BACKOFF_JITTER);
         metadataManager.initialize(
                 (mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state),
                 this::tombstoneMirrorRecords,

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -144,8 +144,8 @@ public class MirrorCoordinator {
     // Executes the appropriate actions for a state transition.
     private void handleStateTransition(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
         switch (newState) {
-            case PREPARING:
-                log.info("PREPARING for topics {}.", topicPartitions);
+            case LOG_TRUNCATION:
+                log.info("LOG_TRUNCATION for topics {}.", topicPartitions);
                 scheduleTruncation(mirrorName, topicPartitions);
                 break;
             case EPOCH_FENCING:
@@ -207,11 +207,13 @@ public class MirrorCoordinator {
         }
     }
 
-    private void updateRetryAttemptsAndPrevState(TopicPartition tp, MirrorPartitionState newState) {
+    private void updateRetryAttemptsAndPrevState(TopicPartition tp, MirrorPartitionState currentState, MirrorPartitionState newState) {
         if (newState == MirrorPartitionState.FAILED) {
             metadataManager.failedRetryAttempts().merge(tp, 1, Integer::sum);
-            metadataManager.prevStateBeforeFailure().put(tp, newState);
-        } else {
+            metadataManager.prevStateBeforeFailure().putIfAbsent(tp, currentState);
+        } else if (newState == MirrorPartitionState.MIRRORING
+                || newState == MirrorPartitionState.STOPPED
+                || newState == MirrorPartitionState.PAUSED) {
             metadataManager.failedRetryAttempts().remove(tp);
             metadataManager.prevStateBeforeFailure().remove(tp);
         }
@@ -226,10 +228,10 @@ public class MirrorCoordinator {
                 return;
             }
             long delay = failedRetryBackoff.backoff(attempt);
-            MirrorPartitionState prevState = metadataManager.prevStateBeforeFailure().getOrDefault(tp, MirrorPartitionState.PREPARING);
+            MirrorPartitionState targetState = metadataManager.prevStateBeforeFailure().getOrDefault(tp, MirrorPartitionState.MIRRORING);
             log.info("Scheduling retry #{} for partition {} in {} ms.", attempt + 1, tp, delay);
             scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
-                () -> transitionTo(mirrorName, Set.of(tp), prevState), delay);
+                () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });
     }
 
@@ -239,7 +241,7 @@ public class MirrorCoordinator {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
-                updateRetryAttemptsAndPrevState(tp, newState);
+                updateRetryAttemptsAndPrevState(tp, currentState, newState);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
@@ -534,8 +536,8 @@ public class MirrorCoordinator {
                                     replicaManager.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
                                     return;
                                 } else {
-                                    log.warn("Failed to truncate to last mirrored offsets for mirror {}, retrying in {} ms", mirrorName, RETRY_DELAY_MS, error);
-                                    scheduleTruncation(mirrorName, topicPartitions, RETRY_DELAY_MS);
+                                    log.warn("Failed to truncate to last mirrored offsets for mirror {}", mirrorName, error);
+                                    transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED);
                                     return;
                                 }
                             }
@@ -570,8 +572,8 @@ public class MirrorCoordinator {
                                     partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING));
                         });
                 } catch (Exception e) {
-                    log.warn("Failed to truncate to last mirrored offsets for mirror {}, retrying in {} ms", mirrorName, RETRY_DELAY_MS, e);
-                    scheduleTruncation(mirrorName, topicPartitions, RETRY_DELAY_MS);
+                    log.warn("Failed to truncate to last mirrored offsets for mirror {}", mirrorName, e);
+                    transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED);
                 }
             }, delayMs);
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -76,7 +76,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -188,6 +188,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     // lets the transition handler skip partitions that are already being processed
     private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
+    private final Map<TopicPartition, MirrorPartitionState> prevStateBeforeFailure = new ConcurrentHashMap<>();
+    private final Map<TopicPartition, Integer> failedRetryAttempts = new ConcurrentHashMap<>();
     private final Set<Uuid> pendingTopicCreations = ConcurrentHashMap.newKeySet();
 
     // metrics
@@ -350,6 +352,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public Map<TopicPartition, MirrorPartitionState> pendingPartitionStates() {
         return pendingPartitionStates;
+    }
+
+    public Map<TopicPartition, MirrorPartitionState> prevStateBeforeFailure() {
+        return prevStateBeforeFailure;
+    }
+
+    public Map<TopicPartition, Integer> failedRetryAttempts() {
+        return failedRetryAttempts;
     }
 
     public void initialize(MirrorUtils.StateTransitioner stateTransitioner,

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -179,6 +179,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
+    private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates = new ConcurrentHashMap<>();
     private final Map<MirrorPartitionState, AtomicLong> partitionStateCounts = new ConcurrentHashMap<>();
     private final Map<MirrorUtils.PartitionKey, Integer> lastMirrorEpochs = new ConcurrentHashMap<>();
 
@@ -360,6 +361,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public Map<TopicPartition, Integer> failedRetryAttempts() {
         return failedRetryAttempts;
+    }
+
+    public Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates() {
+        return partitionPreviousStates;
     }
 
     public void initialize(MirrorUtils.StateTransitioner stateTransitioner,
@@ -716,14 +721,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         // Update cache
                         readMirrorStatesResponse.data().topics().forEach(topic -> {
                             topic.partitions().forEach(partition -> {
+                                MirrorUtils.PartitionKey mpk = new MirrorUtils.PartitionKey(
+                                        mirrorName, topic.name(), partition.partitionIndex());
+                                TopicPartition tp = new TopicPartition(topic.name(), partition.partitionIndex());
                                 if (partition.lastMirrorEpoch() != -1) {
-                                    lastMirrorEpochs.put(new MirrorUtils.PartitionKey(mirrorName, topic.name(), partition.partitionIndex()),
-                                            partition.lastMirrorEpoch());
+                                    lastMirrorEpochs.put(mpk, partition.lastMirrorEpoch());
                                 }
                                 if (partition.state() != -1) {
-                                    partitionStates.put(new MirrorUtils.PartitionKey(mirrorName, topic.name(), partition.partitionIndex()),
-                                            MirrorPartitionState.fromValue(partition.state()));
+                                    partitionStates.put(mpk, MirrorPartitionState.fromValue(partition.state()));
                                 }
+                                partitionPreviousStates.put(mpk, MirrorPartitionState.fromValue(partition.previousState()));
+                                failedRetryAttempts.put(tp, (int) partition.retryAttempt());
                             });
                         });
 
@@ -744,11 +752,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             ReadMirrorStatesResponseData.TopicResult topicResult = new ReadMirrorStatesResponseData.TopicResult().setName(tp);
             List<ReadMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();
             parts.forEach(part -> {
+                MirrorUtils.PartitionKey pk = new MirrorUtils.PartitionKey(mirrorName, tp, part);
                 ReadMirrorStatesResponseData.PartitionResult partitionResult = new ReadMirrorStatesResponseData.PartitionResult();
                 partitionResult.setPartitionIndex(part);
-                partitionResult.setLastMirrorEpoch(lastMirrorEpochs.getOrDefault(new MirrorUtils.PartitionKey(mirrorName, tp, part), -1));
-                partitionResult.setState(partitionStates.getOrDefault(
-                        new MirrorUtils.PartitionKey(mirrorName, tp, part), MirrorPartitionState.UNKNOWN).value());
+                partitionResult.setLastMirrorEpoch(lastMirrorEpochs.getOrDefault(pk, -1));
+                partitionResult.setState(partitionStates.getOrDefault(pk, MirrorPartitionState.UNKNOWN).value());
+                partitionResult.setPreviousState(
+                        partitionPreviousStates.getOrDefault(pk, MirrorPartitionState.UNKNOWN).value());
+                partitionResult.setRetryAttempt(
+                        failedRetryAttempts.getOrDefault(new TopicPartition(tp, part), 0).shortValue());
                 partitionResults.add(partitionResult);
             });
             topicResult.setPartitions(partitionResults);
@@ -882,6 +894,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             partitionStateCounts.computeIfAbsent(oldState, s -> new AtomicLong()).decrementAndGet();
             return null;
         });
+        partitionPreviousStates.remove(key);
     }
 
     void removeLastMirrorEpochs(String mirrorName) {
@@ -1863,6 +1876,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     void clear() {
         partitionStates.clear();
+        partitionPreviousStates.clear();
         partitionStateCounts.clear();
         lastMirrorEpochs.clear();
         sourceClusterIds.clear();

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -135,7 +135,7 @@ import static org.apache.kafka.controller.ConfigurationControlManager.STOPPED_TO
  * Bridges the local destination cluster and remote source clusters for Cluster Mirroring.
  *
  * Implements {@link MetadataPublisher} to detect leadership and config changes, triggering
- * partition state transitions (PREPARING, MIRRORING, STOPPING, STOPPED) via the
+ * partition state transitions (LOG_TRUNCATION, MIRRORING, STOPPING, STOPPED) via the
  * {@link MirrorCoordinator}. Manages remote cluster connections using {@link MirrorSourceSender}
  * and periodically syncs topic metadata, configs, consumer group offsets, and ACLs from source
  * clusters.
@@ -235,7 +235,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         metricsGroup.newGauge("ShareGroupOffsetSyncError", shareGroupOffsetSyncError::get);
         metricsGroup.newGauge("AclSyncError", aclSyncError::get);
         metricsGroup.newGauge("TopicMetadataRefreshError", metadataRefreshError::get);
-        metricsGroup.newGauge("PreparingPartitionState", () -> partitionStateCount(MirrorPartitionState.PREPARING));
+        metricsGroup.newGauge("LogTruncationPartitionState", () -> partitionStateCount(MirrorPartitionState.LOG_TRUNCATION));
         metricsGroup.newGauge("EpochFencingPartitionState", () -> partitionStateCount(MirrorPartitionState.EPOCH_FENCING));
         metricsGroup.newGauge("MirroringPartitionState", () -> partitionStateCount(MirrorPartitionState.MIRRORING));
         metricsGroup.newGauge("PausingPartitionState", () -> partitionStateCount(MirrorPartitionState.PAUSING));
@@ -321,7 +321,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 res.data().topics().forEach(topic ->
                     topic.partitions().forEach(partition -> {
                         TopicPartition resTp = new TopicPartition(topic.name(), partition.partitionIndex());
-                        // treat unrecorded state (-1) as UNKNOWN so the partition can transition to PREPARING
+                        // treat unrecorded state (-1) as UNKNOWN so the partition can transition to LOG_TRUNCATION
                         MirrorPartitionState state = partition.state() != -1
                                 ? MirrorPartitionState.fromValue(partition.state())
                                 : MirrorPartitionState.UNKNOWN;
@@ -503,7 +503,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      *   2. else, move the state to PAUSING state
      * When stopRequested=false and pauseRequested=false:
      *   1. if it's in PAUSED state, we should move it to MIRRORING state. It will happen when users resume mirroring
-     *   2. if it's in UNKNOWN or STOPPED state, we should move it to PREPARING state. It will happen when users startMirrorTopics.
+     *   2. if it's in UNKNOWN or STOPPED state, we should move it to LOG_TRUNCATION state. It will happen when users startMirrorTopics.
      *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should continue to complete the process in previous leader.
      */
     private void applyMirrorStateTransition(String mirrorName, TopicPartition tp,
@@ -526,7 +526,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 t.transitionTo(mirrorName, tp, MirrorPartitionState.MIRRORING);
             } else if (curState == MirrorPartitionState.UNKNOWN
                     || curState == MirrorPartitionState.STOPPED) {
-                t.transitionTo(mirrorName, tp, MirrorPartitionState.PREPARING);
+                t.transitionTo(mirrorName, tp, MirrorPartitionState.LOG_TRUNCATION);
             } else {
                 t.transitionTo(mirrorName, tp, fetchedState != null ? fetchedState : curState);
             }

--- a/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
@@ -26,11 +26,11 @@ public enum MirrorPartitionState {
      * align the local log with the source.
      * Valid from: null, UNKNOWN, STOPPED, FAILED.
      */
-    PREPARING((byte) 0),
+    LOG_TRUNCATION((byte) 0),
 
     /**
      * Checking if bumping the leader epoch is necessary to ensure local leader epoch > source leader epoch.
-     * Valid from: UNKNOWN, PREPARING, STOPPED, FAILED.
+     * Valid from: UNKNOWN, LOG_TRUNCATION, STOPPED, FAILED.
      */
     EPOCH_FENCING((byte) 1),
 
@@ -59,7 +59,7 @@ public enum MirrorPartitionState {
     /**
      * Triggered by StopMirrorTopics API (failover) or topic deletion on the source.
      * The system records the last mirrored offset to the internal topic.
-     * Valid from: PREPARING, MIRRORING, PAUSING (race guard), PAUSED, FAILED.
+     * Valid from: LOG_TRUNCATION, MIRRORING, PAUSING (race guard), PAUSED, FAILED.
      */
     STOPPING((byte) 5),
 
@@ -71,7 +71,7 @@ public enum MirrorPartitionState {
     STOPPED((byte) 6),
 
     /**
-     * An error occurred. Can transition back to PREPARING to retry.
+     * An error occurred. Can transition back to LOG_TRUNCATION to retry.
      * Valid from: any state.
      */
     FAILED((byte) 7),
@@ -95,7 +95,7 @@ public enum MirrorPartitionState {
     public static MirrorPartitionState fromValue(byte value) {
         switch (value) {
             case 0:
-                return PREPARING;
+                return LOG_TRUNCATION;
             case 1:
                 return EPOCH_FENCING;
             case 2:
@@ -122,7 +122,7 @@ public enum MirrorPartitionState {
             return true;
         }
         switch (target) {
-            case PREPARING:
+            case LOG_TRUNCATION:
                 return source == null
                         || source == MirrorPartitionState.UNKNOWN
                         || source == MirrorPartitionState.STOPPED
@@ -130,16 +130,17 @@ public enum MirrorPartitionState {
             case EPOCH_FENCING:
                 return source == MirrorPartitionState.MIRRORING;
             case MIRRORING:
-                return source == MirrorPartitionState.PREPARING
+                return source == MirrorPartitionState.LOG_TRUNCATION
                         || source == MirrorPartitionState.EPOCH_FENCING
-                        || source == MirrorPartitionState.PAUSED;
+                        || source == MirrorPartitionState.PAUSED
+                        || source == MirrorPartitionState.FAILED;
             case PAUSING:
                 return source == MirrorPartitionState.MIRRORING;
             case PAUSED:
                 return source == MirrorPartitionState.PAUSING;
             case STOPPING:
                 // TODO: remove PAUSING once state transitions are serialized via the shared queue
-                return source == MirrorPartitionState.PREPARING
+                return source == MirrorPartitionState.LOG_TRUNCATION
                         || source == MirrorPartitionState.EPOCH_FENCING
                         || source == MirrorPartitionState.MIRRORING
                         || source == MirrorPartitionState.PAUSING

--- a/core/src/main/java/kafka/server/mirror/MirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorUtils.java
@@ -95,7 +95,8 @@ public final class MirrorUtils {
 
     public record PartitionStateInfo(int partition, MirrorPartitionState state, Integer leaderEpoch) { }
 
-    public record PartitionStateLogEntry(String topic, int partition, MirrorPartitionState state, int retryAttempt) { }
+    public record PartitionStateLogEntry(String topic, int partition, MirrorPartitionState state, int retryAttempt,
+                                         MirrorPartitionState previousState) { }
 
     public record PartitionKey(String mirrorName, String topic, int partition) { }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorUtils.java
@@ -39,7 +39,6 @@ import static org.apache.kafka.controller.ConfigurationControlManager.STOPPED_TO
  * Shared data types and utility methods for cluster mirroring components.
  */
 public final class MirrorUtils {
-    public static final int CONNECTION_FAILURE_THRESHOLD = 5;
     public static final int LEADER_EPOCH_BUMP_THRESHOLD = 3;
     public static final int LEADER_EPOCH_BUMP_INCREMENT = 10;
 

--- a/core/src/main/java/kafka/server/mirror/MirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorUtils.java
@@ -39,6 +39,7 @@ import static org.apache.kafka.controller.ConfigurationControlManager.STOPPED_TO
  * Shared data types and utility methods for cluster mirroring components.
  */
 public final class MirrorUtils {
+    public static final int CONNECTION_FAILURE_THRESHOLD = 5;
     public static final int LEADER_EPOCH_BUMP_THRESHOLD = 3;
     public static final int LEADER_EPOCH_BUMP_INCREMENT = 10;
 
@@ -94,7 +95,7 @@ public final class MirrorUtils {
 
     public record PartitionStateInfo(int partition, MirrorPartitionState state, Integer leaderEpoch) { }
 
-    public record PartitionStateLogEntry(String topic, int partition, MirrorPartitionState state) { }
+    public record PartitionStateLogEntry(String topic, int partition, MirrorPartitionState state, int retryAttempt) { }
 
     public record PartitionKey(String mirrorName, String topic, int partition) { }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -524,7 +524,7 @@ abstract class AbstractFetcherThread(name: String,
                     case e: MirrorLeaderEpochExceededException =>
                       error(s"Error while processing data for mirror partition $topicPartition " +
                         s"at offset ${currentFetchState.fetchOffset}, waiting for leader epoch bump.", e)
-                      markPartitionFailed(topicPartition)
+                      markPartitionRemoved(topicPartition)
                       handleMirrorLeaderEpochExceeded(currentFetchState.mirrorName(), topicPartition)
                     case t: Throwable =>
                       // stop monitoring this partition and add it to the set of failed partitions
@@ -631,13 +631,17 @@ abstract class AbstractFetcherThread(name: String,
     } finally partitionMapLock.unlock()
   }
 
-  private def markPartitionFailed(topicPartition: TopicPartition): Unit = {
+  private def markPartitionRemoved(topicPartition: TopicPartition): Unit = {
     partitionMapLock.lock()
     try {
       failedPartitions.add(topicPartition)
       removePartitions(Set(topicPartition))
     } finally partitionMapLock.unlock()
     warn(s"Partition $topicPartition marked as failed")
+  }
+
+  private def markPartitionFailed(topicPartition: TopicPartition): Unit = {
+    markPartitionRemoved(topicPartition)
     handlePartitionFailed(topicPartition)
   }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -638,7 +638,10 @@ abstract class AbstractFetcherThread(name: String,
       removePartitions(Set(topicPartition))
     } finally partitionMapLock.unlock()
     warn(s"Partition $topicPartition marked as failed")
+    handlePartitionFailed(topicPartition)
   }
+
+  protected def handlePartitionFailed(topicPartition: TopicPartition): Unit = {}
 
   /**
    * Returns initial partition fetch state based on current state and the provided `initialFetchState`.

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -159,11 +159,21 @@ abstract class AbstractFetcherThread(name: String,
     )
   }
 
-  // deal with partitions with errors, potentially due to leadership changes
-  private def handlePartitionsWithErrors(partitions: Iterable[TopicPartition], methodName: String): Unit = {
+  private def handlePartitionsWithErrors(partitions: Iterable[TopicPartition], methodName: String,
+                                         fetchException: Option[Throwable] = None): Unit = {
     if (partitions.nonEmpty) {
       debug(s"Handling errors in $methodName for partitions $partitions")
-      delayPartitions(partitions, fetchBackOffMs)
+      if (fetchException.exists(_.isInstanceOf[IOException]) && mirrorName.nonEmpty && isRunning) {
+        try {
+          partitions.foreach(markPartitionRemoved)
+          handleMirrorFetchConnectionFailure(partitions.toSet)
+        } catch {
+          case t: Throwable =>
+            warn(s"Failed to re-resolve source leader for mirror $mirrorName", t)
+        }
+      } else {
+        delayPartitions(partitions, fetchBackOffMs)
+      }
     }
   }
 
@@ -601,16 +611,8 @@ abstract class AbstractFetcherThread(name: String,
       updateMirrorFetchEpoch(mirrorPartitionsWithNewEpoch)
     if (mirrorPartitionsWithNewLeader.nonEmpty && isRunning)
       maybeCreateMirrorFetchers(mirrorPartitionsWithNewLeader)
-    if (fetchException.exists(_.isInstanceOf[IOException]) && partitionsWithError.nonEmpty && mirrorName.nonEmpty && isRunning) {
-      try {
-        handleMirrorFetchConnectionFailure(partitionsWithError.toSet)
-      } catch {
-        case t: Throwable =>
-          warn(s"Failed to re-resolve source leader for mirror $mirrorName", t)
-      }
-    }
     if (partitionsWithError.nonEmpty) {
-      handlePartitionsWithErrors(partitionsWithError, "processFetchRequest")
+      handlePartitionsWithErrors(partitionsWithError, "processFetchRequest", fetchException)
     }
   }
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -18,7 +18,7 @@ package kafka.server.mirror
 
 import kafka.cluster.Partition
 import kafka.server._
-import kafka.server.mirror.MirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD
+import kafka.server.mirror.MirrorUtils.{CONNECTION_FAILURE_THRESHOLD, LEADER_EPOCH_BUMP_THRESHOLD}
 import org.apache.kafka.common.errors.MirrorLeaderEpochExceededException
 import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.common.message.FetchResponseData
@@ -29,7 +29,7 @@ import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.storage.internals.log.{LogAppendInfo, LogStartOffsetIncrementReason}
 
 import java.util.Optional
-import scala.collection.{Map, Set}
+import scala.collection.{Map, Set, mutable}
 import scala.jdk.CollectionConverters._
 
 /**
@@ -57,6 +57,8 @@ class MirrorFetcherThread(name: String,
                                 mirrorName) {
   this.logIdent = logPrefix
 
+  private val connectionFailureCount: mutable.Map[TopicPartition, Int] = mutable.HashMap.empty
+
   override protected def removeFetcherForPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
     replicaMgr.mirrorFetcherManager.removeFetcherForPartitions(partitions)
   }
@@ -72,16 +74,45 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
-  // invalidates cached source leaders for affected partitions when source connection is broken
-  override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
-    replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName, mirrorPartitions.asJava))
-    replicaMgr.maybeCreateMirrorFetchers(mirrorName, mirrorPartitions.asJava)
+  private def incrementConnectionFailures(tp: TopicPartition): Boolean = {
+    val count = connectionFailureCount.getOrElse(tp, 0) + 1
+    connectionFailureCount(tp) = count
+    count >= CONNECTION_FAILURE_THRESHOLD
   }
 
+  private def resetConnectionFailures(tp: TopicPartition): Unit = {
+    connectionFailureCount.remove(tp)
+  }
+
+  // Connection failures are transient: invalidate cached leaders and re-create fetchers
+  // to reconnect. After CONNECTION_FAILURE_THRESHOLD consecutive failures, transition to
+  // FAILED so the coordinator can schedule exponential backoff retries.
+  override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
+    val exhausted = mirrorPartitions.filter(incrementConnectionFailures)
+    if (exhausted.nonEmpty) {
+      exhausted.foreach { tp =>
+        resetConnectionFailures(tp)
+        replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED))
+      }
+    }
+    val remaining = mirrorPartitions -- exhausted
+    if (remaining.nonEmpty) {
+      replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName, remaining.asJava))
+      replicaMgr.maybeCreateMirrorFetchers(mirrorName, remaining.asJava)
+    }
+  }
+
+  // Bridges fetcher failures (e.g. KafkaStorageException) to the mirror state machine,
+  // so the coordinator can schedule exponential backoff retries.
+  override protected def handlePartitionFailed(topicPartition: TopicPartition): Unit = {
+    replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, topicPartition, MirrorPartitionState.FAILED))
+  }
+
+  // Source leader epoch exceeds local epoch: transition to EPOCH_FENCING to bump the
+  // local epoch before allowing further appends. If the bump fails, the coordinator
+  // transitions to FAILED and the exponential backoff retry takes over.
   override protected def handleMirrorLeaderEpochExceeded(mirrorName: String, topicPartition: TopicPartition): Unit = {
-    // when the source cluster's epoch is higher than the destination cluster's epoch, we need to
-    // fence the partition to prevent the source cluster from appending to the destination cluster.
-    replicaMgr.mirrorMetadataManager.get.transitionTo(mirrorName, topicPartition, MirrorPartitionState.EPOCH_FENCING)
+    replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, topicPartition, MirrorPartitionState.EPOCH_FENCING))
   }
 
   def validateLeaderEpoch(topicPartition: TopicPartition, partition: Partition, records: Records): Unit = {
@@ -126,6 +157,7 @@ class MirrorFetcherThread(name: String,
       trace("Mirror follower has replica log end offset %d for partition %s. Received %d bytes of messages and leader hw %d"
         .format(log.logEndOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
 
+    resetConnectionFailures(topicPartition)
     validateLeaderEpoch(topicPartition, partition, records)
 
     // Append batches from the source cluster to the destination partition's log.

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -18,19 +18,18 @@ package kafka.server.mirror
 
 import kafka.cluster.Partition
 import kafka.server._
-import kafka.server.mirror.MirrorUtils.{CONNECTION_FAILURE_THRESHOLD, LEADER_EPOCH_BUMP_THRESHOLD}
+import kafka.server.mirror.MirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD
 import org.apache.kafka.common.errors.MirrorLeaderEpochExceededException
-import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
 import org.apache.kafka.common.requests.FetchResponse
-import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState}
+import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.server.common.OffsetAndEpoch
+import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState}
 import org.apache.kafka.storage.internals.log.{LogAppendInfo, LogStartOffsetIncrementReason}
 
 import java.util.Optional
-import scala.collection.{Map, Set, mutable}
-import scala.jdk.CollectionConverters._
+import scala.collection.{Map, Set}
 
 /**
  * Fetcher thread for cross-cluster mirroring. Unlike ReplicaFetcherThread, this rewrites
@@ -57,8 +56,6 @@ class MirrorFetcherThread(name: String,
                                 mirrorName) {
   this.logIdent = logPrefix
 
-  private val connectionFailureCount: mutable.Map[TopicPartition, Int] = mutable.HashMap.empty
-
   override protected def removeFetcherForPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
     replicaMgr.mirrorFetcherManager.removeFetcherForPartitions(partitions)
   }
@@ -74,31 +71,10 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
-  private def incrementConnectionFailures(tp: TopicPartition): Boolean = {
-    val count = connectionFailureCount.getOrElse(tp, 0) + 1
-    connectionFailureCount(tp) = count
-    count >= CONNECTION_FAILURE_THRESHOLD
-  }
-
-  private def resetConnectionFailures(tp: TopicPartition): Unit = {
-    connectionFailureCount.remove(tp)
-  }
-
-  // Connection failures are transient: invalidate cached leaders and re-create fetchers
-  // to reconnect. After CONNECTION_FAILURE_THRESHOLD consecutive failures, transition to
-  // FAILED so the coordinator can schedule exponential backoff retries.
+  // Transition to FAILED so the coordinator can schedule exponential backoff retries.
   override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
-    val exhausted = mirrorPartitions.filter(incrementConnectionFailures)
-    if (exhausted.nonEmpty) {
-      exhausted.foreach { tp =>
-        resetConnectionFailures(tp)
-        replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED))
-      }
-    }
-    val remaining = mirrorPartitions -- exhausted
-    if (remaining.nonEmpty) {
-      replicaMgr.mirrorMetadataManager.foreach(_.invalidateSourceLeader(mirrorName, remaining.asJava))
-      replicaMgr.maybeCreateMirrorFetchers(mirrorName, remaining.asJava)
+    mirrorPartitions.foreach { tp =>
+      replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED))
     }
   }
 
@@ -157,7 +133,6 @@ class MirrorFetcherThread(name: String,
       trace("Mirror follower has replica log end offset %d for partition %s. Received %d bytes of messages and leader hw %d"
         .format(log.logEndOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
 
-    resetConnectionFailures(topicPartition)
     validateLeaderEpoch(topicPartition, partition, records)
 
     // Append batches from the source cluster to the destination partition's log.

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
@@ -29,6 +29,8 @@
     { "name": "Partition", "type": "int32", "versions": "0",
       "about": "The partition index."},
     { "name": "State", "type": "int8", "versions": "0+",
-      "about": "The mirror partition state." }
+      "about": "The mirror partition state." },
+    { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",
+      "about": "The number of automatic retry attempts while in FAILED state." }
   ]
 }

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
@@ -31,6 +31,8 @@
     { "name": "State", "type": "int8", "versions": "0+",
       "about": "The mirror partition state." },
     { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",
-      "about": "The number of automatic retry attempts while in FAILED state." }
+      "about": "The number of automatic retry attempts while in FAILED state." },
+    { "name": "PreviousState", "type": "int8",  "versions": "0+", "default": 16,
+      "about": "The mirror partition state before this transition; UNKNOWN if not recorded." }
   ]
 }

--- a/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/MirrorConfig.java
@@ -122,10 +122,20 @@ public final class MirrorConfig {
     public static final String FETCH_BACKOFF_MS_DOC = "The amount of time to wait before retrying mirror fetch requests after a failure. " +
             "This controls the backoff for mirror fetcher threads on connection errors or other exceptions from the source cluster.";
 
-    public static final String TRUNCATION_BACKOFF_MS_CONFIG = "mirror.truncation.backoff.ms";
-    public static final long TRUNCATION_BACKOFF_MS_DEFAULT = 5000L;
-    public static final String TRUNCATION_BACKOFF_MS_DOC = "The amount of time to wait before retrying truncation to last mirrored offsets " +
-            "when the source cluster is unavailable during the PREPARING state.";
+    public static final String FAILED_RETRY_INITIAL_BACKOFF_MS_CONFIG = "mirror.failed.retry.initial.backoff.ms";
+    public static final long FAILED_RETRY_INITIAL_BACKOFF_MS_DEFAULT = 1000L;
+    public static final String FAILED_RETRY_INITIAL_BACKOFF_MS_DOC = "The initial backoff time in milliseconds before retrying a mirror partition " +
+            "in FAILED state. The actual delay uses full jitter: a uniform random value in [0, backoff].";
+
+    public static final String FAILED_RETRY_MAX_BACKOFF_MS_CONFIG = "mirror.failed.retry.max.backoff.ms";
+    public static final long FAILED_RETRY_MAX_BACKOFF_MS_DEFAULT = 300000L;
+    public static final String FAILED_RETRY_MAX_BACKOFF_MS_DOC = "The maximum backoff time in milliseconds for retrying a mirror partition in FAILED state.";
+
+    public static final String FAILED_RETRY_MAX_ATTEMPTS_CONFIG = "mirror.failed.retry.max.attempts";
+    public static final int FAILED_RETRY_MAX_ATTEMPTS_DEFAULT = 10;
+    public static final String FAILED_RETRY_MAX_ATTEMPTS_DOC = "The maximum number of automatic retry attempts for a mirror partition in FAILED state. " +
+            "After this limit is reached, manual intervention is required via the start-mirror-topics command. " +
+            "Set to 0 for unlimited retries.";
 
     // Metadata refresh interval
     public static final String METADATA_REFRESH_INTERVAL_MS_CONFIG = "mirror.metadata.refresh.interval.ms";
@@ -387,8 +397,16 @@ public final class MirrorConfig {
         return config.getLong(FETCH_BACKOFF_MS_CONFIG);
     }
 
-    public long truncationBackoffMs() {
-        return config.getLong(TRUNCATION_BACKOFF_MS_CONFIG);
+    public long failedRetryInitialBackoffMs() {
+        return config.getLong(FAILED_RETRY_INITIAL_BACKOFF_MS_CONFIG);
+    }
+
+    public long failedRetryMaxBackoffMs() {
+        return config.getLong(FAILED_RETRY_MAX_BACKOFF_MS_CONFIG);
+    }
+
+    public int failedRetryMaxAttempts() {
+        return config.getInt(FAILED_RETRY_MAX_ATTEMPTS_CONFIG);
     }
 
     /**
@@ -440,7 +458,9 @@ public final class MirrorConfig {
             .define(NUM_REPLICA_FETCHERS_CONFIG, INT, NUM_REPLICA_FETCHERS_DEFAULT, atLeast(1), HIGH, NUM_REPLICA_FETCHERS_DOC)
             .define(METADATA_REFRESH_INTERVAL_MS_CONFIG, LONG, METADATA_REFRESH_INTERVAL_MS_DEFAULT, atLeast(0L), MEDIUM, METADATA_REFRESH_INTERVAL_MS_DOC)
             .define(FETCH_BACKOFF_MS_CONFIG, LONG, FETCH_BACKOFF_MS_DEFAULT, atLeast(0L), MEDIUM, FETCH_BACKOFF_MS_DOC)
-            .define(TRUNCATION_BACKOFF_MS_CONFIG, LONG, TRUNCATION_BACKOFF_MS_DEFAULT, atLeast(0L), MEDIUM, TRUNCATION_BACKOFF_MS_DOC);
+            .define(FAILED_RETRY_INITIAL_BACKOFF_MS_CONFIG, LONG, FAILED_RETRY_INITIAL_BACKOFF_MS_DEFAULT, atLeast(1L), MEDIUM, FAILED_RETRY_INITIAL_BACKOFF_MS_DOC)
+            .define(FAILED_RETRY_MAX_BACKOFF_MS_CONFIG, LONG, FAILED_RETRY_MAX_BACKOFF_MS_DEFAULT, atLeast(1L), MEDIUM, FAILED_RETRY_MAX_BACKOFF_MS_DOC)
+            .define(FAILED_RETRY_MAX_ATTEMPTS_CONFIG, INT, FAILED_RETRY_MAX_ATTEMPTS_DEFAULT, atLeast(0), MEDIUM, FAILED_RETRY_MAX_ATTEMPTS_DOC);
     }
 
     /**


### PR DESCRIPTION
When a mirror partition enters FAILED state, the coordinator now schedules automatic retries with exponential backoff and 20% jitter, using the existing ExponentialBackoff utility. The retry count is persisted in the MirrorPartitionStateValue record so it survives coordinator failovers. Retries stop after a configurable max attempts, requiring manual recovery via start-mirror-topics which resets the counter.

New broker configs:
- mirror.failed.retry.initial.backoff.ms (default 1s)
- mirror.failed.retry.max.backoff.ms (default 300s)
- mirror.failed.retry.max.attempts (default 10, 0 = unlimited)

Also bridges the gap where KafkaStorageException in the fetcher thread silently stalled mirroring: adds an onPartitionFailed hook in AbstractFetcherThread that MirrorFetcherThread overrides to transition the partition to FAILED state on the coordinator.

Removes mirror.truncation.backoff.ms config in favor of a constant.

After CONNECTION_FAILURE_THRESHOLD (5) consecutive connection failures, the partition transition to FAILED, where the coordinator schedules exponential backoff retries. Below the threshold, the fetcher still invalidates cached leaders and re−creates fetchers for a quick reconnect. The counter resets on every successful fetch.
