### PR TITLE
support offsetForLeaderEpoch for mirroring from old kafka

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
@@ -53,11 +53,6 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
         }
 
         public static Builder forMirrorConsumer(OffsetForLeaderTopicCollection epochsByPartition) {
-            // Old versions of this API require CLUSTER permission which is not typically granted
-            // to clients. Beginning with version 3, the broker requires only TOPIC Describe
-            // permission for the topic of each requested partition. In order to ensure client
-            // compatibility, we only send this request when we can guarantee the relaxed permissions.
-
             // The oldest supported source cluster version supports OFFSET_FOR_LEADER_EPOCH v2, so use v2 here.
             OffsetForLeaderEpochRequestData data = new OffsetForLeaderEpochRequestData();
             data.setTopics(epochsByPartition);

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
@@ -52,6 +52,18 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
             this.data = data;
         }
 
+        public static Builder forMirrorConsumer(OffsetForLeaderTopicCollection epochsByPartition) {
+            // Old versions of this API require CLUSTER permission which is not typically granted
+            // to clients. Beginning with version 3, the broker requires only TOPIC Describe
+            // permission for the topic of each requested partition. In order to ensure client
+            // compatibility, we only send this request when we can guarantee the relaxed permissions.
+
+            // The oldest supported source cluster version supports OFFSET_FOR_LEADER_EPOCH v2, so use v2 here.
+            OffsetForLeaderEpochRequestData data = new OffsetForLeaderEpochRequestData();
+            data.setTopics(epochsByPartition);
+            return new Builder((short) 2, ApiKeys.OFFSET_FOR_LEADER_EPOCH.latestVersion(), data);
+        }
+
         public static Builder forConsumer(OffsetForLeaderTopicCollection epochsByPartition) {
             // Old versions of this API require CLUSTER permission which is not typically granted
             // to clients. Beginning with version 3, the broker requires only TOPIC Describe

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -871,8 +871,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         ensureConnection(mirrorName);
         List<MirrorSourceSender> senders = sourceSenders.get(mirrorName);
         if (senders != null && !senders.isEmpty()) {
-            log.info("No cached leader for mirror {} partition {}. Using bootstrap server as initial target.", mirrorName, tp);
-            BrokerEndPoint ep = senders.get(0).brokerEndPoint();
+            log.info("No cached leader for mirror {} partition {}. Using one of the bootstrap server as initial target.", mirrorName, tp);
+            BrokerEndPoint ep = senders.get(random.nextInt(senders.size())).brokerEndPoint();
             // set leaderEpoch to 0 if unknown to trigger source epoch discovery through fencing
             return new ClusterMirrorUtils.LeaderInfo(new Node(ep.id(), ep.host(), ep.port()), 0);
         }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1368,9 +1368,29 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     private void maybeStopDeletedTopics(String mirrorName, Collection<MetadataResponse.TopicMetadata> topicMetadata) {
-        List<String> deletedSourceTopicNames = topicMetadata.stream()
+        List<String> deletedSourceTopicNames = new ArrayList<>(topicMetadata.stream()
                 .filter(tm -> tm.error() == Errors.UNKNOWN_TOPIC_OR_PARTITION)
-                .map(MetadataResponse.TopicMetadata::topic).toList();
+                .map(MetadataResponse.TopicMetadata::topic).toList());
+
+        if (deletedSourceTopicNames.isEmpty()) {
+            return;
+        }
+
+        // In old cluster, it is possible the broker metadata update in progress, and the returned metadata response is stale.
+        // list topic again to make sure it is indeed deleted.
+        Admin srcAdmin = srcAdmins.get(mirrorName);
+        if (srcAdmin == null) {
+            log.error("Source admin client not initialized for mirror {}, skipping config sync", mirrorName);
+            return;
+        }
+        try {
+            Set<String> allTopics = srcAdmin.listTopics().names().get();
+            log.debug("Source topic name list: {}", allTopics);
+            deletedSourceTopicNames.removeAll(allTopics);
+        } catch (Exception e) {
+            log.warn("Failed to describe topic for mirror {}: {}", mirrorName, e.getMessage());
+        }
+
         getConfiguredTopics(mirrorName, true).forEach(name -> {
             if (deletedSourceTopicNames.contains(name)) {
                 log.info("Detected topic {} deleted in remote cluster {}, stopping mirror partitions", name, mirrorName);

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -18,7 +18,6 @@
 package kafka.server
 
 import com.yammer.metrics.core.Meter
-import kafka.server.mirror.MirrorFetcherThread
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.Logging
 import org.apache.kafka.common.errors._
@@ -122,6 +121,10 @@ abstract class AbstractFetcherThread(name: String,
 
   protected def handleMirrorLeaderEpochExceeded(mirrorName: String, topicPartition: TopicPartition): Unit = {}
 
+  protected def leaderEpochFromSource(tp: TopicPartition): Option[Int] = {
+    Option.empty
+  }
+
   override def shutdown(): Unit = {
     initiateShutdown()
     inLock(partitionMapLock) {
@@ -191,10 +194,10 @@ abstract class AbstractFetcherThread(name: String,
         latestEpoch(tp).toScala match {
           case Some(epoch) =>
             // use the leaderEpoch from the source cluster metadata when mirroring
-            val currentLeaderEpoch = if (!this.isInstanceOf[MirrorFetcherThread])
+            val currentLeaderEpoch = if (mirrorName.isBlank)
               state.currentLeaderEpoch
             else
-              this.asInstanceOf[MirrorFetcherThread].leaderEpochInSource(tp)
+              leaderEpochFromSource(tp).getOrElse(state.currentLeaderEpoch())
             partitionsWithEpochs += tp -> new EpochData()
               .setPartition(tp.partition)
               .setCurrentLeaderEpoch(currentLeaderEpoch)
@@ -237,13 +240,12 @@ abstract class AbstractFetcherThread(name: String,
   }
 
   /**
-   * - Build a leader epoch fetch based on partitions that are in the Truncating phase
-   * - Send OffsetsForLeaderEpochRequest, retrieving the latest offset for each partition's
-   * leader epoch. This is the offset the follower should truncate to ensure
-   * accurate log replication.
-   * - Finally truncate the logs for partitions in the truncating phase and mark the
-   * truncation complete. Do this within a lock to ensure no leadership changes can
-   * occur during truncation.
+   * Send OffsetsForLeaderEpochRequest for partitions in the Truncating phase to retrieve
+   * the latest offset for each partition's leader epoch that they should truncate to,
+   * then perform the truncation and mark the truncation complete under lock.
+   *
+   * for mirror threads the currentLeaderEpoch provided might be a fenced leader epoch, which means the source leadership
+   * changed in-flight and the partition will retry on the next doWork cycle.
    */
   private def truncateToEpochEndOffsets(latestEpochsForPartitions: Map[TopicPartition, EpochData]): Unit = {
     val endOffsets = leader.fetchEpochEndOffsets(latestEpochsForPartitions.asJava)
@@ -252,7 +254,6 @@ abstract class AbstractFetcherThread(name: String,
     val partitionsNeedsRefreshMetadata = new util.HashSet[TopicPartition]()
     inLock(partitionMapLock) {
       //Check no leadership and no leader epoch changes happened whilst we were unlocked, fetching epochs
-
       val epochEndOffsets = endOffsets.asScala.filter { case (tp, _) =>
         val curPartitionState = partitionStates.stateValue(tp)
         val partitionEpochRequest = latestEpochsForPartitions.getOrElse(tp, {
@@ -268,10 +269,11 @@ abstract class AbstractFetcherThread(name: String,
       handlePartitionsWithErrors(result.partitionsWithError.asScala, "truncateToEpochEndOffsets")
       updateFetchOffsetAndMaybeMarkTruncationComplete(result.result)
     }
-    // Refresh source metadata out of the partitionMapLock since we will need to acquire MirrorFetcherThread lock and
-    // cause potential deadlock
+    // Log truncation has completed, so it's safe to release the lock for source metadata refresh.
+    // We will need to acquire both MirrorFetcherThread lock and partitionMapLock when removing fetchers, which might cause potential deadlock
+    // if we keep the partitionMapLock here.
     if (!partitionsNeedsRefreshMetadata.isEmpty) {
-      info("refreshing source metadata for " + partitionsNeedsRefreshMetadata)
+      info(s"refreshing source metadata for mirror name $mirrorName with partitions: $partitionsNeedsRefreshMetadata")
       removeFetcherForPartitions(partitionsNeedsRefreshMetadata.asScala)
       refreshSourceClusterMetadata(partitionsNeedsRefreshMetadata.asScala)
     }
@@ -717,6 +719,8 @@ abstract class AbstractFetcherThread(name: String,
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
         state, lastFetchedEpoch, initialFetchState.mirrorName, initialFetchState.mirrorLeaderEpoch)
     } else {
+      // Mirror threads always skip truncation-on-fetch and use the explicit OffsetsForLeaderEpochRequest
+      // path because older source brokers may not include diverging epoch info in fetch responses.
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
         ReplicaState.TRUNCATING, Optional.empty(), initialFetchState.mirrorName, initialFetchState.mirrorLeaderEpoch)
     }

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -393,17 +393,15 @@ abstract class AbstractFetcherThread(name: String,
               partitionsNeedsRefreshMetadata += tp
             }
 
-          case Errors.NOT_LEADER_OR_FOLLOWER =>
+          case error =>
             if (mirrorName.isBlank) {
-              info(s"Retrying leaderEpoch request for partition $tp as the leader reported an error: ${Errors.NOT_LEADER_OR_FOLLOWER}")
+              info(s"Retrying leaderEpoch request for partition $tp as the leader reported an error: $error")
               partitionsWithError += tp
             } else {
+              // If it's mirror thread, the error should be the stale source cluster metadata
+              // Try refresh it to fix the issue.
               partitionsNeedsRefreshMetadata += tp
             }
-
-          case error =>
-            info(s"Retrying leaderEpoch request for partition $tp as the leader reported an error: $error")
-            partitionsWithError += tp
         }
       } else {
         // Partitions may have been removed from the fetcher while the thread was waiting for fetch

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -549,7 +549,7 @@ abstract class AbstractFetcherThread(name: String,
                         if ((validBytes > 0 || currentFetchState.lag.isEmpty || newMirrorLeaderEpoch.orElse(-1) != currentFetchState.mirrorLeaderEpoch().orElse(-1)) &&
                           partitionStates.contains(topicPartition)) {
                           val lastFetchedEpoch =
-                            if (logAppendInfo.lastLeaderEpoch.isPresent && currentFetchState.lastFetchedEpoch.isPresent)
+                            if (logAppendInfo.lastLeaderEpoch.isPresent)
                               logAppendInfo.lastLeaderEpoch else currentFetchState.lastFetchedEpoch
                           val newFetchState = new PartitionFetchState(currentFetchState.topicId, nextOffset, Optional.of(lag),
                             currentFetchState.currentLeaderEpoch, ReplicaState.FETCHING, lastFetchedEpoch, currentFetchState.mirrorName(), newMirrorLeaderEpoch)

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import com.yammer.metrics.core.Meter
+import kafka.server.mirror.MirrorFetcherThread
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.Logging
 import org.apache.kafka.common.errors._
@@ -189,9 +190,14 @@ abstract class AbstractFetcherThread(name: String,
       if (state.isTruncating) {
         latestEpoch(tp).toScala match {
           case Some(epoch) =>
+            // use the leaderEpoch from the source cluster metadata when mirroring
+            val currentLeaderEpoch = if (!this.isInstanceOf[MirrorFetcherThread])
+              state.currentLeaderEpoch
+            else
+              this.asInstanceOf[MirrorFetcherThread].leaderEpochInSource(tp)
             partitionsWithEpochs += tp -> new EpochData()
               .setPartition(tp.partition)
-              .setCurrentLeaderEpoch(state.currentLeaderEpoch)
+              .setCurrentLeaderEpoch(currentLeaderEpoch)
               .setLeaderEpoch(epoch)
           case _ =>
             partitionsWithoutEpochs += tp
@@ -366,6 +372,7 @@ abstract class AbstractFetcherThread(name: String,
                                              latestEpochsForPartitions: Map[TopicPartition, EpochData]): ResultWithPartitions[Map[TopicPartition, OffsetTruncationState]] = {
     val fetchOffsets = mutable.HashMap.empty[TopicPartition, OffsetTruncationState]
     val partitionsWithError = mutable.HashSet.empty[TopicPartition]
+    val partitionsNeedsRefreshMetadata = mutable.HashSet.empty[TopicPartition]
 
     fetchedEpochs.foreachEntry { (tp, leaderEpochOffset) =>
       if (partitionStates.contains(tp)) {
@@ -377,10 +384,22 @@ abstract class AbstractFetcherThread(name: String,
               fetchOffsets.put(tp, offsetTruncationState)
 
           case Errors.FENCED_LEADER_EPOCH =>
-            val currentLeaderEpoch = latestEpochsForPartitions.get(tp)
-              .map(epochEndOffset => Int.box(epochEndOffset.currentLeaderEpoch)).toJava
-            if (onPartitionFenced(tp, currentLeaderEpoch))
+            if (mirrorName.isBlank) {
+              val currentLeaderEpoch = latestEpochsForPartitions.get(tp)
+                .map(epochEndOffset => Int.box(epochEndOffset.currentLeaderEpoch)).toJava
+              if (onPartitionFenced(tp, currentLeaderEpoch))
+                partitionsWithError += tp
+            } else {
+              partitionsNeedsRefreshMetadata += tp
+            }
+
+          case Errors.NOT_LEADER_OR_FOLLOWER =>
+            if (mirrorName.isBlank) {
+              info(s"Retrying leaderEpoch request for partition $tp as the leader reported an error: ${Errors.NOT_LEADER_OR_FOLLOWER}")
               partitionsWithError += tp
+            } else {
+              partitionsNeedsRefreshMetadata += tp
+            }
 
           case error =>
             info(s"Retrying leaderEpoch request for partition $tp as the leader reported an error: $error")
@@ -394,6 +413,11 @@ abstract class AbstractFetcherThread(name: String,
       }
     }
 
+    if (partitionsNeedsRefreshMetadata.nonEmpty) {
+      info("refreshing source metadata for " + partitionsNeedsRefreshMetadata)
+      removeFetcherForPartitions(partitionsNeedsRefreshMetadata)
+      refreshSourceClusterMetadata(partitionsNeedsRefreshMetadata)
+    }
     new ResultWithPartitions(fetchOffsets, partitionsWithError.asJava)
   }
 
@@ -683,7 +707,7 @@ abstract class AbstractFetcherThread(name: String,
       currentState
     } else if (initialFetchState.initOffset < 0) {
       fetchOffsetAndTruncate(tp, initialFetchState.topicId, initialFetchState.currentLeaderEpoch, initialFetchState.mirrorLeaderEpoch)
-    } else if (leader.isTruncationOnFetchSupported) {
+    } else if (leader.isTruncationOnFetchSupported && mirrorName.isBlank) {
       // With old message format, `latestEpoch` will be empty and we use Truncating state to truncate to high watermark
       val lastFetchedEpoch: Optional[Integer] = latestEpoch(tp)
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -249,6 +249,7 @@ abstract class AbstractFetcherThread(name: String,
     val endOffsets = leader.fetchEpochEndOffsets(latestEpochsForPartitions.asJava)
     // Ensure we hold a lock during truncation
 
+    val partitionsNeedsRefreshMetadata = new util.HashSet[TopicPartition]()
     inLock(partitionMapLock) {
       //Check no leadership and no leader epoch changes happened whilst we were unlocked, fetching epochs
 
@@ -263,8 +264,16 @@ abstract class AbstractFetcherThread(name: String,
       }
 
       val result = maybeTruncateToEpochEndOffsets(epochEndOffsets, latestEpochsForPartitions)
+      partitionsNeedsRefreshMetadata.addAll(result.partitionsNeedsRefreshMetadata())
       handlePartitionsWithErrors(result.partitionsWithError.asScala, "truncateToEpochEndOffsets")
       updateFetchOffsetAndMaybeMarkTruncationComplete(result.result)
+    }
+    // Refresh source metadata out of the partitionMapLock since we will need to acquire MirrorFetcherThread lock and
+    // cause potential deadlock
+    if (!partitionsNeedsRefreshMetadata.isEmpty) {
+      info("refreshing source metadata for " + partitionsNeedsRefreshMetadata)
+      removeFetcherForPartitions(partitionsNeedsRefreshMetadata.asScala)
+      refreshSourceClusterMetadata(partitionsNeedsRefreshMetadata.asScala)
     }
   }
 
@@ -411,12 +420,7 @@ abstract class AbstractFetcherThread(name: String,
       }
     }
 
-    if (partitionsNeedsRefreshMetadata.nonEmpty) {
-      info("refreshing source metadata for " + partitionsNeedsRefreshMetadata)
-      removeFetcherForPartitions(partitionsNeedsRefreshMetadata)
-      refreshSourceClusterMetadata(partitionsNeedsRefreshMetadata)
-    }
-    new ResultWithPartitions(fetchOffsets, partitionsWithError.asJava)
+    new ResultWithPartitions(fetchOffsets, partitionsWithError.asJava, partitionsNeedsRefreshMetadata.asJava)
   }
 
   /**

--- a/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
@@ -164,14 +164,14 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
   override def buildFetch(partitions: util.Map[TopicPartition, PartitionFetchState]): ResultWithPartitions[util.Optional[ReplicaFetch]] = {
     // Only include replica in the fetch request if it is not throttled.
     if (quota.isQuotaExceeded) {
-      new ResultWithPartitions(util.Optional.empty(), util.Set.of())
+      new ResultWithPartitions(util.Optional.empty(), util.Set.of(), util.Set.of())
     } else {
       val selectPartition = selectPartitionToFetch(partitions)
       if (selectPartition.isPresent) {
         val (tp, fetchState) = selectPartition.get()
         buildFetchForPartition(tp, fetchState)
       } else {
-        new ResultWithPartitions(util.Optional.empty(), util.Set.of())
+        new ResultWithPartitions(util.Optional.empty(), util.Set.of(), util.Set.of())
       }
     }
   }
@@ -235,7 +235,7 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
       Optional.of(new ReplicaFetch(requestMap, requestBuilder))
     }
 
-    new ResultWithPartitions(fetchRequestOpt, partitionsWithError.asJava)
+    new ResultWithPartitions(fetchRequestOpt, partitionsWithError.asJava, util.Set.of())
   }
 
   private def nextReadyPartition(partitions: Map[TopicPartition, PartitionFetchState]): Option[(TopicPartition, PartitionFetchState)] = {

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -169,7 +169,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
 
 
     val epochRequest = if (isClusterMirror)
-      OffsetsForLeaderEpochRequest.Builder.forConsumer(topics)
+      OffsetsForLeaderEpochRequest.Builder.forMirrorConsumer(topics)
     else
       OffsetsForLeaderEpochRequest.Builder.forFollower(topics, brokerConfig.brokerId)
     debug(s"Sending offset for leader epoch request $epochRequest")

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -262,7 +262,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
       Optional.of(new ReplicaFetch(fetchData.sessionPartitions(), requestBuilder))
     }
 
-    new ResultWithPartitions(fetchRequestOpt, partitionsWithError.asJava)
+    new ResultWithPartitions(fetchRequestOpt, partitionsWithError.asJava, util.Set.of())
   }
 
   /**

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -167,7 +167,11 @@ class RemoteLeaderEndPoint(logPrefix: String,
       topic.partitions.add(epochData)
     }
 
-    val epochRequest = OffsetsForLeaderEpochRequest.Builder.forFollower(topics, brokerConfig.brokerId)
+
+    val epochRequest = if (isClusterMirror)
+      OffsetsForLeaderEpochRequest.Builder.forConsumer(topics)
+    else
+      OffsetsForLeaderEpochRequest.Builder.forFollower(topics, brokerConfig.brokerId)
     debug(s"Sending offset for leader epoch request $epochRequest")
 
     try {

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -167,7 +167,6 @@ class RemoteLeaderEndPoint(logPrefix: String,
       topic.partitions.add(epochData)
     }
 
-
     val epochRequest = if (isClusterMirror)
       OffsetsForLeaderEpochRequest.Builder.forMirrorConsumer(topics)
     else

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -186,8 +186,8 @@ class MirrorFetcherThread(name: String,
     logAppendInfo
   }
 
-  def leaderEpochInSource(tp: TopicPartition): Int = {
-    replicaMgr.mirrorMetadataManager.map(mmm => mmm.resolveSourceLeader(mirrorName, tp).leaderEpoch()).getOrElse(0)
+  override def leaderEpochFromSource(tp: TopicPartition): Option[Int] = {
+    replicaMgr.mirrorMetadataManager.map(mmm => mmm.resolveSourceLeader(mirrorName, tp).leaderEpoch())
   }
 
   // return the mirror partition lag

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -186,6 +186,10 @@ class MirrorFetcherThread(name: String,
     logAppendInfo
   }
 
+  def leaderEpochInSource(tp: TopicPartition): Int = {
+    replicaMgr.mirrorMetadataManager.map(mmm => mmm.resolveSourceLeader(mirrorName, tp).leaderEpoch()).getOrElse(0)
+  }
+
   // return the mirror partition lag
   // TODO: Since we already record the lag in stats, maybe we don't cache the logInfo in mirrorFetcherManager anymore.
   override def getPartitionLag(topicPartition: TopicPartition, leaderHW: Long, nextOffset: Long, mirrorName: String): Long = {

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
@@ -312,7 +312,7 @@ class AbstractFetcherManagerTest {
 
     override def fetchEpochEndOffsets(partitions: java.util.Map[TopicPartition, OffsetForLeaderEpochRequestData.OffsetForLeaderPartition]): java.util.Map[TopicPartition, EpochEndOffset] = java.util.Map.of()
 
-    override def buildFetch(partitions: java.util.Map[TopicPartition, PartitionFetchState]): ResultWithPartitions[java.util.Optional[ReplicaFetch]] = new ResultWithPartitions(java.util.Optional.empty[ReplicaFetch](), java.util.Set.of())
+    override def buildFetch(partitions: java.util.Map[TopicPartition, PartitionFetchState]): ResultWithPartitions[java.util.Optional[ReplicaFetch]] = new ResultWithPartitions(java.util.Optional.empty[ReplicaFetch](), java.util.Set.of(), java.util.Set.of())
 
     override val isTruncationOnFetchSupported: Boolean = false
 

--- a/core/src/test/scala/unit/kafka/server/MockLeaderEndPoint.scala
+++ b/core/src/test/scala/unit/kafka/server/MockLeaderEndPoint.scala
@@ -167,7 +167,7 @@ class MockLeaderEndPoint(sourceBroker: BrokerEndPoint = new BrokerEndPoint(1, "l
         java.util.Optional.empty[ReplicaFetch]()
       else
         Optional.of(new ReplicaFetch(fetchData.asJava, fetchRequest))
-    new ResultWithPartitions(fetchRequestOpt, java.util.Collections.emptySet())
+    new ResultWithPartitions(fetchRequestOpt, java.util.Collections.emptySet(), java.util.Collections.emptySet())
   }
 
   private def checkLeaderEpochAndThrow(expectedEpoch: Int, partitionState: PartitionState): Unit = {

--- a/server/src/main/java/org/apache/kafka/server/ResultWithPartitions.java
+++ b/server/src/main/java/org/apache/kafka/server/ResultWithPartitions.java
@@ -23,5 +23,6 @@ import java.util.Set;
 
 public record ResultWithPartitions<R>(
         R result,
-        Set<TopicPartition> partitionsWithError
+        Set<TopicPartition> partitionsWithError,
+        Set<TopicPartition> partitionsNeedsRefreshMetadata
 ) { }

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -97,6 +97,11 @@ class MirrorUtils:
     """Shared helpers for Cluster Mirroring tests."""
 
     @staticmethod
+    def broker_bootstrap(node):
+        """Return bootstrap server address for a single broker node."""
+        return "%s:9092" % node.account.hostname
+
+    @staticmethod
     def produce_records(logger, kafka, topic, num_records, client_node,
                         bootstrap_servers=None):
         """Produce records on a client node using kafka-producer-perf-test."""

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -244,8 +244,8 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
         self.logger.info("Send 1 message via source broker 0")
-        self.produce_records(self.source_kafka, topic, 1, self.source_client_node,
-                             bootstrap_servers=self.broker_bootstrap(src_broker0))
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.source_client_node,
+                             bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker0))
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -262,8 +262,8 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
             timeout_sec=60, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_state(
-            self.dest_kafka, mirror_name, "MIRRORING", [topic],
+        MirrorUtils.wait_mirror_state(
+            self.logger, self.dest_kafka, self.dest_client_node, mirror_name, "MIRRORING", [topic],
             err_msg="Mirror did not reach MIRRORING state",
         )
 
@@ -271,20 +271,20 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         self.source_kafka.stop_node(src_broker0)
 
         self.logger.info("Send 1 message via source broker 1")
-        self.produce_records(self.source_kafka, topic, 1, self.source_client_node,
-                             bootstrap_servers=self.broker_bootstrap(src_broker1))
-        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, topics)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.source_client_node,
+                             bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker1))
+        MirrorUtils.wait_for_log_convergence(self.logger, self.source_kafka, self.dest_kafka, topics)
 
         self.logger.info("ULE 1: stop broker 1, start broker 0 (stale), elect it as leader")
         self.source_kafka.stop_node(src_broker1)
         self.source_kafka.start_node(src_broker0)
 
         self.logger.info("Send 2 messages via source broker 0")
-        self.produce_records(self.source_kafka, topic, 2, self.source_client_node,
-                             bootstrap_servers=self.broker_bootstrap(src_broker0))
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 2, self.source_client_node,
+                             bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker0))
 
-        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, topics)
+        MirrorUtils.wait_for_log_convergence(self.logger, self.source_kafka, self.dest_kafka, topics)
 
         self.logger.info("Failover: stop mirror so destination topic becomes writable")
         self.dest_kafka.stop_cluster_mirror_topics(self.dest_client_node, mirror_name, topic)
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "STOPPED", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.dest_client_node, mirror_name, "STOPPED", [topic])

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -223,33 +223,29 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
     @parametrize(source_version=str(LATEST_3_9), metadata_quorum=quorum.zk)
     @parametrize(source_version=str(LATEST_4_0), metadata_quorum=quorum.isolated_kraft)
     def test_ule_mirroring(self, source_version, metadata_quorum):
-        """Verify log convergence after unclean leader elections when migration."""
+        """Verify migration with unclean leader elections."""
         self.logger.info("Create source topic with ULE support enabled")
         topic = "my-topic"
         mirror_name = "new-mirror"
-        self.topics = {topic: {"partitions": 1, "replication-factor": 2},}
+        topics = {topic: {"partitions": 1, "replication-factor": 2}}
 
         self.setup_source(KafkaVersion(source_version), metadata_quorum)
         self.setup_dest()
 
         self.source_kafka.create_topic({
-            "topic": topic, "partitions": 1, "replication-factor": 2,
+            "topic": topic, **topics[topic],
             "configs": {"unclean.leader.election.enable": "true"},
         })
 
         src_broker0 = self.source_kafka.nodes[0]
         src_broker1 = self.source_kafka.nodes[1]
 
-        def broker_bootstrap(node):
-            """Return bootstrap server address for a single broker node."""
-            return "%s:9092" % node.account.hostname
-
         self.logger.info("Bounce source brokers to trigger leader elections")
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
         self.logger.info("Send 1 message via source broker 0")
         self.produce_records(self.source_kafka, topic, 1, self.source_client_node,
-                             bootstrap_servers=broker_bootstrap(src_broker0))
+                             bootstrap_servers=self.broker_bootstrap(src_broker0))
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -276,23 +272,18 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
 
         self.logger.info("Send 1 message via source broker 1")
         self.produce_records(self.source_kafka, topic, 1, self.source_client_node,
-                             bootstrap_servers=broker_bootstrap(src_broker1))
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic],
-                                  err_msg="Mirror did not catch up after broker 0 stopped")
-        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, self.topics)
+                             bootstrap_servers=self.broker_bootstrap(src_broker1))
+        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, topics)
 
         self.logger.info("ULE 1: stop broker 1, start broker 0 (stale), elect it as leader")
         self.source_kafka.stop_node(src_broker1)
         self.source_kafka.start_node(src_broker0)
-        time.sleep(5)
 
         self.logger.info("Send 2 messages via source broker 0")
         self.produce_records(self.source_kafka, topic, 2, self.source_client_node,
-                             bootstrap_servers=broker_bootstrap(src_broker0))
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic],
-                                  err_msg="Mirror did not catch up after ULE 1")
+                             bootstrap_servers=self.broker_bootstrap(src_broker0))
 
-        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, self.topics)
+        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, topics)
 
         self.logger.info("Failover: stop mirror so destination topic becomes writable")
         self.dest_kafka.stop_cluster_mirror_topics(self.dest_client_node, mirror_name, topic)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import time
 
 from ducktape.mark import parametrize
 from ducktape.mark.resource import cluster
@@ -216,3 +217,83 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
             count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.dest_client_node,
                                          max_messages=num_records, expected_count=num_records)
             assert count >= num_records, "Expected %d records on %s, got %d" % (num_records, topic, count)
+
+    @cluster(num_nodes=8)
+    @parametrize(source_version=str(LATEST_2_1), metadata_quorum=quorum.zk)
+    @parametrize(source_version=str(LATEST_3_9), metadata_quorum=quorum.zk)
+    @parametrize(source_version=str(LATEST_4_0), metadata_quorum=quorum.isolated_kraft)
+    def test_ule_mirroring(self, source_version, metadata_quorum):
+        """Verify log convergence after unclean leader elections when migration."""
+        self.logger.info("Create source topic with ULE support enabled")
+        topic = "my-topic"
+        mirror_name = "new-mirror"
+        self.topics = {topic: {"partitions": 1, "replication-factor": 2},}
+
+        self.setup_source(KafkaVersion(source_version), metadata_quorum)
+        self.setup_dest()
+
+        self.source_kafka.create_topic({
+            "topic": topic, "partitions": 1, "replication-factor": 2,
+            "configs": {"unclean.leader.election.enable": "true"},
+        })
+
+        src_broker0 = self.source_kafka.nodes[0]
+        src_broker1 = self.source_kafka.nodes[1]
+
+        def broker_bootstrap(node):
+            """Return bootstrap server address for a single broker node."""
+            return "%s:9092" % node.account.hostname
+
+        self.logger.info("Bounce source brokers to trigger leader elections")
+        self.source_kafka.restart_cluster(clean_shutdown=True)
+
+        self.logger.info("Send 1 message via source broker 0")
+        self.produce_records(self.source_kafka, topic, 1, self.source_client_node,
+                             bootstrap_servers=broker_bootstrap(src_broker0))
+
+        self.logger.info("Start cluster mirror on destination")
+        mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
+
+        wait_until(
+            lambda: self.dest_kafka.create_cluster_mirror(
+                self.dest_client_node, mirror_name, mirror_cfg),
+            timeout_sec=60, backoff_sec=2,
+            err_msg="Failed to create cluster mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
+                self.dest_client_node, mirror_name, topic),
+            timeout_sec=60, backoff_sec=2,
+            err_msg="Failed to start mirror topics",
+        )
+        self.wait_mirror_state(
+            self.dest_kafka, mirror_name, "MIRRORING", [topic],
+            err_msg="Mirror did not reach MIRRORING state",
+        )
+
+        self.logger.info("Stop source broker 0 (broker 0 becomes stale)")
+        self.source_kafka.stop_node(src_broker0)
+
+        self.logger.info("Send 1 message via source broker 1")
+        self.produce_records(self.source_kafka, topic, 1, self.source_client_node,
+                             bootstrap_servers=broker_bootstrap(src_broker1))
+        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic],
+                                  err_msg="Mirror did not catch up after broker 0 stopped")
+        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, self.topics)
+
+        self.logger.info("ULE 1: stop broker 1, start broker 0 (stale), elect it as leader")
+        self.source_kafka.stop_node(src_broker1)
+        self.source_kafka.start_node(src_broker0)
+        time.sleep(5)
+
+        self.logger.info("Send 2 messages via source broker 0")
+        self.produce_records(self.source_kafka, topic, 2, self.source_client_node,
+                             bootstrap_servers=broker_bootstrap(src_broker0))
+        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic],
+                                  err_msg="Mirror did not catch up after ULE 1")
+
+        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, self.topics)
+
+        self.logger.info("Failover: stop mirror so destination topic becomes writable")
+        self.dest_kafka.stop_cluster_mirror_topics(self.dest_client_node, mirror_name, topic)
+        self.wait_mirror_state(self.dest_kafka, mirror_name, "STOPPED", [topic])

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -123,7 +123,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
         client_node.account.ssh(
             "pkill -SIGKILL -f '%s' || true" % pattern, allow_fail=True)
 
-
     @staticmethod
     def broker_bootstrap(node):
         """Return bootstrap server address for a single broker node."""

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -124,11 +124,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
             "pkill -SIGKILL -f '%s' || true" % pattern, allow_fail=True)
 
     @staticmethod
-    def broker_bootstrap(node):
-        """Return bootstrap server address for a single broker node."""
-        return "%s:9092" % node.account.hostname
-
-    @staticmethod
     def consume_share_records(logger, kafka, client_node, topic, group,
                               max_messages=None, timeout_ms=30000,
                               expected_count=None, wait_timeout_sec=240):
@@ -196,7 +191,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
         """Trigger unclean leader election on the given node."""
         cmd = "%s --bootstrap-server %s --topic %s --partition 0 --election-type UNCLEAN" % (
             source_kafka.path.script("kafka-leader-election.sh", client_node),
-            ClusterMirroringTest.broker_bootstrap(node), topic)
+            MirrorUtils.broker_bootstrap(node), topic)
         try:
             client_node.account.ssh(cmd, allow_fail=False)
             return True
@@ -807,7 +802,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
         self.logger.info("Send 1 message via source broker 0")
         MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.client_node,
-                             bootstrap_servers=ClusterMirroringTest.broker_bootstrap(src_broker0))
+                             bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker0))
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -834,7 +829,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
         self.logger.info("Send 1 message via source broker 1")
         MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.client_node,
-                             bootstrap_servers=ClusterMirroringTest.broker_bootstrap(src_broker1))
+                             bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker1))
         MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic],
                                   err_msg="Mirror did not catch up after broker 0 stopped")
         ClusterMirroringTest.log_hashes(
@@ -852,7 +847,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
         self.logger.info("Send 2 messages via source broker 0")
         MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 2, self.client_node,
-                             bootstrap_servers=ClusterMirroringTest.broker_bootstrap(src_broker0))
+                             bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker0))
         MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic],
                                   err_msg="Mirror did not catch up after ULE 1")
         ClusterMirroringTest.log_hashes(
@@ -879,7 +874,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
         self.logger.info("Send 6 messages via source broker 1")
         MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 6, self.client_node,
-                             bootstrap_servers=ClusterMirroringTest.broker_bootstrap(src_broker1))
+                             bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker1))
         ClusterMirroringTest.log_hashes(
             self.logger, self.source_kafka, self.dest_kafka, topic,
             "After ULE 2 (broker 1 should have the most up to date data)")


### PR DESCRIPTION
For mirroring, always assume `isTruncationOnFetchSupported == false` and start with traditional way to do offsetForLeaderEpoch request and log truncation. We can't do this after this first fetch response received because the the fetcher might handle fetch response in unexpected way already. For example, the old source returns OUT_OF_RANGE error and return the current high watermark to the fetcher. The fetcher will truncate the to high watermark accordingly, which is not expected. We should truncate based on leader epoch to find the diverging point, instead of the offset.

Added system test for old kafka ULE.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
