### PR TITLE
Fix FAILED state handling in MIRRORING state

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -209,8 +209,7 @@ public class ClusterMirrorCoordinator {
         if (newState == MirrorPartitionState.FAILED) {
             metadataManager.failedRetryAttempts().merge(tp, 1, Integer::sum);
             metadataManager.partitionPreviousStates().putIfAbsent(key, currentState);
-        } else if (newState == MirrorPartitionState.MIRRORING
-                || newState == MirrorPartitionState.STOPPED
+        } else if (newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
             metadataManager.failedRetryAttempts().remove(tp);
             metadataManager.partitionPreviousStates().remove(key);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -226,9 +226,8 @@ public class ClusterMirrorCoordinator {
             }
             long delay = failedRetryBackoff.backoff(attempt);
             MirrorPartitionState targetState = metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
-            log.info("Scheduling retry #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
-            scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
-                () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
+            log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
+            scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });
     }
 

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -226,7 +226,7 @@ public class ClusterMirrorCoordinator {
             }
             long delay = failedRetryBackoff.backoff(attempt);
             MirrorPartitionState targetState = metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
-            log.info("Scheduling retry #{} for partition {} in {} ms with target state {}.", attempt + 1, tp, delay, targetState);
+            log.info("Scheduling retry #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
             scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
                 () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -101,17 +101,20 @@ class MirrorFetcherThread(name: String,
       // The exception will mark this partition as failed and transition mirror state to EPOCH_FENCING.
       throw new MirrorLeaderEpochExceededException(s"Rejecting the batch because the batch leader " +
         s"epoch $highestBatchLeaderEpoch is higher than local leader epoch $localLeaderEpoch")
-    } else if (highestBatchLeaderEpoch > localLeaderEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
-      // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),
-      // schedule a proactive local epoch bump while still allowing the current batch to append.
+    } else {
       replicaMgr.mirrorMetadataManager.foreach { mmm =>
         // successful fetch, remove the failed metadata
         mmm.failedRetryAttempts.remove(topicPartition)
         mmm.partitionPreviousStates().remove(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()))
-        mmm.scheduleBumpLeaderEpochs(partition.getMirrorName().get(), java.util.Set.of(topicPartition))
-          .whenComplete { (_, ex) =>
-            if (ex != null) log.warn(s"Proactive epoch bump failed for $topicPartition", ex)
-          }
+
+        if (highestBatchLeaderEpoch > localLeaderEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
+          // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),
+          // schedule a proactive local epoch bump while still allowing the current batch to append.
+          mmm.scheduleBumpLeaderEpochs(partition.getMirrorName().get(), java.util.Set.of(topicPartition))
+            .whenComplete { (_, ex) =>
+              if (ex != null) log.warn(s"Proactive epoch bump failed for $topicPartition", ex)
+            }
+        }
       }
     }
   }

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -18,7 +18,7 @@ package kafka.server.mirror
 
 import kafka.cluster.Partition
 import kafka.server._
-import kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD
+import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, PartitionKey}
 import org.apache.kafka.common.errors.MirrorLeaderEpochExceededException
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
@@ -105,6 +105,9 @@ class MirrorFetcherThread(name: String,
       // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),
       // schedule a proactive local epoch bump while still allowing the current batch to append.
       replicaMgr.mirrorMetadataManager.foreach { mmm =>
+        // successful fetch, remove the failed metadata
+        mmm.failedRetryAttempts.remove(topicPartition)
+        mmm.partitionPreviousStates().remove(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()))
         mmm.scheduleBumpLeaderEpochs(partition.getMirrorName().get(), java.util.Set.of(topicPartition))
           .whenComplete { (_, ex) =>
             if (ex != null) log.warn(s"Proactive epoch bump failed for $topicPartition", ex)

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -441,9 +441,11 @@ public class ConfigurationControlManager {
                 }
             }
 
-            if (!topic.topicId().equals(Uuid.ZERO_UUID) && topic.numPartitions() > 0) {
+            // create a random uuid if the provided topic id is ZERO_UUID (i.e. the source topic has no topic ID attached)
+            Uuid topicId = topic.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : topic.topicId();
+            if (topic.numPartitions() > 0) {
                 ApiError createError = replicationControl.createMirrorTopic(
-                        topicName, topic.topicId(), topic.numPartitions(), records);
+                        topicName, topicId, topic.numPartitions(), records);
                 if (createError.isFailure() && createError.error() != Errors.TOPIC_ALREADY_EXISTS) {
                     // TODO: emit metric for mirror topic creation failure with error type (e.g. INVALID_REPLICATION_FACTOR)
                     topicRes.setErrorCode(createError.error().code()).setName(topicName);


### PR DESCRIPTION
1. when source cluster doesn't support topic ID (before KIP-516), the startMirrorTopics will send with ZERO_UUID. Need to create a random uuid for it and then create topics
2. Currently, we clean up the failed metadata (i.e. `partitionPreviousStates` and `failedRetryAttempts`) when the new state is MIRRORING/STOPPED/PAUSED because they are the terminated states. But actually, `MIRRORING` is not a terminated state, it will do the mirroring work. When the error happened in MIRRORING state, it'll be in an endless loop:
```
MIRRORING -> FAILED -> backoff done, retry attempt #2 -> 
MIRRORING -> Clean up the `failedRetryAttempts` -> FAILED -> backoff done, retry attempt #2 (should be 3) -> 
MIRRORING -> clean up again... -> FAILED -> backoff done, retry attempt #2 (should be 4)
```
Fix it by cleaning up the failed state for mirroring when having successful fetch.
3. When first time entering failed and starts retry, it'll show:
```
Scheduling retry #2 for partition quickstart-events-0 in 2081 ms with target state MIRRORING
```
This should be the first time retry, update the retry count log.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
