### PR TITLE
Fix pendingTopicCreations not cleared on success in MMM

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1284,11 +1284,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
             @Override
             public void onComplete(ClientResponse response) {
+                pendingTopicCreations.remove(topicId);
                 if (response.responseBody() instanceof CreateTopicsResponse createTopicsResponse) {
                     createTopicsResponse.data().topics().forEach(topic -> {
                         Errors error = Errors.forCode(topic.errorCode());
                         if (error != Errors.NONE) {
-                            pendingTopicCreations.remove(topicId);
                             log.warn("Failed to create mirror topic {} (topicId={}): {}", topicName, topicId, error.message());
                         }
                     });


### PR DESCRIPTION
When mirroring from a pre-KIP-516 source (e.g. Kafka 2.1.1), all topics in the MetadataResponse share topicId ZERO_UUID. The pendingTopicCreations set uses topicId as key, so the first topic locks ZERO_UUID and blocks all subsequent topics. Since the set was only cleared on error (not on success), the lock persisted across sync cycles, permanently preventing creation of remaining mirror topics on the destination.

Move pendingTopicCreations.remove(topicId) to fire on every completion, not just on error. Successful topics are already guarded against re-creation by the metadataImage check in processTopicMetadata.
