### PR TITLE
fixing bugs when supporting old versions

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -204,15 +204,15 @@ public class ClusterMirrorCoordinator {
         }
     }
 
-    private void updateRetryAttemptsAndPrevState(TopicPartition tp, MirrorPartitionState currentState, MirrorPartitionState newState) {
+    private void updateRetryAttemptsAndPrevState(String mirrorName, TopicPartition tp, MirrorPartitionState currentState, MirrorPartitionState newState) {
+        ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
         if (newState == MirrorPartitionState.FAILED) {
             metadataManager.failedRetryAttempts().merge(tp, 1, Integer::sum);
-            metadataManager.prevStateBeforeFailure().putIfAbsent(tp, currentState);
-        } else if (newState == MirrorPartitionState.MIRRORING
-                || newState == MirrorPartitionState.STOPPED
+            metadataManager.partitionPreviousStates().putIfAbsent(key, currentState);
+        } else if (newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
             metadataManager.failedRetryAttempts().remove(tp);
-            metadataManager.prevStateBeforeFailure().remove(tp);
+            metadataManager.partitionPreviousStates().remove(key);
         }
     }
 
@@ -225,8 +225,8 @@ public class ClusterMirrorCoordinator {
                 return;
             }
             long delay = failedRetryBackoff.backoff(attempt);
-            MirrorPartitionState targetState = metadataManager.prevStateBeforeFailure().getOrDefault(tp, MirrorPartitionState.MIRRORING);
-            log.info("Scheduling retry #{} for partition {} in {} ms.", attempt + 1, tp, delay);
+            MirrorPartitionState targetState = metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
+            log.info("Scheduling retry #{} for partition {} in {} ms with target state {}.", attempt + 1, tp, delay, targetState);
             scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
                 () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });
@@ -238,7 +238,7 @@ public class ClusterMirrorCoordinator {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
-                updateRetryAttemptsAndPrevState(tp, currentState, newState);
+                updateRetryAttemptsAndPrevState(mirrorName, tp, currentState, newState);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
@@ -775,7 +775,7 @@ public class ClusterMirrorCoordinator {
                 .setTopicName(topicPartition.topic())
                 .setPartition(topicPartition.partition())
                 .setState(state.value())
-                .setPreviousState(metadataManager.prevStateBeforeFailure().getOrDefault(topicPartition, MirrorPartitionState.UNKNOWN).value())
+                .setPreviousState(metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), MirrorPartitionState.UNKNOWN).value())
                 .setRetryAttempt(retryAttempt);
         var apiVersion = new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
@@ -18,6 +18,7 @@ package kafka.server.mirror;
 
 import kafka.server.KafkaConfig;
 
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogContext;
@@ -100,6 +101,8 @@ public final class ClusterMirrorUtils {
     public record PartitionKey(String mirrorName, String topic, int partition) { }
 
     public record LeaderEpochBump(CompletableFuture<Void> future, Map<TopicPartition, Integer> partitionToEpoch) { }
+
+    public record LeaderInfo(Node node, int leaderEpoch) { }
 
     interface StateTransitioner {
         void transitionTo(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -181,7 +181,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     // lets the transition handler skip partitions that are already being processed
     private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
-    private final Map<TopicPartition, MirrorPartitionState> prevStateBeforeFailure = new ConcurrentHashMap<>();
     private final Map<TopicPartition, Integer> failedRetryAttempts = new ConcurrentHashMap<>();
     private final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
 
@@ -352,10 +351,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return pendingPartitionStates;
     }
 
-    public Map<TopicPartition, MirrorPartitionState> prevStateBeforeFailure() {
-        return prevStateBeforeFailure;
-    }
-
     public Map<TopicPartition, Integer> failedRetryAttempts() {
         return failedRetryAttempts;
     }
@@ -385,6 +380,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public void transitionTo(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
         stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state));
+    }
+
+    // immediately update the source cluster metadata
+    public void scheduleRediscoverSource(String mirrorName) {
+        scheduler.scheduleOnce("rediscover-source", () -> {
+            discoverSourceBrokers(mirrorName);
+            syncSourceTopicState(mirrorName);
+        });
     }
 
     private static final Set<String> NON_CONNECTION_CONFIGS = Set.of(

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.BumpLeaderEpochsRequestData;
 import org.apache.kafka.common.message.CreateAclsRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
@@ -169,7 +170,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     private final Map<String, Uuid> sourceClusterIds = new ConcurrentHashMap<>();
     private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
-    private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
+    private final Map<String, Map<TopicPartition, ClusterMirrorUtils.LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
     private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates = new ConcurrentHashMap<>();
     private final Map<MirrorPartitionState, AtomicLong> partitionStateCounts = new ConcurrentHashMap<>();
@@ -847,15 +848,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /** Updates cached source leader for a specific partition. */
-    public void updateSourceLeader(String mirrorName, TopicPartition tp, Node leader) {
+    public void updateSourceLeader(String mirrorName, TopicPartition tp, ClusterMirrorUtils.LeaderInfo leader) {
         sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>()).put(tp, leader);
     }
 
     /** Resolves source partition leader from cache, falling back to bootstrap server if not cached. */
-    public Node resolveSourceLeader(String mirrorName, TopicPartition tp) {
+    public ClusterMirrorUtils.LeaderInfo resolveSourceLeader(String mirrorName, TopicPartition tp) {
         var partitionLeaders = sourceLeaders.get(mirrorName);
         if (partitionLeaders != null) {
-            Node leader = partitionLeaders.get(tp);
+            ClusterMirrorUtils.LeaderInfo leader = partitionLeaders.get(tp);
             if (leader != null) {
                 return leader;
             }
@@ -870,7 +871,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (senders != null && !senders.isEmpty()) {
             log.info("No cached leader for mirror {} partition {}. Using bootstrap server as initial target.", mirrorName, tp);
             BrokerEndPoint ep = senders.get(0).brokerEndPoint();
-            return new Node(ep.id(), ep.host(), ep.port());
+            // set leaderEpoch to 0 if unknown to trigger source epoch discovery through fencing
+            return new ClusterMirrorUtils.LeaderInfo(new Node(ep.id(), ep.host(), ep.port()), 0);
         }
 
         throw new IllegalStateException("No source senders available for mirror " + mirrorName);
@@ -1269,7 +1271,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 if (partitionMetadata.leaderId.isPresent()) {
                     Node leader = brokerNodes.get(partitionMetadata.leaderId.get());
                     if (leader != null) {
-                        partitionLeaders.put(partitionMetadata.topicPartition, leader);
+                        // set leaderEpoch to 0 if unknown to trigger source epoch discovery through fencing
+                        partitionLeaders.put(partitionMetadata.topicPartition, new ClusterMirrorUtils.LeaderInfo(leader, partitionMetadata.leaderEpoch.orElse(0)));
                     }
                 }
             });
@@ -1573,8 +1576,18 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         shareGroupOffsetSyncError.incrementAndGet();
         try {
-            List<String> sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forShareGroups(),
-                    groupsIncludePattern, groupsExcludePattern);
+            List<String> sourceGroupIds;
+            try {
+                sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forShareGroups(),
+                        groupsIncludePattern, groupsExcludePattern);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnsupportedVersionException) {
+                    log.debug("The source cluster doesn't support share group, skipping share group offset sync");
+                    return;
+                } else {
+                    throw e;
+                }
+            }
             if (sourceGroupIds.isEmpty()) {
                 return;
             }

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -113,7 +113,7 @@ abstract class AbstractFetcherThread(name: String,
 
   protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {}
 
-  protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {}
+  protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition]): Unit = {}
 
   protected def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
     false
@@ -166,7 +166,7 @@ abstract class AbstractFetcherThread(name: String,
       if (fetchException.exists(_.isInstanceOf[IOException]) && mirrorName.nonEmpty && isRunning) {
         try {
           partitions.foreach(markPartitionRemoved)
-          handleMirrorFetchConnectionFailure(partitions.toSet)
+          refreshSourceClusterMetadata(partitions.toSet)
         } catch {
           case t: Throwable =>
             warn(s"Failed to re-resolve source leader for mirror $mirrorName", t)
@@ -276,22 +276,34 @@ abstract class AbstractFetcherThread(name: String,
    * current leader epoch, enabling proper epoch validation when fetching from the source.
    */
   private def updateMirrorFetchEpoch(partitionToData: Map[TopicPartition, PartitionData]): Unit = inLock(partitionMapLock) {
-    val newStates: Map[TopicPartition, PartitionFetchState] = partitionStates.partitionStateMap.asScala
+    val newStates: java.util.Map[TopicPartition, PartitionFetchState] = new util.HashMap[TopicPartition, PartitionFetchState]()
+    val partitionsToBeRemoved: java.util.Set[TopicPartition] = new util.HashSet[TopicPartition]()
+    partitionStates.partitionStateMap.asScala
       .map { case (topicPartition, currentFetchState) =>
         val updatedFetchState = partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
             // Updating currentLeaderEpoch with source cluster leader epoch to pass epoch validation when fetching from source cluster
             val newCurrentLeaderEpoch = partitionData.currentLeader().leaderEpoch()
-            info(s"Discovered new fetch epoch for mirrored partition $topicPartition, " +
-              s"currentLeaderEpoch: ${currentFetchState.currentLeaderEpoch} -> $newCurrentLeaderEpoch")
-            new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
-              newCurrentLeaderEpoch, currentFetchState.delay, currentFetchState.state(), currentFetchState.lastFetchedEpoch(),
-              currentFetchState.dueMs(), currentFetchState.mirrorName(), currentFetchState.mirrorLeaderEpoch())
-          case None => currentFetchState
+
+            if (newCurrentLeaderEpoch > -1) {
+              info(s"Discovered new fetch epoch for mirrored partition $topicPartition, " +
+                s"currentLeaderEpoch: ${currentFetchState.currentLeaderEpoch} -> $newCurrentLeaderEpoch")
+              newStates.put(topicPartition, new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
+                newCurrentLeaderEpoch, currentFetchState.delay, currentFetchState.state(), currentFetchState.lastFetchedEpoch(),
+                currentFetchState.dueMs(), currentFetchState.mirrorName(), currentFetchState.mirrorLeaderEpoch()))
+            } else {
+              // the returned leaderEpoch is < 0, which means the source cluster doesn't support fetch API v9
+              partitionsToBeRemoved.add(topicPartition)
+            }
+          case None => newStates.put(topicPartition, currentFetchState)
         }
         (topicPartition, updatedFetchState)
       }
-    partitionStates.set(newStates.asJava)
+    partitionStates.set(newStates)
+    if (!partitionsToBeRemoved.isEmpty) {
+      removeFetcherForPartitions(partitionsToBeRemoved.asScala)
+      refreshSourceClusterMetadata(partitionsToBeRemoved.asScala)
+    }
   }
 
   /** Reassigns mirrored partitions to new fetcher threads after source leader change. */
@@ -413,8 +425,9 @@ abstract class AbstractFetcherThread(name: String,
     var fetchException: Option[Throwable] = None
 
     try {
-      debug(s"!!! Sending fetch request $fetchRequest")
+      info(s"!!! Sending fetch request $fetchRequest")
       responseData = leader.fetch(fetchRequest).asScala
+      info(s"!!! response: $responseData")
     } catch {
       case t: Throwable =>
         fetchException = Some(t)

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -20,7 +20,7 @@ package kafka.server
 import java.util.{Collections, Optional}
 import kafka.utils.Logging
 import org.apache.kafka.clients.FetchSessionHandler
-import org.apache.kafka.common.errors.KafkaStorageException
+import org.apache.kafka.common.errors.{KafkaStorageException, UnsupportedVersionException}
 import org.apache.kafka.common.{IsolationLevel, Node, TopicPartition, Uuid}
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
@@ -82,7 +82,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
   private val lastSeenEndpointList = new util.HashMap[Integer, Node]()
 
   // cached from the first fetch response; lastFetchedEpoch requires Fetch v12+ (KIP-595)
-  @volatile private var negotiatedFetchVersion: Short = -1
+  @volatile private var supportFetchV12: Boolean = true
 
   override def isTruncationOnFetchSupported: Boolean = true
 
@@ -98,12 +98,18 @@ class RemoteLeaderEndPoint(logPrefix: String,
     val clientResponse = try {
       blockingSender.sendRequest(fetchRequest)
     } catch {
+      case t: UnsupportedVersionException =>
+        if (t.getMessage.contains("Attempted to write a non-default lastFetchedEpoch")) {
+          supportFetchV12 = false
+        }
+        fetchSessionHandler.handleError(t)
+        throw t
       case t: Throwable =>
         fetchSessionHandler.handleError(t)
         throw t
     }
+
     val fetchResponse = clientResponse.responseBody.asInstanceOf[FetchResponse]
-    negotiatedFetchVersion = clientResponse.requestHeader().apiVersion()
     debug("!!! Got fetch response: " + fetchResponse)
     lastSeenEndpointList.clear()
     fetchResponse.data().nodeEndpoints().forEach(
@@ -213,7 +219,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
           // Pre-KIP-595 sources (Fetch < v12) don't support lastFetchedEpoch;
           // skip it until we confirm the source version from the first response.
           val lastFetchedEpoch = if (isTruncationOnFetchSupported
-            && (!isClusterMirror || negotiatedFetchVersion < 0 || negotiatedFetchVersion >= 12))
+            && (!isClusterMirror || supportFetchV12))
             fetchState.lastFetchedEpoch()
           else
             Optional.empty[Integer]

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2648,12 +2648,13 @@ class ReplicaManager(val config: KafkaConfig,
             if (mirrorName != null && !mirrorName.isEmpty) {
               // Get the source partition leader
               val sourceLeader = mirrorMetadataManager.get.resolveSourceLeader(mirrorName, tp)
-              val leaderEndpoint = new BrokerEndPoint(sourceLeader.id(), sourceLeader.host(), sourceLeader.port())
+              val sourceLeaderNode = sourceLeader.node()
+              val leaderEndpoint = new BrokerEndPoint(sourceLeaderNode.id(), sourceLeaderNode.host(), sourceLeaderNode.port())
 
               val fetchState = InitialFetchState(
                 topicId = Some(metadataCache.getTopicId(tp.topic)),
                 leader = leaderEndpoint,
-                currentLeaderEpoch = 0, // this will trigger source epoch discovery through fencing
+                currentLeaderEpoch = sourceLeader.leaderEpoch(),
                 initOffset = partition.localLogOrException.logEndOffset,
                 mirrorName = mirrorName,
                 mirrorLeaderEpoch = Optional.empty()

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -18,7 +18,7 @@ package kafka.server.mirror
 
 import kafka.cluster.Partition
 import kafka.server._
-import kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD
+import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, PartitionKey}
 import org.apache.kafka.common.errors.MirrorLeaderEpochExceededException
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
@@ -74,7 +74,11 @@ class MirrorFetcherThread(name: String,
   // Transition to FAILED so the coordinator can schedule exponential backoff retries.
   override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
     mirrorPartitions.foreach { tp =>
-      replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED))
+      replicaMgr.mirrorMetadataManager.foreach( mmm => {
+        // the leader node in the source cluster might have unclean shutdown, we need to aggressively discover new leader
+        mmm.scheduleRediscoverSource(mirrorName);
+        mmm.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED)
+      })
     }
   }
 
@@ -105,6 +109,10 @@ class MirrorFetcherThread(name: String,
       // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),
       // schedule a proactive local epoch bump while still allowing the current batch to append.
       replicaMgr.mirrorMetadataManager.foreach { mmm =>
+        // successful fetch, remove the failed metadata
+        mmm.failedRetryAttempts.remove(topicPartition)
+        mmm.partitionPreviousStates().remove(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()))
+
         mmm.scheduleBumpLeaderEpochs(partition.getMirrorName().get(), java.util.Set.of(topicPartition))
           .whenComplete { (_, ex) =>
             if (ex != null) log.warn(s"Proactive epoch bump failed for $topicPartition", ex)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -18,7 +18,7 @@ package kafka.server.mirror
 
 import kafka.cluster.Partition
 import kafka.server._
-import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, PartitionKey}
+import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, LeaderInfo, PartitionKey}
 import org.apache.kafka.common.errors.MirrorLeaderEpochExceededException
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
@@ -65,14 +65,14 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorMetadataManager.foreach { mmm =>
       partitionAndOffsets.foreach { case (tp, state) =>
         mmm.updateSourceLeader(mirrorName, tp,
-          new Node(state.leader.id(), state.leader.host(), state.leader.port()))
+          new LeaderInfo(new Node(state.leader.id(), state.leader.host(), state.leader.port()), state.currentLeaderEpoch))
       }
     }
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
   // Transition to FAILED so the coordinator can schedule exponential backoff retries.
-  override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
+  override protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition]): Unit = {
     mirrorPartitions.foreach { tp =>
       replicaMgr.mirrorMetadataManager.foreach( mmm => {
         // the leader node in the source cluster might have unclean shutdown, we need to aggressively discover new leader

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -441,9 +441,11 @@ public class ConfigurationControlManager {
                 }
             }
 
-            if (!topic.topicId().equals(Uuid.ZERO_UUID) && topic.numPartitions() > 0) {
+            // create a random uuid if the provided topic id is ZERO_UUID (i.e. the source topic has no topic ID attached)
+            Uuid topicId = topic.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : topic.topicId();
+            if (topic.numPartitions() > 0) {
                 ApiError createError = replicationControl.createMirrorTopic(
-                        topicName, topic.topicId(), topic.numPartitions(), records);
+                        topicName, topicId, topic.numPartitions(), records);
                 if (createError.isFailure() && createError.error() != Errors.TOPIC_ALREADY_EXISTS) {
                     // TODO: emit metric for mirror topic creation failure with error type (e.g. INVALID_REPLICATION_FACTOR)
                     topicRes.setErrorCode(createError.error().code()).setName(topicName);


### PR DESCRIPTION
4 bugs found when testing with kafka v2.x:

1. when source cluster doesn't support topic ID (before KIP-516), the startMirrorTopics will send with ZERO_UUID. Need to create a random uuid for it and then create topics
2. We accidentally create 2 caches for the same purpose: `prevStateBeforeFailure` and `partitionPreviousStates`. And when loadMirrorMetadata, we store the metadata in `partitionPreviousStates`, but then we check `prevStateBeforeFailure` when FAILED. Unify them.
3. Currently, we clean up the failed metadata (i.e. `partitionPreviousStates` and `failedRetryAttempts`) when the new state is MIRRORING/STOPPED/PAUSED because they are the terminated states. But actually, `MIRRORING` is not a terminated state, it will do the mirroring work. When the error happened in MIRRORING state, it'll be in an endless loop:
```
MIRRORING -> FAILED -> backoff done, retry attempt #2 -> MIRRORING -> Clean up the `failedRetryAttempts` -> FAILED -> backoff done, retry attempt #2 (should be 3) -> MIRRORING -> clean up again...
```
Fix it by cleaning up the failed state for mirroring when having successful fetch.
4. In old kafka, the fetch response won't contain the new leader info, it relies on the consumer to re-discover the metadata. The same situation also happens in new version kafka if the source cluster leader shutdown uncleanly, the mirror fetch request still enter connection failure loop, and keep retrying. Fix it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
