### PR TITLE
Remove sleep and use static methods in STs

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -2185,8 +2185,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         return self.run_cli_tool(node, cmd)
 
     def parse_describe_cluster_mirror(self, cluster_mirror_description):
-        """Parse output of kafka-cluster-mirrors.sh --describe (or describe_cluster_mirror() method above), which is a string of form
-        """
+        """Parse output of kafka-cluster-mirrors.sh --describe"""
         parsed = json.loads(cluster_mirror_description)
         mirrors = {}
         for item in parsed:

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -41,6 +41,7 @@ class ClientService(KafkaPathResolverMixin, Service):
         pass
 
     def stop_node(self, node):
+        # kill any hanging or backgroung client
         node.account.ssh("pkill -SIGKILL -f 'kafka\\.tools\\.' || true", allow_fail=True)
 
     def clean_node(self, node):
@@ -93,9 +94,10 @@ class MirrorConfig:
 
 
 class MirrorUtils:
-    """Shared helpers for cluster mirroring tests."""
+    """Shared helpers for Cluster Mirroring tests."""
 
-    def produce_records(self, kafka, topic, num_records, client_node,
+    @staticmethod
+    def produce_records(logger, kafka, topic, num_records, client_node,
                         bootstrap_servers=None):
         """Produce records on a client node using kafka-producer-perf-test."""
         if bootstrap_servers is None:
@@ -111,9 +113,10 @@ class MirrorUtils:
         output = ""
         for line in client_node.account.ssh_capture(cmd, allow_fail=True):
             output += line
-        self.logger.debug("Producer output for %s:\n%s", topic, output.strip())
+        logger.debug("Producer output for %s:\n%s", topic, output.strip())
 
-    def consume_records(self, kafka, topic, client_node, max_messages=None,
+    @staticmethod
+    def consume_records(logger, kafka, topic, client_node, max_messages=None,
                         timeout_ms=30000, isolation_level=None, group=None,
                         from_beginning=True, expected_count=None,
                         wait_timeout_sec=240):
@@ -140,8 +143,8 @@ class MirrorUtils:
             for line in client_node.account.ssh_capture(cmd, allow_fail=True):
                 if line.strip():
                     count[0] += 1
-            self.logger.info("Consumed %d records from %s so far (expected %s)",
-                             count[0], topic, expected_count)
+            logger.info("Consumed %d records from %s so far (expected %s)",
+                        count[0], topic, expected_count)
             return expected_count is None or count[0] >= expected_count
 
         # When expected_count is set, retry consumption because the high watermark on
@@ -156,9 +159,10 @@ class MirrorUtils:
             try_consume()
         return count[0]
 
-    def all_satisfy_in_mirror(self, kafka, mirror_name, per_partition_condition, topics):
+    @staticmethod
+    def all_satisfy_in_mirror(logger, kafka, client_node, mirror_name, per_partition_condition, topics):
         """Check that all partitions of the given mirror topics satisfy the condition."""
-        output = kafka.describe_cluster_mirror(kafka.nodes[0])
+        output = kafka.describe_cluster_mirror(client_node)
         if output == "":
             return False
 
@@ -166,6 +170,8 @@ class MirrorUtils:
             mirrors = kafka.parse_describe_cluster_mirror(output)
         except (json.JSONDecodeError, KeyError):
             return False
+
+        logger.debug("describe_cluster_mirror: %s", mirrors)
         if mirror_name not in mirrors:
             return False
         mirror = mirrors[mirror_name]
@@ -179,44 +185,44 @@ class MirrorUtils:
                     return False
         return True
 
-    def wait_mirror_state(self, kafka, mirror_name, state, topics,
-                          err_msg=None):
+    @staticmethod
+    def wait_mirror_state(logger, kafka, client_node, mirror_name, state,
+                          topics, err_msg=None):
         """Wait until all mirror partitions reach the given state."""
         def check():
-            self.logger.debug("describe_cluster_mirror: %s",
-                              kafka.describe_cluster_mirror(kafka.nodes[0]))
-            return self.all_satisfy_in_mirror(
-                kafka, mirror_name,
+            return MirrorUtils.all_satisfy_in_mirror(logger,
+                kafka, client_node, mirror_name,
                 lambda p: p["state"] == state, topics)
         if err_msg is None:
             err_msg = "Mirror did not reach %s state" % state
         wait_until(check, timeout_sec=300, backoff_sec=2, err_msg=err_msg)
 
-    def wait_for_metadata_sync(self, kafka, mirror_name, num_cycles=1):
+    @staticmethod
+    def wait_for_metadata_sync(logger, kafka, client_node, mirror_name, num_cycles=1):
         """Wait for metadata sync by sleeping based on the configured refresh interval."""
-        output = kafka.describe_mirror_config(kafka.nodes[0], mirror_name)
+        output = kafka.describe_mirror_config(client_node, mirror_name)
         interval_ms = 30000
         for line in output.splitlines():
             if "mirror.metadata.refresh.interval.ms=" in line:
                 interval_ms = int(line.strip().split()[0].split("=")[1])
                 break
         sleep_s = (interval_ms // 1000) * num_cycles + 2
-        self.logger.info("Waiting %ds for %d metadata sync cycle(s) (interval=%dms)",
-                         sleep_s, num_cycles, interval_ms)
+        logger.info("Waiting %ds for %d metadata sync cycle(s) (interval=%dms)",
+                    sleep_s, num_cycles, interval_ms)
         time.sleep(sleep_s)
 
-    def wait_mirror_lag_zero(self, kafka, mirror_name, topics,
-                             err_msg="Mirror did not catch up"):
+    @staticmethod
+    def wait_mirror_lag_zero(logger, kafka, client_node, mirror_name,
+                             topics, err_msg="Mirror did not catch up"):
         """Wait until all mirror partitions reach MIRRORING state with zero lag."""
         def check():
-            self.logger.debug("describe_cluster_mirror: %s",
-                              kafka.describe_cluster_mirror(kafka.nodes[0]))
-            return self.all_satisfy_in_mirror(
-                kafka, mirror_name,
+            return MirrorUtils.all_satisfy_in_mirror(logger,
+                kafka, client_node, mirror_name,
                 lambda p: p["lag"] == 0 and p["state"] == "MIRRORING", topics)
         wait_until(check, timeout_sec=300, backoff_sec=5, err_msg=err_msg)
 
-    def describe_consumer_group(self, kafka, group, client_node):
+    @staticmethod
+    def describe_consumer_group(kafka, group, client_node):
         """Describe a consumer group on a client node with security support."""
         env_prefix, cmd_suffix = kafka._cmd_security_opts(client_node)
         cmd = "%s%s --bootstrap-server %s --group %s --describe%s" % (
@@ -231,7 +237,8 @@ class MirrorUtils:
                 output += line
         return output
 
-    def wait_for_log_convergence(self, source_kafka, dest_kafka, topics):
+    @staticmethod
+    def wait_for_log_convergence(logger, source_kafka, dest_kafka, topics):
         """Poll until source leader and all dest replica log segment hashes match."""
         def log_segment_hashes(node, topic, partition):
             cmd = "md5sum %s*/%s-%d/*.log 2>/dev/null" % (
@@ -253,8 +260,8 @@ class MirrorUtils:
                         if source.keys() != dest.keys() or any(
                                 source[seg] != dest[seg] for seg in source):
                             return False
-                        self.logger.info("Hashes match for %s-%d dest %s: %d segments verified",
-                                         topic, partition, node.name, len(source))
+                        logger.info("Hashes match for %s-%d dest %s: %d segments verified",
+                                    topic, partition, node.name, len(source))
             return True
 
         wait_until(

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_acls_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_acls_test.py
@@ -146,7 +146,8 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             "upgrade", "mirror.version", CLUSTER_MIRRORING_VERSION
         )
 
-    def create_mirror_config(self, source_kafka):
+    @staticmethod
+    def create_mirror_config(source_kafka):
         mirror_cfg = MirrorConfig(
             source_kafka.bootstrap_servers(source_kafka.security_protocol),
             security_config=source_kafka.security_config,
@@ -156,7 +157,8 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             'username="kafka" password="kafka-secret";'
         return mirror_cfg
 
-    def run_acl_cmd(self, kafka, args, client_node):
+    @staticmethod
+    def run_acl_cmd(kafka, args, client_node):
         if kafka.zk is not None:
             cmd = "%s --authorizer-properties zookeeper.connect=%s %s" % (
                 kafka.path.script("kafka-acls.sh", client_node),
@@ -165,7 +167,8 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             cmd = "%s %s" % (kafka.kafka_acls_cmd_with_optional_security_settings(client_node), args)
         return kafka.run_cli_tool(client_node, cmd)
 
-    def produce_as_client(self, kafka, topic, num_records, client_node):
+    @staticmethod
+    def produce_as_client(logger, kafka, topic, num_records, client_node):
         client_env = "KAFKA_OPTS='-D%s -D%s' " % (
             KafkaService.JAAS_CONF_PROPERTY, KafkaService.KRB5_CONF)
         client_props = str(kafka.security_config.client_config(
@@ -181,9 +184,10 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
         output = ""
         for line in client_node.account.ssh_capture(cmd, allow_fail=False):
             output += line
-        self.logger.debug("Producer output for %s:\n%s", topic, output.strip())
+        logger.debug("Producer output for %s:\n%s", topic, output.strip())
 
-    def consume_as_client(self, kafka, topic, client_node, max_messages,
+    @staticmethod
+    def consume_as_client(logger, kafka, topic, client_node, max_messages,
                           group=None, timeout_ms=30000, expected_count=None,
                           wait_timeout_sec=240):
         client_env = "KAFKA_OPTS='-D%s -D%s' " % (
@@ -205,8 +209,8 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             for line in client_node.account.ssh_capture(cmd, allow_fail=True):
                 if line.strip():
                     count[0] += 1
-            self.logger.debug("Consumed %d records from %s so far (expected %s)",
-                              count[0], topic, expected_count)
+            logger.debug("Consumed %d records from %s so far (expected %s)",
+                         count[0], topic, expected_count)
             return expected_count is None or count[0] >= expected_count
 
         # When expected_count is set, retry consumption because the high watermark on
@@ -221,13 +225,14 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             try_consume()
         return count[0]
 
-    def list_acls(self, kafka, client_node):
-        return self.run_acl_cmd(kafka, "--list", client_node)
+    @staticmethod
+    def list_acls(kafka, client_node):
+        return ClusterMirroringCompAclsTest.run_acl_cmd(kafka, "--list", client_node)
 
     def wait_for_acl_condition(self, kafka, mirror_name, condition, err_msg, client_node):
-        self.wait_for_metadata_sync(kafka, mirror_name)
+        MirrorUtils.wait_for_metadata_sync(self.logger, kafka, client_node, mirror_name)
         def check():
-            dest_acls = self.list_acls(kafka, client_node)
+            dest_acls = ClusterMirroringCompAclsTest.list_acls(kafka, client_node)
             self.logger.debug("Destination ACLs:\n%s" % dest_acls)
             return condition(dest_acls)
         wait_until(check, timeout_sec=300, backoff_sec=5, err_msg=err_msg)
@@ -253,27 +258,26 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             self.source_kafka.create_topic({"topic": t, **cfg})
 
         self.logger.info("Granting ACLs on source cluster")
-        self.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
                          "--add --allow-principal User:client --operation READ --topic my-topic-a",
                          self.source_client_node)
-        self.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
                          "--add --allow-principal User:client --operation WRITE --topic my-topic-a",
                          self.source_client_node)
-        self.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
                          "--add --allow-principal User:client --operation READ --group my-group",
                          self.source_client_node)
-        self.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
                          "--add --allow-principal User:other-client --operation READ --topic new-topic",
                          self.source_client_node)
-        time.sleep(5)
 
         self.logger.info("Producing 10 records to my-topic-a as client user")
-        self.produce_as_client(self.source_kafka, "my-topic-a",
-                               10, self.source_client_node)
+        ClusterMirroringCompAclsTest.produce_as_client(self.logger, self.source_kafka, "my-topic-a",
+                                                       10, self.source_client_node)
 
         self.logger.info("Creating and starting cluster mirror with ACL include filter")
         mirror_name = "my-mirror"
-        mirror_cfg = self.create_mirror_config(self.source_kafka)
+        mirror_cfg = ClusterMirroringCompAclsTest.create_mirror_config(self.source_kafka)
         mirror_cfg.properties["mirror.acl.include"] = "TOPIC;my-topic-.*,GROUP;my-group"
 
         wait_until(
@@ -290,14 +294,14 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
                 err_msg="Failed to start mirror topics for %s" % regex,
             )
         self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag")
-        self.wait_mirror_lag_zero(
-            self.dest_kafka, mirror_name, topics=list(topics.keys()))
+        MirrorUtils.wait_mirror_lag_zero(self.logger,
+            self.dest_kafka, self.dest_client_node, mirror_name, topics=list(topics.keys()))
 
         # Retry consuming because the HW may lag behind mirror lag reaching zero.
         self.logger.info("Consuming 10 records from my-topic-a on destination as client user")
-        count = self.consume_as_client(self.dest_kafka, "my-topic-a",
-                                       self.dest_client_node, max_messages=10,
-                                       group="my-group", expected_count=10)
+        count = ClusterMirroringCompAclsTest.consume_as_client(self.logger, self.dest_kafka, "my-topic-a",
+                                                               self.dest_client_node, max_messages=10,
+                                                               group="my-group", expected_count=10)
         assert count >= 10, "Expected 10 records on my-topic-a, got %d" % count
 
         self.logger.info("Verifying ACL filtering: my-topic-a ACL synced, new-topic ACL filtered out")
@@ -307,16 +311,16 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             "Client READ ACL on my-topic-a should be synced (matches include rule)",
             self.dest_client_node)
 
-        dest_acls = self.list_acls(self.dest_kafka, self.dest_client_node)
+        dest_acls = ClusterMirroringCompAclsTest.list_acls(self.dest_kafka, self.dest_client_node)
         assert "User:other-client" not in dest_acls and "new-topic" not in dest_acls, \
             "Other-client READ ACL on new-topic should not be synced (filtered out)"
 
         self.logger.info("Removing my-topic-a ACLs from source cluster")
-        self.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
                          "--remove --allow-principal User:client --operation READ "
                          "--topic my-topic-a --force",
                          self.source_client_node)
-        self.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
                          "--remove --allow-principal User:client --operation WRITE "
                          "--topic my-topic-a --force",
                          self.source_client_node)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_acls_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_acls_test.py
@@ -85,6 +85,7 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             self.zk.stop()
 
     def setup_source(self, source_version, metadata_quorum):
+        # Separate client node with matching CLI version for the older source cluster.
         self.source_client = ClientService(self.test_context, version=source_version)
         self.source_client.start()
         self.source_client_node = self.source_client.nodes[0]
@@ -119,6 +120,7 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
         self.source_client.setup_security(self.source_kafka.security_config)
 
     def setup_dest(self):
+        # Separate client node with DEV_BRANCH CLI for the destination cluster.
         self.dest_client = ClientService(self.test_context)
         self.dest_client.start()
         self.dest_client_node = self.dest_client.nodes[0]

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -146,10 +146,10 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
 
         self.logger.info("Producing %d records to each source topic", num_records)
         for t in topics:
-            self.produce_records(self.source_kafka, t, num_records, self.source_client_node)
+            MirrorUtils.produce_records(self.logger, self.source_kafka, t, num_records, self.source_client_node)
 
         self.logger.info("Creating consumer group on source by consuming my-topic-a")
-        self.consume_records(self.source_kafka, "my-topic-a", self.source_client_node,
+        MirrorUtils.consume_records(self.logger, self.source_kafka, "my-topic-a", self.source_client_node,
                              max_messages=num_records, group="my-group")
 
         self.logger.info("Setting dynamic topic config on source")
@@ -173,25 +173,24 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
                 err_msg="Failed to start mirror topics for %s" % regex,
             )
         self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag")
-        self.wait_mirror_lag_zero(
-            self.dest_kafka, mirror_name, topics=list(topics.keys()))
+        MirrorUtils.wait_mirror_lag_zero(self.logger,
+            self.dest_kafka, self.dest_client_node, mirror_name, topics=list(topics.keys()))
 
-        self.logger.info("Shutting down the leader of one topic, and send more records and make sure the mirror can still work.")
+        self.logger.info("Shutting down the leader of one topic, and send more records to make sure the mirror can still work.")
         leader_node = self.source_kafka.leader("my-topic-b", 0)
         self.source_kafka.stop_node(leader_node, clean_shutdown=False)
 
         self.logger.info("Producing %d more records to each source topic", num_records)
         for t in topics:
-            self.produce_records(self.source_kafka, t, num_records, self.source_client_node)
+            MirrorUtils.produce_records(self.logger, self.source_kafka, t, num_records, self.source_client_node)
 
         self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag after one source node down")
-        self.wait_mirror_lag_zero(
-            self.dest_kafka, mirror_name, topics=list(topics.keys()))
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.dest_client_node, mirror_name, topics=list(topics.keys()))
 
         self.logger.info("Verifying consumer group offset sync")
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.dest_client_node, mirror_name, num_cycles=2)
         wait_until(
-            lambda: "my-topic-a" in self.describe_consumer_group(
+            lambda: "my-topic-a" in MirrorUtils.describe_consumer_group(
                 self.dest_kafka, "my-group", self.dest_client_node),
             timeout_sec=60, backoff_sec=5,
             err_msg="Expected my-topic-a offset to be synced on destination",
@@ -206,12 +205,12 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         for regex in ["my-topic.*", "new-topic"]:
             self.dest_kafka.stop_cluster_mirror_topics(
                 self.dest_client_node, mirror_name, regex)
-        self.wait_mirror_state(
-            self.dest_kafka, mirror_name, "STOPPED",
+        MirrorUtils.wait_mirror_state(self.logger,
+            self.dest_kafka, self.dest_client_node, mirror_name, "STOPPED",
             topics=list(topics.keys()))
 
         self.logger.info("Verifying destination records after failover")
         for topic in topics:
-            count = self.consume_records(self.dest_kafka, topic, self.dest_client_node,
+            count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.dest_client_node,
                                          max_messages=num_records, expected_count=num_records)
             assert count >= num_records, "Expected %d records on %s, got %d" % (num_records, topic, count)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -76,6 +76,7 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
             self.zk.stop()
 
     def setup_source(self, source_version, metadata_quorum):
+        # Separate client node with matching CLI version for the older source cluster.
         self.source_client = ClientService(self.test_context, version=source_version)
         self.source_client.start()
         self.source_client_node = self.source_client.nodes[0]
@@ -99,6 +100,7 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
         self.source_kafka.start()
 
     def setup_dest(self):
+        # Separate client node with DEV_BRANCH CLI for the destination cluster.
         self.dest_client = ClientService(self.test_context)
         self.dest_client.start()
         self.dest_client_node = self.dest_client.nodes[0]

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -34,6 +34,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
     def __init__(self, test_context):
         """:type test_context: ducktape.tests.test.TestContext"""
         super(ClusterMirroringTest, self).__init__(test_context)
+        # Single client node shared by both clusters (same DEV_BRANCH version).
         self.client = ClientService(test_context)
         server_props = [
             ["auto.create.topics.enable", "false"],

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -15,6 +15,7 @@
 
 import time
 
+from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.mark.resource import cluster
 from ducktape.mark import defaults
 from ducktape.tests.test import Test
@@ -76,7 +77,6 @@ class ClusterMirroringTest(MirrorUtils, Test):
                 "upgrade", "mirror.version", CLUSTER_MIRRORING_VERSION
             )
 
-
     def teardown(self):
         self.client.stop()
         for kafka in [self.dest_kafka, self.source_kafka]:
@@ -87,12 +87,53 @@ class ClusterMirroringTest(MirrorUtils, Test):
                 for node in kafka.nodes:
                     kafka.stop_node(node, clean_shutdown=False)
 
-    def consume_share_records(self, topic, kafka, group, max_messages=None, timeout_ms=30000,
+    @staticmethod
+    def run_background_producer(kafka, client_node, topic, num_records,
+                                throughput=10):
+        """Start a background producer."""
+        cmd = "%s --topic %s --num-records %d --record-size 1 --throughput %d" \
+              " --producer-props bootstrap.servers=%s" % (
+                  kafka.path.script("kafka-producer-perf-test.sh", client_node),
+                  topic, num_records, throughput,
+                  kafka.bootstrap_servers(kafka.security_protocol))
+        client_node.account.ssh("nohup %s >/dev/null 2>&1 &" % cmd, allow_fail=True)
+
+    @staticmethod
+    def run_background_consumer(kafka, client_node, topic, group):
+        """Start a background console consumer."""
+        cmd = "%s --bootstrap-server %s --topic %s --group %s" % (
+            kafka.path.script("kafka-console-consumer.sh", client_node),
+            kafka.bootstrap_servers(kafka.security_protocol),
+            topic, group)
+        client_node.account.ssh("nohup %s >/dev/null 2>&1 &" % cmd, allow_fail=True)
+
+    @staticmethod
+    def run_background_share_consumer(kafka, client_node, topic, group):
+        """Start a background console share consumer."""
+        cmd = "%s --bootstrap-server %s --topic %s --group %s" % (
+            kafka.path.script("kafka-console-share-consumer.sh", client_node),
+            kafka.bootstrap_servers(kafka.security_protocol),
+            topic, group)
+        client_node.account.ssh("nohup %s >/dev/null 2>&1 &" % cmd, allow_fail=True)
+
+    @staticmethod
+    def kill_background_process(client_node, pattern):
+        """Kill background processes matching the given pattern."""
+        client_node.account.ssh(
+            "pkill -SIGKILL -f '%s' || true" % pattern, allow_fail=True)
+
+
+    @staticmethod
+    def broker_bootstrap(node):
+        """Return bootstrap server address for a single broker node."""
+        return "%s:9092" % node.account.hostname
+
+    @staticmethod
+    def consume_share_records(logger, kafka, client_node, topic, group,
+                              max_messages=None, timeout_ms=30000,
                               expected_count=None, wait_timeout_sec=240):
-        # When expected_count is set, retry consumption because the high watermark on
-        # destination replicas may not have advanced yet when mirror lag reaches zero.
         cmd = "%s --bootstrap-server %s --topic %s --group %s --timeout-ms %d" % (
-            kafka.path.script("kafka-console-share-consumer.sh", self.client_node),
+            kafka.path.script("kafka-console-share-consumer.sh", client_node),
             kafka.bootstrap_servers(kafka.security_protocol),
             topic, group, timeout_ms)
         if max_messages is not None:
@@ -100,61 +141,123 @@ class ClusterMirroringTest(MirrorUtils, Test):
         cmd += " 2>/dev/null"
 
         count = [0]
-        def _try_consume():
-            for line in self.client_node.account.ssh_capture(cmd, allow_fail=True):
+        def try_consume():
+            for line in client_node.account.ssh_capture(cmd, allow_fail=True):
                 if line.strip():
                     count[0] += 1
-            self.logger.debug("Share-consumed %d records from %s so far (expected %s)",
-                              count[0], topic, expected_count)
+            logger.debug("Share-consumed %d records from %s so far (expected %s)",
+                         count[0], topic, expected_count)
             return expected_count is None or count[0] >= expected_count
 
         if expected_count is not None:
             deadline = time.time() + wait_timeout_sec
-            _try_consume()
+            try_consume()
             while count[0] < expected_count:
                 if time.time() >= deadline:
                     raise AssertionError(
                         "Expected %d records on %s, got %d" % (expected_count, topic, count[0]))
                 time.sleep(5)
-                _try_consume()
+                try_consume()
         else:
-            _try_consume()
+            try_consume()
         return count[0]
 
-    def run_background_consumer(self, kafka, topic, group):
-        """Start a background console consumer."""
-        cmd = "%s --bootstrap-server %s --topic %s --group %s" % (
-            kafka.path.script("kafka-console-consumer.sh", self.client_node),
+    @staticmethod
+    def get_end_offsets(kafka, client_node, topic, time=-1):
+        """Run kafka-get-offsets and return a {partition: offset} dict."""
+        cmd = "%s --bootstrap-server %s --topic %s --time %s" % (
+            kafka.path.script("kafka-get-offsets.sh", client_node),
             kafka.bootstrap_servers(kafka.security_protocol),
-            topic, group)
-        self.client_node.account.ssh("nohup %s >/dev/null 2>&1 &" % cmd, allow_fail=True)
+            topic, time)
+        offsets = {}
+        for line in client_node.account.ssh_capture(cmd, allow_fail=True):
+            parts = line.strip().split(":")
+            if len(parts) == 3:
+                offsets[int(parts[1])] = int(parts[2])
+        return offsets
 
-    def run_background_share_consumer(self, kafka, topic, group):
-        """Start a background console share consumer."""
-        cmd = "%s --bootstrap-server %s --topic %s --group %s" % (
-            kafka.path.script("kafka-console-share-consumer.sh", self.client_node),
-            kafka.bootstrap_servers(kafka.security_protocol),
-            topic, group)
-        self.client_node.account.ssh("nohup %s >/dev/null 2>&1 &" % cmd, allow_fail=True)
+    @staticmethod
+    def parse_topic_configs(desc):
+        """Extract topic configs from kafka-topics describe output."""
+        for line in desc.splitlines():
+            if "Configs:" in line:
+                configs_str = line.split("Configs:")[1].strip()
+                if not configs_str:
+                    return {}
+                result = {}
+                for pair in configs_str.split(","):
+                    k, v = pair.strip().split("=", 1)
+                    result[k] = v
+                return result
+        return {}
 
-    def get_offset_shell(self, kafka, topic=None, time=None):
-        """Run kafka-get-offsets on the client node."""
-        cmd = "%s --bootstrap-server %s" % (
-            kafka.path.script("kafka-get-offsets.sh", self.client_node),
-            kafka.bootstrap_servers(kafka.security_protocol))
-        if time is not None:
-            cmd += " --time %s" % time
-        if topic is not None:
-            cmd += " --topic %s" % topic
-        output = ""
-        for line in self.client_node.account.ssh_capture(cmd, allow_fail=True):
-            output += line
-        return output
+    @staticmethod
+    def trigger_ule(source_kafka, client_node, node, topic):
+        """Trigger unclean leader election on the given node."""
+        cmd = "%s --bootstrap-server %s --topic %s --partition 0 --election-type UNCLEAN" % (
+            source_kafka.path.script("kafka-leader-election.sh", client_node),
+            ClusterMirroringTest.broker_bootstrap(node), topic)
+        try:
+            client_node.account.ssh(cmd, allow_fail=False)
+            return True
+        except RemoteCommandError:
+            return False
 
-    def kill_background_consumer(self, node, process_class):
-        """Kill a background consumer process by class name."""
-        node.account.ssh(
-            "pkill -SIGKILL -f '%s' || true" % process_class, allow_fail=True)
+    @staticmethod
+    def log_hashes(logger, source_kafka, dest_kafka, topic, label):
+        """Log MD5 hashes of partition log segments for all brokers across both clusters."""
+        logger.info("#### %s-0 %s ####", topic, label)
+        for name, kafka in [("source", source_kafka), ("dest", dest_kafka)]:
+            for node in kafka.nodes:
+                cmd = "md5sum %s*/%s-0/*.log 2>/dev/null" % (
+                    KafkaService.DATA_LOG_DIR_PREFIX, topic)
+                lines = list(node.account.ssh_capture(cmd, allow_fail=True))
+                if lines:
+                    for line in lines:
+                        logger.info("%s %s: %s", name, node.name, line.strip())
+                else:
+                    logger.info("%s %s: n/a", name, node.name)
+
+    @staticmethod
+    def run_txn_producer(client_node, kafka, topic, transactional_id=None, mode="commit",
+                         num_records=1, waiting_ms=0, background=False):
+        """Run TransactionalTestProducer."""
+        cmd = kafka.path.script("kafka-run-class.sh", client_node)
+        cmd += " org.apache.kafka.tools.TransactionalTestProducer"
+        cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
+        cmd += " --topic %s" % topic
+        if transactional_id is not None:
+            cmd += " --transactional-id %s" % transactional_id
+            cmd += " --mode %s" % mode
+            if waiting_ms > 0:
+                cmd += " --waiting-ms %s" % str(waiting_ms)
+        cmd += " --num-records %s" % str(num_records)
+        if background:
+            cmd += " &"
+        client_node.account.ssh(cmd, allow_fail=False)
+
+    @staticmethod
+    def count_ongoing_txns(client_node, kafka, topic, topics):
+        """Count ongoing transactions across all partitions of a topic."""
+        count = 0
+        for partition in range(topics[topic]["partitions"]):
+            cmd = kafka.path.script("kafka-transactions.sh", client_node)
+            cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
+            cmd += " describe-producers --topic %s --partition %d" % (topic, partition)
+            for line in client_node.account.ssh_capture(cmd, allow_fail=True):
+                fields = line.strip().split()
+                if fields and fields[-1] != "None" and fields[-1] != "CurrentTransactionStartOffset":
+                    count += 1
+        return count
+
+    @staticmethod
+    def parse_group_offset(desc, topic):
+        """Parse describe consumer/share group output and return the offset for a topic."""
+        for line in desc.strip().splitlines():
+            fields = line.split()
+            if len(fields) >= 4 and fields[1] == topic:
+                return int(fields[3])
+        return None
 
 
     @cluster(num_nodes=7)
@@ -166,7 +269,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
 
         self.logger.info("Send 3 records to source")
-        self.produce_records(self.source_kafka, topic, 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -183,28 +286,28 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
 
         self.logger.info("Consume from destination (expect 3 records)")
-        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=3,
                                      expected_count=3)
         assert count >= 3, "Expected 3 records on %s, got %d" % (topic, count)
 
         self.logger.info("Produce to destination while mirroring (should fail)")
-        self.produce_records(self.dest_kafka, topic, 1, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.dest_kafka, topic, 1, self.client_node)
 
         self.logger.info("Failover: stop mirror so destination topic becomes writable")
         self.dest_kafka.stop_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "STOPPED", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
 
         self.logger.info("Send 1 record to destination (should work now)")
-        self.produce_records(self.dest_kafka, topic, 1, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.dest_kafka, topic, 1, self.client_node)
 
         self.logger.info("Send 2 more records to source (not mirrored)")
-        self.produce_records(self.source_kafka, topic, 2, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 2, self.client_node)
 
         self.logger.info("Consume from source (expect 5 records)")
-        count = self.consume_records(self.source_kafka, topic, self.client_node, max_messages=5,
+        count = MirrorUtils.consume_records(self.logger, self.source_kafka, topic, self.client_node, max_messages=5,
                                      expected_count=5)
         assert count >= 5, "Expected 5 records on %s, got %d" % (topic, count)
 
@@ -223,10 +326,10 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start reverse mirror topics",
         )
-        self.wait_mirror_lag_zero(self.source_kafka, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.source_kafka, self.client_node, mirror_name, [topic])
 
         self.logger.info("Consume from source (non-mirrored data should be truncated)")
-        count = self.consume_records(self.source_kafka, topic, self.client_node,
+        count = MirrorUtils.consume_records(self.logger, self.source_kafka, topic, self.client_node,
                                      max_messages=5, timeout_ms=5000, expected_count=4)
         assert count >= 4, "Expected 4 records on %s, got %d" % (topic, count)
 
@@ -239,7 +342,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
 
         self.logger.info("Send 3 records to source")
-        self.produce_records(self.source_kafka, topic, 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -256,28 +359,28 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
 
         self.logger.info("Pause mirroring and send 1 more record to source")
         self.dest_kafka.pause_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        self.produce_records(self.source_kafka, topic, 1, self.client_node)
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "PAUSED", [topic])
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.client_node)
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "PAUSED", [topic])
 
         self.logger.info("Consume from destination while paused (expect 3, the 4th is not mirrored yet)")
-        count = self.consume_records(self.dest_kafka, topic, self.client_node,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node,
                                      max_messages=4, timeout_ms=5000)
         assert count == 3, "Expected 3 records on destination while paused, got %d" % count
 
         self.logger.info("Produce to destination while paused (should fail)")
-        self.produce_records(self.dest_kafka, topic, 1, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.dest_kafka, topic, 1, self.client_node)
 
         self.logger.info("Resume mirroring and wait for it to catch up")
         self.dest_kafka.resume_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING", [topic])
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
 
         self.logger.info("Consume from destination (expect 4 records after resume)")
-        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=4,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=4,
                                      expected_count=4)
         assert count >= 4, "Expected 4 records on %s, got %d" % (topic, count)
 
@@ -304,7 +407,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
 
         self.logger.info("describe_mirror_config: %s",
                          self.dest_kafka.describe_mirror_config(self.client_node, mirror_name))
@@ -329,13 +432,13 @@ class ClusterMirroringTest(MirrorUtils, Test):
                          self.dest_kafka.describe_cluster_mirror(self.client_node))
 
         self.logger.info("Verify mirroring still works after config change")
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
 
         self.logger.info("Send records to source and verify they arrive at destination")
-        self.produce_records(self.source_kafka, topic, 3, self.client_node)
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
 
-        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=3,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=3,
                                      expected_count=3)
         assert count >= 3, "Expected 3 records on %s, got %d" % (topic, count)
 
@@ -362,7 +465,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
 
         self.logger.info("Delete mirror while not empty (should fail)")
         self.dest_kafka.delete_cluster_mirror(self.client_node, mirror_name)
@@ -371,7 +474,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
         self.logger.info("Stop mirror topics and wait for STOPPED state")
         self.dest_kafka.stop_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "STOPPED", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
 
         self.logger.info("Delete mirror (should work now)")
         self.dest_kafka.delete_cluster_mirror(self.client_node, mirror_name)
@@ -401,14 +504,14 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
 
         self.logger.info("Delete topic on source and wait for metadata sync")
         self.source_kafka.delete_topic(topic)
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name)
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name)
 
         self.logger.info("Verify mirror partitions transitioned to STOPPED")
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "STOPPED", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -427,10 +530,10 @@ class ClusterMirroringTest(MirrorUtils, Test):
             self.source_kafka.create_topic({"topic": t, **cfg})
 
         self.logger.info("Send records to source topics")
-        self.produce_records(self.source_kafka, "orders-us", 3, self.client_node)
-        self.produce_records(self.source_kafka, "orders-eu", 3, self.client_node)
-        self.produce_records(self.source_kafka, "orders-internal", 2, self.client_node)
-        self.produce_records(self.source_kafka, "payments", 2, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-us", 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-eu", 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-internal", 2, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "payments", 2, self.client_node)
 
         self.logger.info("Start mirror with regex include and exclude")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -448,13 +551,13 @@ class ClusterMirroringTest(MirrorUtils, Test):
         )
 
         self.logger.info("Only orders-us and orders-eu should be mirrored")
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name,
                                   ["orders-us", "orders-eu"])
 
-        count = self.consume_records(self.dest_kafka, "orders-us", self.client_node, max_messages=3,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-us", self.client_node, max_messages=3,
                                      expected_count=3)
         assert count >= 3, "Expected 3 records on orders-us, got %d" % count
-        count = self.consume_records(self.dest_kafka, "orders-eu", self.client_node, max_messages=3,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-eu", self.client_node, max_messages=3,
                                      expected_count=3)
         assert count >= 3, "Expected 3 records on orders-eu, got %d" % count
 
@@ -467,36 +570,33 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
         self.logger.info("Stop orders-eu")
         self.dest_kafka.stop_cluster_mirror_topics(self.client_node, mirror_name, "orders-eu")
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "STOPPED",
-                               topics={"orders-eu": topics_cfg["orders-eu"]})
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", ["orders-eu"])
 
         self.logger.info("Send 3 more records to orders-eu on source (should not be mirrored)")
-        self.produce_records(self.source_kafka, "orders-eu", 3, self.client_node)
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-eu", 3, self.client_node)
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
-        count_eu = self.consume_records(self.dest_kafka, "orders-eu", self.client_node, timeout_ms=5000)
+        count_eu = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-eu", self.client_node, timeout_ms=5000)
         assert count_eu == 3, \
             "Expected 3 records for orders-eu after stop (not 6), got %d" % count_eu
 
         self.logger.info("Verify orders-eu is not re-discovered after two more metadata refresh cycles")
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
         self.logger.info("describe_cluster_mirror: %s",
                          self.dest_kafka.describe_cluster_mirror(self.client_node))
-        count_eu = self.consume_records(self.dest_kafka, "orders-eu", self.client_node, timeout_ms=5000)
+        count_eu = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-eu", self.client_node, timeout_ms=5000)
         assert count_eu == 3, \
             "Expected orders-eu to remain at 3 records (not re-discovered), got %d" % count_eu
 
         self.logger.info("Create new topic on source that matches the include pattern")
         self.source_kafka.create_topic({"topic": "orders-jp", "partitions": 1, "replication-factor": 2})
-        self.produce_records(self.source_kafka, "orders-jp", 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-jp", 3, self.client_node)
 
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING",
-                               topics={"orders-jp": {"partitions": 1, "replication-factor": 2}})
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
-                                  topics={"orders-jp": {"partitions": 1, "replication-factor": 2}})
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", ["orders-jp"])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["orders-jp"])
 
-        count = self.consume_records(self.dest_kafka, "orders-jp", self.client_node, max_messages=3,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-jp", self.client_node, max_messages=3,
                                      expected_count=3)
         assert count >= 3, "Expected 3 records on orders-jp, got %d" % count
 
@@ -504,13 +604,11 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.dest_kafka.alter_mirror_config(
             self.client_node, mirror_name, "mirror.topics.include=[orders-.*,payments]")
 
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING",
-                               topics={"payments": {"partitions": 1, "replication-factor": 2}})
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name,
-                                  topics={"payments": {"partitions": 1, "replication-factor": 2}})
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", ["payments"])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["payments"])
 
-        count = self.consume_records(self.dest_kafka, "payments", self.client_node, max_messages=2,
-                                     expected_count=2)
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, "payments", self.client_node,
+                                            max_messages=2, expected_count=2)
         assert count >= 2, "Expected 2 records on payments, got %d" % count
 
         self.logger.info("Verify orders-internal still doesn't exist on destination after all operations")
@@ -542,32 +640,17 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
 
         self.logger.info("Altering topic config on source")
         self.source_kafka.alter_topic_config(
             topic, "retention.ms=100002,retention.bytes=10000000002,min.insync.replicas=2",
             node=self.client_node)
 
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
-
-        def parse_topic_configs(desc):
-            """Extract topic configs from kafka-topics describe output."""
-            for line in desc.splitlines():
-                if "Configs:" in line:
-                    configs_str = line.split("Configs:")[1].strip()
-                    if not configs_str:
-                        return {}
-                    result = {}
-                    for pair in configs_str.split(","):
-                        k, v = pair.strip().split("=", 1)
-                        result[k] = v
-                    return result
-            return {}
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
         self.logger.info("Verifying excluded properties were not synced to destination")
-        dest_configs = parse_topic_configs(
-            self.dest_kafka.describe_topic(topic, node=self.client_node))
+        dest_configs = ClusterMirroringTest.parse_topic_configs(self.dest_kafka.describe_topic(topic, node=self.client_node))
         self.logger.info("Dest topic configs: %s", dest_configs)
 
         assert dest_configs.get("retention.ms") == "100002", \
@@ -586,11 +669,11 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
 
         self.logger.info("Produce records to source")
-        self.produce_records(self.source_kafka, topic, 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
 
         self.logger.info("Create consumer groups on source by consuming all records")
         for group in ["app-group1", "app-group2", "internal-group1"]:
-            self.consume_records(self.source_kafka, topic, self.client_node, max_messages=3, group=group)
+            MirrorUtils.consume_records(self.logger, self.source_kafka, topic, self.client_node, max_messages=3, group=group)
 
         self.logger.info("Start mirror with groups include (app-.*) and exclude (app-group2)")
         mirror_cfg = MirrorConfig(
@@ -610,8 +693,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
         self.logger.info("Verify only app-group1 is synced on destination")
         groups_output = self.dest_kafka.list_consumer_groups(self.client_node)
@@ -636,7 +719,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
             self.source_kafka.create_topic({"topic": t, **cfg})
 
         for t in topics:
-            self.produce_records(self.source_kafka, t, 100, self.client_node)
+            MirrorUtils.produce_records(self.logger, self.source_kafka, t, 100, self.client_node)
 
         self.logger.info("Bounce source cluster to trigger leader elections before mirroring")
         self.source_kafka.restart_cluster(clean_shutdown=True)
@@ -671,10 +754,14 @@ class ClusterMirroringTest(MirrorUtils, Test):
                 err_msg="Failed to start mirror topics for %s" % mirror_name,
             )
         for mirror_name, (_, topic_list) in mirrors.items():
-            self.wait_mirror_state(
-                self.dest_kafka, mirror_name, "MIRRORING", topics=topic_list,
+            MirrorUtils.wait_mirror_state(self.logger,
+                self.dest_kafka, self.client_node, mirror_name, "MIRRORING", topics=topic_list,
                 err_msg="Failed to start mirror %s" % mirror_name,
             )
+
+        self.logger.info("Start background producers on source topics")
+        for t in topics:
+            ClusterMirroringTest.run_background_producer(self.source_kafka, self.client_node, t, 100)
 
         self.logger.info("Bounce source and dest brokers in interleaved order to trigger leader elections")
         src0, src1 = self.source_kafka.nodes[0], self.source_kafka.nodes[1]
@@ -686,17 +773,17 @@ class ClusterMirroringTest(MirrorUtils, Test):
         ]:
             kafka.restart_node(node)
 
-        self.logger.info("Send more data and wait for all mirrors to catch up")
-        for t in topics:
-            self.produce_records(self.source_kafka, t, 100, self.client_node)
+        self.logger.info("Kill background producers")
+        ClusterMirroringTest.kill_background_process(
+            self.client_node, "ProducerPerformance")
 
         for mirror_name, (_, topic_list) in mirrors.items():
-            self.wait_mirror_lag_zero(
-                self.dest_kafka, mirror_name, topics=topic_list,
+            MirrorUtils.wait_mirror_lag_zero(self.logger,
+                self.dest_kafka, self.client_node, mirror_name, topics=topic_list,
                 err_msg="Mirror %s did not catch up" % mirror_name)
 
         self.logger.info("Poll until source and destination log segment hashes converge")
-        self.wait_for_log_convergence(self.source_kafka, self.dest_kafka, topics)
+        MirrorUtils.wait_for_log_convergence(self.logger, self.source_kafka, self.dest_kafka, topics)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -715,37 +802,12 @@ class ClusterMirroringTest(MirrorUtils, Test):
         src_broker0 = self.source_kafka.nodes[0]
         src_broker1 = self.source_kafka.nodes[1]
 
-        def broker_bootstrap(node):
-            """Return bootstrap server address for a single broker node."""
-            return "%s:9092" % node.account.hostname
-
-        def trigger_ule(node):
-            """Trigger unclean leader election on the given node."""
-            cmd = "%s --bootstrap-server %s --topic %s --partition 0 --election-type UNCLEAN" % (
-                self.source_kafka.path.script("kafka-leader-election.sh", self.client_node),
-                broker_bootstrap(node), topic)
-            self.client_node.account.ssh(cmd, allow_fail=False)
-
-        def log_hashes(label):
-            """Log MD5 hashes of partition log segments for all brokers across both clusters."""
-            self.logger.info("#### %s-0 %s ####", topic, label)
-            for name, kafka in [("source", self.source_kafka), ("dest", self.dest_kafka)]:
-                for node in kafka.nodes:
-                    cmd = "md5sum %s*/%s-0/*.log 2>/dev/null" % (
-                        KafkaService.DATA_LOG_DIR_PREFIX, topic)
-                    lines = list(node.account.ssh_capture(cmd, allow_fail=True))
-                    if lines:
-                        for line in lines:
-                            self.logger.info("%s %s: %s", name, node.name, line.strip())
-                    else:
-                        self.logger.info("%s %s: n/a", name, node.name)
-
         self.logger.info("Bounce source brokers to trigger leader elections")
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
         self.logger.info("Send 1 message via source broker 0")
-        self.produce_records(self.source_kafka, topic, 1, self.client_node,
-                             bootstrap_servers=broker_bootstrap(src_broker0))
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.client_node,
+                             bootstrap_servers=ClusterMirroringTest.broker_bootstrap(src_broker0))
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -762,8 +824,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_state(
-            self.dest_kafka, mirror_name, "MIRRORING", [topic],
+        MirrorUtils.wait_mirror_state(self.logger,
+            self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic],
             err_msg="Mirror did not reach MIRRORING state",
         )
 
@@ -771,44 +833,56 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.stop_node(src_broker0)
 
         self.logger.info("Send 1 message via source broker 1")
-        self.produce_records(self.source_kafka, topic, 1, self.client_node,
-                             bootstrap_servers=broker_bootstrap(src_broker1))
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic],
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.client_node,
+                             bootstrap_servers=ClusterMirroringTest.broker_bootstrap(src_broker1))
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic],
                                   err_msg="Mirror did not catch up after broker 0 stopped")
-        log_hashes("after source broker 0 stopped (broker 0 should be out of sync)")
+        ClusterMirroringTest.log_hashes(
+            self.logger, self.source_kafka, self.dest_kafka, topic,
+            "After source broker 0 stopped (broker 0 should be out of sync)")
 
         self.logger.info("ULE 1: stop broker 1, start broker 0 (stale), elect it as leader")
         self.source_kafka.stop_node(src_broker1)
         self.source_kafka.start_node(src_broker0)
-        time.sleep(5)
-        trigger_ule(src_broker0)
+        wait_until(
+            lambda: ClusterMirroringTest.trigger_ule(
+                self.source_kafka, self.client_node, src_broker0, topic),
+            timeout_sec=30, backoff_sec=2,
+            err_msg="Failed to trigger unclean leader election on %s" % src_broker0.name)
 
         self.logger.info("Send 2 messages via source broker 0")
-        self.produce_records(self.source_kafka, topic, 2, self.client_node,
-                             bootstrap_servers=broker_bootstrap(src_broker0))
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic],
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 2, self.client_node,
+                             bootstrap_servers=ClusterMirroringTest.broker_bootstrap(src_broker0))
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic],
                                   err_msg="Mirror did not catch up after ULE 1")
-        log_hashes("after ULE 1 (broker 1 should be out of sync)")
+        ClusterMirroringTest.log_hashes(
+            self.logger, self.source_kafka, self.dest_kafka, topic,
+            "After ULE 1 (broker 1 should be out of sync)")
 
         self.logger.info("Failover: stop mirror so destination topic becomes writable")
         self.dest_kafka.stop_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "STOPPED", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
         self.logger.info("describe_cluster_mirror: %s",
                          self.dest_kafka.describe_cluster_mirror(self.client_node))
 
         self.logger.info("Send 2 messages via destination broker 0")
-        self.produce_records(self.dest_kafka, topic, 2, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.dest_kafka, topic, 2, self.client_node)
 
         self.logger.info("ULE 2: stop broker 0, start broker 1 (stale), elect it as leader")
         self.source_kafka.stop_node(src_broker0)
         self.source_kafka.start_node(src_broker1)
-        time.sleep(5)
-        trigger_ule(src_broker1)
+        wait_until(
+            lambda: ClusterMirroringTest.trigger_ule(
+                self.source_kafka, self.client_node, src_broker1, topic),
+            timeout_sec=30, backoff_sec=2,
+            err_msg="Failed to trigger unclean leader election on %s" % src_broker1.name)
 
         self.logger.info("Send 6 messages via source broker 1")
-        self.produce_records(self.source_kafka, topic, 6, self.client_node,
-                             bootstrap_servers=broker_bootstrap(src_broker1))
-        log_hashes("after ULE 2 (broker 1 should have the most up to date data)")
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 6, self.client_node,
+                             bootstrap_servers=ClusterMirroringTest.broker_bootstrap(src_broker1))
+        ClusterMirroringTest.log_hashes(
+            self.logger, self.source_kafka, self.dest_kafka, topic,
+            "After ULE 2 (broker 1 should have the most up to date data)")
 
         self.logger.info("Failback: source now mirrors from destination")
         # Mirror stays in LOG_TRUNCATION until all source replicas rejoin ISR for LME truncation
@@ -826,21 +900,21 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start reverse mirror topics",
         )
-        self.wait_mirror_state(self.source_kafka, mirror_name, "LOG_TRUNCATION", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.source_kafka, self.client_node, mirror_name, "LOG_TRUNCATION", [topic])
 
         self.logger.info("Start the stopped source broker so all replicas rejoin ISR for LME truncation")
         self.source_kafka.start_node(src_broker0)
-        self.wait_mirror_state(self.source_kafka, mirror_name, "MIRRORING", [topic],
+        MirrorUtils.wait_mirror_state(self.logger, self.source_kafka, self.client_node, mirror_name, "MIRRORING", [topic],
                                err_msg="Reverse mirror did not reach MIRRORING state")
         self.logger.info("describe_cluster_mirror: %s",
                          self.source_kafka.describe_cluster_mirror(self.client_node))
 
         self.logger.info("Wait for reverse mirror to catch up")
-        self.wait_mirror_lag_zero(self.source_kafka, mirror_name, [topic],
-                                  err_msg="Reverse mirror did not catch up")
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.source_kafka, self.client_node, mirror_name, [topic],
+                                         err_msg="Reverse mirror did not catch up")
 
         self.logger.info("Poll until log segment hashes converge (dest is source of truth after failback)")
-        self.wait_for_log_convergence(self.dest_kafka, self.source_kafka, topics)
+        MirrorUtils.wait_for_log_convergence(self.logger, self.dest_kafka, self.source_kafka, topics)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
@@ -853,52 +927,19 @@ class ClusterMirroringTest(MirrorUtils, Test):
             self.source_kafka.create_topic({"topic": t, **cfg})
 
         self.logger.info("Run initial committed transaction and bounce source to bump leader epoch")
-        def run_producer(kafka, topic, transactional_id=None, mode="commit",
-                         num_records=1, waiting_ms=0, background=False):
-            """Run TransactionalTestProducer."""
-            cmd = kafka.path.script("kafka-run-class.sh", self.client_node)
-            cmd += " org.apache.kafka.tools.TransactionalTestProducer"
-            cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
-            cmd += " --topic %s" % topic
-            if transactional_id is not None:
-                cmd += " --transactional-id %s" % transactional_id
-                cmd += " --mode %s" % mode
-                if waiting_ms > 0:
-                    cmd += " --waiting-ms %s" % str(waiting_ms)
-            cmd += " --num-records %s" % str(num_records)
-            if background:
-                cmd += " &"
-            self.client_node.account.ssh(cmd, allow_fail=False)
-
-        run_producer(self.source_kafka, topic, topic + "-a", "commit")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-a", "commit")
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
-        self.logger.info("Send interleaving transactions, leaving 2 pending")
-        def send_interleaving_txns(topic):
-            """Send interleaved transactional and non-transactional records, leaving 2 txns pending."""
-            run_producer(self.source_kafka, topic, topic + "-a", "commit", waiting_ms=5000, background=True)
-            run_producer(self.source_kafka, topic)
-            run_producer(self.source_kafka, topic, topic + "-b", "pending")
-            run_producer(self.source_kafka, topic, topic + "-d", "pending")
-            run_producer(self.source_kafka, topic, topic + "-c", "abort", waiting_ms=5000, background=True)
-            run_producer(self.source_kafka, topic, topic + "-d", "pending")
-            run_producer(self.source_kafka, topic)
+        self.logger.info("Send interleaved transactional and non-transactional records, leaving 2 txns pending")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-a", "commit", waiting_ms=5000, background=True)
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic)
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-b", "pending")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-d", "pending")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-c", "abort", waiting_ms=5000, background=True)
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-d", "pending")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic)
 
-        def count_ongoing_txns(kafka, topic):
-            """Count ongoing transactions across all partitions of a topic."""
-            count = 0
-            for partition in range(topics[topic]["partitions"]):
-                cmd = kafka.path.script("kafka-transactions.sh", self.client_node)
-                cmd += " --bootstrap-server %s" % kafka.bootstrap_servers(kafka.security_protocol)
-                cmd += " describe-producers --topic %s --partition %d" % (topic, partition)
-                for line in self.client_node.account.ssh_capture(cmd, allow_fail=True):
-                    fields = line.strip().split()
-                    if fields and fields[-1] != "None" and fields[-1] != "CurrentTransactionStartOffset":
-                        count += 1
-            return count
-
-        send_interleaving_txns(topic)
-        ongoing = count_ongoing_txns(self.source_kafka, topic)
+        ongoing = ClusterMirroringTest.count_ongoing_txns(self.client_node, self.source_kafka, topic, topics)
         assert ongoing == 2, "Expected 2 ongoing transactions, got %d" % ongoing
 
         self.logger.info("Create and start cluster mirror, wait for it to catch up")
@@ -928,29 +969,18 @@ class ClusterMirroringTest(MirrorUtils, Test):
             backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
 
         self.logger.info("Stop cluster mirror (aborts pending transactions and writes PID reset barriers)")
         self.dest_kafka.stop_cluster_mirror_topics(
             self.client_node, mirror_name, topic
         )
 
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "STOPPED", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
 
         self.logger.info("Verify extra records on destination from abort markers and PID reset barriers")
-        def parse_end_offsets(output):
-            """Parse get_offset_shell output into a {partition: offset} dict."""
-            offsets = {}
-            for line in output.strip().splitlines():
-                parts = line.strip().split(":")
-                if len(parts) == 3:
-                    offsets[int(parts[1])] = int(parts[2])
-            return offsets
-
-        source_offsets = parse_end_offsets(
-            self.get_offset_shell(self.source_kafka, topic=topic, time=-1))
-        dest_offsets = parse_end_offsets(
-            self.get_offset_shell(self.dest_kafka, topic=topic, time=-1))
+        source_offsets = ClusterMirroringTest.get_end_offsets(self.source_kafka, self.client_node, topic)
+        dest_offsets = ClusterMirroringTest.get_end_offsets(self.dest_kafka, self.client_node, topic)
         extra = sum(dest_offsets.values()) - sum(source_offsets.values())
         # 2 abort markers (one per pending txn) + 1 PID reset barrier per partition
         num_partitions = topics[topic]["partitions"]
@@ -960,19 +990,19 @@ class ClusterMirroringTest(MirrorUtils, Test):
             "source=%s, dest=%s" % (expected_extra, num_partitions, extra, source_offsets, dest_offsets)
 
         self.logger.info("Commit pending transactions on destination and verify consumer counts")
-        run_producer(self.dest_kafka, topic, topic + "-b", "commit")
-        run_producer(self.dest_kafka, topic, topic + "-d", "commit")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.dest_kafka, topic, topic + "-b", "commit")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.dest_kafka, topic, topic + "-d", "commit")
 
         self.logger.info("Checking raw number of records")
-        source_count = self.consume_records(self.source_kafka, topic, self.client_node)
-        dest_count = self.consume_records(self.dest_kafka, topic, self.client_node,
+        source_count = MirrorUtils.consume_records(self.logger, self.source_kafka, topic, self.client_node)
+        dest_count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node,
                                           expected_count=source_count + 2)
         assert dest_count >= source_count + 2, \
             "Expected %d records on %s, got %d" % (source_count + 2, topic, dest_count)
 
         self.logger.info("Checking read_committed consumer can make progress")
         # 4 aborted data records are filtered out: txn-b, txn-c, txn-d fenced, txn-d pending
-        committed_count = self.consume_records(self.dest_kafka, topic, self.client_node,
+        committed_count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node,
                                                isolation_level="read_committed",
                                                expected_count=dest_count - 4)
         assert committed_count >= dest_count - 4, \
@@ -987,12 +1017,12 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.logger.info("Create two topics on source")
         self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
         self.source_kafka.create_topic({"topic": "other-topic", "partitions": 1, "replication-factor": 2})
-        self.produce_records(self.source_kafka, "my-topic", 3, self.client_node)
-        self.produce_records(self.source_kafka, "other-topic", 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "other-topic", 3, self.client_node)
 
         self.logger.info("Create consumer group my-group on source by consuming both topics")
-        self.consume_records(self.source_kafka, "my-topic", self.client_node, max_messages=3, group="my-group")
-        self.consume_records(self.source_kafka, "other-topic", self.client_node, max_messages=3, group="my-group")
+        MirrorUtils.consume_records(self.logger, self.source_kafka, "my-topic", self.client_node, max_messages=3, group="my-group")
+        MirrorUtils.consume_records(self.logger, self.source_kafka, "other-topic", self.client_node, max_messages=3, group="my-group")
 
         self.logger.info("Start mirror with only my-topic (not other-topic)")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -1008,49 +1038,46 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, ["my-topic"])
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["my-topic"])
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
         self.logger.info("Verify my-group on dest has my-topic offset but not other-topic")
-        group_desc = self.describe_consumer_group(self.dest_kafka, "my-group", self.client_node)
+        group_desc = MirrorUtils.describe_consumer_group(self.dest_kafka, "my-group", self.client_node)
         assert "my-topic" in group_desc, \
             "Expected my-topic offset to be synced on destination"
         assert "other-topic" not in group_desc, \
             "Expected other-topic offset to not appear on destination"
 
-        def parse_current_offset(desc, topic):
-            """Parse describe_consumer_group output and return current offset for a topic."""
-            for line in desc.strip().splitlines():
-                fields = line.split()
-                if len(fields) >= 4 and fields[1] == topic:
-                    return int(fields[3])
-            return None
-
         self.logger.info("Produce 2 more records to my-topic and verify synced offset is exactly 3")
-        self.produce_records(self.source_kafka, "my-topic", 2, self.client_node)
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, ["my-topic"])
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 2, self.client_node)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["my-topic"])
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
-        dest_desc = self.describe_consumer_group(self.dest_kafka, "my-group", self.client_node)
-        dest_offset = parse_current_offset(dest_desc, "my-topic")
+        dest_desc = MirrorUtils.describe_consumer_group(self.dest_kafka, "my-group", self.client_node)
+        dest_offset = ClusterMirroringTest.parse_group_offset(dest_desc, "my-topic")
         assert dest_offset == 3, "Expected dest offset 3 (synced from source), got %s" % dest_offset
 
         self.logger.info("Start active consumer on destination (background)")
-        self.run_background_consumer(self.dest_kafka, "my-topic", "my-group")
-        time.sleep(5)
+        ClusterMirroringTest.run_background_consumer(self.dest_kafka, self.client_node, "my-topic", "my-group")
+        wait_until(
+            lambda: ClusterMirroringTest.parse_group_offset(
+                MirrorUtils.describe_consumer_group(self.dest_kafka, "my-group", self.client_node),
+                "my-topic") == 5,
+            timeout_sec=60, backoff_sec=2,
+            err_msg="Background consumer did not commit offset 5 for my-group")
 
         self.logger.info("Reset source offset to 2 to prove sync skips active consumer")
         self.source_kafka.reset_consumer_group_offsets(self.client_node, "my-group", "my-topic", 2)
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
         self.logger.info("Verify source offset is 2 but dest offset is still 5 (sync skipped)")
-        src_desc = self.describe_consumer_group(self.source_kafka, "my-group", self.client_node)
-        dest_desc = self.describe_consumer_group(self.dest_kafka, "my-group", self.client_node)
+        src_desc = MirrorUtils.describe_consumer_group(self.source_kafka, "my-group", self.client_node)
+        dest_desc = MirrorUtils.describe_consumer_group(self.dest_kafka, "my-group", self.client_node)
         self.logger.info("Source group describe: %s", src_desc)
         self.logger.info("Dest group describe: %s", dest_desc)
 
-        src_offset = parse_current_offset(src_desc, "my-topic")
-        dest_offset = parse_current_offset(dest_desc, "my-topic")
+        src_offset = ClusterMirroringTest.parse_group_offset(src_desc, "my-topic")
+        dest_offset = ClusterMirroringTest.parse_group_offset(dest_desc, "my-topic")
         assert src_offset == 2, "Expected source offset 2, got %s" % src_offset
         assert dest_offset == 5, "Expected dest offset 5 (sync skipped), got %s" % dest_offset
 
@@ -1064,24 +1091,33 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.logger.info("Create two topics on source")
         self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
         self.source_kafka.create_topic({"topic": "other-topic", "partitions": 1, "replication-factor": 2})
-        self.produce_records(self.source_kafka, "my-topic", 3, self.client_node)
-        self.produce_records(self.source_kafka, "other-topic", 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "other-topic", 3, self.client_node)
 
         self.logger.info("Set share.auto.offset.reset=earliest and consume both topics")
         self.source_kafka.set_share_group_offset_reset_strategy(share_group, "earliest", node=self.client_node)
-        self.consume_share_records("my-topic", self.source_kafka, share_group, max_messages=3)
-        self.consume_share_records("other-topic", self.source_kafka, share_group, max_messages=3)
+        ClusterMirroringTest.consume_share_records(
+            self.logger, self.source_kafka, self.client_node, "my-topic", share_group, max_messages=3)
+        ClusterMirroringTest.consume_share_records(
+            self.logger, self.source_kafka, self.client_node, "other-topic", share_group, max_messages=3)
 
         self.logger.info("Run background share consumer + produce more data to commit SPSO")
-        self.run_background_share_consumer(self.source_kafka, "my-topic", share_group)
-        self.produce_records(self.source_kafka, "my-topic", 3, self.client_node)
-        time.sleep(5)
+        ClusterMirroringTest.run_background_share_consumer(self.source_kafka, self.client_node, "my-topic", share_group)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 3, self.client_node)
+        wait_until(
+            lambda: len(self.source_kafka.describe_share_group_members(
+                share_group, self.client_node)) > 0,
+            timeout_sec=60, backoff_sec=2,
+            err_msg="Share consumer did not join group %s" % share_group)
 
         self.logger.info("Source share group describe: %s",
                          self.source_kafka.describe_share_group(share_group, self.client_node))
 
+        # Kill the source share consumer so the group is inactive before mirroring starts,
+        # otherwise reset_share_group_offsets will fail on an active group.
         self.logger.info("Kill background share consumer")
-        self.kill_background_consumer(self.client_node, "ConsoleShareConsumer")
+        ClusterMirroringTest.kill_background_process(
+            self.client_node, "ConsoleShareConsumer")
 
         self.logger.info("Start mirror with only my-topic")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -1097,34 +1133,37 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, ["my-topic"])
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["my-topic"])
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
         self.logger.info("Verify my-share-group on dest has my-topic but not other-topic")
         src_desc = self.source_kafka.describe_share_group(share_group, self.client_node)
         dest_desc = self.dest_kafka.describe_share_group(share_group, self.client_node)
         self.logger.info("Source share group describe: %s", src_desc)
         self.logger.info("Dest share group describe: %s", dest_desc)
-        assert "my-topic" in dest_desc, \
-            "Expected my-topic offset to be synced on destination"
-        assert "other-topic" not in dest_desc, \
-            "Expected other-topic offset to not appear on destination"
+        assert "my-topic" in dest_desc, "Expected my-topic offset to be synced on destination"
+        assert "other-topic" not in dest_desc, "Expected other-topic offset to not appear on destination"
 
         self.logger.info("Produce 2 more and consume delta using synced offsets")
-        self.produce_records(self.source_kafka, "my-topic", 2, self.client_node)
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, ["my-topic"])
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 2, self.client_node)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["my-topic"])
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
-        self.consume_share_records("my-topic", self.dest_kafka, share_group, max_messages=2,
-                                   expected_count=2)
+        ClusterMirroringTest.consume_share_records(
+            self.logger, self.dest_kafka, self.client_node, "my-topic", share_group,
+            max_messages=2, expected_count=2)
 
         self.logger.info("Start active share consumer on destination (background)")
-        self.run_background_share_consumer(self.dest_kafka, "my-topic", share_group)
-        time.sleep(5)
+        ClusterMirroringTest.run_background_share_consumer(self.dest_kafka, self.client_node, "my-topic", share_group)
+        wait_until(
+            lambda: len(self.dest_kafka.describe_share_group_members(
+                share_group, self.client_node)) > 0,
+            timeout_sec=60, backoff_sec=2,
+            err_msg="Share consumer did not join group %s on destination" % share_group)
 
         self.logger.info("Reset source offset to earliest to prove sync skips active consumer")
         self.source_kafka.reset_share_group_offsets(self.client_node, share_group, "my-topic")
-        self.wait_for_metadata_sync(self.dest_kafka, mirror_name, num_cycles=2)
+        MirrorUtils.wait_for_metadata_sync(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
 
         self.logger.info("Verify source offset reset but dest offset unchanged (sync skipped)")
         src_desc = self.source_kafka.describe_share_group(share_group, self.client_node)
@@ -1132,16 +1171,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.logger.info("Source share group describe after reset: %s", src_desc)
         self.logger.info("Dest share group describe after reset: %s", dest_desc)
 
-        def parse_share_start_offset(desc, topic):
-            """Parse describe_share_group output and return start offset for a topic."""
-            for line in desc.strip().splitlines():
-                fields = line.split()
-                if len(fields) >= 4 and fields[1] == topic:
-                    return int(fields[3])
-            return None
-
-        src_offset = parse_share_start_offset(src_desc, "my-topic")
-        dest_offset = parse_share_start_offset(dest_desc, "my-topic")
+        src_offset = ClusterMirroringTest.parse_group_offset(src_desc, "my-topic")
+        dest_offset = ClusterMirroringTest.parse_group_offset(dest_desc, "my-topic")
         assert src_offset == 0, "Expected source offset 0 (reset to earliest), got %s" % src_offset
         assert dest_offset == 5, "Expected dest offset 5 (sync skipped), got %s" % dest_offset
 
@@ -1155,12 +1186,12 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
 
         self.logger.info("Produce 3 records and bounce source brokers to bump leader epoch")
-        self.produce_records(self.source_kafka, topic, 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
         for node in self.source_kafka.nodes:
             self.source_kafka.restart_node(node)
 
         self.logger.info("Produce 2 more records after leader elections")
-        self.produce_records(self.source_kafka, topic, 2, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 2, self.client_node)
 
         self.logger.info("Start cluster mirror")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -1176,16 +1207,16 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
 
         self.logger.info("Consume 2 records from destination with a consumer group (commits offsets with source LE)")
-        count = self.consume_records(self.dest_kafka, topic, self.client_node,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node,
                                      max_messages=2, group=group, expected_count=2)
         assert count >= 2, "Expected 2 records on %s, got %d" % (topic, count)
 
         self.logger.info("Restart consumer (triggers OffsetFetch and refreshCommittedOffsets)")
         # Without the epoch bump fix, this would hang because source LE > local LE
-        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=2,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=2,
                                      timeout_ms=20000, group=group, from_beginning=False,
                                      expected_count=2)
         assert count >= 2, "Expected 2 records on %s after restart, got %d" % (topic, count)
@@ -1199,7 +1230,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.create_topic({"topic": topic, "partitions": 3, "replication-factor": 1})
 
         self.logger.info("Produce initial records and start cluster mirror")
-        self.produce_records(self.source_kafka, topic, 3, self.client_node)
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
 
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
         wait_until(
@@ -1214,24 +1245,24 @@ class ClusterMirroringTest(MirrorUtils, Test):
             timeout_sec=300, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
 
         self.logger.info("Stop all source brokers to trigger FAILED state")
         for node in self.source_kafka.nodes:
             self.source_kafka.stop_node(node)
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "FAILED", [topic],
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "FAILED", [topic],
                                err_msg="Mirror did not reach FAILED state after source shutdown")
 
         self.logger.info("Restart source brokers so scheduled retry can recover")
         for node in self.source_kafka.nodes:
             self.source_kafka.start_node(node)
-        self.wait_mirror_state(self.dest_kafka, mirror_name, "MIRRORING", [topic],
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic],
                                err_msg="Mirror did not recover to MIRRORING after source restart")
 
         self.logger.info("Verify data still flows after recovery")
-        self.produce_records(self.source_kafka, topic, 3, self.client_node)
-        self.wait_mirror_lag_zero(self.dest_kafka, mirror_name, [topic])
+        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
 
-        count = self.consume_records(self.dest_kafka, topic, self.client_node, max_messages=6,
+        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=6,
                                      expected_count=6)
         assert count >= 6, "Expected 6 records on %s, got %d" % (topic, count)


### PR DESCRIPTION
This patch replaces fixd-time sleep in tests with wait for result logic. It also uses static for all utility methods and moves them to the test class in order to make test methods easier to maintain. We can move them to common when shared by more than two tests across all CM tests.

For log convergence tests we are now running the producer in the background to be closer to a real use case.
