### PR TITLE
MirrorMetadataManager: derive AdminClient props from broker config

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/internals/BrokerSecurityConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/internals/BrokerSecurityConfigs.java
@@ -134,6 +134,10 @@ public class BrokerSecurityConfigs {
     public static final String SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG = "sasl.mechanism.inter.broker.protocol";
     public static final String SASL_MECHANISM_INTER_BROKER_PROTOCOL_DOC = "SASL mechanism used for inter-broker communication. Default is GSSAPI.";
 
+    public static final String SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_CONFIG = "sasl.mechanism.mirror.admin.protocol";
+    public static final String SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_DOC = "SASL mechanism used for mirror admin communication on destination cluster. " +
+            "If this is unset, it defaults to the value of " + SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG + ".";
+
     // The allowlist of the SASL OAUTHBEARER endpoints
     public static final String ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG = "org.apache.kafka.sasl.oauthbearer.allowed.urls";
     public static final String ALLOWED_SASL_OAUTHBEARER_URLS_DEFAULT = "";
@@ -181,6 +185,7 @@ public class BrokerSecurityConfigs {
                     "Protocol used to communicate with brokers.")
             .define(SaslConfigs.SASL_MECHANISM, ConfigDef.Type.STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, ConfigDef.Importance.MEDIUM, SaslConfigs.SASL_MECHANISM_DOC)
             .define(BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG, STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, MEDIUM, BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_DOC)
+            .define(BrokerSecurityConfigs.SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_CONFIG, STRING, null, MEDIUM, BrokerSecurityConfigs.SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_DOC)
             .define(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG, LIST, BrokerSecurityConfigs.DEFAULT_SASL_ENABLED_MECHANISMS, MEDIUM, BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_DOC)
             .define(BrokerSecurityConfigs.SASL_SERVER_CALLBACK_HANDLER_CLASS_CONFIG, CLASS, null, MEDIUM, BrokerSecurityConfigs.SASL_SERVER_CALLBACK_HANDLER_CLASS_DOC)
             .define(BrokerSecurityConfigs.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_CONFIG, LIST, BrokerSecurityConfigs.DEFAULT_SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES, MEDIUM, BrokerSecurityConfigs.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
@@ -193,7 +193,7 @@ public class ChannelBuilders {
      * @return a mutable RecordingMap. The elements got from RecordingMap are marked as "used".
      */
     @SuppressWarnings("unchecked")
-    static Map<String, Object> channelBuilderConfigs(final AbstractConfig config, final ListenerName listenerName) {
+    public static Map<String, Object> channelBuilderConfigs(final AbstractConfig config, final ListenerName listenerName) {
         Map<String, Object> parsedConfigs;
         if (listenerName == null)
             parsedConfigs = (Map<String, Object>) config.values();

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -1018,7 +1018,10 @@ public class ClusterMirrorCoordinator {
         return metadataManager.getMirrorStates(mirrorName);
     }
 
-    /** Maps a mirror record key to a __mirror_state partition index. */
+    /**
+     * Maps a mirror record key to a __mirror_state partition index.
+     * Used by MirrorMetadataManager to route WriteMirrorStates and ReadMirrorStates RPCs to the correct coordinator broker.
+     */
     public int getCoordinatorPartitionByKey(ClusterMirrorRecordKey key) {
         if (!isRunning.get()) {
             throw Errors.COORDINATOR_NOT_AVAILABLE.exception();
@@ -1026,6 +1029,11 @@ public class ClusterMirrorCoordinator {
         return Utils.abs(key.asCoordinatorKey().hashCode()) % brokerConfig.mirrorConfig().stateTopicNumPartitions();
     }
 
+    /**
+     * Maps a mirror name to a __mirror_state partition index.
+     * Used by MirrorMetadataManager to check whether the local broker is the coordinator for a given mirror
+     * and needs to periodicaly refresh its metadata from the source cluster.
+     */
     private int getCoordinatorPartitionByName(String mirrorName) {
         if (!isRunning.get()) {
             throw Errors.COORDINATOR_NOT_AVAILABLE.exception();

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -166,9 +166,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     private volatile MetadataImage metadataImage = MetadataImage.EMPTY;
 
-    private volatile MirrorStateSender mirrorStateSender;
-    private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>();
-    private volatile Admin dstAdmin;
+    private volatile MirrorStateSender mirrorStateSender; // raw WriteMirrorStates/ReadMirrorStates RPCs to coord brokers
+    private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>(); // source cluster metadata discovery (one per mirror)
+    private volatile Admin dstAdmin; // group offset and ACLs sync
 
     private final Map<String, Uuid> sourceClusterIds = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, ClusterMirrorUtils.LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
@@ -260,11 +260,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return false;
     }
 
-    /** Wires in the state transitioner, tombstone handler, and coordinator partition finders. */
+    /**
+     * Called by ClusterMirrorCoordinator on startup.
+     * Creates and starts the MirrorStateSender used for WriteMirrorStates and ReadMirrorStates RPCs.
+     * Wires in the state transitioner, tombstone handler, and coordinator partition finders.
+     */
     public void initialize(ClusterMirrorUtils.StateTransitioner stateTransitioner,
                            Consumer<String> tombStoneHandler,
-                           Function<ClusterMirrorRecordKey, Integer> coordinatorPartitionByKeyFinder,
-                           Function<String, Integer> coordinatorPartitionByNameFinder) {
+                           Function<ClusterMirrorRecordKey, Integer> coordPartitionByKeyFinder,
+                           Function<String, Integer> coordPartitionByNameFinder) {
         if (mirrorStateSender == null) {
             mirrorStateSender = new MirrorStateSender(MirrorStateSender.class.getSimpleName(),
                     NetworkUtils.buildNetworkClient(MirrorMetadataManager.class.getSimpleName(), brokerConfig, metrics, time, new LogContext(name())),
@@ -274,8 +278,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         this.stateTransitioner = Optional.of(stateTransitioner);
         this.mirrorDeletionHandler = Optional.of(tombStoneHandler);
-        this.coordPartitionFinderByKey = Optional.of(coordinatorPartitionByKeyFinder);
-        this.coordPartitionFinderByName = Optional.of(coordinatorPartitionByNameFinder);
+        this.coordPartitionFinderByKey = Optional.of(coordPartitionByKeyFinder);
+        this.coordPartitionFinderByName = Optional.of(coordPartitionByNameFinder);
 
         this.isInitialized = true;
     }
@@ -1592,7 +1596,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     // Visible for testing
     static Properties buildDestAdminClientProps(KafkaConfig brokerConfig) {
         ListenerName mirrorAdminListener = brokerConfig.mirrorAdminListenerName();
-        Endpoint endpoint = (Endpoint) brokerConfig.effectiveAdvertisedBrokerListeners()
+        Endpoint endpoint = brokerConfig.effectiveAdvertisedBrokerListeners()
                 .filter(e -> e.listener().equals(mirrorAdminListener.value()))
                 .head();
 
@@ -1611,14 +1615,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         String mirrorAdminSaslMechanism = brokerConfig.saslMechanismMirrorAdminProtocol();
         if (securityProtocol == SecurityProtocol.SASL_SSL || securityProtocol == SecurityProtocol.SASL_PLAINTEXT) {
             props.put(SaslConfigs.SASL_MECHANISM, mirrorAdminSaslMechanism);
-            // To avoid overwriting it below
-            configs.remove(SaslConfigs.SASL_MECHANISM);
         }
 
         String saslMechanismConfigPrefix = mirrorAdminListener.saslMechanismConfigPrefix(mirrorAdminSaslMechanism);
         Map<String, ?> saslMechanismConfigs = brokerConfig.originalsWithPrefix(saslMechanismConfigPrefix, true);
 
         securityConfigs.forEach(key -> {
+            if (key.equals(SaslConfigs.SASL_MECHANISM)) return;
             if (saslMechanismConfigs.containsKey(key)) {
                 props.put(key, saslMechanismConfigs.get(key));
             } else if (configs.containsKey(key)) {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1596,7 +1596,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     // Visible for testing
     static Properties buildDestAdminClientProps(KafkaConfig brokerConfig) {
         ListenerName mirrorAdminListener = brokerConfig.mirrorAdminListenerName();
-        Endpoint endpoint = brokerConfig.effectiveAdvertisedBrokerListeners()
+        Endpoint endpoint = (Endpoint) brokerConfig.effectiveAdvertisedBrokerListeners()
                 .filter(e -> e.listener().equals(mirrorAdminListener.value()))
                 .head();
 

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -46,7 +46,6 @@ import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
@@ -1606,14 +1605,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         Map<String, ?> configs = ChannelBuilders.channelBuilderConfigs(brokerConfig, mirrorAdminListener);
 
         // Get all the security configs
-        Set<String> securityConfigs = new HashSet<>();
-
-        ConfigDef securityConfigDef = new ConfigDef();
-        SaslConfigs.addClientSaslSupport(securityConfigDef);
-        SslConfigs.addClientSslSupport(securityConfigDef);
-        securityConfigs.addAll(securityConfigDef.configKeys().keySet());
+        ConfigDef securityConfigDef = new ConfigDef().withClientSaslSupport().withClientSslSupport();
+        Set<String> securityConfigs = new HashSet<>(securityConfigDef.configKeys().keySet());
 
         String mirrorAdminSaslMechanism = brokerConfig.saslMechanismMirrorAdminProtocol();
+        if (securityProtocol == SecurityProtocol.SASL_SSL || securityProtocol == SecurityProtocol.SASL_PLAINTEXT) {
+            props.put(SaslConfigs.SASL_MECHANISM, mirrorAdminSaslMechanism);
+            // To avoid overwriting it below
+            configs.remove(SaslConfigs.SASL_MECHANISM);
+        }
+
         String saslMechanismConfigPrefix = mirrorAdminListener.saslMechanismConfigPrefix(mirrorAdminSaslMechanism);
         Map<String, ?> saslMechanismConfigs = brokerConfig.originalsWithPrefix(saslMechanismConfigPrefix, true);
 
@@ -1628,10 +1629,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 props.put(key, value);
             }
         });
-
-        if (securityProtocol == SecurityProtocol.SASL_SSL || securityProtocol == SecurityProtocol.SASL_PLAINTEXT) {
-            props.put(SaslConfigs.SASL_MECHANISM, mirrorAdminSaslMechanism);
-        }
 
         return props;
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -23,6 +23,7 @@ import kafka.server.ReplicaManager;
 
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ClusterMirrorDescription;
 import org.apache.kafka.clients.admin.Config;
@@ -34,6 +35,7 @@ import org.apache.kafka.clients.admin.ListGroupsOptions;
 import org.apache.kafka.clients.admin.ListShareGroupOffsetsSpec;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
@@ -41,7 +43,10 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
@@ -58,6 +63,8 @@ import org.apache.kafka.common.message.ReadMirrorStatesResponseData;
 import org.apache.kafka.common.message.StartMirrorTopicsRequestData;
 import org.apache.kafka.common.message.WriteMirrorStatesRequestData;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.network.ChannelBuilders;
+import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.BumpLeaderEpochsRequest;
 import org.apache.kafka.common.requests.CreateAclsRequest;
@@ -74,6 +81,7 @@ import org.apache.kafka.common.requests.StopMirrorTopicsRequest;
 import org.apache.kafka.common.requests.WriteMirrorStatesRequest;
 import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
 import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.mirror.ClusterMirrorRecordKey;
@@ -282,9 +290,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     private Admin getOrCreateDestAdmin() {
         if (dstAdmin == null) {
-            var endpoint = brokerConfig.effectiveAdvertisedBrokerListeners().head();
-            Properties props = new Properties();
-            props.put(BOOTSTRAP_SERVERS_CONFIG, endpoint.host() + ":" + endpoint.port());
+            Properties props = buildDestAdminClientProps(brokerConfig);
             dstAdmin = Admin.create(props);
         }
         return dstAdmin;
@@ -1582,6 +1588,52 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
         data.setTopics(topicResults);
         responseCallback.accept(new ReadMirrorStatesResponse(data));
+    }
+
+    // Visible for testing
+    static Properties buildDestAdminClientProps(KafkaConfig brokerConfig) {
+        ListenerName mirrorAdminListener = brokerConfig.mirrorAdminListenerName();
+        Endpoint endpoint = (Endpoint) brokerConfig.effectiveAdvertisedBrokerListeners()
+                .filter(e -> e.listener().equals(mirrorAdminListener.value()))
+                .head();
+
+        Properties props = new Properties();
+        props.put(BOOTSTRAP_SERVERS_CONFIG, endpoint.host() + ":" + endpoint.port());
+
+        SecurityProtocol securityProtocol = endpoint.securityProtocol();
+        props.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, securityProtocol.name);
+
+        Map<String, ?> configs = ChannelBuilders.channelBuilderConfigs(brokerConfig, mirrorAdminListener);
+
+        // Get all the security configs
+        Set<String> securityConfigs = new HashSet<>();
+
+        ConfigDef securityConfigDef = new ConfigDef();
+        SaslConfigs.addClientSaslSupport(securityConfigDef);
+        SslConfigs.addClientSslSupport(securityConfigDef);
+        securityConfigs.addAll(securityConfigDef.configKeys().keySet());
+
+        String mirrorAdminSaslMechanism = brokerConfig.saslMechanismMirrorAdminProtocol();
+        String saslMechanismConfigPrefix = mirrorAdminListener.saslMechanismConfigPrefix(mirrorAdminSaslMechanism);
+        Map<String, ?> saslMechanismConfigs = brokerConfig.originalsWithPrefix(saslMechanismConfigPrefix, true);
+
+        securityConfigs.forEach(key -> {
+            if (saslMechanismConfigs.containsKey(key)) {
+                props.put(key, saslMechanismConfigs.get(key));
+            } else if (configs.containsKey(key)) {
+                Object value = configs.get(key);
+                if (value == null) {
+                    return;
+                }
+                props.put(key, value);
+            }
+        });
+
+        if (securityProtocol == SecurityProtocol.SASL_SSL || securityProtocol == SecurityProtocol.SASL_PLAINTEXT) {
+            props.put(SaslConfigs.SASL_MECHANISM, mirrorAdminSaslMechanism);
+        }
+
+        return props;
     }
 
     /** Updates cached source leader for a specific partition. */

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -614,9 +614,11 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     val listenerNames = listeners.map(l => ListenerName.normalised(l.listener)).toSet
     if (processRoles.contains(ProcessRole.BrokerRole)) {
       validateAdvertisedBrokerListenersNonEmptyForBroker()
-      require(mirrorAdminListenerName() != null, s"${ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG} listener name must be configured")
       require(advertisedBrokerListenerNames.contains(interBrokerListenerName),
         s"${ReplicationConfigs.INTER_BROKER_LISTENER_NAME_CONFIG} must be a listener name defined in ${SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG}. " +
+          s"The valid options based on currently configured listeners are ${advertisedBrokerListenerNames.map(_.value).mkString(",")}")
+      require(advertisedBrokerListenerNames.contains(mirrorAdminListenerName),
+        s"${ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG} must be a listener name defined in ${SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG}. " +
           s"The valid options based on currently configured listeners are ${advertisedBrokerListenerNames.map(_.value).mkString(",")}")
       require(advertisedBrokerListenerNames.subsetOf(listenerNames),
         s"${SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG} listener names must be equal to or a subset of the ones defined in ${SocketServerConfigs.LISTENERS_CONFIG}. " +

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -403,6 +403,11 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
 
   def saslMechanismInterBrokerProtocol = getString(BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG)
 
+  def saslMechanismMirrorAdminProtocol: String = {
+    val configured = getString(BrokerSecurityConfigs.SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_CONFIG)
+    if (configured != null) configured else saslMechanismInterBrokerProtocol
+  }
+
   /** ********* Fetch Configuration **************/
   val maxIncrementalFetchSessionCacheSlots = getInt(ServerConfigs.MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_CONFIG)
   val fetchMaxBytes = getInt(ServerConfigs.FETCH_MAX_BYTES_CONFIG)
@@ -609,6 +614,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     val listenerNames = listeners.map(l => ListenerName.normalised(l.listener)).toSet
     if (processRoles.contains(ProcessRole.BrokerRole)) {
       validateAdvertisedBrokerListenersNonEmptyForBroker()
+      require(mirrorAdminListenerName() != null, s"${ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG} listener name must be configured")
       require(advertisedBrokerListenerNames.contains(interBrokerListenerName),
         s"${ReplicationConfigs.INTER_BROKER_LISTENER_NAME_CONFIG} must be a listener name defined in ${SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG}. " +
           s"The valid options based on currently configured listeners are ${advertisedBrokerListenerNames.map(_.value).mkString(",")}")

--- a/core/src/test/java/kafka/server/mirror/MirrorMetadataManagerTest.java
+++ b/core/src/test/java/kafka/server/mirror/MirrorMetadataManagerTest.java
@@ -63,7 +63,7 @@ public class MirrorMetadataManagerTest {
     }
 
     @Test
-    public void testParseMirrorAdminPropsDefaultsToInterBrokerProtocol() throws Exception {
+    public void testParseMirrorAdminPropsDefaultsToInterBrokerProtocol() {
         // Given
         KafkaConfig config = new KafkaConfig(initialProps);
 
@@ -78,7 +78,7 @@ public class MirrorMetadataManagerTest {
     }
 
     @Test
-    public void testParseMirrorAdminPropsParsesMirrorListenerWhenConfiguredExplicitly() throws Exception {
+    public void testParseMirrorAdminPropsParsesMirrorListenerWhenConfiguredExplicitly() {
         // Given
         initialProps.setProperty(ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG, "MIRROR");
         initialProps.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_CONFIG, PlainSaslServer.PLAIN_MECHANISM);

--- a/core/src/test/java/kafka/server/mirror/MirrorMetadataManagerTest.java
+++ b/core/src/test/java/kafka/server/mirror/MirrorMetadataManagerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server.mirror;
+
+import kafka.server.KafkaConfig;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.network.SocketServerConfigs;
+import org.apache.kafka.raft.QuorumConfig;
+import org.apache.kafka.server.config.KRaftConfigs;
+import org.apache.kafka.server.config.ReplicationConfigs;
+import org.apache.kafka.server.config.ServerConfigs;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MirrorMetadataManagerTest {
+    private Properties initialProps;
+
+    @BeforeEach
+    public void beforeEach() {
+        initialProps = new Properties();
+        initialProps.setProperty(KRaftConfigs.PROCESS_ROLES_CONFIG, "broker");
+        initialProps.setProperty(ServerConfigs.BROKER_ID_CONFIG, "1");
+        initialProps.setProperty(QuorumConfig.QUORUM_BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        initialProps.setProperty(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER");
+
+        initialProps.setProperty(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG, "PLAIN,SCRAM-SHA-256");
+        initialProps.setProperty(ReplicationConfigs.INTER_BROKER_LISTENER_NAME_CONFIG, "INTERNAL");
+        initialProps.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG, "SCRAM-SHA-256");
+        initialProps.setProperty(SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG, "CONTROLLER:PLAINTEXT,INTERNAL:SASL_PLAINTEXT");
+        initialProps.setProperty(SocketServerConfigs.LISTENERS_CONFIG, "INTERNAL://:9093");
+
+        String prefix = "listener.name.internal.scram-sha-256.";
+        initialProps.setProperty(prefix + SaslConfigs.SASL_JAAS_CONFIG, "jaasConfig");
+    }
+
+    @Test
+    public void testParseMirrorAdminPropsDefaultsToInterBrokerProtocol() throws Exception {
+        // Given
+        KafkaConfig config = new KafkaConfig(initialProps);
+
+        // When
+        Properties parsedConfig = MirrorMetadataManager.buildDestAdminClientProps(config);
+
+        // Then
+        assertEquals("SCRAM-SHA-256", parsedConfig.get(SaslConfigs.SASL_MECHANISM));
+        assertEquals("SASL_PLAINTEXT", parsedConfig.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG));
+        assertEquals("jaasConfig", parsedConfig.get(SaslConfigs.SASL_JAAS_CONFIG));
+    }
+
+    @Test
+    public void testParseMirrorAdminPropsParsesMirrorListenerWhenConfiguredExplicitly() throws Exception {
+        initialProps.setProperty(ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG, "MIRROR");
+        initialProps.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_CONFIG, "PLAIN");
+        initialProps.setProperty(SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG, "CONTROLLER:PLAINTEXT,INTERNAL:SASL_PLAINTEXT,MIRROR:SASL_SSL");
+        initialProps.setProperty(SocketServerConfigs.LISTENERS_CONFIG, "INTERNAL://:9093,MIRROR://:9094");
+
+        String prefix = "listener.name.mirror.plain.";
+        initialProps.setProperty(prefix + SaslConfigs.SASL_JAAS_CONFIG, "jaasConfigMirror");
+        KafkaConfig config = new KafkaConfig(initialProps);
+
+        // When
+        Properties parsedConfig = MirrorMetadataManager.buildDestAdminClientProps(config);
+
+        // Then
+        assertEquals("PLAIN", parsedConfig.get(SaslConfigs.SASL_MECHANISM));
+        assertEquals("SASL_SSL", parsedConfig.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG));
+        assertEquals("jaasConfigMirror", parsedConfig.get(SaslConfigs.SASL_JAAS_CONFIG));
+    }
+}

--- a/core/src/test/java/kafka/server/mirror/MirrorMetadataManagerTest.java
+++ b/core/src/test/java/kafka/server/mirror/MirrorMetadataManagerTest.java
@@ -19,8 +19,11 @@ package kafka.server.mirror;
 import kafka.server.KafkaConfig;
 
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.ScramMechanism;
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.security.plain.internals.PlainSaslServer;
 import org.apache.kafka.network.SocketServerConfigs;
 import org.apache.kafka.raft.QuorumConfig;
 import org.apache.kafka.server.config.KRaftConfigs;
@@ -30,6 +33,7 @@ import org.apache.kafka.server.config.ServerConfigs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,15 +48,18 @@ public class MirrorMetadataManagerTest {
         initialProps.setProperty(ServerConfigs.BROKER_ID_CONFIG, "1");
         initialProps.setProperty(QuorumConfig.QUORUM_BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         initialProps.setProperty(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER");
-
-        initialProps.setProperty(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG, "PLAIN,SCRAM-SHA-256");
+        initialProps.setProperty(
+                BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
+                String.format("%s,%s", PlainSaslServer.PLAIN_MECHANISM, ScramMechanism.SCRAM_SHA_256.mechanismName())
+        );
         initialProps.setProperty(ReplicationConfigs.INTER_BROKER_LISTENER_NAME_CONFIG, "INTERNAL");
-        initialProps.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG, "SCRAM-SHA-256");
+        initialProps.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG, ScramMechanism.SCRAM_SHA_256.mechanismName());
         initialProps.setProperty(SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG, "CONTROLLER:PLAINTEXT,INTERNAL:SASL_PLAINTEXT");
         initialProps.setProperty(SocketServerConfigs.LISTENERS_CONFIG, "INTERNAL://:9093");
 
-        String prefix = "listener.name.internal.scram-sha-256.";
-        initialProps.setProperty(prefix + SaslConfigs.SASL_JAAS_CONFIG, "jaasConfig");
+        String prefix = "listener.name.internal.";
+        initialProps.setProperty(prefix + ScramMechanism.SCRAM_SHA_256.mechanismName().toLowerCase(Locale.ROOT) + "." + SaslConfigs.SASL_JAAS_CONFIG, "jaasConfig");
+        initialProps.setProperty(prefix + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "/path/to/keystore.jks");
     }
 
     @Test
@@ -64,28 +71,32 @@ public class MirrorMetadataManagerTest {
         Properties parsedConfig = MirrorMetadataManager.buildDestAdminClientProps(config);
 
         // Then
-        assertEquals("SCRAM-SHA-256", parsedConfig.get(SaslConfigs.SASL_MECHANISM));
+        assertEquals(ScramMechanism.SCRAM_SHA_256.mechanismName(), parsedConfig.get(SaslConfigs.SASL_MECHANISM));
         assertEquals("SASL_PLAINTEXT", parsedConfig.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG));
         assertEquals("jaasConfig", parsedConfig.get(SaslConfigs.SASL_JAAS_CONFIG));
+        assertEquals("/path/to/keystore.jks", parsedConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
     }
 
     @Test
     public void testParseMirrorAdminPropsParsesMirrorListenerWhenConfiguredExplicitly() throws Exception {
+        // Given
         initialProps.setProperty(ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG, "MIRROR");
-        initialProps.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_CONFIG, "PLAIN");
+        initialProps.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_CONFIG, PlainSaslServer.PLAIN_MECHANISM);
         initialProps.setProperty(SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG, "CONTROLLER:PLAINTEXT,INTERNAL:SASL_PLAINTEXT,MIRROR:SASL_SSL");
         initialProps.setProperty(SocketServerConfigs.LISTENERS_CONFIG, "INTERNAL://:9093,MIRROR://:9094");
 
-        String prefix = "listener.name.mirror.plain.";
-        initialProps.setProperty(prefix + SaslConfigs.SASL_JAAS_CONFIG, "jaasConfigMirror");
+        String prefix = "listener.name.mirror.";
+        initialProps.setProperty(prefix + PlainSaslServer.PLAIN_MECHANISM.toLowerCase(Locale.ROOT) + "." + SaslConfigs.SASL_JAAS_CONFIG, "jaasConfigMirror");
+        initialProps.setProperty(prefix + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "/path/to/keystore-mirror.jks");
         KafkaConfig config = new KafkaConfig(initialProps);
 
         // When
         Properties parsedConfig = MirrorMetadataManager.buildDestAdminClientProps(config);
 
         // Then
-        assertEquals("PLAIN", parsedConfig.get(SaslConfigs.SASL_MECHANISM));
+        assertEquals(PlainSaslServer.PLAIN_MECHANISM, parsedConfig.get(SaslConfigs.SASL_MECHANISM));
         assertEquals("SASL_SSL", parsedConfig.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG));
         assertEquals("jaasConfigMirror", parsedConfig.get(SaslConfigs.SASL_JAAS_CONFIG));
+        assertEquals("/path/to/keystore-mirror.jks", parsedConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
     }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -591,6 +591,8 @@ class KafkaConfigTest {
   @Test
   def testMirrorAdminListenerNameExplicitlySet(): Unit = {
     val props = createDefaultConfig()
+    props.setProperty(SocketServerConfigs.LISTENERS_CONFIG, "PLAINTEXT://localhost:0,CONTROLLER://localhost:5000,MIRROR://localhost:5001")
+    props.setProperty(SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG, "MIRROR:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
     props.setProperty(ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG, "MIRROR")
     val config = KafkaConfig.fromProps(props)
     assertNotEquals(ListenerName.normalised("MIRROR"), config.interBrokerListenerName())

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -582,6 +582,40 @@ class KafkaConfigTest {
   }
 
   @Test
+  def testMirrorAdminListenerNameDefaultsToInterBrokerListenerName(): Unit = {
+    val props = createDefaultConfig()
+    val config = KafkaConfig.fromProps(props)
+    assertEquals(config.interBrokerListenerName, config.mirrorAdminListenerName)
+  }
+
+  @Test
+  def testMirrorAdminListenerNameExplicitlySet(): Unit = {
+    val props = createDefaultConfig()
+    props.setProperty(ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG, "MIRROR")
+    val config = KafkaConfig.fromProps(props)
+    assertNotEquals(ListenerName.normalised("MIRROR"), config.interBrokerListenerName())
+    assertEquals(ListenerName.normalised("MIRROR"), config.mirrorAdminListenerName)
+  }
+
+  @Test
+  def testSaslMechanismMirrorAdminProtocolDefaultsToInterBrokerProtocol(): Unit = {
+    val props = createDefaultConfig()
+    props.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG, "PLAIN")
+    val config = KafkaConfig.fromProps(props)
+    assertEquals(config.saslMechanismInterBrokerProtocol, config.saslMechanismMirrorAdminProtocol)
+  }
+
+  @Test
+  def testSaslMechanismMirrorAdminProtocolExplicitlySet(): Unit = {
+    val props = createDefaultConfig()
+    props.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG, "PLAIN")
+    props.setProperty(BrokerSecurityConfigs.SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_CONFIG, "SCRAM-SHA-256")
+    val config = KafkaConfig.fromProps(props)
+    assertEquals("SCRAM-SHA-256", config.saslMechanismMirrorAdminProtocol)
+    assertEquals("PLAIN", config.saslMechanismInterBrokerProtocol)
+  }
+
+  @Test
   def testCaseInsensitiveListenerProtocol(): Unit = {
     val props = new Properties()
     props.setProperty(KRaftConfigs.PROCESS_ROLES_CONFIG, "broker")
@@ -935,6 +969,7 @@ class KafkaConfigTest {
         //Sasl Configs
         case KRaftConfigs.SASL_MECHANISM_CONTROLLER_PROTOCOL_CONFIG => // ignore
         case BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG => // ignore
+        case BrokerSecurityConfigs.SASL_MECHANISM_MIRROR_ADMIN_PROTOCOL_CONFIG => // ignore
         case SaslConfigs.SASL_MECHANISM => // ignore string
         case BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG =>
         case SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS =>

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -119,6 +119,22 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         return interBrokerListenerNameAndSecurityProtocol().getValue();
     }
 
+    public ListenerName mirrorAdminListenerName() {
+        String mirrorAdminListenerName = getString(ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG);
+        if (mirrorAdminListenerName == null) {
+            return interBrokerListenerName();
+        }
+
+        ListenerName listenerName = ListenerName.normalised(mirrorAdminListenerName);
+        SecurityProtocol securityProtocol = effectiveListenerSecurityProtocolMap().get(listenerName);
+        if (securityProtocol == null) {
+            throw new ConfigException("Listener with name " + listenerName.value() + " defined in " +
+                    ReplicationConfigs.MIRROR_ADMIN_LISTENER_NAME_CONFIG + " not found in " +
+                    SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG + ".");
+        }
+        return listenerName;
+    }
+
     public Map<ListenerName, SecurityProtocol> effectiveListenerSecurityProtocolMap() {
         Map<ListenerName, SecurityProtocol> mapValue =
                 getMap(SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG,

--- a/server/src/main/java/org/apache/kafka/server/config/ReplicationConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/config/ReplicationConfigs.java
@@ -129,6 +129,10 @@ public class ReplicationConfigs {
     public static final String INTER_BROKER_LISTENER_NAME_DOC = "Name of listener used for communication between brokers. If this is unset, the listener name is defined by " + INTER_BROKER_SECURITY_PROTOCOL_CONFIG +
            ". It is an error to set this and " + INTER_BROKER_SECURITY_PROTOCOL_CONFIG + " properties at the same time.";
 
+    public static final String MIRROR_ADMIN_LISTENER_NAME_CONFIG = "mirror.admin.listener.name";
+    public static final String MIRROR_ADMIN_LISTENER_NAME_DOC = "Name of listener used for cluster mirror admin communication on destination cluster. " +
+            "If this is unset, it defaults to the value of inter.broker.listener.name.";
+
     public static final String REPLICA_SELECTOR_CLASS_CONFIG = "replica.selector.class";
     public static final String REPLICA_SELECTOR_CLASS_DOC = "The fully qualified class name that implements ReplicaSelector. This is used by the broker to find the preferred read replica. By default, we use an implementation that returns the leader.";
 
@@ -158,6 +162,7 @@ public class ReplicationConfigs {
             .define(UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, BOOLEAN, LogConfig.DEFAULT_UNCLEAN_LEADER_ELECTION_ENABLE, HIGH, UNCLEAN_LEADER_ELECTION_ENABLE_DOC)
             .define(INTER_BROKER_SECURITY_PROTOCOL_CONFIG, STRING, INTER_BROKER_SECURITY_PROTOCOL_DEFAULT, ConfigDef.ValidString.in(Utils.enumOptions(SecurityProtocol.class)), MEDIUM, INTER_BROKER_SECURITY_PROTOCOL_DOC)
             .define(INTER_BROKER_LISTENER_NAME_CONFIG, STRING, null, MEDIUM, INTER_BROKER_LISTENER_NAME_DOC)
+            .define(MIRROR_ADMIN_LISTENER_NAME_CONFIG, STRING, null, MEDIUM, MIRROR_ADMIN_LISTENER_NAME_DOC)
             .define(REPLICA_SELECTOR_CLASS_CONFIG, STRING, null, MEDIUM, REPLICA_SELECTOR_CLASS_DOC);
 
 }

--- a/server/src/main/java/org/apache/kafka/server/config/ReplicationConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/config/ReplicationConfigs.java
@@ -131,7 +131,7 @@ public class ReplicationConfigs {
 
     public static final String MIRROR_ADMIN_LISTENER_NAME_CONFIG = "mirror.admin.listener.name";
     public static final String MIRROR_ADMIN_LISTENER_NAME_DOC = "Name of listener used for cluster mirror admin communication on destination cluster. " +
-            "If this is unset, it defaults to the value of inter.broker.listener.name.";
+            "If this is unset, it defaults to the value of " + INTER_BROKER_LISTENER_NAME_CONFIG + ".";
 
     public static final String REPLICA_SELECTOR_CLASS_CONFIG = "replica.selector.class";
     public static final String REPLICA_SELECTOR_CLASS_DOC = "The fully qualified class name that implements ReplicaSelector. This is used by the broker to find the preferred read replica. By default, we use an implementation that returns the leader.";


### PR DESCRIPTION
I observed some failures with the initialisation of [dstAdmin](https://github.com/showuon/kafka/blob/f4a2e972ed876705c1798a342aeec8d7330a7c0c/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java#L829) in a cluster that uses SASL_SSL with mTLS, because we're not passing any security configs to the constructor.

There's some [machinery](https://github.com/showuon/kafka/blob/f4a2e972ed876705c1798a342aeec8d7330a7c0c/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java#L122) in ChannelBuilders to parse the broker configuration and create a ChannelBuilder from it for a given listener which is then used to create a KafkaChannel for IBP connections. Unfortunately the AdminClient doesn't expose a way to override the underlying KafkaChannel.

This change re-uses `ChannelBuilders#channelBuilderConfigs(config, listenerName)` with the inter-broker listener and use that to construct admin-client props