### PR TITLE
Refactor Controller.createClusterMirror signature

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -207,15 +207,12 @@ class ControllerApis(
     val createMirrorRequest = request.body[CreateClusterMirrorRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal, OptionalLong.empty())
     val altersByName = new util.HashMap[String, Entry[AlterConfigOp.OpType, String]]()
-    val configChanges = new util.HashMap[ConfigResource, util.Map[String, Entry[AlterConfigOp.OpType, String]]]()
-    val resource = new ConfigResource(ConfigResource.Type.forId(64), createMirrorRequest.data().mirrorName())
     createMirrorRequest.data().config.forEach { config =>
       altersByName.put(config.name, new util.AbstractMap.SimpleEntry[AlterConfigOp.OpType, String](
         AlterConfigOp.OpType.forId(0), config.value))
     }
-    configChanges.put(resource, altersByName)
 
-    controller.createClusterMirror(context, configChanges)
+    controller.createClusterMirror(context, createMirrorRequest.data().mirrorName(), altersByName)
       .handle[Unit] { (response, exception) =>
         if (exception != null) {
           requestHelper.handleError(request, exception)

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.controller;
 
+import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.FeatureUpdate;
@@ -536,36 +537,33 @@ public class ConfigurationControlManager {
     }
 
     ControllerResult<CreateClusterMirrorResponseData> addMirrorConfig(
-            Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
-            boolean newlyCreatedResource
+        String mirrorName,
+        Map<String, Map.Entry<AlterConfigOp.OpType, String>> configChanges
     ) {
         List<ApiMessageAndVersion> outputRecords = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         CreateClusterMirrorResponseData data = new CreateClusterMirrorResponseData();
 
-        for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> resourceEntry :
-                configChanges.entrySet()) {
-            String mirrorName = resourceEntry.getKey().name();
-            if (mirrorName.endsWith(STOPPED_TOPIC_SUFFIX) || mirrorName.endsWith(PAUSED_TOPIC_SUFFIX)) {
-                data.setErrorCode(Errors.INVALID_CLUSTER_MIRROR_NAME.code());
-                data.setErrorMessage("Mirror name must not end with '"
-                    + STOPPED_TOPIC_SUFFIX + "' or '" + PAUSED_TOPIC_SUFFIX + "'");
-                return ControllerResult.of(List.of(), data);
-            }
-
-            final Map<String, String> existingConfig = getConfigs(resourceEntry.getKey());
-            if (!existingConfig.isEmpty()) {
-                data.setErrorCode(CLUSTER_MIRROR_ALREADY_EXISTS.code())
-                    .setErrorMessage("Mirror '" + mirrorName + "' already exists");
-                return ControllerResult.of(List.of(), data);
-            }
-
-            ApiError apiError = incrementalAlterConfigResource(resourceEntry.getKey(),
-                    resourceEntry.getValue(),
-                    newlyCreatedResource,
-                    outputRecords);
-            // TODO: Should handle the error here
-            log.info("!!! addMirrorConfig apiError: {} for {}", apiError, resourceEntry);
+        if (mirrorName.endsWith(STOPPED_TOPIC_SUFFIX) || mirrorName.endsWith(PAUSED_TOPIC_SUFFIX)) {
+            data.setErrorCode(Errors.INVALID_CLUSTER_MIRROR_NAME.code());
+            data.setErrorMessage("Mirror name must not end with '"
+                + STOPPED_TOPIC_SUFFIX + "' or '" + PAUSED_TOPIC_SUFFIX + "'");
+            return ControllerResult.of(List.of(), data);
         }
+
+        ConfigResource configResource = new ConfigResource(Type.CLUSTER_MIRROR, mirrorName);
+        final Map<String, String> existingConfig = getConfigs(configResource);
+        if (!existingConfig.isEmpty()) {
+            data.setErrorCode(CLUSTER_MIRROR_ALREADY_EXISTS.code())
+                .setErrorMessage("Mirror '" + mirrorName + "' already exists");
+            return ControllerResult.of(List.of(), data);
+        }
+
+        ApiError apiError = incrementalAlterConfigResource(configResource,
+            configChanges,
+            false,
+            outputRecords);
+        // TODO: Should handle the error here
+        log.info("!!! addMirrorConfig apiError: {} for {} {}", apiError, configResource, configChanges);
         outputRecords.addAll(createClearElrRecordsAsNeeded(outputRecords));
 
         data.setErrorCode((short) 0);

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -154,7 +154,8 @@ public interface Controller extends AclMutator, AutoCloseable {
 
     CompletableFuture<CreateClusterMirrorResponseData> createClusterMirror(
             ControllerRequestContext context,
-            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
+            String mirrorName,
+            Map<String, Map.Entry<AlterConfigOp.OpType, String>> configChanges
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1775,11 +1775,12 @@ public final class QuorumController implements Controller {
     @Override
     public CompletableFuture<CreateClusterMirrorResponseData> createClusterMirror(
             ControllerRequestContext context,
-            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
+            String mirrorName,
+            Map<String, Map.Entry<AlterConfigOp.OpType, String>> configChanges
     ) {
         return appendWriteEvent("createClusterMirror", context.deadlineNs(), () -> {
             ControllerResult<CreateClusterMirrorResponseData> result =
-                    configurationControl.addMirrorConfig(configChanges, false);
+                    configurationControl.addMirrorConfig(mirrorName, configChanges);
             return result;
         });
     }

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/MockController.java
@@ -107,7 +107,8 @@ public class MockController implements Controller {
     @Override
     public CompletableFuture<CreateClusterMirrorResponseData> createClusterMirror(
             ControllerRequestContext context,
-            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges
+            String mirrorName,
+            Map<String, Map.Entry<AlterConfigOp.OpType, String>> configChanges
     ) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Settle on the one-mirror-at-time model and remove `newlyCreatedResource`.
