### PR TITLE
Fix stuck STOPPING state when mirror topic has no records

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -710,6 +710,12 @@ public class ClusterMirrorCoordinator {
             });
         });
 
+        // No partitions need updating (e.g. empty topic with no leader epoch)
+        if (localByCoordPartition.isEmpty() && remoteTopicMetadata.isEmpty()) {
+            future.complete(null);
+            return future;
+        }
+
         // Update in-memory cache once with all offsets
         var updatedOffsets = metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets, Map.of());
 


### PR DESCRIPTION
In updateLastMirrorEpochs, when a topic has no records, latestEpoch() returns empty, so the inner offset map is empty. Neither the local nor the remote write path executes, leaving the CompletableFuture never completed. This blocks the entire STOPPING chain (sendBumpLeaderEpochs, abortOngoingTransactions, writeMirrorPidResetAndStop).

Complete the future immediately when no partitions need updating.