### PR TITLE
Force refresh source cluster metadata for old version source kafka

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -307,14 +307,22 @@ public class FetchRequest extends AbstractRequest {
                     fetchRequestData.topics().add(fetchTopic);
                 }
 
+
+
                 FetchRequestData.FetchPartition fetchPartition = new FetchRequestData.FetchPartition()
                     .setPartition(topicPartition.partition())
                     .setCurrentLeaderEpoch(partitionData.currentLeaderEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
-                    .setLastFetchedEpoch(partitionData.lastFetchedEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
-                    .setMirrorLeaderEpoch(partitionData.mirrorLeaderEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
                     .setFetchOffset(partitionData.fetchOffset)
                     .setLogStartOffset(partitionData.logStartOffset)
                     .setPartitionMaxBytes(partitionData.maxBytes);
+
+                if (version >= 12) {
+                    fetchPartition.setLastFetchedEpoch(partitionData.lastFetchedEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH));
+                }
+
+                if (version >= 19) {
+                    fetchPartition.setMirrorLeaderEpoch(partitionData.mirrorLeaderEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH));
+                }
 
                 fetchTopic.partitions().add(fetchPartition);
             }

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -307,8 +307,6 @@ public class FetchRequest extends AbstractRequest {
                     fetchRequestData.topics().add(fetchTopic);
                 }
 
-
-
                 FetchRequestData.FetchPartition fetchPartition = new FetchRequestData.FetchPartition()
                     .setPartition(topicPartition.partition())
                     .setCurrentLeaderEpoch(partitionData.currentLeaderEpoch.orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -225,7 +225,8 @@ public class ClusterMirrorCoordinator {
                 return;
             }
             long delay = failedRetryBackoff.backoff(attempt);
-            MirrorPartitionState targetState = metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
+            MirrorPartitionState targetState = metadataManager.partitionPreviousStates()
+                    .getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
             log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
             scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -209,8 +209,7 @@ public class ClusterMirrorCoordinator {
         if (newState == MirrorPartitionState.FAILED) {
             metadataManager.failedRetryAttempts().merge(tp, 1, Integer::sum);
             metadataManager.partitionPreviousStates().putIfAbsent(key, currentState);
-        } else if (newState == MirrorPartitionState.MIRRORING
-                || newState == MirrorPartitionState.STOPPED
+        } else if (newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
             metadataManager.failedRetryAttempts().remove(tp);
             metadataManager.partitionPreviousStates().remove(key);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -204,15 +204,16 @@ public class ClusterMirrorCoordinator {
         }
     }
 
-    private void updateRetryAttemptsAndPrevState(TopicPartition tp, MirrorPartitionState currentState, MirrorPartitionState newState) {
+    private void updateRetryAttemptsAndPrevState(String mirrorName, TopicPartition tp, MirrorPartitionState currentState, MirrorPartitionState newState) {
+        ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
         if (newState == MirrorPartitionState.FAILED) {
             metadataManager.failedRetryAttempts().merge(tp, 1, Integer::sum);
-            metadataManager.prevStateBeforeFailure().putIfAbsent(tp, currentState);
+            metadataManager.partitionPreviousStates().putIfAbsent(key, currentState);
         } else if (newState == MirrorPartitionState.MIRRORING
                 || newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
             metadataManager.failedRetryAttempts().remove(tp);
-            metadataManager.prevStateBeforeFailure().remove(tp);
+            metadataManager.partitionPreviousStates().remove(key);
         }
     }
 
@@ -225,8 +226,8 @@ public class ClusterMirrorCoordinator {
                 return;
             }
             long delay = failedRetryBackoff.backoff(attempt);
-            MirrorPartitionState targetState = metadataManager.prevStateBeforeFailure().getOrDefault(tp, MirrorPartitionState.MIRRORING);
-            log.info("Scheduling retry #{} for partition {} in {} ms.", attempt + 1, tp, delay);
+            MirrorPartitionState targetState = metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
+            log.info("Scheduling retry #{} for partition {} in {} ms with target state {}.", attempt + 1, tp, delay, targetState);
             scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
                 () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });
@@ -238,7 +239,7 @@ public class ClusterMirrorCoordinator {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
-                updateRetryAttemptsAndPrevState(tp, currentState, newState);
+                updateRetryAttemptsAndPrevState(mirrorName, tp, currentState, newState);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
@@ -775,7 +776,7 @@ public class ClusterMirrorCoordinator {
                 .setTopicName(topicPartition.topic())
                 .setPartition(topicPartition.partition())
                 .setState(state.value())
-                .setPreviousState(metadataManager.prevStateBeforeFailure().getOrDefault(topicPartition, MirrorPartitionState.UNKNOWN).value())
+                .setPreviousState(metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), MirrorPartitionState.UNKNOWN).value())
                 .setRetryAttempt(retryAttempt);
         var apiVersion = new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -226,7 +226,7 @@ public class ClusterMirrorCoordinator {
             }
             long delay = failedRetryBackoff.backoff(attempt);
             MirrorPartitionState targetState = metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
-            log.info("Scheduling retry #{} for partition {} in {} ms with target state {}.", attempt + 1, tp, delay, targetState);
+            log.info("Scheduling retry #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
             scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
                 () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -204,15 +204,15 @@ public class ClusterMirrorCoordinator {
         }
     }
 
-    private void updateRetryAttemptsAndPrevState(TopicPartition tp, MirrorPartitionState currentState, MirrorPartitionState newState) {
+    private void updateRetryAttemptsAndPrevState(String mirrorName, TopicPartition tp, MirrorPartitionState currentState, MirrorPartitionState newState) {
+        ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
         if (newState == MirrorPartitionState.FAILED) {
             metadataManager.failedRetryAttempts().merge(tp, 1, Integer::sum);
-            metadataManager.prevStateBeforeFailure().putIfAbsent(tp, currentState);
-        } else if (newState == MirrorPartitionState.MIRRORING
-                || newState == MirrorPartitionState.STOPPED
+            metadataManager.partitionPreviousStates().putIfAbsent(key, currentState);
+        } else if (newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
             metadataManager.failedRetryAttempts().remove(tp);
-            metadataManager.prevStateBeforeFailure().remove(tp);
+            metadataManager.partitionPreviousStates().remove(key);
         }
     }
 
@@ -225,8 +225,8 @@ public class ClusterMirrorCoordinator {
                 return;
             }
             long delay = failedRetryBackoff.backoff(attempt);
-            MirrorPartitionState targetState = metadataManager.prevStateBeforeFailure().getOrDefault(tp, MirrorPartitionState.MIRRORING);
-            log.info("Scheduling retry #{} for partition {} in {} ms.", attempt + 1, tp, delay);
+            MirrorPartitionState targetState = metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
+            log.info("Scheduling retry #{} for partition {} in {} ms with target state {}.", attempt + 1, tp, delay, targetState);
             scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
                 () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });
@@ -238,7 +238,7 @@ public class ClusterMirrorCoordinator {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
-                updateRetryAttemptsAndPrevState(tp, currentState, newState);
+                updateRetryAttemptsAndPrevState(mirrorName, tp, currentState, newState);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
@@ -775,7 +775,7 @@ public class ClusterMirrorCoordinator {
                 .setTopicName(topicPartition.topic())
                 .setPartition(topicPartition.partition())
                 .setState(state.value())
-                .setPreviousState(metadataManager.prevStateBeforeFailure().getOrDefault(topicPartition, MirrorPartitionState.UNKNOWN).value())
+                .setPreviousState(metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), MirrorPartitionState.UNKNOWN).value())
                 .setRetryAttempt(retryAttempt);
         var apiVersion = new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -939,7 +939,9 @@ public class ClusterMirrorCoordinator {
                                 ClusterMirrorUtils.PartitionKey pk = new ClusterMirrorUtils.PartitionKey(
                                         clusterName, value.topic(), value.partition());
                                 metadataManager.updatePartitionState(pk, value.state());
-                                metadataManager.partitionPreviousStates().put(pk, value.previousState());
+                                if (value.previousState() != MirrorPartitionState.UNKNOWN) {
+                                    metadataManager.partitionPreviousStates().putIfAbsent(pk, value.previousState());
+                                }
                                 TopicPartition tp = new TopicPartition(value.topic(), value.partition());
                                 if (value.state() == MirrorPartitionState.FAILED && value.retryAttempt() > 0) {
                                     metadataManager.failedRetryAttempts().put(tp, value.retryAttempt());

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
@@ -18,6 +18,7 @@ package kafka.server.mirror;
 
 import kafka.server.KafkaConfig;
 
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogContext;
@@ -100,6 +101,8 @@ public final class ClusterMirrorUtils {
     public record PartitionKey(String mirrorName, String topic, int partition) { }
 
     public record LeaderEpochBump(CompletableFuture<Void> future, Map<TopicPartition, Integer> partitionToEpoch) { }
+
+    public record LeaderInfo(Node node, int leaderEpoch) { }
 
     interface StateTransitioner {
         void transitionTo(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -181,7 +181,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     // lets the transition handler skip partitions that are already being processed
     private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
-    private final Map<TopicPartition, MirrorPartitionState> prevStateBeforeFailure = new ConcurrentHashMap<>();
     private final Map<TopicPartition, Integer> failedRetryAttempts = new ConcurrentHashMap<>();
     private final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
 
@@ -352,10 +351,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return pendingPartitionStates;
     }
 
-    public Map<TopicPartition, MirrorPartitionState> prevStateBeforeFailure() {
-        return prevStateBeforeFailure;
-    }
-
     public Map<TopicPartition, Integer> failedRetryAttempts() {
         return failedRetryAttempts;
     }
@@ -385,6 +380,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public void transitionTo(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
         stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state));
+    }
+
+    // immediately update the source cluster metadata
+    public void scheduleRediscoverSource(String mirrorName) {
+        scheduler.scheduleOnce("rediscover-source", () -> {
+            discoverSourceBrokers(mirrorName);
+            syncSourceTopicState(mirrorName);
+        });
     }
 
     private static final Set<String> NON_CONNECTION_CONFIGS = Set.of(

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1244,10 +1244,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         );
 
         if (response.responseBody() instanceof MetadataResponse metadataResponse) {
-            log.info("Periodic metadata response: {}", metadataResponse);
-            if (!metadataResponse.errors().isEmpty()) {
-                return Optional.empty();
-            }
+            log.debug("Periodic metadata response: {}", metadataResponse);
             Map<Integer, Node> brokerNodes = new HashMap<>();
             metadataResponse.brokers().forEach(broker -> brokerNodes.put(broker.id(), broker));
             processTopicMetadata(mirrorName, metadataResponse.topicMetadata(), brokerNodes);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -740,8 +740,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 if (partition.state() != -1) {
                                     partitionStates.put(mpk, MirrorPartitionState.fromValue(partition.state()));
                                 }
-                                // putIfAbsent to avoid overwriting a locally-set previous state from a FAILED transition
-                                partitionPreviousStates.putIfAbsent(mpk, MirrorPartitionState.fromValue(partition.previousState()));
+                                MirrorPartitionState prevState = MirrorPartitionState.fromValue(partition.previousState());
+                                if (prevState != MirrorPartitionState.UNKNOWN) {
+                                    partitionPreviousStates.putIfAbsent(mpk, prevState);
+                                }
                                 failedRetryAttempts.put(tp, (int) partition.retryAttempt());
                             });
                         });

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -740,7 +740,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 if (partition.state() != -1) {
                                     partitionStates.put(mpk, MirrorPartitionState.fromValue(partition.state()));
                                 }
-                                partitionPreviousStates.put(mpk, MirrorPartitionState.fromValue(partition.previousState()));
+                                // putIfAbsent to avoid overwriting a locally-set previous state from a FAILED transition
+                                partitionPreviousStates.putIfAbsent(mpk, MirrorPartitionState.fromValue(partition.previousState()));
                                 failedRetryAttempts.put(tp, (int) partition.retryAttempt());
                             });
                         });

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.BumpLeaderEpochsRequestData;
 import org.apache.kafka.common.message.CreateAclsRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
@@ -169,7 +170,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     private final Map<String, Uuid> sourceClusterIds = new ConcurrentHashMap<>();
     private final Map<String, List<MirrorSourceSender>> sourceSenders = new ConcurrentHashMap<>();
-    private final Map<String, Map<TopicPartition, Node>> sourceLeaders = new ConcurrentHashMap<>();
+    private final Map<String, Map<TopicPartition, ClusterMirrorUtils.LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
     private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates = new ConcurrentHashMap<>();
     private final Map<MirrorPartitionState, AtomicLong> partitionStateCounts = new ConcurrentHashMap<>();
@@ -847,15 +848,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /** Updates cached source leader for a specific partition. */
-    public void updateSourceLeader(String mirrorName, TopicPartition tp, Node leader) {
+    public void updateSourceLeader(String mirrorName, TopicPartition tp, ClusterMirrorUtils.LeaderInfo leader) {
         sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>()).put(tp, leader);
     }
 
     /** Resolves source partition leader from cache, falling back to bootstrap server if not cached. */
-    public Node resolveSourceLeader(String mirrorName, TopicPartition tp) {
+    public ClusterMirrorUtils.LeaderInfo resolveSourceLeader(String mirrorName, TopicPartition tp) {
         var partitionLeaders = sourceLeaders.get(mirrorName);
         if (partitionLeaders != null) {
-            Node leader = partitionLeaders.get(tp);
+            ClusterMirrorUtils.LeaderInfo leader = partitionLeaders.get(tp);
             if (leader != null) {
                 return leader;
             }
@@ -870,7 +871,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (senders != null && !senders.isEmpty()) {
             log.info("No cached leader for mirror {} partition {}. Using bootstrap server as initial target.", mirrorName, tp);
             BrokerEndPoint ep = senders.get(0).brokerEndPoint();
-            return new Node(ep.id(), ep.host(), ep.port());
+            // set leaderEpoch to 0 if unknown to trigger source epoch discovery through fencing
+            return new ClusterMirrorUtils.LeaderInfo(new Node(ep.id(), ep.host(), ep.port()), 0);
         }
 
         throw new IllegalStateException("No source senders available for mirror " + mirrorName);
@@ -1269,7 +1271,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 if (partitionMetadata.leaderId.isPresent()) {
                     Node leader = brokerNodes.get(partitionMetadata.leaderId.get());
                     if (leader != null) {
-                        partitionLeaders.put(partitionMetadata.topicPartition, leader);
+                        // set leaderEpoch to 0 if unknown to trigger source epoch discovery through fencing
+                        partitionLeaders.put(partitionMetadata.topicPartition, new ClusterMirrorUtils.LeaderInfo(leader, partitionMetadata.leaderEpoch.orElse(0)));
                     }
                 }
             });
@@ -1573,8 +1576,18 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         shareGroupOffsetSyncError.incrementAndGet();
         try {
-            List<String> sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forShareGroups(),
-                    groupsIncludePattern, groupsExcludePattern);
+            List<String> sourceGroupIds;
+            try {
+                sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forShareGroups(),
+                        groupsIncludePattern, groupsExcludePattern);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnsupportedVersionException) {
+                    log.debug("The source cluster doesn't support share group, skipping share group offset sync");
+                    return;
+                } else {
+                    throw e;
+                }
+            }
             if (sourceGroupIds.isEmpty()) {
                 return;
             }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -181,7 +181,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     // lets the transition handler skip partitions that are already being processed
     private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
-    private final Map<TopicPartition, MirrorPartitionState> prevStateBeforeFailure = new ConcurrentHashMap<>();
     private final Map<TopicPartition, Integer> failedRetryAttempts = new ConcurrentHashMap<>();
     private final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
 
@@ -350,10 +349,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public Map<TopicPartition, MirrorPartitionState> pendingPartitionStates() {
         return pendingPartitionStates;
-    }
-
-    public Map<TopicPartition, MirrorPartitionState> prevStateBeforeFailure() {
-        return prevStateBeforeFailure;
     }
 
     public Map<TopicPartition, Integer> failedRetryAttempts() {

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -113,7 +113,7 @@ abstract class AbstractFetcherThread(name: String,
 
   protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {}
 
-  protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {}
+  protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition]): Unit = {}
 
   protected def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
     false
@@ -166,7 +166,7 @@ abstract class AbstractFetcherThread(name: String,
       if (fetchException.exists(_.isInstanceOf[IOException]) && mirrorName.nonEmpty && isRunning) {
         try {
           partitions.foreach(markPartitionRemoved)
-          handleMirrorFetchConnectionFailure(partitions.toSet)
+          refreshSourceClusterMetadata(partitions.toSet)
         } catch {
           case t: Throwable =>
             warn(s"Failed to re-resolve source leader for mirror $mirrorName", t)
@@ -276,22 +276,34 @@ abstract class AbstractFetcherThread(name: String,
    * current leader epoch, enabling proper epoch validation when fetching from the source.
    */
   private def updateMirrorFetchEpoch(partitionToData: Map[TopicPartition, PartitionData]): Unit = inLock(partitionMapLock) {
-    val newStates: Map[TopicPartition, PartitionFetchState] = partitionStates.partitionStateMap.asScala
+    val newStates: java.util.Map[TopicPartition, PartitionFetchState] = new util.HashMap[TopicPartition, PartitionFetchState]()
+    val partitionsToBeRemoved: java.util.Set[TopicPartition] = new util.HashSet[TopicPartition]()
+    partitionStates.partitionStateMap.asScala
       .map { case (topicPartition, currentFetchState) =>
         val updatedFetchState = partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
             // Updating currentLeaderEpoch with source cluster leader epoch to pass epoch validation when fetching from source cluster
             val newCurrentLeaderEpoch = partitionData.currentLeader().leaderEpoch()
-            info(s"Discovered new fetch epoch for mirrored partition $topicPartition, " +
-              s"currentLeaderEpoch: ${currentFetchState.currentLeaderEpoch} -> $newCurrentLeaderEpoch")
-            new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
-              newCurrentLeaderEpoch, currentFetchState.delay, currentFetchState.state(), currentFetchState.lastFetchedEpoch(),
-              currentFetchState.dueMs(), currentFetchState.mirrorName(), currentFetchState.mirrorLeaderEpoch())
-          case None => currentFetchState
+
+            if (newCurrentLeaderEpoch > -1) {
+              info(s"Discovered new fetch epoch for mirrored partition $topicPartition, " +
+                s"currentLeaderEpoch: ${currentFetchState.currentLeaderEpoch} -> $newCurrentLeaderEpoch")
+              newStates.put(topicPartition, new PartitionFetchState(currentFetchState.topicId, currentFetchState.fetchOffset(), currentFetchState.lag,
+                newCurrentLeaderEpoch, currentFetchState.delay, currentFetchState.state(), currentFetchState.lastFetchedEpoch(),
+                currentFetchState.dueMs(), currentFetchState.mirrorName(), currentFetchState.mirrorLeaderEpoch()))
+            } else {
+              // the returned leaderEpoch is < 0, which means the source cluster doesn't support fetch API v9
+              partitionsToBeRemoved.add(topicPartition)
+            }
+          case None => newStates.put(topicPartition, currentFetchState)
         }
         (topicPartition, updatedFetchState)
       }
-    partitionStates.set(newStates.asJava)
+    partitionStates.set(newStates)
+    if (!partitionsToBeRemoved.isEmpty) {
+      removeFetcherForPartitions(partitionsToBeRemoved.asScala)
+      refreshSourceClusterMetadata(partitionsToBeRemoved.asScala)
+    }
   }
 
   /** Reassigns mirrored partitions to new fetcher threads after source leader change. */
@@ -413,8 +425,9 @@ abstract class AbstractFetcherThread(name: String,
     var fetchException: Option[Throwable] = None
 
     try {
-      debug(s"!!! Sending fetch request $fetchRequest")
+      info(s"!!! Sending fetch request $fetchRequest")
       responseData = leader.fetch(fetchRequest).asScala
+      info(s"!!! response: $responseData")
     } catch {
       case t: Throwable =>
         fetchException = Some(t)

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -279,7 +279,7 @@ abstract class AbstractFetcherThread(name: String,
     val newStates: java.util.Map[TopicPartition, PartitionFetchState] = new util.HashMap[TopicPartition, PartitionFetchState]()
     val partitionsToBeRemoved: java.util.Set[TopicPartition] = new util.HashSet[TopicPartition]()
     partitionStates.partitionStateMap.asScala
-      .map { case (topicPartition, currentFetchState) =>
+      .foreach { case (topicPartition, currentFetchState) =>
         val updatedFetchState = partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
             // Updating currentLeaderEpoch with source cluster leader epoch to pass epoch validation when fetching from source cluster

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -293,6 +293,7 @@ abstract class AbstractFetcherThread(name: String,
                 currentFetchState.dueMs(), currentFetchState.mirrorName(), currentFetchState.mirrorLeaderEpoch()))
             } else {
               // the returned leaderEpoch is < 0, which means the source cluster doesn't support fetch API v9
+              // need to refresh source cluster metadata and retry
               partitionsToBeRemoved.add(topicPartition)
             }
           case None => newStates.put(topicPartition, currentFetchState)

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -280,7 +280,7 @@ abstract class AbstractFetcherThread(name: String,
     val partitionsToBeRemoved: java.util.Set[TopicPartition] = new util.HashSet[TopicPartition]()
     partitionStates.partitionStateMap.asScala
       .foreach { case (topicPartition, currentFetchState) =>
-        val updatedFetchState = partitionToData.get(topicPartition) match {
+        partitionToData.get(topicPartition) match {
           case Some(partitionData) =>
             // Updating currentLeaderEpoch with source cluster leader epoch to pass epoch validation when fetching from source cluster
             val newCurrentLeaderEpoch = partitionData.currentLeader().leaderEpoch()
@@ -298,7 +298,6 @@ abstract class AbstractFetcherThread(name: String,
             }
           case None => newStates.put(topicPartition, currentFetchState)
         }
-        (topicPartition, updatedFetchState)
       }
     partitionStates.set(newStates)
     if (!partitionsToBeRemoved.isEmpty) {

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -81,9 +81,6 @@ class RemoteLeaderEndPoint(logPrefix: String,
   private val fetchSize = brokerConfig.replicaFetchMaxBytes
   private val lastSeenEndpointList = new util.HashMap[Integer, Node]()
 
-  // cached from the first fetch response; lastFetchedEpoch requires Fetch v12+ (KIP-595)
-  @volatile private var supportFetchV12: Boolean = true
-
   override def isTruncationOnFetchSupported: Boolean = true
 
   override def initiateClose(): Unit = blockingSender.initiateClose()
@@ -98,13 +95,6 @@ class RemoteLeaderEndPoint(logPrefix: String,
     val clientResponse = try {
       blockingSender.sendRequest(fetchRequest)
     } catch {
-      case t: UnsupportedVersionException =>
-        if (t.getMessage.contains("Attempted to write a non-default lastFetchedEpoch")) {
-          debug("The source cluster doesn't support fetch API v12. Don't set `lastFetchedEpoch` field.")
-          supportFetchV12 = false
-        }
-        fetchSessionHandler.handleError(t)
-        throw t
       case t: Throwable =>
         fetchSessionHandler.handleError(t)
         throw t
@@ -218,8 +208,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
           val logStartOffset = replicaManager.localLogOrException(topicPartition).logStartOffset
           // Pre-KIP-595 sources (Fetch < v12) don't support lastFetchedEpoch;
           // skip it until we confirm the source version from the first response.
-          val lastFetchedEpoch = if (isTruncationOnFetchSupported
-            && (!isClusterMirror || supportFetchV12))
+          val lastFetchedEpoch = if (isTruncationOnFetchSupported)
             fetchState.lastFetchedEpoch()
           else
             Optional.empty[Integer]

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -20,7 +20,7 @@ package kafka.server
 import java.util.{Collections, Optional}
 import kafka.utils.Logging
 import org.apache.kafka.clients.FetchSessionHandler
-import org.apache.kafka.common.errors.{KafkaStorageException, UnsupportedVersionException}
+import org.apache.kafka.common.errors.KafkaStorageException
 import org.apache.kafka.common.{IsolationLevel, Node, TopicPartition, Uuid}
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -20,7 +20,7 @@ package kafka.server
 import java.util.{Collections, Optional}
 import kafka.utils.Logging
 import org.apache.kafka.clients.FetchSessionHandler
-import org.apache.kafka.common.errors.KafkaStorageException
+import org.apache.kafka.common.errors.{KafkaStorageException, UnsupportedVersionException}
 import org.apache.kafka.common.{IsolationLevel, Node, TopicPartition, Uuid}
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
@@ -82,7 +82,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
   private val lastSeenEndpointList = new util.HashMap[Integer, Node]()
 
   // cached from the first fetch response; lastFetchedEpoch requires Fetch v12+ (KIP-595)
-  @volatile private var negotiatedFetchVersion: Short = -1
+  @volatile private var supportFetchV12: Boolean = true
 
   override def isTruncationOnFetchSupported: Boolean = true
 
@@ -98,12 +98,18 @@ class RemoteLeaderEndPoint(logPrefix: String,
     val clientResponse = try {
       blockingSender.sendRequest(fetchRequest)
     } catch {
+      case t: UnsupportedVersionException =>
+        if (t.getMessage.contains("Attempted to write a non-default lastFetchedEpoch")) {
+          supportFetchV12 = false
+        }
+        fetchSessionHandler.handleError(t)
+        throw t
       case t: Throwable =>
         fetchSessionHandler.handleError(t)
         throw t
     }
+
     val fetchResponse = clientResponse.responseBody.asInstanceOf[FetchResponse]
-    negotiatedFetchVersion = clientResponse.requestHeader().apiVersion()
     debug("!!! Got fetch response: " + fetchResponse)
     lastSeenEndpointList.clear()
     fetchResponse.data().nodeEndpoints().forEach(
@@ -213,7 +219,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
           // Pre-KIP-595 sources (Fetch < v12) don't support lastFetchedEpoch;
           // skip it until we confirm the source version from the first response.
           val lastFetchedEpoch = if (isTruncationOnFetchSupported
-            && (!isClusterMirror || negotiatedFetchVersion < 0 || negotiatedFetchVersion >= 12))
+            && (!isClusterMirror || supportFetchV12))
             fetchState.lastFetchedEpoch()
           else
             Optional.empty[Integer]

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -100,6 +100,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
     } catch {
       case t: UnsupportedVersionException =>
         if (t.getMessage.contains("Attempted to write a non-default lastFetchedEpoch")) {
+          debug("The source cluster doesn't support fetch API v12. Don't set `lastFetchedEpoch` field.")
           supportFetchV12 = false
         }
         fetchSessionHandler.handleError(t)
@@ -110,7 +111,6 @@ class RemoteLeaderEndPoint(logPrefix: String,
     }
 
     val fetchResponse = clientResponse.responseBody.asInstanceOf[FetchResponse]
-    debug("!!! Got fetch response: " + fetchResponse)
     lastSeenEndpointList.clear()
     fetchResponse.data().nodeEndpoints().forEach(
       node => lastSeenEndpointList.put(node.nodeId(), new Node(node.nodeId(), node.host(), node.port(), node.rack())))

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2648,12 +2648,13 @@ class ReplicaManager(val config: KafkaConfig,
             if (mirrorName != null && !mirrorName.isEmpty) {
               // Get the source partition leader
               val sourceLeader = mirrorMetadataManager.get.resolveSourceLeader(mirrorName, tp)
-              val leaderEndpoint = new BrokerEndPoint(sourceLeader.id(), sourceLeader.host(), sourceLeader.port())
+              val sourceLeaderNode = sourceLeader.node()
+              val leaderEndpoint = new BrokerEndPoint(sourceLeaderNode.id(), sourceLeaderNode.host(), sourceLeaderNode.port())
 
               val fetchState = InitialFetchState(
                 topicId = Some(metadataCache.getTopicId(tp.topic)),
                 leader = leaderEndpoint,
-                currentLeaderEpoch = 0, // this will trigger source epoch discovery through fencing
+                currentLeaderEpoch = sourceLeader.leaderEpoch(),
                 initOffset = partition.localLogOrException.logEndOffset,
                 mirrorName = mirrorName,
                 mirrorLeaderEpoch = Optional.empty()

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -101,17 +101,20 @@ class MirrorFetcherThread(name: String,
       // The exception will mark this partition as failed and transition mirror state to EPOCH_FENCING.
       throw new MirrorLeaderEpochExceededException(s"Rejecting the batch because the batch leader " +
         s"epoch $highestBatchLeaderEpoch is higher than local leader epoch $localLeaderEpoch")
-    } else if (highestBatchLeaderEpoch > localLeaderEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
-      // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),
-      // schedule a proactive local epoch bump while still allowing the current batch to append.
+    } else {
       replicaMgr.mirrorMetadataManager.foreach { mmm =>
         // successful fetch, remove the failed metadata
         mmm.failedRetryAttempts.remove(topicPartition)
         mmm.partitionPreviousStates().remove(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()))
-        mmm.scheduleBumpLeaderEpochs(partition.getMirrorName().get(), java.util.Set.of(topicPartition))
-          .whenComplete { (_, ex) =>
-            if (ex != null) log.warn(s"Proactive epoch bump failed for $topicPartition", ex)
-          }
+
+        if (highestBatchLeaderEpoch > localLeaderEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
+          // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),
+          // schedule a proactive local epoch bump while still allowing the current batch to append.
+          mmm.scheduleBumpLeaderEpochs(partition.getMirrorName().get(), java.util.Set.of(topicPartition))
+            .whenComplete { (_, ex) =>
+              if (ex != null) log.warn(s"Proactive epoch bump failed for $topicPartition", ex)
+            }
+        }
       }
     }
   }

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -73,11 +73,9 @@ class MirrorFetcherThread(name: String,
 
   // Transition to FAILED so the coordinator can schedule exponential backoff retries.
   override protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition]): Unit = {
+    replicaMgr.mirrorMetadataManager.foreach(_.scheduleRediscoverSource(mirrorName))
     mirrorPartitions.foreach { tp =>
-      replicaMgr.mirrorMetadataManager.foreach( mmm => {
-        mmm.scheduleRediscoverSource(mirrorName);
-        mmm.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED)
-      })
+      replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED))
     }
   }
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -75,7 +75,6 @@ class MirrorFetcherThread(name: String,
   override protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition]): Unit = {
     mirrorPartitions.foreach { tp =>
       replicaMgr.mirrorMetadataManager.foreach( mmm => {
-        // the leader node in the source cluster might have unclean shutdown, we need to aggressively discover new leader
         mmm.scheduleRediscoverSource(mirrorName);
         mmm.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED)
       })

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -18,7 +18,7 @@ package kafka.server.mirror
 
 import kafka.cluster.Partition
 import kafka.server._
-import kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD
+import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, PartitionKey}
 import org.apache.kafka.common.errors.MirrorLeaderEpochExceededException
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
@@ -105,6 +105,9 @@ class MirrorFetcherThread(name: String,
       // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),
       // schedule a proactive local epoch bump while still allowing the current batch to append.
       replicaMgr.mirrorMetadataManager.foreach { mmm =>
+        // successful fetch, remove the failed metadata
+        mmm.failedRetryAttempts.remove(topicPartition)
+        mmm.partitionPreviousStates().remove(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()))
         mmm.scheduleBumpLeaderEpochs(partition.getMirrorName().get(), java.util.Set.of(topicPartition))
           .whenComplete { (_, ex) =>
             if (ex != null) log.warn(s"Proactive epoch bump failed for $topicPartition", ex)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -18,7 +18,7 @@ package kafka.server.mirror
 
 import kafka.cluster.Partition
 import kafka.server._
-import kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD
+import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, PartitionKey}
 import org.apache.kafka.common.errors.MirrorLeaderEpochExceededException
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
@@ -74,7 +74,11 @@ class MirrorFetcherThread(name: String,
   // Transition to FAILED so the coordinator can schedule exponential backoff retries.
   override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
     mirrorPartitions.foreach { tp =>
-      replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED))
+      replicaMgr.mirrorMetadataManager.foreach( mmm => {
+        // the leader node in the source cluster might have unclean shutdown, we need to aggressively discover new leader
+        mmm.scheduleRediscoverSource(mirrorName);
+        mmm.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED)
+      })
     }
   }
 
@@ -105,6 +109,10 @@ class MirrorFetcherThread(name: String,
       // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),
       // schedule a proactive local epoch bump while still allowing the current batch to append.
       replicaMgr.mirrorMetadataManager.foreach { mmm =>
+        // successful fetch, remove the failed metadata
+        mmm.failedRetryAttempts.remove(topicPartition)
+        mmm.partitionPreviousStates().remove(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()))
+
         mmm.scheduleBumpLeaderEpochs(partition.getMirrorName().get(), java.util.Set.of(topicPartition))
           .whenComplete { (_, ex) =>
             if (ex != null) log.warn(s"Proactive epoch bump failed for $topicPartition", ex)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -18,7 +18,7 @@ package kafka.server.mirror
 
 import kafka.cluster.Partition
 import kafka.server._
-import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, PartitionKey}
+import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, LeaderInfo, PartitionKey}
 import org.apache.kafka.common.errors.MirrorLeaderEpochExceededException
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
@@ -65,14 +65,14 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorMetadataManager.foreach { mmm =>
       partitionAndOffsets.foreach { case (tp, state) =>
         mmm.updateSourceLeader(mirrorName, tp,
-          new Node(state.leader.id(), state.leader.host(), state.leader.port()))
+          new LeaderInfo(new Node(state.leader.id(), state.leader.host(), state.leader.port()), state.currentLeaderEpoch))
       }
     }
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
   // Transition to FAILED so the coordinator can schedule exponential backoff retries.
-  override protected def handleMirrorFetchConnectionFailure(mirrorPartitions: Set[TopicPartition]): Unit = {
+  override protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition]): Unit = {
     mirrorPartitions.foreach { tp =>
       replicaMgr.mirrorMetadataManager.foreach( mmm => {
         // the leader node in the source cluster might have unclean shutdown, we need to aggressively discover new leader

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -441,9 +441,11 @@ public class ConfigurationControlManager {
                 }
             }
 
-            if (!topic.topicId().equals(Uuid.ZERO_UUID) && topic.numPartitions() > 0) {
+            // create a random uuid if the provided topic id is ZERO_UUID (i.e. the source topic has no topic ID attached)
+            Uuid topicId = topic.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : topic.topicId();
+            if (topic.numPartitions() > 0) {
                 ApiError createError = replicationControl.createMirrorTopic(
-                        topicName, topic.topicId(), topic.numPartitions(), records);
+                        topicName, topicId, topic.numPartitions(), records);
                 if (createError.isFailure() && createError.error() != Errors.TOPIC_ALREADY_EXISTS) {
                     // TODO: emit metric for mirror topic creation failure with error type (e.g. INVALID_REPLICATION_FACTOR)
                     topicRes.setErrorCode(createError.error().code()).setName(topicName);

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -41,7 +41,7 @@ class ClientService(KafkaPathResolverMixin, Service):
         pass
 
     def stop_node(self, node):
-        pass
+        node.account.ssh("pkill -SIGKILL -f 'kafka\\.tools\\.' || true", allow_fail=True)
 
     def clean_node(self, node):
         pass

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -108,12 +108,15 @@ class MirrorUtils:
                   topic, num_records, bootstrap_servers,
                   cmd_suffix.replace("--command-config", "--producer.config")
                   if cmd_suffix else "")
-        client_node.account.ssh(cmd, allow_fail=True)
+        output = ""
+        for line in client_node.account.ssh_capture(cmd, allow_fail=True):
+            output += line
+        self.logger.debug("Producer output for %s:\n%s", topic, output.strip())
 
     def consume_records(self, kafka, topic, client_node, max_messages=None,
                         timeout_ms=30000, isolation_level=None, group=None,
-                        from_beginning=True):
-        """Consume records on a client node and return count."""
+                        from_beginning=True, expected_count=None,
+                        wait_timeout_sec=240):
         env_prefix, cmd_suffix = kafka._cmd_security_opts(client_node)
         cmd = "%s%s --bootstrap-server %s --topic %s --timeout-ms %d" % (
             env_prefix,
@@ -131,11 +134,30 @@ class MirrorUtils:
         if cmd_suffix:
             cmd += cmd_suffix.replace("--command-config", "--consumer.config")
         cmd += " 2>/dev/null"
-        count = 0
-        for line in client_node.account.ssh_capture(cmd, allow_fail=True):
-            if line.strip():
-                count += 1
-        return count
+
+        count = [0]
+        def try_consume():
+            for line in client_node.account.ssh_capture(cmd, allow_fail=True):
+                if line.strip():
+                    count[0] += 1
+            self.logger.info("Consumed %d records from %s so far (expected %s)",
+                             count[0], topic, expected_count)
+            return expected_count is None or count[0] >= expected_count
+
+        # When expected_count is set, retry consumption because the high watermark on
+        # destination replicas may not have advanced yet when mirror lag reaches zero.
+        if expected_count is not None:
+            deadline = time.time() + wait_timeout_sec
+            try_consume()
+            while count[0] < expected_count:
+                if time.time() >= deadline:
+                    raise AssertionError(
+                        "Expected %d records on %s, got %d" % (expected_count, topic, count[0]))
+                time.sleep(5)
+                try_consume()
+        else:
+            try_consume()
+        return count[0]
 
     def all_satisfy_in_mirror(self, kafka, mirror_name, per_partition_condition, topics):
         """Check that all partitions of the given mirror topics satisfy the condition."""

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_acls_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_acls_test.py
@@ -178,10 +178,14 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
                   topic, num_records,
                   kafka.bootstrap_servers(kafka.security_protocol),
                   client_props)
-        client_node.account.ssh(cmd, allow_fail=False)
+        output = ""
+        for line in client_node.account.ssh_capture(cmd, allow_fail=False):
+            output += line
+        self.logger.debug("Producer output for %s:\n%s", topic, output.strip())
 
     def consume_as_client(self, kafka, topic, client_node, max_messages,
-                          group=None, timeout_ms=30000):
+                          group=None, timeout_ms=30000, expected_count=None,
+                          wait_timeout_sec=240):
         client_env = "KAFKA_OPTS='-D%s -D%s' " % (
             KafkaService.JAAS_CONF_PROPERTY, KafkaService.KRB5_CONF)
         client_props = str(kafka.security_config.client_config(
@@ -195,11 +199,30 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
         if group is not None:
             cmd += " --group %s" % group
         cmd += " --consumer.config <(echo '%s') 2>/dev/null" % client_props
-        count = 0
-        for line in client_node.account.ssh_capture(cmd, allow_fail=True):
-            if line.strip():
-                count += 1
-        return count
+
+        count = [0]
+        def try_consume():
+            for line in client_node.account.ssh_capture(cmd, allow_fail=True):
+                if line.strip():
+                    count[0] += 1
+            self.logger.debug("Consumed %d records from %s so far (expected %s)",
+                              count[0], topic, expected_count)
+            return expected_count is None or count[0] >= expected_count
+
+        # When expected_count is set, retry consumption because the high watermark on
+        # destination replicas may not have advanced yet when mirror lag reaches zero.
+        if expected_count is not None:
+            deadline = time.time() + wait_timeout_sec
+            try_consume()
+            while count[0] < expected_count:
+                if time.time() >= deadline:
+                    raise AssertionError(
+                        "Expected %d records on %s, got %d" % (expected_count, topic, count[0]))
+                time.sleep(5)
+                try_consume()
+        else:
+            _try_consume()
+        return count[0]
 
     def list_acls(self, kafka, client_node):
         return self.run_acl_cmd(kafka, "--list", client_node)
@@ -273,11 +296,11 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(
             self.dest_kafka, mirror_name, topics=list(topics.keys()))
 
+        # Retry consuming because the HW may lag behind mirror lag reaching zero.
         self.logger.info("Consuming 10 records from my-topic-a on destination as client user")
-        count = self.consume_as_client(self.dest_kafka, "my-topic-a",
-                                       self.dest_client_node, max_messages=10,
-                                       group="my-group")
-        assert count == 10, "Expected 10 records on destination for my-topic-a, got %d" % count
+        self.consume_as_client(self.dest_kafka, "my-topic-a",
+                               self.dest_client_node, max_messages=10,
+                               group="my-group", expected_count=10)
 
         self.logger.info("Verifying ACL filtering: my-topic-a ACL synced, new-topic ACL filtered out")
         self.wait_for_acl_condition(

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -197,10 +197,5 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
 
         self.logger.info("Verifying destination records after failover")
         for topic in topics:
-            wait_until(
-                lambda t=topic: self.consume_records(
-                    self.dest_kafka, t, self.dest_client_node, max_messages=num_records
-                ) == num_records,
-                timeout_sec=60, backoff_sec=5,
-                err_msg="Expected %d records on destination for %s" % (num_records, topic),
-            )
+            self.consume_records(self.dest_kafka, topic, self.dest_client_node,
+                                max_messages=num_records, expected_count=num_records)

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -163,7 +163,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Verify failover makes destination writable and failback truncates non-mirrored data."""
         topic = "my-topic"
         mirror_name = "my-mirror"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
 
         self.logger.info("Send 3 records to source")
@@ -234,7 +233,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Verify that pausing stops replication and resuming catches up."""
         topic = "my-topic"
         mirror_name = "my-mirror"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
 
         self.logger.info("Send 3 records to source")
@@ -285,7 +283,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Verify that updating mirror config triggers reconnection and mirroring continues."""
         topic = "my-topic"
         mirror_name = "my-mirror"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
 
         self.logger.info("Start cluster mirror on destination")
@@ -343,7 +340,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Verify that a mirror cannot be deleted while not empty, but can after stopping all topics."""
         topic = "my-topic"
         mirror_name = "my-mirror"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
 
         self.logger.info("Start cluster mirror on destination")
@@ -383,7 +379,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Verify that deleting a source topic transitions mirror partitions to STOPPED."""
         topic = "my-topic"
         mirror_name = "my-mirror"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
 
         self.logger.info("Start cluster mirror on destination")
@@ -448,10 +443,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         )
 
         self.logger.info("Only orders-us and orders-eu should be mirrored")
-        self.topics = {
-            "orders-us": topics_cfg["orders-us"],
-            "orders-eu": topics_cfg["orders-eu"],
-        }
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
                                   ["orders-us", "orders-eu"])
 
@@ -493,7 +484,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.create_topic({"topic": "orders-jp", "partitions": 1, "replication-factor": 2})
         self.produce_records(self.source_kafka, "orders-jp", 3, self.client_node)
 
-        self.topics["orders-jp"] = {"partitions": 1, "replication-factor": 2}
         self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING",
                                topics={"orders-jp": {"partitions": 1, "replication-factor": 2}})
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
@@ -506,7 +496,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.dest_kafka.alter_mirror_config(
             self.client_node, mirror_name, "mirror.topics.include=[orders-.*,payments]")
 
-        self.topics["payments"] = {"partitions": 1, "replication-factor": 2}
         self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING",
                                topics={"payments": {"partitions": 1, "replication-factor": 2}})
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
@@ -526,7 +515,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Verify that excluded topic properties are not synced to destination."""
         topic = "my-topic"
         mirror_name = "my-mirror"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
 
         self.logger.info("Starting cluster mirror with properties exclude")
@@ -586,7 +574,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Verify consumer group offset mirroring with include/exclude filtering."""
         topic = "my-topic"
         mirror_name = "my-mirror"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
 
         self.logger.info("Produce records to source")
@@ -631,15 +618,15 @@ class ClusterMirroringTest(MirrorUtils, Test):
     def test_log_convergence(self, metadata_quorum):
         """Verify that mirrored log segments are byte identical to source after bouncing both clusters."""
         self.logger.info("Create source topics and produce initial data")
-        self.topics = {
+        topics = {
             "my-topic-a": {"partitions": 3, "replication-factor": 2},
             "my-topic-b": {"partitions": 2, "replication-factor": 2},
             "new-topic": {"partitions": 1, "replication-factor": 2},
         }
-        for t, cfg in self.topics.items():
+        for t, cfg in topics.items():
             self.source_kafka.create_topic({"topic": t, **cfg})
 
-        for t in self.topics:
+        for t in topics:
             self.produce_records(self.source_kafka, t, 100, self.client_node)
 
         self.logger.info("Bounce source cluster to trigger leader elections before mirroring")
@@ -691,7 +678,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
             kafka.restart_node(node)
 
         self.logger.info("Send more data and wait for all mirrors to catch up")
-        for t in self.topics:
+        for t in topics:
             self.produce_records(self.source_kafka, t, 100, self.client_node)
 
         for mirror_name, (_, topic_list) in mirrors.items():
@@ -700,7 +687,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
                 err_msg="Mirror %s did not catch up" % mirror_name)
 
         self.logger.info("Poll until source and destination log segment hashes converge")
-        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, self.topics)
+        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, topics)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -709,10 +696,10 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.logger.info("Create source topic with ULE support enabled")
         topic = "my-topic"
         mirror_name = "new-mirror"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        topics = {topic: {"partitions": 1, "replication-factor": 2}}
 
         self.source_kafka.create_topic({
-            "topic": topic, "partitions": 1, "replication-factor": 2,
+            "topic": topic, **topics[topic],
             "configs": {"mirror.support.unclean.leader.election": "true"},
         })
 
@@ -844,7 +831,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
                                   err_msg="Reverse mirror did not catch up")
 
         self.logger.info("Poll until log segment hashes converge (dest is source of truth after failback)")
-        self.wait_for_log_convergence(self.dest_kafka, self.source_kafka, self.topics)
+        self.wait_for_log_convergence(self.dest_kafka, self.source_kafka, topics)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -852,8 +839,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Verify that stop operation aborts pending transactions and allows committed reads."""
         self.logger.info("Create source topic")
         topic = "my-topic"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
-        for t, cfg in self.topics.items():
+        topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        for t, cfg in topics.items():
             self.source_kafka.create_topic({"topic": t, **cfg})
 
         self.logger.info("Run initial committed transaction and bounce source to bump leader epoch")
@@ -891,7 +878,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
         def count_ongoing_txns(kafka, topic):
             """Count ongoing transactions across all partitions of a topic."""
             count = 0
-            for partition in range(self.topics[topic]["partitions"]):
+            for partition in range(topics[topic]["partitions"]):
                 cmd = kafka.path.script("kafka-transactions.sh", self.client_node)
                 cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
                 cmd += " describe-producers --topic %s --partition %d" % (topic, partition)
@@ -957,7 +944,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
             self.get_offset_shell(self.dest_kafka, topic=topic, time=-1))
         extra = sum(dest_offsets.values()) - sum(source_offsets.values())
         # 2 abort markers (one per pending txn) + 1 PID reset barrier per partition
-        num_partitions = self.topics[topic]["partitions"]
+        num_partitions = topics[topic]["partitions"]
         expected_extra = 2 + num_partitions
         assert extra == expected_extra, \
             "Expected %d extra records (2 abort + %d PID reset) on destination, got %d. " \
@@ -995,7 +982,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.consume_records(self.source_kafka, "other-topic", self.client_node, max_messages=3, group="my-group")
 
         self.logger.info("Start mirror with only my-topic (not other-topic)")
-        self.topics = {"my-topic": {"partitions": 1, "replication-factor": 2}}
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
@@ -1085,7 +1071,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.kill_background_consumer(self.client_node, "ConsoleShareConsumer")
 
         self.logger.info("Start mirror with only my-topic")
-        self.topics = {"my-topic": {"partitions": 1, "replication-factor": 2}}
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
@@ -1154,7 +1139,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         topic = "my-topic"
         mirror_name = "my-mirror"
         group = "my-group"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2}}
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
 
         self.logger.info("Produce 3 records and bounce source brokers to bump leader epoch")
@@ -1197,7 +1181,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Verify that mirror recovers from FAILED state after source cluster comes back."""
         topic = "my-topic"
         mirror_name = "my-mirror"
-        self.topics = {topic: {"partitions": 3, "replication-factor": 2}}
         self.source_kafka.create_topic({"topic": topic, "partitions": 3, "replication-factor": 1})
 
         self.logger.info("Produce initial records and start cluster mirror")

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -87,8 +87,10 @@ class ClusterMirroringTest(MirrorUtils, Test):
                 for node in kafka.nodes:
                     kafka.stop_node(node, clean_shutdown=False)
 
-    def consume_share_records(self, topic, kafka, group, max_messages=None, timeout_ms=30000):
-        """Consume records using kafka-console-share-consumer and return count."""
+    def consume_share_records(self, topic, kafka, group, max_messages=None, timeout_ms=30000,
+                              expected_count=None, wait_timeout_sec=240):
+        # When expected_count is set, retry consumption because the high watermark on
+        # destination replicas may not have advanced yet when mirror lag reaches zero.
         cmd = "%s --bootstrap-server %s --topic %s --group %s --timeout-ms %d" % (
             kafka.path.script("kafka-console-share-consumer.sh", self.client_node),
             kafka.bootstrap_servers(kafka.security_protocol),
@@ -96,11 +98,28 @@ class ClusterMirroringTest(MirrorUtils, Test):
         if max_messages is not None:
             cmd += " --max-messages %d" % max_messages
         cmd += " 2>/dev/null"
-        count = 0
-        for line in self.client_node.account.ssh_capture(cmd, allow_fail=True):
-            if line.strip():
-                count += 1
-        return count
+
+        count = [0]
+        def _try_consume():
+            for line in self.client_node.account.ssh_capture(cmd, allow_fail=True):
+                if line.strip():
+                    count[0] += 1
+            self.logger.debug("Share-consumed %d records from %s so far (expected %s)",
+                              count[0], topic, expected_count)
+            return expected_count is None or count[0] >= expected_count
+
+        if expected_count is not None:
+            deadline = time.time() + wait_timeout_sec
+            _try_consume()
+            while count[0] < expected_count:
+                if time.time() >= deadline:
+                    raise AssertionError(
+                        "Expected %d records on %s, got %d" % (expected_count, topic, count[0]))
+                time.sleep(5)
+                _try_consume()
+        else:
+            _try_consume()
+        return count[0]
 
     def run_background_consumer(self, kafka, topic, group):
         """Start a background console consumer."""
@@ -168,8 +187,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
         self.logger.info("Consume from destination (expect 3 records)")
-        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3)
-        assert count == 3, "Expected 3 records on destination, got %d" % count
+        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3,
+                             expected_count=3)
 
         self.logger.info("Produce to destination while mirroring (should fail)")
         self.produce_records(self.dest_kafka, topic, 1, self.client_node)
@@ -185,8 +204,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.produce_records(self.source_kafka, topic, 2, self.client_node)
 
         self.logger.info("Consume from source (expect 5 records)")
-        count = self.consume_records(self.source_kafka, topic, self.client_node, max_messages=5)
-        assert count == 5, "Expected 5 records on source, got %d" % count
+        self.consume_records(self.source_kafka, topic, self.client_node, max_messages=5,
+                             expected_count=5)
 
         self.logger.info("Failback: source mirrors from destination (same mirror name to retrieve LMO)")
         mirror_cfg = MirrorConfig(self.dest_kafka.bootstrap_servers())
@@ -206,10 +225,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.source_kafka, mirror_name, [topic])
 
         self.logger.info("Consume from source (non-mirrored data should be truncated)")
-        count = self.consume_records(self.source_kafka, topic, self.client_node,
-                                     max_messages=5, timeout_ms=5000)
-        assert count == 4, \
-            "Expected 4 records on source after failback (non-mirrored data truncated), got %d" % count
+        self.consume_records(self.source_kafka, topic, self.client_node,
+                             max_messages=5, timeout_ms=5000, expected_count=4)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -259,8 +276,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
         self.logger.info("Consume from destination (expect 4 records after resume)")
-        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=4)
-        assert count == 4, "Expected 4 records on destination after resume, got %d" % count
+        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=4,
+                             expected_count=4)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -317,8 +334,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.produce_records(self.source_kafka, topic, 3, self.client_node)
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
-        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3)
-        assert count == 3, "Expected 3 records on destination after config update, got %d" % count
+        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3,
+                             expected_count=3)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -438,10 +455,10 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
                                   ["orders-us", "orders-eu"])
 
-        count_us = self.consume_records(self.dest_kafka, "orders-us", self.client_node, max_messages=3)
-        assert count_us == 3, "Expected 3 records for orders-us, got %d" % count_us
-        count_eu = self.consume_records(self.dest_kafka, "orders-eu", self.client_node, max_messages=3)
-        assert count_eu == 3, "Expected 3 records for orders-eu, got %d" % count_eu
+        self.consume_records(self.dest_kafka, "orders-us", self.client_node, max_messages=3,
+                             expected_count=3)
+        self.consume_records(self.dest_kafka, "orders-eu", self.client_node, max_messages=3,
+                             expected_count=3)
 
         self.logger.info("Verify excluded and non-matching topics don't exist on destination")
         dest_topics = list(self.dest_kafka.list_topics(self.client_node))
@@ -482,8 +499,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
                                   topics={"orders-jp": {"partitions": 1, "replication-factor": 2}})
 
-        count_jp = self.consume_records(self.dest_kafka, "orders-jp", self.client_node, max_messages=3)
-        assert count_jp == 3, "Expected 3 records for orders-jp, got %d" % count_jp
+        self.consume_records(self.dest_kafka, "orders-jp", self.client_node, max_messages=3,
+                             expected_count=3)
 
         self.logger.info("Add payments to include pattern via alter config")
         self.dest_kafka.alter_mirror_config(
@@ -495,8 +512,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
                                   topics={"payments": {"partitions": 1, "replication-factor": 2}})
 
-        count_pay = self.consume_records(self.dest_kafka, "payments", self.client_node, max_messages=2)
-        assert count_pay == 2, "Expected 2 records for payments, got %d" % count_pay
+        self.consume_records(self.dest_kafka, "payments", self.client_node, max_messages=2,
+                             expected_count=2)
 
         self.logger.info("Verify orders-internal still doesn't exist on destination after all operations")
         dest_topics = list(self.dest_kafka.list_topics(self.client_node))
@@ -952,17 +969,14 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
         self.logger.info("Checking raw number of records")
         source_count = self.consume_records(self.source_kafka, topic, self.client_node)
-        dest_count = self.consume_records(self.dest_kafka, topic, self.client_node)
-        assert dest_count == source_count + 2, \
-            "Expected dest to have exactly 2 more records than source, " \
-            "got source=%d, dest=%d" % (source_count, dest_count)
+        dest_count = self.consume_records(self.dest_kafka, topic, self.client_node,
+                                          expected_count=source_count + 2)
 
         self.logger.info("Checking read_committed consumer can make progress")
         # 4 aborted data records are filtered out: txn-b, txn-c, txn-d fenced, txn-d pending
-        dest_committed = self.consume_records(self.dest_kafka, topic, self.client_node,
-                                              isolation_level="read_committed")
-        assert dest_committed == dest_count - 4, \
-            "Expected dest_committed=%d, got %d" % (dest_count - 4, dest_committed)
+        self.consume_records(self.dest_kafka, topic, self.client_node,
+                             isolation_level="read_committed",
+                             expected_count=dest_count - 4)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -1103,8 +1117,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, ["my-topic"])
         self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
 
-        count = self.consume_share_records("my-topic", self.dest_kafka, share_group, max_messages=2)
-        assert count == 2, "Expected 2 delta records using synced offsets, got %d" % count
+        self.consume_share_records("my-topic", self.dest_kafka, share_group, max_messages=2,
+                                   expected_count=2)
 
         self.logger.info("Start active share consumer on destination (background)")
         self.run_background_share_consumer(self.dest_kafka, "my-topic", share_group)
@@ -1168,15 +1182,14 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
         self.logger.info("Consume 2 records from destination with a consumer group (commits offsets with source LE)")
-        count1 = self.consume_records(self.dest_kafka, topic, self.client_node,
-                                      max_messages=2, group=group)
-        assert count1 == 2, "Expected 2 records on first consume, got %d" % count1
+        self.consume_records(self.dest_kafka, topic, self.client_node,
+                             max_messages=2, group=group, expected_count=2)
 
         self.logger.info("Restart consumer (triggers OffsetFetch and refreshCommittedOffsets)")
         # Without the epoch bump fix, this would hang because source LE > local LE
-        count2 = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=2,
-                                      timeout_ms=20000, group=group, from_beginning=False)
-        assert count2 == 2, "Expected 2 records on resumed consume, got %d" % count2
+        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=2,
+                             timeout_ms=20000, group=group, from_beginning=False,
+                             expected_count=2)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -1221,5 +1234,5 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.produce_records(self.source_kafka, topic, 3, self.client_node)
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
-        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=6)
-        assert count == 6, "Expected 6 records after recovery, got %d" % count
+        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=6,
+                             expected_count=6)

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -1054,6 +1054,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
         dest_offset = parse_current_offset(dest_desc, "my-topic")
         assert src_offset == 2, "Expected source offset 2, got %s" % src_offset
         assert dest_offset == 5, "Expected dest offset 5 (sync skipped), got %s" % dest_offset
+        self.kill_background_consumer(self.client_node, "ConsoleConsumer")
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -1054,7 +1054,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         dest_offset = parse_current_offset(dest_desc, "my-topic")
         assert src_offset == 2, "Expected source offset 2, got %s" % src_offset
         assert dest_offset == 5, "Expected dest offset 5 (sync skipped), got %s" % dest_offset
-        self.kill_background_consumer(self.client_node, "ConsoleConsumer")
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])


### PR DESCRIPTION
1. In old kafka, the fetch response won't contain the new leader info, it relies on the consumer to re-discover the metadata. The same situation also happens in new version kafka if the source cluster leader shutdown uncleanly, the mirror fetch request still enter connection failure loop, and keep retrying.
2. When source cluster has higher leader epoch (ex: source: LE: 2, destination LE: 0), the fetch response will return `FENCED_LEADER_EPOCH`. Currently, we update the fetch leader epoch by the `currentLeader` field in the fetch response and then fetch again. But if it's the old version kafka source cluster, the fetch response doesn't contain the `currentLeader` field. We need to discover it by ourselves. Applying the same solution as (1), we store source cluster partition LE in cache like source leader endpoint, and adopt the LE when first mirror fetch to avoid one round of fetch request/response to get the correct LE.
3. Don't output the whole error stack when source cluster doesn't support share group. Improve it by only outputting debug log.
4. When source cluster is under fetch API v12, the error will be thrown before sending out the fetch request. So the `negotiatedFetchVersion` will always be `-1` in this case. Improve it by catching the `UnsupportedVersionException` in the right place and update the `supportFetchV12`. After the change, the log will be like this, the 2nd fetch request will not include `negotiatedFetchVersion` anymore.
```
# sent with `negotiatedFetchVersion`
[2026-05-25 16:39:12,901] INFO [MirrorFetcher id=4, fetcherId=0, leaderId=799657186, mirrorName=my-link] !!! Sending fetch request (type=FetchRequest, replicaId=-1, maxWait=1000, minBytes=1, maxBytes=10485760, fetchData={quickstart-events-0=PartitionData(topicId=3SJva4v5RYqVUXZHtpuNPw, fetchOffset=2, logStartOffset=0, maxBytes=1048576, currentLeaderEpoch=Optional[0], lastFetchedEpoch=Optional[16], mirrorLeaderEpoch=Optional.empty)}, isolationLevel=read_uncommitted, removed=, replaced=, metadata=(sessionId=INVALID, epoch=INITIAL), rackId=) (kafka.server.mirror.MirrorFetcherThread)
[2026-05-25 16:39:12,905] INFO [MirrorFetcher id=4, fetcherId=0, leaderId=799657186, mirrorName=my-link] Error sending fetch request (sessionId=INVALID, epoch=INITIAL) to node 799657186: (org.apache.kafka.clients.FetchSessionHandler)
org.apache.kafka.common.errors.UnsupportedVersionException: Attempted to write a non-default lastFetchedEpoch at version 11
[2026-05-25 16:39:12,907] WARN [MirrorFetcher id=4, fetcherId=0, leaderId=799657186, mirrorName=my-link] Error in response for fetch request (type=FetchRequest, replicaId=-1, maxWait=1000, minBytes=1, maxBytes=10485760, fetchData={quickstart-events-0=PartitionData(topicId=3SJva4v5RYqVUXZHtpuNPw, fetchOffset=2, logStartOffset=0, maxBytes=1048576, currentLeaderEpoch=Optional[0], lastFetchedEpoch=Optional[16], mirrorLeaderEpoch=Optional.empty)}, isolationLevel=read_uncommitted, removed=, replaced=, metadata=(sessionId=INVALID, epoch=INITIAL), rackId=) (kafka.server.mirror.MirrorFetcherThread)

# sent without `negotiatedFetchVersion`
[2026-05-25 16:39:13,914] INFO [MirrorFetcher id=4, fetcherId=0, leaderId=799657186, mirrorName=my-link] !!! Sending fetch request (type=FetchRequest, replicaId=-1, maxWait=1000, minBytes=1, maxBytes=10485760, fetchData={quickstart-events-0=PartitionData(topicId=3SJva4v5RYqVUXZHtpuNPw, fetchOffset=2, logStartOffset=0, maxBytes=1048576, currentLeaderEpoch=Optional[0], lastFetchedEpoch=Optional.empty, mirrorLeaderEpoch=Optional.empty)}, isolationLevel=read_uncommitted, removed=, replaced=, metadata=(sessionId=INVALID, epoch=INITIAL), rackId=) (kafka.server.mirror.MirrorFetcherThread)
[2026-05-25 16:39:13,934] INFO [MirrorFetcher id=4, fetcherId=0, leaderId=799657186, mirrorName=my-link] !!! response: Map(quickstart-events-0 -> PartitionData(partitionIndex=0, errorCode=74, highWatermark=-1, lastStableOffset=-1, logStartOffset=-1, divergingEpoch=EpochEndOffset(epoch=-1, endOffset=-1), mirrorLeaderEpoch=-1, currentLeader=LeaderIdAndEpoch(leaderId=-1, leaderEpoch=-1), snapshotId=SnapshotId(endOffset=-1, epoch=-1), abortedTransactions=null, preferredReadReplica=-1, records=MemoryRecords(size=0, buffer=java.nio.HeapByteBuffer[pos=0 lim=0 cap=0]))) (kafka.server.mirror.MirrorFetcherThread)
[2026-05-25 16:39:13,944] INFO [MirrorMetadataManager id=4] Adding 2 discovered broker(s) to source senders for mirror my-link: BrokerEndPoint[id=0, host=192.168.3.213, port=9092], BrokerEndPoint[id=1, host=192.168.3.213, port=9091] (kafka.server.mirror.MirrorMetadataManager)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
