### PR TITLE
Fix stuck LOG_TRUNCATION state when source lacks DESCRIBE_CLUSTER

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -513,7 +513,7 @@ public class ClusterMirrorCoordinator {
     /** Schedules truncation to align replicas with last mirrored epoch. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
         final Consumer<TopicPartition> truncateCallback =
-            partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.EPOCH_FENCING);
+            partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING);
         scheduler.scheduleOnce("LastMirrorEpochsTruncation",
             () -> {
                 try {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1694,7 +1694,8 @@ class ReplicaManager(val config: KafkaConfig,
           })
         }
         val partition = getPartitionOrException(tp)
-        val mirrorUncleanLeaderElection = metadataCache.config(new ConfigResource(ConfigResource.Type.TOPIC, tp.topic())).get(TopicConfig.MIRROR_SUPPORT_UNCLEAN_LEADER_ELECTION_CONFIG).asInstanceOf[String]
+        val mirrorUncleanLeaderElection = metadataCache.config(new ConfigResource(ConfigResource.Type.TOPIC, tp.topic()))
+          .get(TopicConfig.MIRROR_SUPPORT_UNCLEAN_LEADER_ELECTION_CONFIG).asInstanceOf[String]
         val waitForAllReplicas = mirrorUncleanLeaderElection != null && mirrorUncleanLeaderElection.toBoolean
 
         partition.maybeCompleteTruncation(log, waitForAllReplicas = waitForAllReplicas, onCompleteCallback = Optional.of(callback),


### PR DESCRIPTION
When mirroring from an older Kafka version that does not support DESCRIBE_CLUSTER_MIRRORS, the truncation callback tried to transition from LOG_TRUNCATION to EPOCH_FENCING. This transition is invalid because EPOCH_FENCING is only reachable from MIRRORING, so partitions stayed stuck in LOG_TRUNCATION indefinitely.

Change the truncation callback to transition directly to MIRRORING, matching the normal path. EPOCH_FENCING remains reserved for the re-fencing cycle on an already-running mirror.