### PR TITLE
Add migration test for LE difference and source node down cases

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/MirrorPartitionStaleMetadataException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/MirrorPartitionStaleMetadataException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class MirrorPartitionStaleMetadataException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MirrorPartitionStaleMetadataException(String message) {
+        super(message);
+    }
+
+    public MirrorPartitionStaleMetadataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -349,6 +349,8 @@ public class ClusterMirrorCoordinator {
     public void writePartitionStateInfo(String mirrorName,
                                         Map<String, Set<ClusterMirrorUtils.PartitionStateInfo>> topicMetadata,
                                         Consumer<WriteMirrorStatesResponse> callback) {
+        List<CompletableFuture<Optional<TopicPartition>>> updateMirrorPartitionStateFutures = new ArrayList<>();
+
         String updatedMirrorName = ClusterMirrorUtils.originalMirrorName(mirrorName);
         Map<String, Map<Integer, Integer>> offsets = new HashMap<>();
         Map<String, Set<Integer>> tps = new HashMap<>();
@@ -358,7 +360,7 @@ public class ClusterMirrorCoordinator {
                 TopicPartition tp = new TopicPartition(topic, partition.partition());
                 partitionIndices.add(tp.partition());
                 if (partition.state() != null && partition.state() != MirrorPartitionState.UNKNOWN) {
-                    updateMirrorPartitionState(updatedMirrorName, tp, partition.state());
+                    updateMirrorPartitionStateFutures.add(updateMirrorPartitionState(updatedMirrorName, tp, partition.state()));
                 }
                 if (partition.leaderEpoch() != -1) {
                     offsets.putIfAbsent(topic, new HashMap<>());
@@ -368,23 +370,32 @@ public class ClusterMirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
-        updateLastMirrorEpochs(updatedMirrorName, offsets);
-
-        WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
-        List<WriteMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
-        tps.forEach((topic, indices) -> {
-            List<WriteMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();
-            indices.forEach(i -> {
-                WriteMirrorStatesResponseData.PartitionResult partitionResult = new WriteMirrorStatesResponseData.PartitionResult();
-                partitionResult.setPartitionIndex(i);
-                partitionResult.setErrorCode((short) 0);
-                partitionResults.add(partitionResult);
+        CompletableFuture<Void> updateLastMirrorEpochsFuture = updateLastMirrorEpochs(updatedMirrorName, offsets);
+        CompletableFuture.allOf(updateMirrorPartitionStateFutures.toArray(CompletableFuture[]::new))
+            .thenCompose((v) -> updateLastMirrorEpochsFuture)
+            .whenComplete((v, e) -> {
+                WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
+                if  (e != null) {
+                    log.error("Failed to update last mirror partition state and LME for {}: {}", updatedMirrorName, e);
+                    data.setErrorCode(Errors.forException(e).code());
+                    data.setErrorMessage(e.getMessage());
+                } else {
+                    log.info("!!! write completes:" + topicMetadata);
+                    List<WriteMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
+                    tps.forEach((topic, indices) -> {
+                        List<WriteMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();
+                        indices.forEach(i -> {
+                            WriteMirrorStatesResponseData.PartitionResult partitionResult = new WriteMirrorStatesResponseData.PartitionResult();
+                            partitionResult.setPartitionIndex(i);
+                            partitionResult.setErrorCode((short) 0);
+                            partitionResults.add(partitionResult);
+                        });
+                        topicResults.add(new WriteMirrorStatesResponseData.TopicResult().setName(topic).setPartitions(partitionResults));
+                    });
+                    data.setTopics(topicResults);
+                }
+                callback.accept(new WriteMirrorStatesResponse(data));
             });
-            topicResults.add(new WriteMirrorStatesResponseData.TopicResult().setName(topic).setPartitions(partitionResults));
-        });
-
-        data.setTopics(topicResults);
-        callback.accept(new WriteMirrorStatesResponse(data));
     }
 
     public void getCachedPartitionMetadata(String mirrorName,
@@ -939,14 +950,13 @@ public class ClusterMirrorCoordinator {
                                 ClusterMirrorUtils.PartitionKey pk = new ClusterMirrorUtils.PartitionKey(
                                         clusterName, value.topic(), value.partition());
                                 metadataManager.updatePartitionState(pk, value.state());
-                                if (value.previousState() != MirrorPartitionState.UNKNOWN) {
-                                    metadataManager.partitionPreviousStates().putIfAbsent(pk, value.previousState());
-                                }
                                 TopicPartition tp = new TopicPartition(value.topic(), value.partition());
                                 if (value.state() == MirrorPartitionState.FAILED && value.retryAttempt() > 0) {
                                     metadataManager.failedRetryAttempts().put(tp, value.retryAttempt());
+                                    metadataManager.partitionPreviousStates().put(pk, value.previousState());
                                 } else {
                                     metadataManager.failedRetryAttempts().remove(tp);
+                                    metadataManager.partitionPreviousStates().remove(pk);
                                 }
                             } else {
                                 throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -370,13 +370,13 @@ public class ClusterMirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
-        // wait until partition states and LME update complete then return the response
+        // execute in parallel for efficiency, but wait for all partition state updates first, THEN wait for LME update
         CompletableFuture<Void> updateLastMirrorEpochsFuture = updateLastMirrorEpochs(updatedMirrorName, offsets);
         CompletableFuture.allOf(updateMirrorPartitionStateFutures.toArray(CompletableFuture[]::new))
             .thenCompose(v -> updateLastMirrorEpochsFuture)
             .whenComplete((v, e) -> {
                 WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
-                if  (e != null) {
+                if (e != null) {
                     log.error("Failed to update last mirror partition state and LME for {}: {}", mirrorName, e);
                     data.setErrorCode(Errors.forException(e).code());
                     data.setErrorMessage(e.getMessage());
@@ -892,6 +892,7 @@ public class ClusterMirrorCoordinator {
         }
     }
 
+    // Replays the mirror state log to rebuild in-memory partition states, epochs, and retry metadata.
     private void loadMirrorMetadata(TopicPartition topicPartition) {
         log.info("Loading mirror metadata from {}.", topicPartition);
         long logEndOffset = replicaManager.getLogEndOffset(topicPartition).getOrElse(() -> -1L);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -370,17 +370,17 @@ public class ClusterMirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
+        // wait until partition states and LME update complete then return the response
         CompletableFuture<Void> updateLastMirrorEpochsFuture = updateLastMirrorEpochs(updatedMirrorName, offsets);
         CompletableFuture.allOf(updateMirrorPartitionStateFutures.toArray(CompletableFuture[]::new))
             .thenCompose((v) -> updateLastMirrorEpochsFuture)
             .whenComplete((v, e) -> {
                 WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
                 if  (e != null) {
-                    log.error("Failed to update last mirror partition state and LME for {}: {}", updatedMirrorName, e);
+                    log.error("Failed to update last mirror partition state and LME for {}: {}", mirrorName, e);
                     data.setErrorCode(Errors.forException(e).code());
                     data.setErrorMessage(e.getMessage());
                 } else {
-                    log.info("!!! write completes:" + topicMetadata);
                     List<WriteMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
                     tps.forEach((topic, indices) -> {
                         List<WriteMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -225,7 +225,8 @@ public class ClusterMirrorCoordinator {
                 return;
             }
             long delay = failedRetryBackoff.backoff(attempt);
-            MirrorPartitionState targetState = metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
+            MirrorPartitionState targetState = metadataManager.partitionPreviousStates()
+                    .getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
             log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
             scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
                 () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -228,8 +228,7 @@ public class ClusterMirrorCoordinator {
             MirrorPartitionState targetState = metadataManager.partitionPreviousStates()
                     .getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
             log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
-            scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
-                () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
+            scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });
     }
 

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -225,10 +225,10 @@ public class ClusterMirrorCoordinator {
                 return;
             }
             long delay = failedRetryBackoff.backoff(attempt);
-            MirrorPartitionState targetState = metadataManager.partitionPreviousStates()
-                    .getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
+            MirrorPartitionState targetState = metadataManager.partitionPreviousStates().getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
             log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
-            scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
+            scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
+                () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });
     }
 

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -373,7 +373,7 @@ public class ClusterMirrorCoordinator {
         // wait until partition states and LME update complete then return the response
         CompletableFuture<Void> updateLastMirrorEpochsFuture = updateLastMirrorEpochs(updatedMirrorName, offsets);
         CompletableFuture.allOf(updateMirrorPartitionStateFutures.toArray(CompletableFuture[]::new))
-            .thenCompose((v) -> updateLastMirrorEpochsFuture)
+            .thenCompose(v -> updateLastMirrorEpochsFuture)
             .whenComplete((v, e) -> {
                 WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
                 if  (e != null) {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -740,11 +740,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 if (partition.state() != -1) {
                                     partitionStates.put(mpk, MirrorPartitionState.fromValue(partition.state()));
                                 }
-                                MirrorPartitionState prevState = MirrorPartitionState.fromValue(partition.previousState());
-                                if (prevState != MirrorPartitionState.UNKNOWN) {
-                                    partitionPreviousStates.putIfAbsent(mpk, prevState);
+                                if (partition.state() == MirrorPartitionState.FAILED.value()) {
+                                    partitionPreviousStates.put(mpk, MirrorPartitionState.fromValue(partition.previousState()));
+                                    failedRetryAttempts.put(tp, (int) partition.retryAttempt());
                                 }
-                                failedRetryAttempts.put(tp, (int) partition.retryAttempt());
                             });
                         });
 

--- a/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
@@ -119,9 +119,7 @@ public enum MirrorPartitionState {
     @SuppressWarnings("checkstyle:cyclomaticComplexity")
     public static boolean isValidTransition(MirrorPartitionState source, MirrorPartitionState target) {
         if (source == target) {
-            // Re-running MIRRORING is needed because the fetcher thread might be removed
-            // For other states, to avoid unnecessary duplicated operation, skip it.
-            return target == MIRRORING;
+            return true;
         }
         switch (target) {
             case LOG_TRUNCATION:

--- a/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorPartitionState.java
@@ -119,7 +119,9 @@ public enum MirrorPartitionState {
     @SuppressWarnings("checkstyle:cyclomaticComplexity")
     public static boolean isValidTransition(MirrorPartitionState source, MirrorPartitionState target) {
         if (source == target) {
-            return true;
+            // Re-running MIRRORING is needed because the fetcher thread might be removed
+            // For other states, to avoid unnecessary duplicated operation, skip it.
+            return target == MIRRORING;
         }
         switch (target) {
             case LOG_TRUNCATION:

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -338,6 +338,7 @@ abstract class AbstractFetcherThread(name: String,
       val stalePartitions = partitionToData.keySet
       warn(s"No endpoint info to redirect mirror partitions $stalePartitions, refreshing source metadata")
       stalePartitions.foreach(markPartitionRemoved)
+      removeFetcherForPartitions(stalePartitions)
       refreshSourceClusterMetadata(stalePartitions)
     }
   }

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -333,6 +333,12 @@ abstract class AbstractFetcherThread(name: String,
       info("!!! maybeCreateMirrorFetchers: " + newStates)
       removeFetcherForPartitions(newStates.keySet)
       addFetcherForPartitions(newStates)
+    } else if (partitionToData.nonEmpty && leader.lastSeenEndpoints().isEmpty) {
+      // Old source without nodeEndpoints in Fetch response, so we need to rediscover via metadata
+      val stalePartitions = partitionToData.keySet
+      warn(s"No endpoint info to redirect mirror partitions $stalePartitions, refreshing source metadata")
+      stalePartitions.foreach(markPartitionRemoved)
+      refreshSourceClusterMetadata(stalePartitions)
     }
   }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -545,12 +545,12 @@ abstract class AbstractFetcherThread(name: String,
                       markPartitionFailed(topicPartition)
                     case e: MirrorLeaderEpochExceededException =>
                       error(s"Error while processing data for mirror partition $topicPartition " +
-                        s"at offset ${currentFetchState.fetchOffset}, waiting for leader epoch bump.", e)
+                        s"at offset ${currentFetchState.fetchOffset}, triggering leader epoch bump.", e)
                       markPartitionRemoved(topicPartition)
                       handleMirrorLeaderEpochExceeded(currentFetchState.mirrorName(), topicPartition)
                     case e: MirrorPartitionStaleMetadataException =>
                       error(s"Error while processing data for mirror partition $topicPartition " +
-                        s"at offset ${currentFetchState.fetchOffset}, waiting for metadata update.", e)
+                        s"at offset ${currentFetchState.fetchOffset}, triggering metadata update.", e)
                       markPartitionRemoved(topicPartition)
                       refreshSourceClusterMetadata(Set(topicPartition))
                     case t: Throwable =>

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -548,6 +548,11 @@ abstract class AbstractFetcherThread(name: String,
                         s"at offset ${currentFetchState.fetchOffset}, waiting for leader epoch bump.", e)
                       markPartitionRemoved(topicPartition)
                       handleMirrorLeaderEpochExceeded(currentFetchState.mirrorName(), topicPartition)
+                    case e: MirrorPartitionStaleMetadataException =>
+                      error(s"Error while processing data for mirror partition $topicPartition " +
+                        s"at offset ${currentFetchState.fetchOffset}, waiting for metadata update.", e)
+                      markPartitionRemoved(topicPartition)
+                      refreshSourceClusterMetadata(Set(topicPartition))
                     case t: Throwable =>
                       // stop monitoring this partition and add it to the set of failed partitions
                       error(s"Unexpected error occurred while processing data for partition $topicPartition " +

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -92,7 +92,8 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, topicPartition, MirrorPartitionState.EPOCH_FENCING))
   }
 
-  def validateLeaderEpoch(topicPartition: TopicPartition, partition: Partition, records: Records, partitionLeaderEpoch: Int): Unit = {
+  // Validates batch epoch against local epoch (destination) and partition epoch (source metadata).
+  private def validateLeaderEpoch(topicPartition: TopicPartition, partition: Partition, records: Records, partitionLeaderEpoch: Int): Unit = {
     val localLeaderEpoch = partition.getLeaderEpoch
     val highestBatchLeaderEpoch = if (records.lastBatch().isPresent)
       records.lastBatch().get().partitionLeaderEpoch() else -1
@@ -125,7 +126,7 @@ class MirrorFetcherThread(name: String,
       // With the fix of KAFKA-18723, the follower node will reject the batches and endlessly re-fetch.
       // Fix it by throwing exception and handle it by refresh the source cluster metadata.
       throw new MirrorPartitionStaleMetadataException(s"Rejecting the batch because the batch leader " +
-        s"epoch $highestBatchLeaderEpoch is higher than previously known leader epoch $partitionLeaderEpoch." +
+        s"epoch $highestBatchLeaderEpoch is higher than previously known leader epoch $partitionLeaderEpoch. " +
         s"Will refresh the source cluster metadata and retry.")
     }
   }

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -19,7 +19,7 @@ package kafka.server.mirror
 import kafka.cluster.Partition
 import kafka.server._
 import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, LeaderInfo, PartitionKey}
-import org.apache.kafka.common.errors.MirrorLeaderEpochExceededException
+import org.apache.kafka.common.errors.{MirrorLeaderEpochExceededException, MirrorPartitionStaleMetadataException}
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
 import org.apache.kafka.common.requests.FetchResponse
@@ -92,11 +92,11 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, topicPartition, MirrorPartitionState.EPOCH_FENCING))
   }
 
-  def validateLeaderEpoch(topicPartition: TopicPartition, partition: Partition, records: Records): Unit = {
+  def validateLeaderEpoch(topicPartition: TopicPartition, partition: Partition, records: Records, partitionLeaderEpoch: Int): Unit = {
     val localLeaderEpoch = partition.getLeaderEpoch
     val highestBatchLeaderEpoch = if (records.lastBatch().isPresent)
       records.lastBatch().get().partitionLeaderEpoch() else -1
-    log.trace(s"Current highestBatchLeaderEpoch: $highestBatchLeaderEpoch, localLeaderEpoch: $localLeaderEpoch")
+    log.trace(s"Current highestBatchLeaderEpoch: $highestBatchLeaderEpoch, localLeaderEpoch: $localLeaderEpoch, partition: $topicPartition, partitionLE: $partitionLeaderEpoch")
     if (highestBatchLeaderEpoch > localLeaderEpoch) {
       // React by fencing this partition when source records are already ahead of the local leader epoch.
       // The exception will mark this partition as failed and transition mirror state to EPOCH_FENCING.
@@ -117,6 +117,15 @@ class MirrorFetcherThread(name: String,
             }
         }
       }
+    }
+
+    if (highestBatchLeaderEpoch > partitionLeaderEpoch) {
+      // When this happens in intra-cluster, UnifiedLog will reject the batch and wait for the partition change
+      // metadata log to recreate fetcher thread.
+      // But if it happens in inter-cluster mirroring, we will never get the partition change metadata log,
+      // so we need to handle that by refreshing the source cluster metadata
+      throw new MirrorPartitionStaleMetadataException(s"Rejecting the batch because the batch leader " +
+        s"epoch $highestBatchLeaderEpoch is higher than previously known leader epoch $partitionLeaderEpoch")
     }
   }
 
@@ -140,7 +149,7 @@ class MirrorFetcherThread(name: String,
       trace("Mirror follower has replica log end offset %d for partition %s. Received %d bytes of messages and leader hw %d"
         .format(log.logEndOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
 
-    validateLeaderEpoch(topicPartition, partition, records)
+    validateLeaderEpoch(topicPartition, partition, records, partitionLeaderEpoch)
 
     // Append batches from the source cluster to the destination partition's log.
     val logAppendInfo = partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false, partitionLeaderEpoch, isMirrorLeader = true)

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -120,12 +120,13 @@ class MirrorFetcherThread(name: String,
     }
 
     if (highestBatchLeaderEpoch > partitionLeaderEpoch) {
-      // When this happens in intra-cluster, UnifiedLog will reject the batch and wait for the partition change
-      // metadata log to recreate fetcher thread.
-      // But if it happens in inter-cluster mirroring, we will never get the partition change metadata log,
-      // so we need to handle that by refreshing the source cluster metadata
+      // In old version, the leader epoch will be incremented "when follower is down". When this happens, the leader
+      // will still serve the fetch request with "currentLeaderEpoch=X", even though the leader's leader epoch is "X+1".
+      // With the fix of KAFKA-18723, the follower node will reject the batches and endlessly re-fetch.
+      // Fix it by throwing exception and handle it by refresh the source cluster metadata.
       throw new MirrorPartitionStaleMetadataException(s"Rejecting the batch because the batch leader " +
-        s"epoch $highestBatchLeaderEpoch is higher than previously known leader epoch $partitionLeaderEpoch")
+        s"epoch $highestBatchLeaderEpoch is higher than previously known leader epoch $partitionLeaderEpoch." +
+        s"Will refresh the source cluster metadata and retry.")
     }
   }
 

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -149,10 +149,7 @@ class MirrorUtils:
         if expected_count is not None:
             deadline = time.time() + wait_timeout_sec
             try_consume()
-            while count[0] < expected_count:
-                if time.time() >= deadline:
-                    raise AssertionError(
-                        "Expected %d records on %s, got %d" % (expected_count, topic, count[0]))
+            while count[0] < expected_count and time.time() < deadline:
                 time.sleep(5)
                 try_consume()
         else:

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -115,7 +115,7 @@ class MirrorUtils:
 
     def consume_records(self, kafka, topic, client_node, max_messages=None,
                         timeout_ms=30000, isolation_level=None, group=None,
-                        from_beginning=True, expected_count=None,
+                            from_beginning=True, expected_count=None,
                         wait_timeout_sec=240):
         env_prefix, cmd_suffix = kafka._cmd_security_opts(client_node)
         cmd = "%s%s --bootstrap-server %s --topic %s --timeout-ms %d" % (

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -115,7 +115,7 @@ class MirrorUtils:
 
     def consume_records(self, kafka, topic, client_node, max_messages=None,
                         timeout_ms=30000, isolation_level=None, group=None,
-                            from_beginning=True, expected_count=None,
+                        from_beginning=True, expected_count=None,
                         wait_timeout_sec=240):
         env_prefix, cmd_suffix = kafka._cmd_security_opts(client_node)
         cmd = "%s%s --bootstrap-server %s --topic %s --timeout-ms %d" % (

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_acls_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_acls_test.py
@@ -214,14 +214,11 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
         if expected_count is not None:
             deadline = time.time() + wait_timeout_sec
             try_consume()
-            while count[0] < expected_count:
-                if time.time() >= deadline:
-                    raise AssertionError(
-                        "Expected %d records on %s, got %d" % (expected_count, topic, count[0]))
+            while count[0] < expected_count and time.time() < deadline:
                 time.sleep(5)
                 try_consume()
         else:
-            _try_consume()
+            try_consume()
         return count[0]
 
     def list_acls(self, kafka, client_node):
@@ -298,9 +295,10 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
 
         # Retry consuming because the HW may lag behind mirror lag reaching zero.
         self.logger.info("Consuming 10 records from my-topic-a on destination as client user")
-        self.consume_as_client(self.dest_kafka, "my-topic-a",
-                               self.dest_client_node, max_messages=10,
-                               group="my-group", expected_count=10)
+        count = self.consume_as_client(self.dest_kafka, "my-topic-a",
+                                       self.dest_client_node, max_messages=10,
+                                       group="my-group", expected_count=10)
+        assert count >= 10, "Expected 10 records on my-topic-a, got %d" % count
 
         self.logger.info("Verifying ACL filtering: my-topic-a ACL synced, new-topic ACL filtered out")
         self.wait_for_acl_condition(

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -123,8 +123,8 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
 
     @cluster(num_nodes=8)
     @parametrize(source_version=str(LATEST_2_1), metadata_quorum=quorum.zk)
-    @parametrize(source_version=str(LATEST_3_9), metadata_quorum=quorum.zk)
-    @parametrize(source_version=str(LATEST_4_0), metadata_quorum=quorum.isolated_kraft)
+#     @parametrize(source_version=str(LATEST_3_9), metadata_quorum=quorum.zk)
+#     @parametrize(source_version=str(LATEST_4_0), metadata_quorum=quorum.isolated_kraft)
     def test_mirroring(self, source_version, metadata_quorum):
         """Verify migration with data, consumer groups, and topic config sync."""
         self.setup_source(KafkaVersion(source_version), metadata_quorum)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -132,16 +132,16 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
 
         num_records = 100
         topics = {
-            "my-topic-a": {"partitions": 1, "replication-factor": 2},
+            "my-topic-a": {"partitions": 3, "replication-factor": 2},
             "my-topic-b": {"partitions": 1, "replication-factor": 2},
-            "new-topic": {"partitions": 1, "replication-factor": 2},
+            "new-topic": {"partitions": 2, "replication-factor": 2},
         }
 
         self.logger.info("Creating topics on source cluster")
         for t, cfg in topics.items():
             self.source_kafka.create_topic({"topic": t, **cfg})
 
-        # restart source cluster to bump the partitions leader epoch
+        self.logger.info("Restart source cluster to bump the partitions leader epoch")
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
         self.logger.info("Producing %d records to each source topic", num_records)
@@ -166,7 +166,6 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
             err_msg="Failed to create cluster mirror",
         )
         for regex in ["my-topic.*", "new-topic"]:
-#         for regex in ["my-topic.*"]:
             wait_until(
                 lambda r=regex: "Started" in self.dest_kafka.start_cluster_mirror_topics(
                     self.dest_client_node, mirror_name, r),
@@ -177,8 +176,9 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(
             self.dest_kafka, mirror_name, topics=list(topics.keys()))
 
-        leader_node = self.source_kafka.leader("my-topic-a", 0)
-        self.source_kafka.stop_node(leader_node)
+        self.logger.info("Shutting down the leader of one topic, and send more records and make sure the mirror can still work.")
+        leader_node = self.source_kafka.leader("my-topic-b", 0)
+        self.source_kafka.stop_node(leader_node, clean_shutdown=False)
 
         self.logger.info("Producing %d more records to each source topic", num_records)
         for t in topics:

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -141,6 +141,9 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         for t, cfg in topics.items():
             self.source_kafka.create_topic({"topic": t, **cfg})
 
+        # restart source cluster to bump the partitions leader epoch
+        self.source_kafka.restart_cluster(clean_shutdown=True)
+
         self.logger.info("Producing %d records to each source topic", num_records)
         for t in topics:
             self.produce_records(self.source_kafka, t, num_records, self.source_client_node)
@@ -172,6 +175,17 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag")
         self.wait_mirror_lag_zero(
             self.dest_kafka, mirror_name, topics=list(topics.keys()))
+
+        leader_node = self.source_kafka.leader("my-topic-b", 0)
+        self.source_kafka.stop_node(leader_node)
+
+        self.logger.info("Producing %d more records to each source topic", num_records)
+            for t in topics:
+                self.produce_records(self.source_kafka, t, num_records, self.source_client_node)
+
+        self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag after one source node down")
+            self.wait_mirror_lag_zero(
+                self.dest_kafka, mirror_name, topics=list(topics.keys()))
 
         self.logger.info("Verifying consumer group offset sync")
         self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -134,7 +134,7 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         topics = {
             "my-topic-a": {"partitions": 1, "replication-factor": 2},
 #             "my-topic-b": {"partitions": 1, "replication-factor": 2},
-#             "new-topic": {"partitions": 2, "replication-factor": 2},
+            "new-topic": {"partitions": 1, "replication-factor": 2},
         }
 
         self.logger.info("Creating topics on source cluster")
@@ -165,8 +165,8 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
             timeout_sec=20, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
-#         for regex in ["my-topic.*", "new-topic"]:
-        for regex in ["my-topic.*"]:
+        for regex in ["my-topic.*", "new-topic"]:
+#         for regex in ["my-topic.*"]:
             wait_until(
                 lambda r=regex: "Started" in self.dest_kafka.start_cluster_mirror_topics(
                     self.dest_client_node, mirror_name, r),

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -133,7 +133,7 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         num_records = 100
         topics = {
             "my-topic-a": {"partitions": 1, "replication-factor": 2},
-#             "my-topic-b": {"partitions": 1, "replication-factor": 2},
+            "my-topic-b": {"partitions": 1, "replication-factor": 2},
             "new-topic": {"partitions": 1, "replication-factor": 2},
         }
 

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -176,16 +176,16 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(
             self.dest_kafka, mirror_name, topics=list(topics.keys()))
 
-#         leader_node = self.source_kafka.leader("my-topic-b", 0)
-#         self.source_kafka.stop_node(leader_node)
-#
-#         self.logger.info("Producing %d more records to each source topic", num_records)
-#             for t in topics:
-#                 self.produce_records(self.source_kafka, t, num_records, self.source_client_node)
-#
-#         self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag after one source node down")
-#             self.wait_mirror_lag_zero(
-#                 self.dest_kafka, mirror_name, topics=list(topics.keys()))
+        leader_node = self.source_kafka.leader("my-topic-b", 0)
+        self.source_kafka.stop_node(leader_node)
+
+        self.logger.info("Producing %d more records to each source topic", num_records)
+        for t in topics:
+            self.produce_records(self.source_kafka, t, num_records, self.source_client_node)
+
+        self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag after one source node down")
+        self.wait_mirror_lag_zero(
+            self.dest_kafka, mirror_name, topics=list(topics.keys()))
 
         self.logger.info("Verifying consumer group offset sync")
         self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -165,7 +165,8 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
             timeout_sec=20, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
-        for regex in ["my-topic.*", "new-topic"]:
+#         for regex in ["my-topic.*", "new-topic"]:
+        for regex in ["my-topic.*"]:
             wait_until(
                 lambda r=regex: "Started" in self.dest_kafka.start_cluster_mirror_topics(
                     self.dest_client_node, mirror_name, r),

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -176,16 +176,16 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(
             self.dest_kafka, mirror_name, topics=list(topics.keys()))
 
-        leader_node = self.source_kafka.leader("my-topic-b", 0)
-        self.source_kafka.stop_node(leader_node)
-
-        self.logger.info("Producing %d more records to each source topic", num_records)
-            for t in topics:
-                self.produce_records(self.source_kafka, t, num_records, self.source_client_node)
-
-        self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag after one source node down")
-            self.wait_mirror_lag_zero(
-                self.dest_kafka, mirror_name, topics=list(topics.keys()))
+#         leader_node = self.source_kafka.leader("my-topic-b", 0)
+#         self.source_kafka.stop_node(leader_node)
+#
+#         self.logger.info("Producing %d more records to each source topic", num_records)
+#             for t in topics:
+#                 self.produce_records(self.source_kafka, t, num_records, self.source_client_node)
+#
+#         self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag after one source node down")
+#             self.wait_mirror_lag_zero(
+#                 self.dest_kafka, mirror_name, topics=list(topics.keys()))
 
         self.logger.info("Verifying consumer group offset sync")
         self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -132,9 +132,9 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
 
         num_records = 100
         topics = {
-            "my-topic-a": {"partitions": 3, "replication-factor": 2},
-            "my-topic-b": {"partitions": 1, "replication-factor": 2},
-            "new-topic": {"partitions": 2, "replication-factor": 2},
+            "my-topic-a": {"partitions": 1, "replication-factor": 2},
+#             "my-topic-b": {"partitions": 1, "replication-factor": 2},
+#             "new-topic": {"partitions": 2, "replication-factor": 2},
         }
 
         self.logger.info("Creating topics on source cluster")

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -212,5 +212,6 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
 
         self.logger.info("Verifying destination records after failover")
         for topic in topics:
-            self.consume_records(self.dest_kafka, topic, self.dest_client_node,
-                                max_messages=num_records, expected_count=num_records)
+            count = self.consume_records(self.dest_kafka, topic, self.dest_client_node,
+                                         max_messages=num_records, expected_count=num_records)
+            assert count >= num_records, "Expected %d records on %s, got %d" % (num_records, topic, count)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -123,8 +123,8 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
 
     @cluster(num_nodes=8)
     @parametrize(source_version=str(LATEST_2_1), metadata_quorum=quorum.zk)
-#     @parametrize(source_version=str(LATEST_3_9), metadata_quorum=quorum.zk)
-#     @parametrize(source_version=str(LATEST_4_0), metadata_quorum=quorum.isolated_kraft)
+    @parametrize(source_version=str(LATEST_3_9), metadata_quorum=quorum.zk)
+    @parametrize(source_version=str(LATEST_4_0), metadata_quorum=quorum.isolated_kraft)
     def test_mirroring(self, source_version, metadata_quorum):
         """Verify migration with data, consumer groups, and topic config sync."""
         self.setup_source(KafkaVersion(source_version), metadata_quorum)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -177,7 +177,7 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(
             self.dest_kafka, mirror_name, topics=list(topics.keys()))
 
-        leader_node = self.source_kafka.leader("my-topic-b", 0)
+        leader_node = self.source_kafka.leader("my-topic-a", 0)
         self.source_kafka.stop_node(leader_node)
 
         self.logger.info("Producing %d more records to each source topic", num_records)

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -186,8 +186,9 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
         self.logger.info("Consume from destination (expect 3 records)")
-        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3,
-                             expected_count=3)
+        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3,
+                                     expected_count=3)
+        assert count >= 3, "Expected 3 records on %s, got %d" % (topic, count)
 
         self.logger.info("Produce to destination while mirroring (should fail)")
         self.produce_records(self.dest_kafka, topic, 1, self.client_node)
@@ -203,8 +204,9 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.produce_records(self.source_kafka, topic, 2, self.client_node)
 
         self.logger.info("Consume from source (expect 5 records)")
-        self.consume_records(self.source_kafka, topic, self.client_node, max_messages=5,
-                             expected_count=5)
+        count = self.consume_records(self.source_kafka, topic, self.client_node, max_messages=5,
+                                     expected_count=5)
+        assert count >= 5, "Expected 5 records on %s, got %d" % (topic, count)
 
         self.logger.info("Failback: source mirrors from destination (same mirror name to retrieve LMO)")
         mirror_cfg = MirrorConfig(self.dest_kafka.bootstrap_servers())
@@ -224,8 +226,9 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.source_kafka, mirror_name, [topic])
 
         self.logger.info("Consume from source (non-mirrored data should be truncated)")
-        self.consume_records(self.source_kafka, topic, self.client_node,
-                             max_messages=5, timeout_ms=5000, expected_count=4)
+        count = self.consume_records(self.source_kafka, topic, self.client_node,
+                                     max_messages=5, timeout_ms=5000, expected_count=4)
+        assert count >= 4, "Expected 4 records on %s, got %d" % (topic, count)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -274,8 +277,9 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
         self.logger.info("Consume from destination (expect 4 records after resume)")
-        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=4,
-                             expected_count=4)
+        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=4,
+                                     expected_count=4)
+        assert count >= 4, "Expected 4 records on %s, got %d" % (topic, count)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -331,8 +335,9 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.produce_records(self.source_kafka, topic, 3, self.client_node)
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
-        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3,
-                             expected_count=3)
+        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3,
+                                     expected_count=3)
+        assert count >= 3, "Expected 3 records on %s, got %d" % (topic, count)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -446,10 +451,12 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
                                   ["orders-us", "orders-eu"])
 
-        self.consume_records(self.dest_kafka, "orders-us", self.client_node, max_messages=3,
-                             expected_count=3)
-        self.consume_records(self.dest_kafka, "orders-eu", self.client_node, max_messages=3,
-                             expected_count=3)
+        count = self.consume_records(self.dest_kafka, "orders-us", self.client_node, max_messages=3,
+                                     expected_count=3)
+        assert count >= 3, "Expected 3 records on orders-us, got %d" % count
+        count = self.consume_records(self.dest_kafka, "orders-eu", self.client_node, max_messages=3,
+                                     expected_count=3)
+        assert count >= 3, "Expected 3 records on orders-eu, got %d" % count
 
         self.logger.info("Verify excluded and non-matching topics don't exist on destination")
         dest_topics = list(self.dest_kafka.list_topics(self.client_node))
@@ -489,8 +496,9 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
                                   topics={"orders-jp": {"partitions": 1, "replication-factor": 2}})
 
-        self.consume_records(self.dest_kafka, "orders-jp", self.client_node, max_messages=3,
-                             expected_count=3)
+        count = self.consume_records(self.dest_kafka, "orders-jp", self.client_node, max_messages=3,
+                                     expected_count=3)
+        assert count >= 3, "Expected 3 records on orders-jp, got %d" % count
 
         self.logger.info("Add payments to include pattern via alter config")
         self.dest_kafka.alter_mirror_config(
@@ -501,8 +509,9 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
                                   topics={"payments": {"partitions": 1, "replication-factor": 2}})
 
-        self.consume_records(self.dest_kafka, "payments", self.client_node, max_messages=2,
-                             expected_count=2)
+        count = self.consume_records(self.dest_kafka, "payments", self.client_node, max_messages=2,
+                                     expected_count=2)
+        assert count >= 2, "Expected 2 records on payments, got %d" % count
 
         self.logger.info("Verify orders-internal still doesn't exist on destination after all operations")
         dest_topics = list(self.dest_kafka.list_topics(self.client_node))
@@ -958,12 +967,16 @@ class ClusterMirroringTest(MirrorUtils, Test):
         source_count = self.consume_records(self.source_kafka, topic, self.client_node)
         dest_count = self.consume_records(self.dest_kafka, topic, self.client_node,
                                           expected_count=source_count + 2)
+        assert dest_count >= source_count + 2, \
+            "Expected %d records on %s, got %d" % (source_count + 2, topic, dest_count)
 
         self.logger.info("Checking read_committed consumer can make progress")
         # 4 aborted data records are filtered out: txn-b, txn-c, txn-d fenced, txn-d pending
-        self.consume_records(self.dest_kafka, topic, self.client_node,
-                             isolation_level="read_committed",
-                             expected_count=dest_count - 4)
+        committed_count = self.consume_records(self.dest_kafka, topic, self.client_node,
+                                               isolation_level="read_committed",
+                                               expected_count=dest_count - 4)
+        assert committed_count >= dest_count - 4, \
+            "Expected %d read_committed records on %s, got %d" % (dest_count - 4, topic, committed_count)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -1166,14 +1179,16 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
         self.logger.info("Consume 2 records from destination with a consumer group (commits offsets with source LE)")
-        self.consume_records(self.dest_kafka, topic, self.client_node,
-                             max_messages=2, group=group, expected_count=2)
+        count = self.consume_records(self.dest_kafka, topic, self.client_node,
+                                     max_messages=2, group=group, expected_count=2)
+        assert count >= 2, "Expected 2 records on %s, got %d" % (topic, count)
 
         self.logger.info("Restart consumer (triggers OffsetFetch and refreshCommittedOffsets)")
         # Without the epoch bump fix, this would hang because source LE > local LE
-        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=2,
-                             timeout_ms=20000, group=group, from_beginning=False,
-                             expected_count=2)
+        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=2,
+                                     timeout_ms=20000, group=group, from_beginning=False,
+                                     expected_count=2)
+        assert count >= 2, "Expected 2 records on %s after restart, got %d" % (topic, count)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -1217,5 +1232,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.produce_records(self.source_kafka, topic, 3, self.client_node)
         self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
 
-        self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=6,
-                             expected_count=6)
+        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=6,
+                                     expected_count=6)
+        assert count >= 6, "Expected 6 records on %s, got %d" % (topic, count)


### PR DESCRIPTION
1. restart source cluster before producing data to topics so that the source cluster LE will be higher than destination cluster. Make sure the destination cluster can (a) re-discover the LE in the source and send fetch request again (b) bump LE to make sure LE > source batch LE
2. During mirroring, unclean shutdown one of the leader node, the destination leader should enter FAILED and re-discover the source metadata and connect to the new leader node. 
3. bug: only update failed related state when current state is FAILED because when in other states, the failed previousState or retryAttempt is meaningless.
4. bug: When handling `WRITE_MIRROR_STATES`, we don't wait until all states persist completes and return the response. The result is that sometimes the leader node completes a `WRITE_MIRROR_STATES`, and later `READ_MIRROR_STATES` from remote coordinator, it'll get the old state back, which mess up the state machine transition. Fix it by waiting for writes then return the response.
5. Mysterious leader epoch increment: In old version, the leader epoch will be incremented _when the follower node is down_. At this point of time, the fetch request can still work without issue (i.e. fetch request with currentLeaderEpoch: X, but the leader's leader epoch is "X+1"). So, the destination will receive the data successfully. But since in [KAFKA-18723](https://issues.apache.org/jira/browse/KAFKA-18723), we added a gate to prevent to append records LE > local LE, it keeps rejecting the batch. Fix it by throwing `MirrorPartitionStaleMetadataException` and handle it to refresh the source cluster metadata.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
