### PR TITLE
Use Admin API for config, ACL, and cluster ID sync in MirrorMetadataManager

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -701,6 +701,12 @@ public class ClusterMirrorCoordinator {
             });
         });
 
+        // No partitions need updating (e.g. empty topic with no leader epoch)
+        if (localByCoordPartition.isEmpty() && remoteTopicMetadata.isEmpty()) {
+            future.complete(null);
+            return future;
+        }
+
         // Update in-memory cache once with all offsets
         var updatedOffsets = metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets, Map.of());
 

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -93,7 +93,6 @@ import static org.apache.kafka.common.utils.Utils.require;
 public class ClusterMirrorCoordinator {
     private static final long RETRY_DELAY_MS = 5000L;
 
-    private final String name;
     private final Logger log;
     private final AtomicBoolean isActive = new AtomicBoolean(false);
     private final KafkaConfig brokerConfig;
@@ -120,7 +119,7 @@ public class ClusterMirrorCoordinator {
             Time time,
             MirrorMetadataManager mirrorMetadataManager
     ) {
-        this.name = "[" + ClusterMirrorCoordinator.class.getSimpleName() + " id=" + brokerConfig.nodeId() + "] ";
+        String name = "[" + ClusterMirrorCoordinator.class.getSimpleName() + " id=" + brokerConfig.nodeId() + "] ";
         this.log = new LogContext(name).logger(ClusterMirrorCoordinator.class);
         this.brokerConfig = brokerConfig;
         this.replicaManager = replicaManager;
@@ -499,8 +498,8 @@ public class ClusterMirrorCoordinator {
         metadataManager.initialize(
                 (mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state),
                 this::tombstoneMirrorRecords,
-                key -> getCoordinatorPartitionByKey(key),
-                mirrorName -> getCoordinatorPartitionByName(mirrorName));
+                this::getCoordinatorPartitionByKey,
+                this::getCoordinatorPartitionByName);
 
         scheduler.startup();
 
@@ -511,13 +510,8 @@ public class ClusterMirrorCoordinator {
         log.info("Startup complete.");
     }
 
-    /** Schedules truncation to align replicas with last mirrored offsets before resuming. */
+    /** Schedules truncation to align replicas with last mirrored epoch. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
-        scheduleTruncation(mirrorName, topicPartitions, 0);
-    }
-
-    /** Schedules truncation with retry on failure, using mirror.truncation.backoff.ms as retry delay. */
-    private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions, long delayMs) {
         final Consumer<TopicPartition> truncateCallback =
             partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.EPOCH_FENCING);
         scheduler.scheduleOnce("LastMirrorEpochsTruncation",
@@ -532,12 +526,11 @@ public class ClusterMirrorCoordinator {
                                     Map<TopicPartition, Integer> epochs = topicPartitions.stream()
                                         .collect(Collectors.toMap(tp -> tp, tp -> -1));
                                     replicaManager.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
-                                    return;
                                 } else {
                                     log.warn("Failed to truncate to last mirrored offsets for mirror {}", mirrorName, error);
                                     transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED);
-                                    return;
                                 }
+                                return;
                             }
 
                             ClusterMirrorDescription description = descriptions.get(mirrorName);
@@ -573,7 +566,7 @@ public class ClusterMirrorCoordinator {
                     log.warn("Failed to truncate to last mirrored offsets for mirror {}", mirrorName, e);
                     transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED);
                 }
-            }, delayMs);
+            }, 0);
     }
 
     /**
@@ -907,8 +900,7 @@ public class ClusterMirrorCoordinator {
 
                     if (fetchDataInfo.records instanceof MemoryRecords) {
                         memRecords = (MemoryRecords) fetchDataInfo.records;
-                    } else if (fetchDataInfo.records instanceof FileRecords) {
-                        FileRecords fileRecords = (FileRecords) fetchDataInfo.records;
+                    } else if (fetchDataInfo.records instanceof FileRecords fileRecords) {
                         int sizeInBytes = fileRecords.sizeInBytes();
                         int bytesNeeded = Math.max(maxLength, sizeInBytes);
 
@@ -926,9 +918,7 @@ public class ClusterMirrorCoordinator {
                     } else {
                         return null;
                     }
-                    Iterator<MutableRecordBatch> itr = memRecords.batches().iterator();
-                    while (itr.hasNext()) {
-                        MutableRecordBatch batch = itr.next();
+                    for (MutableRecordBatch batch : memRecords.batches()) {
                         batch.iterator().forEachRemaining(record -> {
                             require(record.hasKey(), "Mirror log's key should not be null");
                             short version = record.key().getShort();
@@ -962,9 +952,7 @@ public class ClusterMirrorCoordinator {
             }
 
             // we've read all the mirrored records, transition the state for each topic partitions
-            ClusterMirrorUtils.StateTransitionCallback callback = (mirrorName, topics, state)
-                    -> handleStateTransition(mirrorName, topics, state);
-            metadataManager.applyLoadedPartitionStates(callback);
+            metadataManager.applyLoadedPartitionStates(this::handleStateTransition);
 
             return null;
         });

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -99,7 +99,6 @@ public class ClusterMirrorCoordinator {
     private final KafkaConfig brokerConfig;
     private final ReplicaManager replicaManager;
     private final MirrorMetadataManager metadataManager;
-    private final Map<String, MirrorSourceSender> sourceSenders;
     private final Scheduler scheduler;
     private final Metrics metrics;
     private final MetadataCache metadataCache;
@@ -131,7 +130,6 @@ public class ClusterMirrorCoordinator {
         this.time = time;
         this.serde = new ClusterMirrorRecordSerde();
         this.metadataCache = metadataCache;
-        this.sourceSenders = new HashMap<>();
     }
 
     private boolean isLocalCoordinator(String mirrorName, String topic, int partition) {
@@ -985,17 +983,11 @@ public class ClusterMirrorCoordinator {
             int partitionIndex,
             OptionalInt partitionLeaderEpoch
     ) {
-        sourceSenders.clear();
-        metadataManager.failedRetryAttempts().clear();
         metadataManager.clear();
     }
 
     public Set<String> getConfiguredMirrors() {
         return metadataManager.getConfiguredMirrors();
-    }
-
-    public Set<String> getConfiguredTopics(String mirrorName) {
-        return metadataManager.getConfiguredTopics(mirrorName);
     }
 
     public int getActiveTopicCount(String mirrorName) {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ClusterMirrorDescription;
+import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.DescribeClusterMirrorsResult;
 import org.apache.kafka.clients.admin.GroupListing;
@@ -37,7 +38,6 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.acl.AccessControlEntryFilter;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigResource;
@@ -47,7 +47,6 @@ import org.apache.kafka.common.message.CreateAclsRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.DeleteAclsRequestData;
-import org.apache.kafka.common.message.DescribeConfigsRequestData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.ReadMirrorStatesRequestData;
@@ -63,10 +62,6 @@ import org.apache.kafka.common.requests.CreatePartitionsRequest;
 import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
-import org.apache.kafka.common.requests.DescribeAclsRequest;
-import org.apache.kafka.common.requests.DescribeAclsResponse;
-import org.apache.kafka.common.requests.DescribeConfigsRequest;
-import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
@@ -76,8 +71,6 @@ import org.apache.kafka.common.requests.StartMirrorTopicsRequest;
 import org.apache.kafka.common.requests.StopMirrorTopicsRequest;
 import org.apache.kafka.common.requests.WriteMirrorStatesRequest;
 import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
-import org.apache.kafka.common.resource.PatternType;
-import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -147,9 +140,6 @@ import static org.apache.kafka.controller.ConfigurationControlManager.STOPPED_TO
  */
 @SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
 public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
-    private static final ResourcePatternFilter ANY_RESOURCE = new ResourcePatternFilter(ResourceType.ANY, null, PatternType.ANY);
-    private static final AclBindingFilter ANY_RESOURCE_ACL = new AclBindingFilter(ANY_RESOURCE, AccessControlEntryFilter.ANY);
-
     private final String name;
     private final Logger log;
     private final KafkaConfig brokerConfig;
@@ -803,7 +793,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /** Creates Admin clients for source mirrors and the local destination, if not already initialized. */
-    private void ensureAdminClients(Set<String> mirrors) {
+    private void createAdminClients(Set<String> mirrors) {
         for (String mirrorName : mirrors) {
             srcAdmins.computeIfAbsent(mirrorName, k -> {
                 Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
@@ -996,7 +986,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         log.info("Syncing metadata for mirrors: {}", mirrors);
         mirrors.forEach(this::ensureConnection);
-        ensureAdminClients(mirrors);
+        createAdminClients(mirrors);
 
         // snapshot keyset to avoid ConcurrentModificationException
         for (String mirrorName : Set.copyOf(sourceSenders.keySet())) {
@@ -1396,57 +1386,57 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     private void syncTopicConfigurations(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        Admin srcAdmin = srcAdmins.get(mirrorName);
+        if (srcAdmin == null) {
+            log.error("Source admin client not initialized for mirror {}, skipping config sync", mirrorName);
+            return;
+        }
+
         Set<String> topics = getConfiguredTopics(mirrorName);
         log.debug("Describing topic configs for topics: {}", topics);
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         topicConfigSyncError.incrementAndGet();
 
-        List<DescribeConfigsRequestData.DescribeConfigsResource> describeConfigsResources =
-            topics.stream()
-                .map(topic -> new DescribeConfigsRequestData.DescribeConfigsResource()
-                    .setResourceType(ConfigResource.Type.TOPIC.id())
-                    .setResourceName(topic))
-                .toList();
+        Collection<ConfigResource> resources = topics.stream()
+            .map(topic -> new ConfigResource(ConfigResource.Type.TOPIC, topic))
+            .toList();
 
-        DescribeConfigsRequest.Builder describeConfigsRequest =
-            new DescribeConfigsRequest.Builder(new DescribeConfigsRequestData().setResources(describeConfigsResources));
-
-        var describeConfigResponse = trySendSourceClusterRequest(mirrorName, describeConfigsRequest);
-        if (describeConfigResponse.responseBody() instanceof DescribeConfigsResponse describeConfigsRes) {
-            log.debug("Periodic describe config response: {}", describeConfigsRes);
-            Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(describeConfigsRes, mirrorConfig);
+        try {
+            Map<ConfigResource, Config> sourceConfigs = srcAdmin.describeConfigs(resources)
+                .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(sourceConfigs, mirrorConfig);
             applyConfigurationChanges(configsToChange);
+        } catch (Exception e) {
+            log.warn("Failed to describe topic configs for mirror {}: {}", mirrorName, e.getMessage());
         }
     }
 
     private Map<String, Map<String, String>> detectConfigurationChanges(
-            DescribeConfigsResponse describeConfigsRes, ClusterMirrorConfig mirrorConfig) {
+            Map<ConfigResource, Config> sourceConfigs, ClusterMirrorConfig mirrorConfig) {
         Map<String, Map<String, String>> configsToChange = new HashMap<>();
         Pattern excludePattern = mirrorConfig.topicPropertiesExcludePattern();
 
-        describeConfigsRes.data().results().forEach(describeConfigResult -> {
-            if (describeConfigResult.resourceType() == ConfigResource.Type.TOPIC.id()) {
-                Properties props = metadataCache.topicConfig(describeConfigResult.resourceName());
+        sourceConfigs.forEach((resource, config) -> {
+            if (resource.type() == ConfigResource.Type.TOPIC) {
+                Properties props = metadataCache.topicConfig(resource.name());
                 Map<String, String> conChange = new HashMap<>();
 
-                describeConfigResult.configs().forEach(con -> {
-                    // Ensures the destination cluster's mirror.name setting is never overwritten
-                    // by source cluster configs (which wouldn't have this config set)
-                    if (con.configSource() == DescribeConfigsResponse.ConfigSource.TOPIC_CONFIG.id()
-                            && !con.name().equals(TopicConfig.MIRROR_NAME_CONFIG)
-                            && (excludePattern == null || !excludePattern.matcher(con.name()).matches())) {
-                        if (props.containsKey(con.name())) {
-                            if (!props.get(con.name()).equals(con.value())) {
-                                conChange.put(con.name(), con.value());
+                config.entries().forEach(entry -> {
+                    if (entry.source() == ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG
+                            && !entry.name().equals(TopicConfig.MIRROR_NAME_CONFIG)
+                            && (excludePattern == null || !excludePattern.matcher(entry.name()).matches())) {
+                        if (props.containsKey(entry.name())) {
+                            if (!props.get(entry.name()).equals(entry.value())) {
+                                conChange.put(entry.name(), entry.value());
                             }
                         } else {
-                            conChange.put(con.name(), con.value());
+                            conChange.put(entry.name(), entry.value());
                         }
                     }
                 });
 
                 if (!conChange.isEmpty()) {
-                    configsToChange.put(describeConfigResult.resourceName(), conChange);
+                    configsToChange.put(resource.name(), conChange);
                 }
             }
         });
@@ -1645,29 +1635,33 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         // TODO: How do we disambiguate ACLs that reference the same resource name
         //       when multiple cluster mirrors exist?
 
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        aclSyncError.incrementAndGet();
-
-        // list remote acls
-        var describeAclsRequest = new DescribeAclsRequest.Builder(ANY_RESOURCE_ACL);
-        var describeAclsResponse = trySendSourceClusterRequest(mirrorName, describeAclsRequest);
-        if (!(describeAclsResponse.responseBody() instanceof DescribeAclsResponse aclsResponse)) {
-            log.warn("Unexpected ACL response type from remote cluster: {}", describeAclsResponse);
+        Admin srcAdmin = srcAdmins.get(mirrorName);
+        if (srcAdmin == null) {
+            log.error("Source admin client not initialized for mirror {}, skipping ACL sync", mirrorName);
             return;
         }
 
-        log.debug("Describe ACLs response from remote cluster {}: {}", mirrorName, aclsResponse);
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        aclSyncError.incrementAndGet();
 
-        // Filter ACLs by include rules
-        List<ClusterMirrorConfig.AclRule> aclIncludeRules = mirrorConfig.aclIncludeRules();
-        var allRemoteAcls = DescribeAclsResponse.aclBindings(aclsResponse.acls()).stream()
-                .filter(acl -> aclIncludeRules.stream().anyMatch(rule -> rule.matches(acl)))
-                .toList();
-        var aclChanges = detectACLChanges(allRemoteAcls);
-        applyAccessControlListChanges(mirrorName, aclChanges);
+        try {
+            Collection<AclBinding> remoteAcls = srcAdmin.describeAcls(AclBindingFilter.ANY)
+                .values().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            log.debug("Describe ACLs response from remote cluster {}: {}", mirrorName, remoteAcls);
+
+            List<ClusterMirrorConfig.AclRule> aclIncludeRules = mirrorConfig.aclIncludeRules();
+            var allRemoteAcls = remoteAcls.stream()
+                    .filter(acl -> aclIncludeRules.stream().anyMatch(rule -> rule.matches(acl)))
+                    .toList();
+            var aclChanges = detectAccessControlListsChanges(allRemoteAcls);
+            applyAccessControlListChanges(mirrorName, aclChanges);
+        } catch (Exception e) {
+            log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
+        }
     }
 
-    private ACLChanges detectACLChanges(List<AclBinding> allRemoteAcls) {
+    private ACLChanges detectAccessControlListsChanges(List<AclBinding> allRemoteAcls) {
         var addACLsList = new ArrayList<AclBinding>();
         var deleteACLsList = new ArrayList<AclBinding>();
         var current = metadataImage.acls().acls().values();
@@ -1857,17 +1851,19 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (cached != null) {
             return cached;
         }
-        // cache miss: resolve by sending a synchronous metadata request
-        ensureConnection(mirrorName);
+        // lazily create the admin client
+        // handles the edge case where getSourceClusterId is called before periodicSync
+        Admin srcAdmin = srcAdmins.computeIfAbsent(mirrorName, k -> {
+            Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
+            return Admin.create(props);
+        });
         try {
-            var response = trySendSourceClusterRequest(mirrorName, MetadataRequest.Builder.allTopics());
-            if (response.responseBody() instanceof MetadataResponse metadataResponse) {
-                String clusterId = metadataResponse.clusterId();
-                if (clusterId != null && !clusterId.isEmpty()) {
-                    cached = Uuid.fromString(clusterId);
-                    sourceClusterIds.put(mirrorName, cached);
-                    return cached;
-                }
+            String clusterId = srcAdmin.describeCluster()
+                .clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            if (clusterId != null && !clusterId.isEmpty()) {
+                cached = Uuid.fromString(clusterId);
+                sourceClusterIds.put(mirrorName, cached);
+                return cached;
             }
         } catch (Exception e) {
             log.warn("Failed to resolve source cluster ID for mirror {}", mirrorName, e);
@@ -1876,6 +1872,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     void clear() {
+        failedRetryAttempts.clear();
         partitionStates.clear();
         partitionPreviousStates.clear();
         partitionStateCounts.clear();

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -262,10 +262,21 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             delta.topicsDelta().createdTopicIds().forEach(pendingTopicCreations::remove);
         }
 
-        maybeRecreateConnection(delta, newImage);
+        Set<String> reconnectedMirrors = maybeRecreateConnection(delta, newImage);
 
         // get all mirror partition leaders on this node based on the delta
         Set<TopicPartition> mirrorLeaders = getMirrorLeadersAndClearFollowerStates(delta, newImage);
+
+        // after a connection config change (e.g. bootstrap.servers), fetchers were removed
+        // and must be recreated by re-evaluating MIRRORING partitions for the affected mirrors
+        if (!reconnectedMirrors.isEmpty()) {
+            partitionStates.forEach((key, state) -> {
+                if (reconnectedMirrors.contains(key.mirrorName()) && state == MirrorPartitionState.MIRRORING) {
+                    mirrorLeaders.add(new TopicPartition(key.topic(), key.partition()));
+                }
+            });
+        }
+
         if (mirrorLeaders.isEmpty()) {
             return;
         }
@@ -386,7 +397,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             ClusterMirrorConfig.MIRROR_GROUPS_INCLUDE_CONFIG, ClusterMirrorConfig.MIRROR_GROUPS_EXCLUDE_CONFIG,
             ClusterMirrorConfig.MIRROR_ACL_INCLUDE_CONFIG);
 
-    private void maybeRecreateConnection(MetadataDelta delta, MetadataImage newImage) {
+    private Set<String> maybeRecreateConnection(MetadataDelta delta, MetadataImage newImage) {
+        Set<String> reconnectedMirrors = new HashSet<>();
         if (delta.configsDelta() != null) {
             delta.configsDelta().changes().entrySet().stream()
                 .filter(e -> e.getKey().type() == ConfigResource.Type.CLUSTER_MIRROR)
@@ -410,10 +422,18 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                     + "to trigger reconnection with updated configuration.", mirrorName);
                             senders.forEach(MirrorSourceSender::close);
                         }
+                        Admin admin = srcAdmins.remove(mirrorName);
+                        if (admin != null) {
+                            admin.close();
+                        }
                         mirrorFetcherManagerSupplier.get().removeFetchersForMirror(mirrorName);
+                        if (!mirrorDeleted) {
+                            reconnectedMirrors.add(mirrorName);
+                        }
                     }
                 });
         }
+        return reconnectedMirrors;
     }
 
     /** Returns mirror partitions led by this broker, detecting both leadership and config changes */

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.message.BumpLeaderEpochsRequestData;
 import org.apache.kafka.common.message.CreateAclsRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
@@ -108,6 +109,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -183,13 +185,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Map<TopicPartition, Integer> failedRetryAttempts = new ConcurrentHashMap<>();
     private final Set<Uuid> pendingTopicCreations = ConcurrentHashMap.newKeySet();
 
-    // metrics
-    private KafkaMetricsGroup metricsGroup;
-    private AtomicLong metadataRefreshError;
-    private AtomicLong topicConfigSyncError;
-    private AtomicLong consumerGroupOffsetSyncError;
-    private AtomicLong shareGroupOffsetSyncError;
-    private AtomicLong aclSyncError;
+    private final AtomicLong metadataRefreshError;
+    private final AtomicLong topicConfigSyncError;
+    private final AtomicLong consumerGroupOffsetSyncError;
+    private final AtomicLong shareGroupOffsetSyncError;
+    private final AtomicLong aclSyncError;
 
     public MirrorMetadataManager(
         KafkaConfig brokerConfig,
@@ -213,7 +213,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         this.metadataCache = metadataCache;
         this.scheduler = scheduler;
 
-        this.metricsGroup = new KafkaMetricsGroup(this.getClass());
+        // metrics
+        KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(this.getClass());
         this.metadataRefreshError = new AtomicLong();
         this.topicConfigSyncError = new AtomicLong();
         this.consumerGroupOffsetSyncError = new AtomicLong();
@@ -456,17 +457,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             // get all resources containing the non-empty mirror name change
             Map<ConfigResource, ConfigurationDelta> mirrorNameChanged = delta.configsDelta().changes().entrySet().stream().filter(entry ->
                             entry.getValue().changes().containsKey(TopicConfig.MIRROR_NAME_CONFIG) &&
-                                    !entry.getValue().changes().get(TopicConfig.MIRROR_NAME_CONFIG).isEmpty()
+                                    entry.getValue().changes().get(TopicConfig.MIRROR_NAME_CONFIG).isPresent()
                                     && !entry.getValue().changes().get(TopicConfig.MIRROR_NAME_CONFIG).get().isBlank())
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             // get all topics from the resources
             Set<String> topicsWithMirrorNameChanged = mirrorNameChanged.keySet().stream()
                     .filter(configResource -> configResource.type().equals(ConfigResource.Type.TOPIC))
-                    .map(configResource -> configResource.name()).collect(Collectors.toSet());
+                    .map(ConfigResource::name).collect(Collectors.toSet());
 
             // get the partition leader is the local node
-            topicsWithMirrorNameChanged.stream().forEach(topic -> {
+            topicsWithMirrorNameChanged.forEach(topic -> {
                 TopicImage topicImage = image.topics().getTopic(topic);
                 if (topicImage != null) {
                     topicImage.partitions().forEach((partitionId, partition) -> {
@@ -827,14 +828,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         throw new KafkaException("Failed to send request to any source server for mirror " + mirrorName, lastException);
     }
 
-    /** Invalidates cached source leaders for specific partitions, leaving other partitions' cached leaders intact. */
-    public void invalidateSourceLeader(String mirrorName, java.util.Set<TopicPartition> partitions) {
-        var partitionLeaders = sourceLeaders.get(mirrorName);
-        if (partitionLeaders != null) {
-            partitions.forEach(partitionLeaders::remove);
-        }
-    }
-
     /** Updates cached source leader for a specific partition. */
     public void updateSourceLeader(String mirrorName, TopicPartition tp, Node leader) {
         sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>()).put(tp, leader);
@@ -992,9 +985,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         for (String mirrorName : Set.copyOf(sourceSenders.keySet())) {
             try {
                 discoverSourceBrokers(mirrorName);
-                log.info("Syncing source topic state for mirror {}", mirrorName);
                 var metadataResponse = syncSourceTopicState(mirrorName);
-                log.info("Syncing coordinator metadata for mirror {}", mirrorName);
                 syncCoordinatorMetadata(mirrorName, metadataResponse);
             } catch (Exception e) {
                 log.error("Failed to sync metadata for mirror {}", mirrorName, e);
@@ -1077,10 +1068,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     private Map<TopicPartition, Integer> buildSourceEpochBumpTargets(String mirrorName, MetadataResponse metadataResponse, Set<TopicPartition> topicPartitions) {
-        Set<String> mirrorTopics = new HashSet<>();
-        if (topicPartitions.isEmpty()) {
-            mirrorTopics = getConfiguredTopics(mirrorName);
-        }
+        Set<String> mirrorTopics = topicPartitions.isEmpty() ? getConfiguredTopics(mirrorName, false) : Set.of();
         Map<TopicPartition, Integer> leaderEpochFromMetadata = new HashMap<>();
         for (MetadataResponse.TopicMetadata topicMetadata : metadataResponse.topicMetadata()) {
             if (topicMetadata.error() != Errors.NONE) {
@@ -1089,29 +1077,36 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             if (!mirrorTopics.isEmpty() && !mirrorTopics.contains(topicMetadata.topic())) {
                 continue;
             }
-            for (MetadataResponse.PartitionMetadata partitionMetadata : topicMetadata.partitionMetadata()) {
-                TopicPartition tp = partitionMetadata.topicPartition;
-                if (!topicPartitions.isEmpty() && !topicPartitions.contains(tp)) {
-                    continue;
-                }
-                if (partitionMetadata.leaderEpoch.isEmpty()) {
-                    continue;
-                }
-                if (metadataImage.topics().getTopic(tp.topic()) == null ||
-                        metadataImage.topics().getTopic(tp.topic()).partitions().get(tp.partition()) == null) {
-                    continue;
-                }
-                int epoch = partitionMetadata.leaderEpoch.get();
-                int localEpoch = metadataImage.topics().getTopic(tp.topic()).partitions().get(tp.partition()).leaderEpoch;
-                if (epoch > localEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
-                    // will throw exception when overflow, but this should not happen
-                    int newEpoch = Math.addExact(epoch, LEADER_EPOCH_BUMP_INCREMENT);
-                    leaderEpochFromMetadata.put(tp, newEpoch);
-                }
+            collectEpochBumpTargets(topicMetadata, topicPartitions, leaderEpochFromMetadata);
+        }
+        if (!leaderEpochFromMetadata.isEmpty()) {
+            log.info("Bumping leader epoch for partitions {} to {}", topicPartitions, leaderEpochFromMetadata);
+        }
+        return leaderEpochFromMetadata;
+    }
+
+    private void collectEpochBumpTargets(MetadataResponse.TopicMetadata topicMetadata,
+                                         Set<TopicPartition> topicPartitions,
+                                         Map<TopicPartition, Integer> leaderEpochFromMetadata) {
+        for (MetadataResponse.PartitionMetadata partitionMetadata : topicMetadata.partitionMetadata()) {
+            TopicPartition tp = partitionMetadata.topicPartition;
+            if (!topicPartitions.isEmpty() && !topicPartitions.contains(tp)) {
+                continue;
+            }
+            if (partitionMetadata.leaderEpoch.isEmpty()) {
+                continue;
+            }
+            TopicImage topicImage = metadataImage.topics().getTopic(tp.topic());
+            if (topicImage == null || topicImage.partitions().get(tp.partition()) == null) {
+                continue;
+            }
+            int epoch = partitionMetadata.leaderEpoch.get();
+            int localEpoch = topicImage.partitions().get(tp.partition()).leaderEpoch;
+            if (epoch > localEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
+                int newEpoch = Math.addExact(epoch, LEADER_EPOCH_BUMP_INCREMENT);
+                leaderEpochFromMetadata.put(tp, newEpoch);
             }
         }
-        log.info("Bumping leader epoch for partitions {} to {}", topicPartitions, leaderEpochFromMetadata);
-        return leaderEpochFromMetadata;
     }
 
     public Map<TopicPartition, Integer> buildLocalEpochBumpTargets(LogManager logManager, Set<TopicPartition> topicPartitions) {
@@ -1219,7 +1214,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Runs on every broker to keep partition leaders, topic creation, deletion, and partition counts in sync.
      */
     private Optional<MetadataResponse> syncSourceTopicState(String mirrorName) {
-        Set<String> topics = getConfiguredTopics(mirrorName);
+        log.info("Syncing source topic state for mirror {}", mirrorName);
+        Set<String> topics = getConfiguredTopics(mirrorName, false);
         if (topics.isEmpty()) {
             return Optional.empty();
         }
@@ -1369,6 +1365,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
 
+        log.info("Syncing coordinator metadata for mirror {}", mirrorName);
         ensureConnection(mirrorName);
 
         try {
@@ -1392,7 +1389,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
 
-        Set<String> topics = getConfiguredTopics(mirrorName);
+        Set<String> topics = getConfiguredTopics(mirrorName, false);
         log.debug("Describing topic configs for topics: {}", topics);
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         topicConfigSyncError.incrementAndGet();
@@ -1489,7 +1486,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
 
-        Set<String> mirrorTopics = getConfiguredTopics(mirrorName);
+        Set<String> mirrorTopics = getConfiguredTopics(mirrorName, false);
         if (mirrorTopics.isEmpty()) {
             return;
         }
@@ -1622,7 +1619,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     .map(GroupListing::groupId)
                     .collect(Collectors.toSet()));
         } catch (Exception e) {
-            log.warn("Failed to list destination groups, skipping offset sync cycle: {}", e);
+            log.warn("Failed to list destination groups, skipping offset sync cycle.", e);
             return Optional.empty();
         }
     }
@@ -1656,6 +1653,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     .toList();
             var aclChanges = detectAccessControlListsChanges(allRemoteAcls);
             applyAccessControlListChanges(mirrorName, aclChanges);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof SecurityDisabledException) {
+                log.debug("ACL sync skipped for mirror {}: {}", mirrorName, e.getCause().getMessage());
+            } else {
+                log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
+            }
         } catch (Exception e) {
             log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
         }
@@ -1802,11 +1805,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .collect(Collectors.toSet());
     }
 
-    /** Returns the set of topic names configured for the given mirror, excluding paused topics. */
-    Set<String> getConfiguredTopics(String mirrorName) {
-        return getConfiguredTopics(mirrorName, false, true);
-    }
-
+    /** Returns the set of topic names configured for the given mirror. */
     Set<String> getConfiguredTopics(String mirrorName, boolean includePaused) {
         return getConfiguredTopics(mirrorName, includePaused, true);
     }
@@ -1891,13 +1890,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         snapshot.values().forEach(senders -> senders.forEach(MirrorSourceSender::close));
     }
 
-    private static class TimeoutHandler implements ControllerRequestCompletionHandler {
-        private final Logger log;
-
-        TimeoutHandler(Logger log) {
-            this.log = log;
-        }
-
+    private record TimeoutHandler(Logger log) implements ControllerRequestCompletionHandler {
         @Override
         public void onTimeout() {
             log.warn("Controller request timed out");

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -61,7 +61,7 @@ LABEL ducker.creator=$ducker_creator
 
 # Update Linux and install necessary utilities.
 RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute iproute2 iputils-ping && apt-get -y clean
-RUN python3 -m pip install -U pip==21.1.1;
+RUN python3 -m pip install -U pip;
 # NOTE: ducktape 0.14.0 supports py 3.9, 3.10, 3.11, 3.12 and 3.13
 COPY requirements.txt requirements.txt
 RUN pip3 install --upgrade -r requirements.txt

--- a/tests/docker/requirements.txt
+++ b/tests/docker/requirements.txt
@@ -17,7 +17,7 @@ cffi
 virtualenv 
 pyasn1 
 boto3 
-pycrypto 
+pycryptodome 
 pywinrm 
 ipaddress 
 debugpy 

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -791,9 +791,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             override_configs[config_property.UNSTABLE_API_VERSIONS_ENABLE] = str(True)
             override_configs[config_property.UNSTABLE_FEATURE_VERSIONS_ENABLE] = str(True)
 
-        if self.use_cluster_mirroring:
-            override_configs[config_property.UNSTABLE_API_VERSIONS_ENABLE] = 'true'
-            override_configs[config_property.UNSTABLE_FEATURE_VERSIONS_ENABLE] = 'true'
+        if self.use_cluster_mirroring is True:
+            override_configs[config_property.UNSTABLE_API_VERSIONS_ENABLE] = str(True)
+            override_configs[config_property.UNSTABLE_FEATURE_VERSIONS_ENABLE] = str(True)
 
         #update template configs with test override configs
         configs.update(override_configs)
@@ -1352,6 +1352,16 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.info("Running alter message format command...\n%s" % cmd)
         node.account.ssh(cmd)
 
+    def alter_topic_config(self, topic, config, node=None):
+        if node is None:
+            node = self.nodes[0]
+        force_use_zk_connection = not self.all_nodes_configs_command_uses_bootstrap_server()
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --entity-name %s --entity-type topics --alter --add-config %s" % \
+              (self.kafka_configs_cmd_with_optional_security_settings(node, force_use_zk_connection), topic, config)
+        self.logger.info("Running alter topic config command...\n%s" % cmd)
+        node.account.ssh(cmd)
+
     def kafka_acls_cmd_with_optional_security_settings(self, node, kafka_security_protocol = None, override_command_config = None):
         if self.quorum_info.using_kraft and not self.quorum_info.has_brokers:
             raise Exception("Must invoke kafka-acls against a broker, not a KRaft controller")
@@ -1817,7 +1827,23 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 output += line
         self.logger.debug(output)
         return output
-    
+
+    def reset_consumer_group_offsets(self, node, group, topic, offset):
+        consumer_group_script = self.path.script("kafka-consumer-groups.sh", node)
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s --group %s --topic %s --reset-offsets --to-offset %d --execute" % \
+               (consumer_group_script, self.bootstrap_servers(self.security_protocol),
+                group, topic, offset)
+        return self.run_cli_tool(node, cmd)
+
+    def reset_share_group_offsets(self, node, group, topic, strategy="--to-earliest"):
+        share_group_script = self.path.script("kafka-share-groups.sh", node)
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s --group %s --topic %s --reset-offsets %s --execute" % \
+               (share_group_script, self.bootstrap_servers(self.security_protocol),
+                group, topic, strategy)
+        return self.run_cli_tool(node, cmd)
+
     def describe_share_group(self, group, node=None, command_config=None):
         """ Describe a share group.
         """
@@ -1843,7 +1869,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 output += line
         self.logger.debug(output)
         return output
-    
+
     def describe_share_group_members(self, group, node=None, command_config=None):
         """ Describe members of a share group.
         """
@@ -1861,7 +1887,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
               (share_group_script,
                self.bootstrap_servers(self.security_protocol),
                command_config, group)
-        
+
         cmd += " --members"
 
         output_lines = []
@@ -2021,7 +2047,11 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def java_class_name(self):
         return "kafka\.Kafka"
 
-    def create_cluster_mirror(self, node, mirror_name, mirror_config_file):
+    def create_cluster_mirror(self, node, mirror_name, mirror_config):
+        mirror_config_file = "/mnt/cluster_mirroring/cluster_mirror.properties"
+        node.account.ssh("mkdir -p /mnt/cluster_mirroring", allow_fail=False)
+        node.account.create_file(mirror_config_file, str(mirror_config))
+
         cluster_mirror_script = self.path.script("kafka-cluster-mirrors.sh", node)
 
         cmd = fix_opts_for_new_jvm(node)
@@ -2031,6 +2061,22 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 mirror_name,
                 mirror_config_file)
         return self.run_cli_tool(node, cmd)
+
+    def delete_cluster_mirror(self, node, mirror_name):
+        cluster_mirror_script = self.path.script("kafka-cluster-mirrors.sh", node)
+
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s --delete --mirror %s" % \
+               (cluster_mirror_script,
+                self.bootstrap_servers(self.security_protocol),
+                mirror_name)
+        output = ""
+        self.logger.debug(cmd)
+        for line in node.account.ssh_capture(cmd, allow_fail=True):
+            if not line.startswith("SLF4J"):
+                output += line
+        self.logger.debug(output)
+        return output
 
     def list_cluster_mirror(self, node):
         cluster_mirror_script = self.path.script("kafka-cluster-mirrors.sh", node)
@@ -2051,34 +2097,54 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         return self.run_cli_tool(node, cmd)
 
 
-    def _cluster_mirror_action(self, node, mirror_name, topics, action):
-        assert topics is not None and len(topics) > 0
+    def _cluster_mirror_action(self, node, mirror_name, topics_regex, action, exclude=None):
+        assert topics_regex is not None and len(topics_regex) > 0
         cluster_mirror_script = self.path.script("kafka-cluster-mirrors.sh", node)
 
         cmd = fix_opts_for_new_jvm(node)
-        topic_names = ' '.join(['--topics %s' % topic for topic in topics])
-        cmd += "%s --bootstrap-server %s --%s --mirror %s %s" % \
+        cmd += "%s --bootstrap-server %s --%s --mirror %s --topics %s" % \
                (cluster_mirror_script,
                 self.bootstrap_servers(self.security_protocol),
                 action,
                 mirror_name,
-                topic_names)
+                topics_regex)
+        if exclude is not None:
+            cmd += " --exclude %s" % exclude
         return self.run_cli_tool(node, cmd)
 
-    def start_cluster_mirror_topics(self, node, mirror_name, topics):
-        return self._cluster_mirror_action(node, mirror_name, topics, 'start')
+    def start_cluster_mirror_topics(self, node, mirror_name, topics_regex, exclude=None):
+        return self._cluster_mirror_action(node, mirror_name, topics_regex, 'start', exclude=exclude)
 
-    def delete_topics_from_cluster_mirror(self, node, mirror_name, topics):
-        return self._cluster_mirror_action(node, mirror_name, topics, 'delete')
+    def stop_cluster_mirror_topics(self, node, mirror_name, topics_regex):
+        return self._cluster_mirror_action(node, mirror_name, topics_regex, 'stop')
 
-    def delete_topics_from_cluster_mirror(self, node, mirror_name, topics):
-        return self._cluster_mirror_action(node, mirror_name, topics, 'pause')
+    def pause_cluster_mirror_topics(self, node, mirror_name, topics_regex):
+        return self._cluster_mirror_action(node, mirror_name, topics_regex, 'pause')
 
-    def delete_topics_from_cluster_mirror(self, node, mirror_name, topics):
-        return self._cluster_mirror_action(node, mirror_name, topics, 'resume')
+    def resume_cluster_mirror_topics(self, node, mirror_name, topics_regex):
+        return self._cluster_mirror_action(node, mirror_name, topics_regex, 'resume')
 
-    def stop_cluster_mirror_topics(self, node, mirror_name, topics):
-        return self._cluster_mirror_action(node, mirror_name, topics, 'stop')
+    def alter_mirror_config(self, node, mirror_name, config):
+        config_script = self.path.script("kafka-configs.sh", node)
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s --entity-type mirrors --entity-name %s --alter --add-config %s" % \
+               (config_script, self.bootstrap_servers(self.security_protocol),
+                mirror_name, config)
+        output = ""
+        self.logger.debug(cmd)
+        for line in node.account.ssh_capture(cmd, allow_fail=True):
+            if not line.startswith("SLF4J"):
+                output += line
+        self.logger.debug(output)
+        return output
+
+    def describe_mirror_config(self, node, mirror_name):
+        config_script = self.path.script("kafka-configs.sh", node)
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s --entity-type mirrors --entity-name %s --describe" % \
+               (config_script, self.bootstrap_servers(self.security_protocol),
+                mirror_name)
+        return self.run_cli_tool(node, cmd)
 
     def parse_describe_cluster_mirror(self, cluster_mirror_description):
         """Parse output of kafka-cluster-mirrors.sh --describe (or describe_cluster_mirror() method above), which is a string of form

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -13,32 +13,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+import json
 import os
+import time
 
 from ducktape.mark.resource import cluster
 from ducktape.mark import defaults
+from ducktape.services.service import Service
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
+from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
 from kafkatest.services.kafka import KafkaService, quorum
-from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.security.security_config import SecurityConfig
 from kafkatest.version import (
     CLUSTER_MIRRORING_METADATA_VERSION,
     CLUSTER_MIRRORING_VERSION,
 )
-import itertools
+
 
 class ClusterMirrorConfig:
+    """Configuration for a cluster mirror connection properties file."""
     def __init__(
         self,
         bootstrap_servers: str,
         mirror_topic_properties_exclude: str = None,
         mirror_groups_include: str = None,
+        mirror_groups_exclude: str = None,
         mirror_acl_include: str = None,
         security_config: SecurityConfig = None,
     ):
         self.properties = {
             "bootstrap.servers": bootstrap_servers,
+            "mirror.metadata.refresh.interval.ms": "10000",
         }
         if mirror_topic_properties_exclude is not None:
             self.properties["mirror.topic.properties.exclude"] = (
@@ -46,6 +53,8 @@ class ClusterMirrorConfig:
             )
         if mirror_groups_include is not None:
             self.properties["mirror.groups.include"] = mirror_groups_include
+        if mirror_groups_exclude is not None:
+            self.properties["mirror.groups.exclude"] = mirror_groups_exclude
         if mirror_acl_include is not None:
             self.properties["mirror.acl.include"] = (mirror_acl_include,)
 
@@ -67,59 +76,75 @@ class ClusterMirrorConfig:
         """
         return self.props()
 
+
+class ClientService(KafkaPathResolverMixin, Service):
+    """Provides dedicated nodes for running Kafka CLI tools (producers, consumers)."""
+    def start_node(self, node):
+        pass
+
+    def stop_node(self, node):
+        pass
+
+    def clean_node(self, node):
+        pass
+
+
 class ClusterMirroringTest(Test):
-    PERSISTENT_ROOT = "/mnt/cluster_mirroring"
-    MIRROR_CONFIG_FILE = os.path.join(PERSISTENT_ROOT, "cluster_mirror.properties")
+    """Tests for KIP-1279 Cluster Mirroring using a source and destination cluster."""
 
     def __init__(self, test_context):
         """:type test_context: ducktape.tests.test.TestContext"""
         super(ClusterMirroringTest, self).__init__(test_context)
-        topic = "my-topic"
-        self.topics = {topic: {"partitions": 3, "replication-factor": 3}}
+        # Defaults for a 2-broker cluster (unstable.* is set by use_cluster_mirroring)
+        server_props = [
+            ["auto.create.topics.enable", "false"],
+            ["default.replication.factor", "2"],
+            ["min.insync.replicas", "1"],
+            ["offsets.topic.replication.factor", "2"],
+            ["transaction.state.log.replication.factor", "2"],
+            ["transaction.state.log.min.isr", "1"],
+            ["share.coordinator.state.topic.replication.factor", "2"],
+            ["share.coordinator.state.topic.min.isr", "1"],
+            ["mirror.topic.replication.factor", "2"],
+        ]
         self.source_kafka = KafkaService(
             test_context,
-            num_nodes=3,
+            num_nodes=2,
             zk=None,
-            topics=self.topics,
             use_cluster_mirroring=True,
             controller_num_nodes_override=1,
+            server_prop_overrides=server_props,
         )
         self.dest_kafka = KafkaService(
-            test_context, num_nodes=3, zk=None, use_cluster_mirroring=True,
+            test_context, num_nodes=2, zk=None, use_cluster_mirroring=True,
             controller_num_nodes_override=1,
-        )
-        self.producer = VerifiableProducer(
-            self.test_context,
-            num_nodes=1,
-            kafka=self.source_kafka,
-            topic=topic,
-            throughput=100,
+            server_prop_overrides=server_props,
         )
 
     def setup(self):
         self.source_kafka.start()
         self.dest_kafka.start()
 
-        self.logger.info(
-            "Changing metadata.version in destination to %s"
-            % CLUSTER_MIRRORING_METADATA_VERSION
-        )
-        self.dest_kafka.upgrade_metadata_version(CLUSTER_MIRRORING_METADATA_VERSION)
-        self.logger.info(
-            "Changing mirror.version in destination to %s" % CLUSTER_MIRRORING_VERSION
-        )
-        self.dest_kafka.run_features_command(
-            "upgrade", "mirror.version", CLUSTER_MIRRORING_VERSION
-        )
+        for kafka in [self.source_kafka, self.dest_kafka]:
+            self.logger.info(
+                "Changing metadata.version on %s to %s", kafka, CLUSTER_MIRRORING_METADATA_VERSION
+            )
+            kafka.upgrade_metadata_version(CLUSTER_MIRRORING_METADATA_VERSION)
+            self.logger.info(
+                "Changing mirror.version on %s to %s", kafka, CLUSTER_MIRRORING_VERSION
+            )
+            kafka.run_features_command(
+                "upgrade", "mirror.version", CLUSTER_MIRRORING_VERSION
+            )
 
-        self.producer.start()
+        # Dedicated client nodes shared across tests
+        # Producers and consumers are created per test on these nodes
+        self.client = ClientService(self.test_context, num_nodes=2)
+        self.producer_node = self.client.nodes[0]
+        self.consumer_node = self.client.nodes[1]
 
     def teardown(self):
-        if any(self.producer.alive(node) for node in self.producer.nodes):
-            try:
-                self.producer.stop()
-            except Exception as e:
-                self.logger.warning("Error stopping producer: %s" % str(e))
+        self.client.stop()
         for kafka in [self.dest_kafka, self.source_kafka]:
             try:
                 kafka.stop()
@@ -128,18 +153,68 @@ class ClusterMirroringTest(Test):
                 for node in kafka.nodes:
                     kafka.stop_node(node, clean_shutdown=False)
 
-    def all_satisfy_in_mirror(self, kafka_node, mirror_name, per_partition_condition):
-        """Check that all partitions of all mirrored topics satisfy the given condition."""
-        output = self.dest_kafka.describe_cluster_mirror(kafka_node)
+    def produce_records(self, node, topic, num_records):
+        """Produce records to a specific broker node using kafka-producer-perf-test."""
+        bootstrap_servers = "%s:9092" % node.account.hostname
+        cmd = "%s --topic %s --num-records %d --record-size 1 --throughput -1" \
+              " --producer-props bootstrap.servers=%s" % (
+                  self.client.path.script("kafka-producer-perf-test.sh"),
+                  topic, num_records, bootstrap_servers)
+        self.producer_node.account.ssh(cmd, allow_fail=True)
+
+    def consume_records(self, topic, kafka, max_messages=None, timeout_ms=10000,
+                        isolation_level=None, group=None, from_beginning=True):
+        """Consume records and return count using kafka-console-consumer."""
+        cmd = "%s --bootstrap-server %s --topic %s --timeout-ms %d" % (
+            self.client.path.script("kafka-console-consumer.sh"),
+            kafka.bootstrap_servers(kafka.security_protocol),
+            topic, timeout_ms)
+        if from_beginning:
+            cmd += " --from-beginning"
+        if max_messages is not None:
+            cmd += " --max-messages %d" % max_messages
+        if isolation_level is not None:
+            cmd += " --isolation-level %s" % isolation_level
+        if group is not None:
+            cmd += " --group %s" % group
+        # Suppress stderr to avoid counting "Processed a total of N messages" line
+        cmd += " 2>/dev/null"
+        count = 0
+        for line in self.consumer_node.account.ssh_capture(cmd, allow_fail=True):
+            if line.strip():
+                count += 1
+        return count
+
+    def consume_share_records(self, topic, kafka, group, max_messages=None, timeout_ms=10000):
+        """Consume records using kafka-console-share-consumer and return count."""
+        cmd = "%s --bootstrap-server %s --topic %s --group %s --timeout-ms %d" % (
+            self.client.path.script("kafka-console-share-consumer.sh"),
+            kafka.bootstrap_servers(kafka.security_protocol),
+            topic, group, timeout_ms)
+        if max_messages is not None:
+            cmd += " --max-messages %d" % max_messages
+        cmd += " 2>/dev/null"
+        count = 0
+        for line in self.consumer_node.account.ssh_capture(cmd, allow_fail=True):
+            if line.strip():
+                count += 1
+        return count
+
+    def all_satisfy_in_mirror(self, kafka, kafka_node, mirror_name, per_partition_condition, topics=None):
+        """Check that all partitions of the given mirror topics satisfy the condition."""
+        output = kafka.describe_cluster_mirror(kafka_node)
         if output == "":
             return False
 
-        mirrors = self.dest_kafka.parse_describe_cluster_mirror(output)
+        try:
+            mirrors = kafka.parse_describe_cluster_mirror(output)
+        except (json.JSONDecodeError, KeyError):
+            return False
         if mirror_name not in mirrors:
             return False
         mirror = mirrors[mirror_name]
 
-        for topic in self.topics:
+        for topic in (topics if topics is not None else self.topics):
             if topic not in mirror:
                 return False
 
@@ -148,136 +223,798 @@ class ClusterMirroringTest(Test):
                     return False
         return True
 
-    @cluster(num_nodes=9)
-    @defaults(metadata_quorum=[quorum.isolated_kraft])
-    def test_log_convergence(self, metadata_quorum):
-        """Verify that mirrored log segments are byte identical to source after bouncing both clusters."""
-        mirror_cfg = {
-            "name": "my-mirror",
-            "cfg": ClusterMirrorConfig(self.source_kafka.bootstrap_servers()),
-        }
-        self.logger.info(
-            "Creating mirror %s with settings %s", mirror_cfg["name"], mirror_cfg["cfg"]
-        )
-        kafka_node = self.dest_kafka.nodes[0]
+    def wait_mirror_state(self, kafka, kafka_node, mirror_name, state, topics=None,
+                          err_msg=None):
+        """Wait until all mirror partitions reach the given state."""
+        def check():
+            self.logger.debug("describe_cluster_mirror: %s",
+                              kafka.describe_cluster_mirror(kafka_node))
+            return self.all_satisfy_in_mirror(
+                kafka, kafka_node, mirror_name,
+                lambda p: p["state"] == state, topics)
+        if err_msg is None:
+            err_msg = "Mirror did not reach %s state" % state
+        wait_until(check, timeout_sec=60, backoff_sec=2, err_msg=err_msg)
 
-        prop_file = str(mirror_cfg["cfg"])
-        self.logger.info(prop_file)
-        kafka_node.account.ssh(
-            "mkdir -p %s" % ClusterMirroringTest.PERSISTENT_ROOT, allow_fail=False
-        )
-        kafka_node.account.create_file(
-            ClusterMirroringTest.MIRROR_CONFIG_FILE, prop_file
-        )
+    def wait_mirror_lag_zero(self, kafka, kafka_node, mirror_name, topics=None,
+                             err_msg="Mirror did not catch up"):
+        """Wait until all mirror partitions reach MIRRORING state with zero lag."""
+        def check():
+            self.logger.debug("describe_cluster_mirror: %s",
+                              kafka.describe_cluster_mirror(kafka_node))
+            return self.all_satisfy_in_mirror(
+                kafka, kafka_node, mirror_name,
+                lambda p: p["lag"] == 0 and p["state"] == "MIRRORING", topics)
+        wait_until(check, timeout_sec=120, backoff_sec=5, err_msg=err_msg)
 
-        wait_until(
-            lambda: self.dest_kafka.create_cluster_mirror(
-                kafka_node, mirror_cfg["name"], ClusterMirroringTest.MIRROR_CONFIG_FILE
-            ),
-            timeout_sec=20,
-            backoff_sec=2,
-            err_msg="Failed to create cluster mirror",
-        )
+    def wait_for_metadata_sync(self, kafka, node, mirror_name, num_cycles=1):
+        """Wait for metadata sync by sleeping based on the configured refresh interval."""
+        output = kafka.describe_mirror_config(node, mirror_name)
+        interval_ms = 30000
+        for line in output.splitlines():
+            if "mirror.metadata.refresh.interval.ms=" in line:
+                # Format: "  mirror.metadata.refresh.interval.ms=10000 sensitive=false synonyms={...}"
+                interval_ms = int(line.strip().split()[0].split("=")[1])
+                break
+        sleep_s = (interval_ms // 1000) * num_cycles + 2
+        self.logger.info("Waiting %ds for %d metadata sync cycle(s) (interval=%dms)",
+                         sleep_s, num_cycles, interval_ms)
+        time.sleep(sleep_s)
 
-        wait_until(
-            lambda: (
-                "Started"
-                in self.dest_kafka.start_cluster_mirror_topics(
-                    kafka_node, mirror_cfg["name"], self.topics.keys()
-                )
-            ),
-            timeout_sec=20,
-            backoff_sec=2,
-            err_msg="Failed to start mirror topics",
-        )
-
-        wait_until(
-            lambda: self.all_satisfy_in_mirror(
-                kafka_node, mirror_cfg["name"], lambda p: p["state"] == "MIRRORING"
-            ),
-            timeout_sec=20,
-            backoff_sec=2,
-            err_msg="Failed to start mirrors",
-        )
-
-        wait_until(
-            lambda: self.producer.num_acked >= 5,
-            timeout_sec=10,
-            backoff_sec=2,
-            err_msg="Failed to produce to source cluster",
-        )
-
-        acked = self.producer.num_acked
-        self.source_kafka.restart_cluster(clean_shutdown=True)
-        wait_until(
-            lambda: self.producer.num_acked - acked > 1000,
-            timeout_sec=60,
-            backoff_sec=2,
-            err_msg="Failed to produce since source cluster bounced",
-        )
-
-        acked = self.producer.num_acked
-        self.dest_kafka.restart_cluster(clean_shutdown=True)
-
-        wait_until(
-            lambda: self.producer.num_acked - acked > 1000,
-            timeout_sec=60,
-            backoff_sec=2,
-            err_msg="Failed to produce since destination cluster bounced",
-        )
-        self.producer.stop()
-
-        wait_until(
-            lambda: self.all_satisfy_in_mirror(
-                kafka_node, mirror_cfg["name"],
-                lambda p: p["lag"] == 0 and p["state"] == "MIRRORING"
-            ),
-            timeout_sec=60,
-            backoff_sec=2,
-            err_msg="Failed to start mirrors",
-        )
-
-        def log_segment_hashes(kafka, topic, partition=0):
-            """Return a dict mapping segment file names to their MD5 hashes."""
-            leader_node = kafka.leader(topic, partition)
+    def wait_for_log_convergence(self, source_kafka, dest_kafka):
+        """Poll until source leader and all dest replica log segment hashes match."""
+        def log_segment_hashes(node, topic, partition):
             cmd = "md5sum %s*/%s-%d/*.log 2>/dev/null" % (
                 KafkaService.DATA_LOG_DIR_PREFIX, topic, partition)
             hashes = {}
-            for line in leader_node.account.ssh_capture(cmd, allow_fail=True):
+            for line in node.account.ssh_capture(cmd, allow_fail=True):
                 parts = line.strip().split()
                 if len(parts) == 2:
                     hashes[os.path.basename(parts[1])] = parts[0]
             return hashes
 
-        # Check log segments convergence by comparing md5 hashes
-        for topic, cfg in self.topics.items():
-            for partition in range(cfg["partitions"]):
-                source_hashes = log_segment_hashes(self.source_kafka, topic, partition)
-                dest_hashes = log_segment_hashes(self.dest_kafka, topic, partition)
-                assert source_hashes.keys() == dest_hashes.keys(), \
-                    "Segment files differ for %s-%d: source=%s, dest=%s" % (
-                        topic, partition, sorted(source_hashes.keys()), sorted(dest_hashes.keys()))
-                mismatches = []
-                for seg in source_hashes:
-                    if source_hashes[seg] != dest_hashes[seg]:
-                        mismatches.append("%s: source=%s, dest=%s" % (
-                            seg, source_hashes[seg], dest_hashes[seg]))
-                assert not mismatches, \
-                    "Log segment mismatch for %s-%d:\n  %s" % (topic, partition, "\n  ".join(mismatches))
+        def check():
+            for topic, cfg in self.topics.items():
+                for partition in range(cfg["partitions"]):
+                    source = log_segment_hashes(
+                        source_kafka.leader(topic, partition), topic, partition)
+                    for node in dest_kafka.replicas(topic, partition):
+                        dest = log_segment_hashes(node, topic, partition)
+                        if source.keys() != dest.keys() or any(
+                                source[seg] != dest[seg] for seg in source):
+                            return False
+                        self.logger.info("Hashes match for %s-%d dest %s: %d segments verified",
+                                         topic, partition, node.name, len(source))
+            return True
 
-    @cluster(num_nodes=9)
+        wait_until(
+            check,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg="Log segments did not converge between source and destination",
+        )
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_start_stop(self, metadata_quorum):
+        """Verify failover makes destination writable and failback truncates non-mirrored data."""
+        topic = "my-topic"
+        mirror_name = "my-mirror"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
+
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Send 3 records to source
+        self.produce_records(src_node, topic, 3)
+
+        # Start cluster mirror on destination
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+
+        # Consume from destination (expect 3 records)
+        count = self.consume_records(topic, self.dest_kafka, max_messages=3)
+        assert count == 3, "Expected 3 records on destination, got %d" % count
+
+        # Produce to destination while mirroring (should fail)
+        self.produce_records(dest_node, topic, 1)
+
+        # Failover: stop mirror so destination topic becomes writable
+        self.dest_kafka.stop_cluster_mirror_topics(dest_node, mirror_name, topic)
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "STOPPED")
+
+        # Send 1 record to destination (should work now)
+        self.produce_records(dest_node, topic, 1)
+
+        # Send 2 more records to source (not mirrored)
+        self.produce_records(src_node, topic, 2)
+
+        # Consume from source (expect 5 records)
+        count = self.consume_records(topic, self.source_kafka, max_messages=5)
+        assert count == 5, "Expected 5 records on source, got %d" % count
+
+        # Failback: source mirrors from destination (same mirror name to retrieve LMO)
+        src_node = self.source_kafka.nodes[0]
+        mirror_cfg = ClusterMirrorConfig(self.dest_kafka.bootstrap_servers())
+
+        wait_until(
+            lambda: self.source_kafka.create_cluster_mirror(
+                src_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create reverse cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.source_kafka.start_cluster_mirror_topics(
+                src_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start reverse mirror topics",
+        )
+        self.wait_mirror_lag_zero(self.source_kafka, src_node, mirror_name)
+
+        # Consume from source (non-mirrored data should be truncated)
+        count = self.consume_records(topic, self.source_kafka, max_messages=5, timeout_ms=5000)
+        assert count == 4, \
+            "Expected 4 records on source after failback (non-mirrored data truncated), got %d" % count
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_pause_resume(self, metadata_quorum):
+        """Verify that pausing stops replication and resuming catches up."""
+        topic = "my-topic"
+        mirror_name = "my-mirror"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
+
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Send 3 records to source
+        self.produce_records(src_node, topic, 3)
+
+        # Start cluster mirror on destination
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+
+        # Pause mirroring and send 1 more record to source
+        self.dest_kafka.pause_cluster_mirror_topics(dest_node, mirror_name, topic)
+        self.produce_records(src_node, topic, 1)
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "PAUSED")
+
+        # Consume from destination while paused (expect 3, the 4th is not mirrored yet)
+        count = self.consume_records(topic, self.dest_kafka, max_messages=4, timeout_ms=5000)
+        assert count == 3, "Expected 3 records on destination while paused, got %d" % count
+
+        # Produce to destination while paused (should fail)
+        self.produce_records(dest_node, topic, 1)
+
+        # Resume mirroring and wait for it to catch up
+        self.dest_kafka.resume_cluster_mirror_topics(dest_node, mirror_name, topic)
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING")
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+
+        # Consume from destination (expect 4 records after resume)
+        count = self.consume_records(topic, self.dest_kafka, max_messages=4)
+        assert count == 4, "Expected 4 records on destination after resume, got %d" % count
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_config_update(self, metadata_quorum):
+        """Verify that updating mirror config triggers reconnection and mirroring continues."""
+        topic = "my-topic"
+        mirror_name = "my-mirror"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
+
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Start cluster mirror on destination
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING")
+
+        self.logger.info("describe_mirror_config: %s",
+                         self.dest_kafka.describe_mirror_config(dest_node, mirror_name))
+        self.logger.info("list_cluster_mirror: %s",
+                         self.dest_kafka.list_cluster_mirror(dest_node))
+        self.logger.info("describe_cluster_mirror: %s",
+                         self.dest_kafka.describe_cluster_mirror(dest_node))
+
+        # Alter config with invalid config (should fail)
+        self.dest_kafka.alter_mirror_config(dest_node, mirror_name, "invalid.config=foo")
+
+        # Alter config with valid bootstrap.servers pointing to source broker 1 (triggers reconnection)
+        new_bootstrap = "%s:9092" % self.source_kafka.nodes[1].account.hostname
+        self.dest_kafka.alter_mirror_config(dest_node, mirror_name,
+                                            "bootstrap.servers=%s" % new_bootstrap)
+
+        self.logger.info("describe_mirror_config: %s",
+                         self.dest_kafka.describe_mirror_config(dest_node, mirror_name))
+        self.logger.info("list_cluster_mirror: %s",
+                         self.dest_kafka.list_cluster_mirror(dest_node))
+        self.logger.info("describe_cluster_mirror: %s",
+                         self.dest_kafka.describe_cluster_mirror(dest_node))
+
+        # Verify mirroring still works after config change
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING")
+
+        # Send records to source and verify they arrive at destination
+        self.produce_records(src_node, topic, 3)
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+
+        count = self.consume_records(topic, self.dest_kafka, max_messages=3)
+        assert count == 3, "Expected 3 records on destination after config update, got %d" % count
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_mirror_deletion(self, metadata_quorum):
+        """Verify that a mirror cannot be deleted while not empty, but can after stopping all topics."""
+        topic = "my-topic"
+        mirror_name = "my-mirror"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
+
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Start cluster mirror on destination
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING")
+
+        # Delete mirror while not empty (should fail)
+        self.dest_kafka.delete_cluster_mirror(dest_node, mirror_name)
+        output = self.dest_kafka.list_cluster_mirror(dest_node)
+        assert mirror_name in output, "Mirror should still exist after failed deletion"
+
+        # Stop mirror topics and wait for STOPPED state
+        self.dest_kafka.stop_cluster_mirror_topics(dest_node, mirror_name, topic)
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "STOPPED")
+
+        # Delete mirror (should work now)
+        self.dest_kafka.delete_cluster_mirror(dest_node, mirror_name)
+        output = self.dest_kafka.list_cluster_mirror(dest_node)
+        assert mirror_name not in output, "Mirror should be gone after deletion"
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_topic_deletion(self, metadata_quorum):
+        """Verify that deleting a source topic transitions mirror partitions to STOPPED."""
+        topic = "my-topic"
+        mirror_name = "my-mirror"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
+
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Start cluster mirror on destination
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING")
+
+        # Delete topic on source and wait for metadata sync
+        self.source_kafka.delete_topic(topic)
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name)
+
+        # Verify mirror partitions transitioned to STOPPED
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "STOPPED")
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_topics_filtering(self, metadata_quorum):
+        """Verify topic include/exclude filtering, stopped topics not re-discovered, and auto-discovery."""
+        mirror_name = "my-mirror"
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Create 4 topics on source
+        topics_cfg = {
+            "orders-us": {"partitions": 1, "replication-factor": 2},
+            "orders-eu": {"partitions": 1, "replication-factor": 2},
+            "orders-internal": {"partitions": 1, "replication-factor": 2},
+            "payments": {"partitions": 1, "replication-factor": 2},
+        }
+        for t, cfg in topics_cfg.items():
+            self.source_kafka.create_topic({"topic": t, **cfg})
+
+        # Send records to source topics
+        self.produce_records(src_node, "orders-us", 3)
+        self.produce_records(src_node, "orders-eu", 3)
+        self.produce_records(src_node, "orders-internal", 2)
+        self.produce_records(src_node, "payments", 2)
+
+        # Start mirror with regex include and exclude
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, "orders-.*", exclude="orders-internal"),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+
+        # Only orders-us and orders-eu should be mirrored
+        self.topics = {
+            "orders-us": topics_cfg["orders-us"],
+            "orders-eu": topics_cfg["orders-eu"],
+        }
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+
+        count_us = self.consume_records("orders-us", self.dest_kafka, max_messages=3)
+        assert count_us == 3, "Expected 3 records for orders-us, got %d" % count_us
+        count_eu = self.consume_records("orders-eu", self.dest_kafka, max_messages=3)
+        assert count_eu == 3, "Expected 3 records for orders-eu, got %d" % count_eu
+
+        # Verify excluded and non-matching topics don't exist on destination
+        dest_topics = list(self.dest_kafka.list_topics(dest_node))
+        assert "orders-internal" not in dest_topics, \
+            "Expected orders-internal to not exist on destination (excluded)"
+        assert "payments" not in dest_topics, \
+            "Expected payments to not exist on destination (not included)"
+
+        # Stop orders-eu
+        self.dest_kafka.stop_cluster_mirror_topics(dest_node, mirror_name, "orders-eu")
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "STOPPED",
+                               topics={"orders-eu": topics_cfg["orders-eu"]})
+
+        # Send 3 more records to orders-eu on source (should not be mirrored)
+        self.produce_records(src_node, "orders-eu", 3)
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        count_eu = self.consume_records("orders-eu", self.dest_kafka, timeout_ms=5000)
+        assert count_eu == 3, \
+            "Expected 3 records for orders-eu after stop (not 6), got %d" % count_eu
+
+        # Verify orders-eu is not re-discovered after two more metadata refresh cycles
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        self.logger.info("describe_cluster_mirror: %s",
+                         self.dest_kafka.describe_cluster_mirror(dest_node))
+        count_eu = self.consume_records("orders-eu", self.dest_kafka, timeout_ms=5000)
+        assert count_eu == 3, \
+            "Expected orders-eu to remain at 3 records (not re-discovered), got %d" % count_eu
+
+        # Create new topic on source that matches the include pattern
+        self.source_kafka.create_topic({"topic": "orders-jp", "partitions": 1, "replication-factor": 2})
+        self.produce_records(src_node, "orders-jp", 3)
+
+        self.topics["orders-jp"] = {"partitions": 1, "replication-factor": 2}
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING",
+                               topics={"orders-jp": {"partitions": 1, "replication-factor": 2}})
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name,
+                                  topics={"orders-jp": {"partitions": 1, "replication-factor": 2}})
+
+        count_jp = self.consume_records("orders-jp", self.dest_kafka, max_messages=3)
+        assert count_jp == 3, "Expected 3 records for orders-jp, got %d" % count_jp
+
+        # Add payments to include pattern via alter config
+        self.dest_kafka.alter_mirror_config(
+            dest_node, mirror_name, "mirror.topics.include=[orders-.*,payments]")
+
+        self.topics["payments"] = {"partitions": 1, "replication-factor": 2}
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING",
+                               topics={"payments": {"partitions": 1, "replication-factor": 2}})
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name,
+                                  topics={"payments": {"partitions": 1, "replication-factor": 2}})
+
+        count_pay = self.consume_records("payments", self.dest_kafka, max_messages=2)
+        assert count_pay == 2, "Expected 2 records for payments, got %d" % count_pay
+
+        # Verify orders-internal still doesn't exist on destination after all operations
+        dest_topics = list(self.dest_kafka.list_topics(dest_node))
+        assert "orders-internal" not in dest_topics, \
+            "Expected orders-internal to still not exist on destination (excluded)"
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_props_exclude(self, metadata_quorum):
+        """Verify that excluded topic properties are not synced to destination."""
+        topic = "my-topic"
+        mirror_name = "my-mirror"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
+
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        mirror_cfg = ClusterMirrorConfig(
+            self.source_kafka.bootstrap_servers(),
+            mirror_topic_properties_exclude="retention.bytes,min.insync.replicas")
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING")
+
+        self.source_kafka.alter_topic_config(
+            topic, "retention.ms=100002,retention.bytes=10000000002,min.insync.replicas=2",
+            node=src_node)
+
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        def parse_topic_configs(desc):
+            """Extract topic configs from kafka-topics describe output."""
+            for line in desc.splitlines():
+                if "Configs:" in line:
+                    configs_str = line.split("Configs:")[1].strip()
+                    if not configs_str:
+                        return {}
+                    result = {}
+                    for pair in configs_str.split(","):
+                        k, v = pair.strip().split("=", 1)
+                        result[k] = v
+                    return result
+            return {}
+
+        dest_configs = parse_topic_configs(
+            self.dest_kafka.describe_topic(topic, node=dest_node))
+        self.logger.info("Dest topic configs: %s", dest_configs)
+
+        assert dest_configs.get("retention.ms") == "100002", \
+            "Expected dest retention.ms=100002 (synced), got %s" % dest_configs.get("retention.ms")
+        assert dest_configs.get("retention.bytes") != "10000000002", \
+            "Expected dest retention.bytes to not be synced (excluded), got %s" % dest_configs.get("retention.bytes")
+        assert dest_configs.get("min.insync.replicas") != "2", \
+            "Expected dest min.insync.replicas to not be synced (excluded), got %s" % dest_configs.get("min.insync.replicas")
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_groups_filtering(self, metadata_quorum):
+        """Verify consumer group offset mirroring with include/exclude filtering."""
+        topic = "my-topic"
+        mirror_name = "my-mirror"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
+
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Produce records to source
+        self.produce_records(src_node, topic, 3)
+
+        # Create consumer groups on source by consuming all records
+        for group in ["app-group1", "app-group2", "internal-group1"]:
+            self.consume_records(topic, self.source_kafka, max_messages=3, group=group)
+
+        # Start mirror with groups include (app-.*) and exclude (app-group2)
+        mirror_cfg = ClusterMirrorConfig(
+            self.source_kafka.bootstrap_servers(),
+            mirror_groups_include="app-.*",
+            mirror_groups_exclude="app-group2",
+        )
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        # Verify only app-group1 is synced on destination
+        groups_output = self.dest_kafka.list_consumer_groups(dest_node)
+        assert "app-group1" in groups_output, \
+            "Expected app-group1 to be synced on destination"
+        assert "app-group2" not in groups_output, \
+            "Expected app-group2 to be excluded from destination"
+        assert "internal-group1" not in groups_output, \
+            "Expected internal-group1 to not be included on destination"
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_log_convergence(self, metadata_quorum):
+        """Verify that mirrored log segments are byte identical to source after bouncing both clusters."""
+        # Create source topics and produce initial data
+        self.topics = {
+            "my-topic-a": {"partitions": 3, "replication-factor": 2},
+            "my-topic-b": {"partitions": 2, "replication-factor": 2},
+            "new-topic": {"partitions": 1, "replication-factor": 2},
+        }
+        for t, cfg in self.topics.items():
+            self.source_kafka.create_topic({"topic": t, **cfg})
+
+        for t in self.topics:
+            self.produce_records(self.source_kafka.nodes[0], t, 100)
+
+        # Bounce source cluster to trigger leader elections before mirroring
+        self.source_kafka.restart_cluster(clean_shutdown=True)
+
+        # Create and start cluster mirrors
+        kafka_node = self.dest_kafka.nodes[0]
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+
+        # mirrors map mirror name to (topics_regex, topic_list)
+        mirrors = {
+            "my-mirror": ("my-topic.*", ["my-topic-a", "my-topic-b"]),
+            "new-mirror": ("new-topic", ["new-topic"]),
+        }
+
+        for mirror_name in mirrors:
+            self.logger.info("Creating mirror %s", mirror_name)
+            wait_until(
+                lambda mn=mirror_name: self.dest_kafka.create_cluster_mirror(
+                    kafka_node, mn, mirror_cfg
+                ),
+                timeout_sec=20,
+                backoff_sec=2,
+                err_msg="Failed to create cluster mirror %s" % mirror_name,
+            )
+        for mirror_name, (topics_regex, _) in mirrors.items():
+            wait_until(
+                lambda mn=mirror_name, tr=topics_regex: (
+                    "Started"
+                    in self.dest_kafka.start_cluster_mirror_topics(kafka_node, mn, tr)
+                ),
+                timeout_sec=20,
+                backoff_sec=2,
+                err_msg="Failed to start mirror topics for %s" % mirror_name,
+            )
+        for mirror_name, (_, topic_list) in mirrors.items():
+            self.wait_mirror_state(
+                self.dest_kafka, kafka_node, mirror_name, "MIRRORING", topic_list,
+                err_msg="Failed to start mirror %s" % mirror_name,
+            )
+
+        # Bounce source and dest brokers in interleaved order to trigger leader elections
+        src0, src1 = self.source_kafka.nodes[0], self.source_kafka.nodes[1]
+        dst0, dst1 = self.dest_kafka.nodes[0], self.dest_kafka.nodes[1]
+        for kafka, node in [
+            (self.dest_kafka, dst0), (self.dest_kafka, dst1),
+            (self.source_kafka, src1), (self.dest_kafka, dst0),
+            (self.source_kafka, src0), (self.dest_kafka, dst1),
+        ]:
+            kafka.restart_node(node)
+
+        # Send more data and wait for all mirrors to catch up
+        for t in self.topics:
+            self.produce_records(self.source_kafka.nodes[0], t, 100)
+
+        for mirror_name, (_, topic_list) in mirrors.items():
+            self.wait_mirror_lag_zero(
+                self.dest_kafka, kafka_node, mirror_name, topic_list,
+                "Mirror %s did not catch up" % mirror_name)
+
+        # Poll until source and destination log segment hashes converge
+        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka)
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_log_convergence_ule(self, metadata_quorum):
+        """Verify log convergence after unclean leader elections and failover/failback."""
+        # Create source topic with ULE support enabled
+        topic = "my-topic"
+        mirror_name = "new-mirror"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+
+        self.source_kafka.create_topic({
+            "topic": topic, "partitions": 1, "replication-factor": 2,
+            "configs": {"mirror.support.unclean.leader.election": "true"},
+        })
+
+        src_broker0 = self.source_kafka.nodes[0]
+        src_broker1 = self.source_kafka.nodes[1]
+        dest_node = self.dest_kafka.nodes[0]
+
+        def broker_bootstrap(node):
+            """Return bootstrap server address for a single broker node."""
+            return "%s:9092" % node.account.hostname
+
+        def trigger_ule(node):
+            """Trigger unclean leader election on the given node."""
+            cmd = "%s --bootstrap-server %s --topic %s --partition 0 --election-type UNCLEAN" % (
+                self.client.path.script("kafka-leader-election.sh"),
+                broker_bootstrap(node), topic)
+            self.producer_node.account.ssh(cmd, allow_fail=False)
+
+        def log_hashes(label):
+            """Log MD5 hashes of partition log segments for all brokers across both clusters."""
+            self.logger.info("#### %s-0 %s ####", topic, label)
+            for name, kafka in [("source", self.source_kafka), ("dest", self.dest_kafka)]:
+                for node in kafka.nodes:
+                    cmd = "md5sum %s*/%s-0/*.log 2>/dev/null" % (
+                        KafkaService.DATA_LOG_DIR_PREFIX, topic)
+                    lines = list(node.account.ssh_capture(cmd, allow_fail=True))
+                    if lines:
+                        for line in lines:
+                            self.logger.info("%s %s: %s", name, node.name, line.strip())
+                    else:
+                        self.logger.info("%s %s: n/a", name, node.name)
+
+        # Bounce source brokers to trigger leader elections
+        self.source_kafka.restart_cluster(clean_shutdown=True)
+
+        # Send 1 message via source broker 0
+        self.produce_records(src_broker0, topic, 1)
+
+        # Start cluster mirror on destination
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_state(
+            self.dest_kafka, dest_node, mirror_name, "MIRRORING",
+            err_msg="Mirror did not reach MIRRORING state",
+        )
+
+        # Stop source broker 0 (broker 0 becomes stale)
+        self.source_kafka.stop_node(src_broker0)
+
+        # Send 1 message via source broker 1
+        self.produce_records(src_broker1, topic, 1)
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name,
+                                  err_msg="Mirror did not catch up after broker 0 stopped")
+        log_hashes("after source broker 0 stopped (broker 0 should be out of sync)")
+
+        # ULE 1: stop broker 1, start broker 0 (stale), elect it as leader
+        self.source_kafka.stop_node(src_broker1)
+        self.source_kafka.start_node(src_broker0)
+        time.sleep(5)
+        trigger_ule(src_broker0)
+
+        # Send 2 messages via source broker 0
+        self.produce_records(src_broker0, topic, 2)
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name,
+                                  err_msg="Mirror did not catch up after ULE 1")
+        log_hashes("after ULE 1 (broker 1 should be out of sync)")
+
+        # Failover: stop mirror so destination topic becomes writable
+        self.dest_kafka.stop_cluster_mirror_topics(dest_node, mirror_name, topic)
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "STOPPED")
+        self.logger.info("describe_cluster_mirror: %s",
+                         self.dest_kafka.describe_cluster_mirror(dest_node))
+
+        # Send 2 messages via destination broker 0
+        self.produce_records(self.dest_kafka.nodes[0], topic, 2)
+
+        # ULE 2: stop broker 0, start broker 1 (stale), elect it as leader
+        self.source_kafka.stop_node(src_broker0)
+        self.source_kafka.start_node(src_broker1)
+        time.sleep(5)
+        trigger_ule(src_broker1)
+
+        # Send 6 messages via source broker 1
+        self.produce_records(src_broker1, topic, 6)
+        log_hashes("after ULE 2 (broker 1 should have the most up to date data)")
+
+        # Failback: source now mirrors from destination
+        # Mirror stays in LOG_TRUNCATION until all source replicas rejoin ISR for LME truncation
+        src_node = src_broker1
+        mirror_cfg = ClusterMirrorConfig(self.dest_kafka.bootstrap_servers())
+
+        wait_until(
+            lambda: self.source_kafka.create_cluster_mirror(
+                src_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create reverse cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.source_kafka.start_cluster_mirror_topics(
+                src_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start reverse mirror topics",
+        )
+        self.wait_mirror_state(self.source_kafka, src_node, mirror_name, "LOG_TRUNCATION")
+
+        # Start the stopped source broker so all replicas rejoin ISR for LME truncation
+        self.source_kafka.start_node(src_broker0)
+        self.wait_mirror_state(self.source_kafka, src_node, mirror_name, "MIRRORING",
+                               err_msg="Reverse mirror did not reach MIRRORING state")
+        self.logger.info("describe_cluster_mirror: %s",
+                         self.source_kafka.describe_cluster_mirror(src_node))
+
+        # Wait for reverse mirror to catch up
+        self.wait_mirror_lag_zero(self.source_kafka, src_node, mirror_name,
+                                  err_msg="Reverse mirror did not catch up")
+
+        # Poll until log segment hashes converge (dest is source of truth after failback)
+        self.wait_for_log_convergence(self.dest_kafka, self.source_kafka)
+
+    @cluster(num_nodes=8)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_stop_with_txns(self, metadata_quorum):
-        """Verify that STOPPING transition aborts pending transactions and allows committed reads."""
-        mirror_name = "my-mirror"
-        kafka_node = self.dest_kafka.nodes[0]
-        topic = list(self.topics.keys())[0]
+        """Verify that stop operation aborts pending transactions and allows committed reads."""
+        # Create source topic
+        topic = "my-topic"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        for t, cfg in self.topics.items():
+            self.source_kafka.create_topic({"topic": t, **cfg})
 
+        # Run initial committed transaction and bounce source to bump leader epoch
         def run_producer(kafka, topic, transactional_id=None, mode="commit",
                          num_records=1, waiting_ms=0, background=False):
-            """Run TransactionalTestProducer via SSH on the first broker node."""
-            node = kafka.nodes[0]
-            cmd = kafka.path.script("kafka-run-class.sh", node)
+            """Run TransactionalTestProducer on the dedicated producer client node."""
+            cmd = self.client.path.script("kafka-run-class.sh")
             cmd += " org.apache.kafka.tools.TransactionalTestProducer"
             cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
             cmd += " --topic %s" % topic
@@ -289,27 +1026,12 @@ class ClusterMirroringTest(Test):
             cmd += " --num-records %s" % str(num_records)
             if background:
                 cmd += " &"
-            node.account.ssh(cmd, allow_fail=False)
+            self.producer_node.account.ssh(cmd, allow_fail=False)
 
         run_producer(self.source_kafka, topic, topic + "-a", "commit")
-
-        self.logger.info("Restarting source brokers to bump leader epoch")
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
-        def count_ongoing_txns(kafka, topic):
-            """Count ongoing transactions across all partitions using describe-producers."""
-            node = kafka.nodes[0]
-            count = 0
-            for partition in range(self.topics[topic]["partitions"]):
-                cmd = kafka.path.script("kafka-transactions.sh", node)
-                cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
-                cmd += " describe-producers --topic %s --partition %d" % (topic, partition)
-                for line in node.account.ssh_capture(cmd, allow_fail=True):
-                    fields = line.strip().split()
-                    if fields and fields[-1] != "None" and fields[-1] != "CurrentTransactionStartOffset":
-                        count += 1
-            return count
-
+        # Send interleaving transactions, leaving 2 pending
         def send_interleaving_txns(topic):
             """Send interleaved transactional and non-transactional records, leaving 2 txns pending."""
             run_producer(self.source_kafka, topic, topic + "-a", "commit", waiting_ms=5000, background=True)
@@ -320,74 +1042,61 @@ class ClusterMirroringTest(Test):
             run_producer(self.source_kafka, topic, topic + "-d", "pending")
             run_producer(self.source_kafka, topic)
 
+        def count_ongoing_txns(kafka, topic):
+            """Count ongoing transactions across all partitions of a topic."""
+            count = 0
+            for partition in range(self.topics[topic]["partitions"]):
+                cmd = self.client.path.script("kafka-transactions.sh")
+                cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
+                cmd += " describe-producers --topic %s --partition %d" % (topic, partition)
+                for line in self.producer_node.account.ssh_capture(cmd, allow_fail=True):
+                    fields = line.strip().split()
+                    if fields and fields[-1] != "None" and fields[-1] != "CurrentTransactionStartOffset":
+                        count += 1
+            return count
+
         send_interleaving_txns(topic)
         ongoing = count_ongoing_txns(self.source_kafka, topic)
         assert ongoing == 2, "Expected 2 ongoing transactions, got %d" % ongoing
 
-        self.producer.stop()
+        # Create and start cluster mirror, wait for it to catch up
+        mirror_name = "my-mirror"
+        kafka_node = self.dest_kafka.nodes[0]
 
         mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
         self.logger.info(
             "Creating mirror %s with settings %s", mirror_name, mirror_cfg
         )
-        prop_file = str(mirror_cfg)
-        kafka_node.account.ssh(
-            "mkdir -p %s" % ClusterMirroringTest.PERSISTENT_ROOT, allow_fail=False
-        )
-        kafka_node.account.create_file(
-            ClusterMirroringTest.MIRROR_CONFIG_FILE, prop_file
-        )
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                kafka_node, mirror_name, ClusterMirroringTest.MIRROR_CONFIG_FILE
+                kafka_node, mirror_name, mirror_cfg
             ),
             timeout_sec=20,
             backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
-
         wait_until(
             lambda: (
                 "Started"
                 in self.dest_kafka.start_cluster_mirror_topics(
-                    kafka_node, mirror_name, self.topics.keys()
+                    kafka_node, mirror_name, topic
                 )
             ),
             timeout_sec=20,
             backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
+        self.wait_mirror_lag_zero(self.dest_kafka, kafka_node, mirror_name)
 
-        wait_until(
-            lambda: self.all_satisfy_in_mirror(
-                kafka_node, mirror_name,
-                lambda p: p["lag"] == 0 and p["state"] == "MIRRORING"
-            ),
-            timeout_sec=60,
-            backoff_sec=2,
-            err_msg="Mirror did not catch up",
-        )
-
-        self.logger.info("Stopping mirror topics for %s", mirror_name)
+        # Stop cluster mirror (aborts pending transactions and writes PID reset barriers)
         self.dest_kafka.stop_cluster_mirror_topics(
-            kafka_node, mirror_name, self.topics.keys()
+            kafka_node, mirror_name, topic
         )
 
-        def check_stopped():
-            output = self.dest_kafka.describe_cluster_mirror(kafka_node)
-            self.logger.info("describe_cluster_mirror: %s", output)
-            return self.all_satisfy_in_mirror(
-                kafka_node, mirror_name, lambda p: p["state"] == "STOPPED"
-            )
+        self.wait_mirror_state(self.dest_kafka, kafka_node, mirror_name, "STOPPED")
 
-        wait_until(
-            check_stopped,
-            timeout_sec=60,
-            backoff_sec=2,
-            err_msg="Mirror topics did not reach STOPPED state",
-        )
-
+        # Verify extra records on destination from abort markers and PID reset barriers
         def parse_end_offsets(output):
             """Parse get_offset_shell output into a {partition: offset} dict."""
             offsets = {}
@@ -409,32 +1118,302 @@ class ClusterMirroringTest(Test):
             "Expected %d extra records (2 abort + %d PID reset) on destination, got %d. " \
             "source=%s, dest=%s" % (expected_extra, num_partitions, extra, source_offsets, dest_offsets)
 
+        # Commit pending transactions on destination and verify consumer counts
         run_producer(self.dest_kafka, topic, topic + "-b", "commit")
         run_producer(self.dest_kafka, topic, topic + "-d", "commit")
 
-        def run_consumer(kafka, topic, isolation_level="read_uncommitted"):
-            """Run console consumer and return the record count."""
-            node = kafka.nodes[0]
-            cmd = kafka.path.script("kafka-console-consumer.sh", node)
-            cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
-            cmd += " --topic %s --from-beginning" % topic
-            cmd += " --isolation-level %s" % isolation_level
-            cmd += " --timeout-ms 10000"
-            count = 0
-            for line in node.account.ssh_capture(cmd, allow_fail=True):
-                if line.strip():
-                    count += 1
-            return count
-
-        # checking raw number of records
-        source_count = run_consumer(self.source_kafka, topic)
-        dest_count = run_consumer(self.dest_kafka, topic)
+        # Checking raw number of records
+        source_count = self.consume_records(topic, self.source_kafka)
+        dest_count = self.consume_records(topic, self.dest_kafka)
         assert dest_count == source_count + 2, \
             "Expected dest to have exactly 2 more records than source, " \
             "got source=%d, dest=%d" % (source_count, dest_count)
 
-        # checking read_committed consumer can make progress
+        # Checking read_committed consumer can make progress
         # 4 aborted data records are filtered out: txn-b, txn-c, txn-d fenced, txn-d pending
-        dest_committed = run_consumer(self.dest_kafka, topic, "read_committed")
+        dest_committed = self.consume_records(topic, self.dest_kafka, isolation_level="read_committed")
         assert dest_committed == dest_count - 4, \
             "Expected dest_committed=%d, got %d" % (dest_count - 4, dest_committed)
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_consumer_groups_commit(self, metadata_quorum):
+        """Verify consumer group offset sync for mirror topics and active consumer protection."""
+        mirror_name = "my-mirror"
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Create two topics on source
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
+        self.source_kafka.create_topic({"topic": "other-topic", "partitions": 1, "replication-factor": 2})
+        self.produce_records(src_node, "my-topic", 3)
+        self.produce_records(src_node, "other-topic", 3)
+
+        # Create consumer group my-group on source by consuming both topics
+        self.consume_records("my-topic", self.source_kafka, max_messages=3, group="my-group")
+        self.consume_records("other-topic", self.source_kafka, max_messages=3, group="my-group")
+
+        # Start mirror with only my-topic (not other-topic)
+        self.topics = {"my-topic": {"partitions": 1, "replication-factor": 2}}
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, "my-topic"),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        # Verify my-group on dest has my-topic offset but not other-topic
+        group_desc = self.dest_kafka.describe_consumer_group("my-group", dest_node)
+        assert "my-topic" in group_desc, \
+            "Expected my-topic offset to be synced on destination"
+        assert "other-topic" not in group_desc, \
+            "Expected other-topic offset to not appear on destination"
+
+        def parse_current_offset(desc, topic):
+            """Parse describe_consumer_group output and return current offset for a topic."""
+            for line in desc.strip().splitlines():
+                fields = line.split()
+                if len(fields) >= 4 and fields[1] == topic:
+                    return int(fields[3])
+            return None
+
+        # Produce 2 more records to my-topic and verify synced offset is exactly 3
+        self.produce_records(src_node, "my-topic", 2)
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        dest_desc = self.dest_kafka.describe_consumer_group("my-group", dest_node)
+        dest_offset = parse_current_offset(dest_desc, "my-topic")
+        assert dest_offset == 3, "Expected dest offset 3 (synced from source), got %s" % dest_offset
+
+        # Start active consumer on destination (background)
+        consumer_cmd = "%s --bootstrap-server %s --topic my-topic --group my-group" % (
+            self.client.path.script("kafka-console-consumer.sh"),
+            self.dest_kafka.bootstrap_servers(self.dest_kafka.security_protocol))
+        self.consumer_node.account.ssh("nohup %s >/dev/null 2>&1 &" % consumer_cmd, allow_fail=True)
+        time.sleep(5)
+
+        # Reset source offset to 2 to prove sync skips active consumer
+        self.source_kafka.reset_consumer_group_offsets(src_node, "my-group", "my-topic", 2)
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        # Verify source offset is 2 but dest offset is still 5 (sync skipped)
+        src_desc = self.source_kafka.describe_consumer_group("my-group", src_node)
+        dest_desc = self.dest_kafka.describe_consumer_group("my-group", dest_node)
+        self.logger.info("Source group describe: %s", src_desc)
+        self.logger.info("Dest group describe: %s", dest_desc)
+
+        src_offset = parse_current_offset(src_desc, "my-topic")
+        dest_offset = parse_current_offset(dest_desc, "my-topic")
+        assert src_offset == 2, "Expected source offset 2, got %s" % src_offset
+        assert dest_offset == 5, "Expected dest offset 5 (sync skipped), got %s" % dest_offset
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_share_groups_commit(self, metadata_quorum):
+        """Verify share group offset sync for mirror topics and active consumer protection."""
+        mirror_name = "my-mirror"
+        share_group = "my-share-group"
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Create two topics on source
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
+        self.source_kafka.create_topic({"topic": "other-topic", "partitions": 1, "replication-factor": 2})
+        self.produce_records(src_node, "my-topic", 3)
+        self.produce_records(src_node, "other-topic", 3)
+
+        # Set share.auto.offset.reset=earliest and consume both topics
+        self.source_kafka.set_share_group_offset_reset_strategy(share_group, "earliest")
+        self.consume_share_records("my-topic", self.source_kafka, share_group, max_messages=3)
+        self.consume_share_records("other-topic", self.source_kafka, share_group, max_messages=3)
+
+        # Run background share consumer + produce more data to commit SPSO
+        share_consumer_cmd = "%s --bootstrap-server %s --topic my-topic --group %s" % (
+            self.client.path.script("kafka-console-share-consumer.sh"),
+            self.source_kafka.bootstrap_servers(self.source_kafka.security_protocol),
+            share_group)
+        self.consumer_node.account.ssh("nohup %s >/dev/null 2>&1 &" % share_consumer_cmd,
+                                       allow_fail=True)
+        self.produce_records(src_node, "my-topic", 3)
+        time.sleep(5)
+
+        self.logger.info("Source share group describe: %s",
+                         self.source_kafka.describe_share_group(share_group, src_node))
+
+        # Kill background share consumer
+        self.consumer_node.account.ssh(
+            "pkill -SIGKILL -f 'ConsoleShareConsumer' || true", allow_fail=True)
+
+        # Start mirror with only my-topic
+        self.topics = {"my-topic": {"partitions": 1, "replication-factor": 2}}
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, "my-topic"),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        # Verify my-share-group on dest has my-topic but not other-topic
+        src_desc = self.source_kafka.describe_share_group(share_group, src_node)
+        dest_desc = self.dest_kafka.describe_share_group(share_group, dest_node)
+        self.logger.info("Source share group describe: %s", src_desc)
+        self.logger.info("Dest share group describe: %s", dest_desc)
+        assert "my-topic" in dest_desc, \
+            "Expected my-topic offset to be synced on destination"
+        assert "other-topic" not in dest_desc, \
+            "Expected other-topic offset to not appear on destination"
+
+        # Produce 2 more and consume delta using synced offsets
+        self.produce_records(src_node, "my-topic", 2)
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        count = self.consume_share_records("my-topic", self.dest_kafka, share_group, max_messages=2)
+        assert count == 2, "Expected 2 delta records using synced offsets, got %d" % count
+
+        # Start active share consumer on destination (background)
+        dest_share_cmd = "%s --bootstrap-server %s --topic my-topic --group %s" % (
+            self.client.path.script("kafka-console-share-consumer.sh"),
+            self.dest_kafka.bootstrap_servers(self.dest_kafka.security_protocol),
+            share_group)
+        self.consumer_node.account.ssh("nohup %s >/dev/null 2>&1 &" % dest_share_cmd,
+                                       allow_fail=True)
+        time.sleep(5)
+
+        # Reset source offset to earliest to prove sync skips active consumer
+        self.source_kafka.reset_share_group_offsets(src_node, share_group, "my-topic")
+        self.wait_for_metadata_sync(self.dest_kafka, dest_node, mirror_name, num_cycles=2)
+
+        # Verify source offset reset but dest offset unchanged (sync skipped)
+        src_desc = self.source_kafka.describe_share_group(share_group, src_node)
+        dest_desc = self.dest_kafka.describe_share_group(share_group, dest_node)
+        self.logger.info("Source share group describe after reset: %s", src_desc)
+        self.logger.info("Dest share group describe after reset: %s", dest_desc)
+
+        def parse_share_start_offset(desc, topic):
+            """Parse describe_share_group output and return start offset for a topic."""
+            for line in desc.strip().splitlines():
+                fields = line.split()
+                if len(fields) >= 4 and fields[1] == topic:
+                    return int(fields[3])
+            return None
+
+        src_offset = parse_share_start_offset(src_desc, "my-topic")
+        dest_offset = parse_share_start_offset(dest_desc, "my-topic")
+        assert src_offset == 0, "Expected source offset 0 (reset to earliest), got %s" % src_offset
+        assert dest_offset == 5, "Expected dest offset 5 (sync skipped), got %s" % dest_offset
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_epoch_bump(self, metadata_quorum):
+        """Verify that consumers on mirror topics with source leader epochs don't hang on restart."""
+        topic = "my-topic"
+        mirror_name = "my-mirror"
+        group = "my-group"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
+
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Produce 3 records and bounce source brokers to bump leader epoch
+        self.produce_records(src_node, topic, 3)
+        for node in self.source_kafka.nodes:
+            self.source_kafka.restart_node(node)
+
+        # Produce 2 more records after leader elections
+        self.produce_records(src_node, topic, 2)
+
+        # Start cluster mirror
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+
+        # Consume 2 records from destination with a consumer group (commits offsets with source LE)
+        count1 = self.consume_records(topic, self.dest_kafka, max_messages=2, group=group)
+        assert count1 == 2, "Expected 2 records on first consume, got %d" % count1
+
+        # Restart consumer (triggers OffsetFetch and refreshCommittedOffsets)
+        # Without the epoch bump fix, this would hang because source LE > local LE
+        count2 = self.consume_records(topic, self.dest_kafka, max_messages=2,
+                                      timeout_ms=20000, group=group, from_beginning=False)
+        assert count2 == 2, "Expected 2 records on resumed consume, got %d" % count2
+
+    @cluster(num_nodes=8)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_failed_retry(self, metadata_quorum):
+        """Verify that mirror recovers from FAILED state after source cluster comes back."""
+        topic = "my-topic"
+        mirror_name = "my-mirror"
+        self.topics = {topic: {"partitions": 3, "replication-factor": 2}}
+        self.source_kafka.create_topic({"topic": topic, "partitions": 3, "replication-factor": 1})
+
+        src_node = self.source_kafka.nodes[0]
+        dest_node = self.dest_kafka.nodes[0]
+
+        # Produce initial records and start cluster mirror
+        self.produce_records(src_node, topic, 3)
+
+        mirror_cfg = ClusterMirrorConfig(self.source_kafka.bootstrap_servers())
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                dest_node, mirror_name, mirror_cfg),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                dest_node, mirror_name, topic),
+            timeout_sec=20, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING")
+
+        # Stop all source brokers to trigger FAILED state
+        for node in self.source_kafka.nodes:
+            self.source_kafka.stop_node(node)
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "FAILED",
+                               err_msg="Mirror did not reach FAILED state after source shutdown")
+
+        # Restart source brokers so scheduled retry can recover
+        for node in self.source_kafka.nodes:
+            self.source_kafka.start_node(node)
+        self.wait_mirror_state(self.dest_kafka, dest_node, mirror_name, "MIRRORING",
+                               err_msg="Mirror did not recover to MIRRORING after source restart")
+
+        # Verify data still flows after recovery
+        self.produce_records(self.source_kafka.nodes[0], topic, 3)
+        self.wait_mirror_lag_zero(self.dest_kafka, dest_node, mirror_name)
+
+        count = self.consume_records(topic, self.dest_kafka, max_messages=6)
+        assert count == 6, "Expected 6 records after recovery, got %d" % count


### PR DESCRIPTION
Migrate three MirrorMetadataManager operations from the low-level
trySendSourceClusterRequest (MirrorSourceSender) path to the Admin API,
aligning them with the pattern already used by group offset sync.

syncTopicConfigurations now uses Admin.describeConfigs() instead of
manually building DescribeConfigsRequest. syncAccessControlLists now
uses Admin.describeAcls() which returns Collection<AclBinding> directly,
removing the DescribeAclsResponse conversion step. getSourceClusterId
now uses Admin.describeCluster() with lazy client initialization.

Also removes the unused sourceSenders field and getConfiguredTopics
wrapper from ClusterMirrorCoordinator, and moves failedRetryAttempts
cleanup into MirrorMetadataManager.clear().
