### PR TITLE
read retryAttempt and previousState from remote coordinator

### DIFF
--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -40,7 +40,11 @@
         { "name": "State", "type": "int8", "versions": "0+",
           "about": "The mirror partition state." },
         { "name": "ErrorCode", "type": "int16", "versions": "0",
-          "about": "The error code, or 0 if there was no error." }
+          "about": "The error code, or 0 if there was no error." },
+        { "name": "PreviousState", "type": "int8", "taggedVersions": "0+", "tag": 0, "default": 16,
+          "about": "The mirror partition state before the last transition; UNKNOWN if not recorded." },
+        { "name": "RetryAttempt", "type": "int16", "taggedVersions": "0+", "tag": 1, "default": 0,
+          "about": "The number of automatic retry attempts while in FAILED state." }
       ]}
     ]}
   ]

--- a/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorCoordinator.java
@@ -939,8 +939,10 @@ public class MirrorCoordinator {
                             } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
                                 String clusterName = readMirrorNameFromKey(record.key());
                                 MirrorUtils.PartitionStateLogEntry value = readMirrorPartitionStateValue(record.value());
-                                metadataManager.updatePartitionState(
-                                        new MirrorUtils.PartitionKey(clusterName, value.topic(), value.partition()), value.state());
+                                MirrorUtils.PartitionKey pk = new MirrorUtils.PartitionKey(
+                                        clusterName, value.topic(), value.partition());
+                                metadataManager.updatePartitionState(pk, value.state());
+                                metadataManager.partitionPreviousStates().put(pk, value.previousState());
                                 TopicPartition tp = new TopicPartition(value.topic(), value.partition());
                                 if (value.state() == MirrorPartitionState.FAILED && value.retryAttempt() > 0) {
                                     metadataManager.failedRetryAttempts().put(tp, value.retryAttempt());

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -179,6 +179,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
+    private final Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates = new ConcurrentHashMap<>();
     private final Map<MirrorPartitionState, AtomicLong> partitionStateCounts = new ConcurrentHashMap<>();
     private final Map<MirrorUtils.PartitionKey, Integer> lastMirrorEpochs = new ConcurrentHashMap<>();
 
@@ -360,6 +361,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public Map<TopicPartition, Integer> failedRetryAttempts() {
         return failedRetryAttempts;
+    }
+
+    public Map<MirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates() {
+        return partitionPreviousStates;
     }
 
     public void initialize(MirrorUtils.StateTransitioner stateTransitioner,
@@ -716,14 +721,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         // Update cache
                         readMirrorStatesResponse.data().topics().forEach(topic -> {
                             topic.partitions().forEach(partition -> {
+                                MirrorUtils.PartitionKey mpk = new MirrorUtils.PartitionKey(
+                                        mirrorName, topic.name(), partition.partitionIndex());
+                                TopicPartition tp = new TopicPartition(topic.name(), partition.partitionIndex());
                                 if (partition.lastMirrorEpoch() != -1) {
-                                    lastMirrorEpochs.put(new MirrorUtils.PartitionKey(mirrorName, topic.name(), partition.partitionIndex()),
-                                            partition.lastMirrorEpoch());
+                                    lastMirrorEpochs.put(mpk, partition.lastMirrorEpoch());
                                 }
                                 if (partition.state() != -1) {
-                                    partitionStates.put(new MirrorUtils.PartitionKey(mirrorName, topic.name(), partition.partitionIndex()),
-                                            MirrorPartitionState.fromValue(partition.state()));
+                                    partitionStates.put(mpk, MirrorPartitionState.fromValue(partition.state()));
                                 }
+                                partitionPreviousStates.put(mpk, MirrorPartitionState.fromValue(partition.previousState()));
+                                failedRetryAttempts.put(tp, (int) partition.retryAttempt());
                             });
                         });
 
@@ -744,11 +752,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             ReadMirrorStatesResponseData.TopicResult topicResult = new ReadMirrorStatesResponseData.TopicResult().setName(tp);
             List<ReadMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();
             parts.forEach(part -> {
+                MirrorUtils.PartitionKey pk = new MirrorUtils.PartitionKey(mirrorName, tp, part);
                 ReadMirrorStatesResponseData.PartitionResult partitionResult = new ReadMirrorStatesResponseData.PartitionResult();
                 partitionResult.setPartitionIndex(part);
-                partitionResult.setLastMirrorEpoch(lastMirrorEpochs.getOrDefault(new MirrorUtils.PartitionKey(mirrorName, tp, part), -1));
-                partitionResult.setState(partitionStates.getOrDefault(
-                        new MirrorUtils.PartitionKey(mirrorName, tp, part), MirrorPartitionState.UNKNOWN).value());
+                partitionResult.setLastMirrorEpoch(lastMirrorEpochs.getOrDefault(pk, -1));
+                partitionResult.setState(partitionStates.getOrDefault(pk, MirrorPartitionState.UNKNOWN).value());
+                partitionResult.setPreviousState(
+                        partitionPreviousStates.getOrDefault(pk, MirrorPartitionState.UNKNOWN).value());
+                partitionResult.setRetryAttempt(
+                        failedRetryAttempts.getOrDefault(new TopicPartition(tp, part), 0).shortValue());
                 partitionResults.add(partitionResult);
             });
             topicResult.setPartitions(partitionResults);
@@ -882,6 +894,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             partitionStateCounts.computeIfAbsent(oldState, s -> new AtomicLong()).decrementAndGet();
             return null;
         });
+        partitionPreviousStates.remove(key);
     }
 
     void removeLastMirrorEpochs(String mirrorName) {
@@ -1863,6 +1876,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     void clear() {
         partitionStates.clear();
+        partitionPreviousStates.clear();
         partitionStateCounts.clear();
         lastMirrorEpochs.clear();
         sourceClusterIds.clear();


### PR DESCRIPTION
Read `retryAttempt` and `previousState` from remote coordinator, so that the leader node can get the correct value.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
