### PR TITLE
Complete MMM migration to Admin API

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2262,7 +2262,7 @@ public class KafkaAdminClient extends AdminClient {
                     }
                     Uuid topicId = cluster.topicId(topicName);
                     Integer authorizedOperations = response.topicAuthorizedOperations(topicName).get();
-                    TopicDescription topicDescription = getTopicDescriptionFromCluster(cluster, topicName, topicId, authorizedOperations);
+                    TopicDescription topicDescription = getTopicDescriptionFromCluster(cluster, topicName, topicId, authorizedOperations, response);
                     future.complete(topicDescription);
                 }
             }
@@ -2481,7 +2481,7 @@ public class KafkaAdminClient extends AdminClient {
                     }
 
                     Integer authorizedOperations = response.topicAuthorizedOperations(topicName).get();
-                    TopicDescription topicDescription = getTopicDescriptionFromCluster(cluster, topicName, topicId, authorizedOperations);
+                    TopicDescription topicDescription = getTopicDescriptionFromCluster(cluster, topicName, topicId, authorizedOperations, response);
                     future.complete(topicDescription);
                 }
             }
@@ -2512,14 +2512,29 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     private TopicDescription getTopicDescriptionFromCluster(Cluster cluster, String topicName, Uuid topicId,
-                                                            Integer authorizedOperations) {
+                                                            Integer authorizedOperations,
+                                                            MetadataResponse metadataResponse) {
+        Map<Integer, Optional<Integer>> partitionEpochs = new HashMap<>();
+        if (metadataResponse != null) {
+            for (MetadataResponse.TopicMetadata tm : metadataResponse.topicMetadata()) {
+                if (tm.topic().equals(topicName)) {
+                    for (MetadataResponse.PartitionMetadata pm : tm.partitionMetadata()) {
+                        partitionEpochs.put(pm.topicPartition.partition(),
+                                pm.leaderEpoch.isPresent() ? Optional.of(pm.leaderEpoch.get()) : Optional.empty());
+                    }
+                    break;
+                }
+            }
+        }
+
         boolean isInternal = cluster.internalTopics().contains(topicName);
         List<PartitionInfo> partitionInfos = cluster.partitionsForTopic(topicName);
         List<TopicPartitionInfo> partitions = new ArrayList<>(partitionInfos.size());
         for (PartitionInfo partitionInfo : partitionInfos) {
+            Optional<Integer> leaderEpoch = partitionEpochs.getOrDefault(partitionInfo.partition(), Optional.empty());
             TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(
                 partitionInfo.partition(), leader(partitionInfo), Arrays.asList(partitionInfo.replicas()),
-                Arrays.asList(partitionInfo.inSyncReplicas()));
+                Arrays.asList(partitionInfo.inSyncReplicas()), List.of(), List.of(), leaderEpoch);
             partitions.add(topicPartitionInfo);
         }
         partitions.sort(Comparator.comparingInt(TopicPartitionInfo::partition));

--- a/clients/src/main/java/org/apache/kafka/common/TopicPartitionInfo.java
+++ b/clients/src/main/java/org/apache/kafka/common/TopicPartitionInfo.java
@@ -20,6 +20,7 @@ package org.apache.kafka.common;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -32,6 +33,7 @@ public class TopicPartitionInfo {
     private final List<Node> isr;
     private final List<Node> elr;
     private final List<Node> lastKnownElr;
+    private final Optional<Integer> leaderEpoch;
 
     /**
      * Create an instance of this class with the provided parameters.
@@ -52,12 +54,25 @@ public class TopicPartitionInfo {
         List<Node> elr,
         List<Node> lastKnownElr
     ) {
+        this(partition, leader, replicas, isr, elr, lastKnownElr, Optional.empty());
+    }
+
+    public TopicPartitionInfo(
+        int partition,
+        Node leader,
+        List<Node> replicas,
+        List<Node> isr,
+        List<Node> elr,
+        List<Node> lastKnownElr,
+        Optional<Integer> leaderEpoch
+    ) {
         this.partition = partition;
         this.leader = leader;
         this.replicas = Collections.unmodifiableList(replicas);
         this.isr = Collections.unmodifiableList(isr);
         this.elr = Collections.unmodifiableList(elr);
         this.lastKnownElr = Collections.unmodifiableList(lastKnownElr);
+        this.leaderEpoch = leaderEpoch;
     }
 
     public TopicPartitionInfo(int partition, Node leader, List<Node> replicas, List<Node> isr) {
@@ -67,6 +82,7 @@ public class TopicPartitionInfo {
         this.isr = Collections.unmodifiableList(isr);
         this.elr = null;
         this.lastKnownElr = null;
+        this.leaderEpoch = Optional.empty();
     }
 
     /**
@@ -114,12 +130,17 @@ public class TopicPartitionInfo {
         return lastKnownElr;
     }
 
+    public Optional<Integer> leaderEpoch() {
+        return leaderEpoch;
+    }
+
     public String toString() {
         String elrString = elr != null ? elr.stream().map(Node::toString).collect(Collectors.joining(", ")) : "N/A";
         String lastKnownElrString = lastKnownElr != null ? lastKnownElr.stream().map(Node::toString).collect(Collectors.joining(", ")) : "N/A";
         return "(partition=" + partition + ", leader=" + leader + ", replicas=" +
             replicas.stream().map(Node::toString).collect(Collectors.joining(", ")) + ", isr=" + isr.stream().map(Node::toString).collect(Collectors.joining(", ")) +
-            ", elr=" + elrString + ", lastKnownElr=" + lastKnownElrString + ")";
+            ", elr=" + elrString + ", lastKnownElr=" + lastKnownElrString +
+            ", leaderEpoch=" + leaderEpoch.orElse(-1) + ")";
     }
 
     @Override
@@ -134,7 +155,8 @@ public class TopicPartitionInfo {
             Objects.equals(replicas, that.replicas) &&
             Objects.equals(isr, that.isr) &&
             Objects.equals(elr, that.elr) &&
-            Objects.equals(lastKnownElr, that.lastKnownElr);
+            Objects.equals(lastKnownElr, that.lastKnownElr) &&
+            Objects.equals(leaderEpoch, that.leaderEpoch);
     }
 
     @Override
@@ -145,6 +167,7 @@ public class TopicPartitionInfo {
         result = 31 * result + (isr != null ? isr.hashCode() : 0);
         result = 31 * result + (elr != null ? elr.hashCode() : 0);
         result = 31 * result + (lastKnownElr != null ? lastKnownElr.hashCode() : 0);
+        result = 31 * result + leaderEpoch.hashCode();
         return result;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.protocol.Readable;
 
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class DescribeTopicPartitionsResponse extends AbstractResponse {
@@ -74,12 +75,16 @@ public class DescribeTopicPartitionsResponse extends AbstractResponse {
     public static TopicPartitionInfo partitionToTopicPartitionInfo(
         DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponsePartition partition,
         Map<Integer, Node> nodes) {
+        Optional<Integer> leaderEpoch = partition.leaderEpoch() >= 0
+            ? Optional.of(partition.leaderEpoch())
+            : Optional.empty();
         return new TopicPartitionInfo(
             partition.partitionIndex(),
             nodes.get(partition.leaderId()),
             partition.replicaNodes().stream().map(id -> nodes.getOrDefault(id, new Node(id, "", -1))).collect(Collectors.toList()),
             partition.isrNodes().stream().map(id -> nodes.getOrDefault(id, new Node(id, "", -1))).collect(Collectors.toList()),
             partition.eligibleLeaderReplicas().stream().map(id -> nodes.getOrDefault(id, new Node(id, "", -1))).collect(Collectors.toList()),
-            partition.lastKnownElr().stream().map(id -> nodes.getOrDefault(id, new Node(id, "", -1))).collect(Collectors.toList()));
+            partition.lastKnownElr().stream().map(id -> nodes.getOrDefault(id, new Node(id, "", -1))).collect(Collectors.toList()),
+            leaderEpoch);
     }
 }

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -87,7 +87,7 @@ import static org.apache.kafka.common.utils.Utils.require;
 
 /**
  * Coordinates partition-level state transitions for Cluster Mirroring.
- * Persists state and last mirrored offsets in the {@code __cluster_mirror_state} topic,
+ * Persists state and last mirrored offsets in the {@code __mirror_state} topic,
  * distributed across brokers by hashing the mirror record key to a partition.
  */
 public class ClusterMirrorCoordinator {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -87,48 +87,45 @@ import static org.apache.kafka.common.utils.Utils.require;
 
 /**
  * Coordinates partition-level state transitions for Cluster Mirroring.
- * Persists state and last mirrored offsets in the {@code __mirror_state} topic,
- * distributed across brokers by hashing the mirror record key to a partition.
+ * Persists partition state and last mirror epochs in {@code __mirror_state} topic.
+ *
+ * Coordinator load is distributed across the cluster by hashing each mirror
+ * record key (mirror name + topic id + partition) to a partition of the
+ * {@code __mirror_state} topic. Each broker is the coordinator for the
+ * partitions it leads in that topic. Writes targeting a remote coordinator
+ * are forwarded via {@link MirrorMetadataManager}.
  */
 public class ClusterMirrorCoordinator {
-    private static final long RETRY_DELAY_MS = 5000L;
-
     private final Logger log;
-    private final AtomicBoolean isActive = new AtomicBoolean(false);
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
+
     private final KafkaConfig brokerConfig;
     private final ReplicaManager replicaManager;
     private final MirrorMetadataManager metadataManager;
+    private final MetadataCache metadataCache;
+    private final ClusterMirrorRecordSerde serde = new ClusterMirrorRecordSerde();
     private final Scheduler scheduler;
     private final Metrics metrics;
-    private final MetadataCache metadataCache;
     private final Time time;
-    private final ClusterMirrorRecordSerde serde;
-
-    // Exponential backoff for FAILED state retries with 20% jitter.
-    // With defaults (initial=1s, max=300s): attempt 0 ~1s, attempt 1 ~2s, attempt 2 ~4s, ..., attempt 8+ ~300s.
-    private ExponentialBackoff failedRetryBackoff;
-
-    private volatile int numPartitions = -1;
 
     public ClusterMirrorCoordinator(
             KafkaConfig brokerConfig,
             ReplicaManager replicaManager,
+            MirrorMetadataManager metadataManager,
+            MetadataCache metadataCache,
             Scheduler scheduler,
             Metrics metrics,
-            MetadataCache metadataCache,
-            Time time,
-            MirrorMetadataManager mirrorMetadataManager
+            Time time
     ) {
         String name = "[" + ClusterMirrorCoordinator.class.getSimpleName() + " id=" + brokerConfig.nodeId() + "] ";
         this.log = new LogContext(name).logger(ClusterMirrorCoordinator.class);
         this.brokerConfig = brokerConfig;
         this.replicaManager = replicaManager;
-        this.metadataManager = mirrorMetadataManager;
+        this.metadataManager = metadataManager;
+        this.metadataCache = metadataCache;
         this.scheduler = scheduler;
         this.metrics = metrics;
         this.time = time;
-        this.serde = new ClusterMirrorRecordSerde();
-        this.metadataCache = metadataCache;
     }
 
     private boolean isLocalCoordinator(String mirrorName, String topic, int partition) {
@@ -138,7 +135,155 @@ public class ClusterMirrorCoordinator {
         return optLeaderAndIsr.isPresent() && optLeaderAndIsr.get().leader() == brokerConfig.nodeId();
     }
 
-    // Executes the appropriate actions for a state transition.
+    /** Starts the coordinator scheduler and mirror state sender. */
+    public void startup() {
+        if (!isRunning.compareAndSet(false, true)) {
+            log.warn("Is already running.");
+            return;
+        }
+
+        log.info("Starting up.");
+
+        metadataManager.initialize(
+                (mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state),
+                this::tombstoneMirrorRecords,
+                this::getCoordinatorPartitionByKey,
+                this::getCoordinatorPartitionByName);
+
+        scheduler.startup();
+
+        // periodically query source cluster to get the metadata
+        scheduler.schedule("MirrorMetadataRefresh", metadataManager::periodicSync, 0,
+                brokerConfig.mirrorConfig().metadataRefreshIntervalMs());
+
+        log.info("Startup complete.");
+    }
+
+    /** Shuts down the coordinator scheduler and mirror state sender. */
+    public void shutdown() {
+        if (!isRunning.compareAndSet(true, false)) {
+            log.warn("Is already shutting down.");
+            return;
+        }
+
+        log.info("Shutting down.");
+
+        // stop the periodic scheduler to prevent tasks running after shutdown
+        try {
+            scheduler.shutdown();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while shutting down scheduler", e);
+        }
+
+        Utils.closeQuietly(metrics, "ClusterMirrorCoordinator metrics");
+
+        log.info("Shutdown complete.");
+    }
+
+    /** Loads metadata from __mirror_state on leadership election. */
+    public void onElection(
+            int partitionIndex,
+            int partitionLeaderEpoch
+    ) {
+        loadMirrorMetadata(new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, partitionIndex));
+    }
+
+    /** Clears cached metadata on leadership resignation. */
+    public void onResignation(
+            int partitionIndex,
+            OptionalInt partitionLeaderEpoch
+    ) {
+        metadataManager.clearCache();
+    }
+
+    // Replays the mirror state log to rebuild in-memory partition states, epochs, and retry metadata.
+    private void loadMirrorMetadata(TopicPartition topicPartition) {
+        log.info("Loading mirror metadata from {}.", topicPartition);
+        long logEndOffset = replicaManager.getLogEndOffset(topicPartition).getOrElse(() -> -1L);
+
+        replicaManager.getLog(topicPartition).foreach(partitionLog -> {
+            ByteBuffer buffer = ByteBuffer.allocate(0);
+
+            // loop breaks if leader changes at any time during the load, since logEndOffset is -1
+            long currOffset = partitionLog.logStartOffset();
+
+            // loop breaks if no records have been read, since the end of the log has been reached
+            boolean readAtLeastOneRecord = true;
+            int maxLength = 5 * 1024 * 1024;
+
+            try {
+                // might need a lock
+                while (currOffset < logEndOffset && readAtLeastOneRecord && isRunning.get()) {
+                    log.debug("Reading mirror data from {} at offset {}.", topicPartition, currOffset);
+                    FetchDataInfo fetchDataInfo = partitionLog.read(currOffset, maxLength, FetchIsolation.LOG_END, true);
+
+                    readAtLeastOneRecord = fetchDataInfo.records.sizeInBytes() > 0;
+
+                    MemoryRecords memRecords;
+
+                    if (fetchDataInfo.records instanceof MemoryRecords) {
+                        memRecords = (MemoryRecords) fetchDataInfo.records;
+                    } else if (fetchDataInfo.records instanceof FileRecords fileRecords) {
+                        int sizeInBytes = fileRecords.sizeInBytes();
+                        int bytesNeeded = Math.max(maxLength, sizeInBytes);
+
+                        // minOneMessage = true in the above read means that the buffer may need to be grown to ensure progress can be made
+                        if (buffer.capacity() < bytesNeeded) {
+                            if (maxLength < bytesNeeded)
+                                log.warn("Loaded mirror data from {} with buffer larger ({} bytes) than " +
+                                        "{} bytes)", topicPartition, bytesNeeded, maxLength);
+
+                            buffer = ByteBuffer.allocate(bytesNeeded);
+                        }
+                        buffer.clear();
+                        fileRecords.readInto(buffer, 0);
+                        memRecords = MemoryRecords.readableRecords(buffer);
+                    } else {
+                        return null;
+                    }
+                    for (MutableRecordBatch batch : memRecords.batches()) {
+                        batch.iterator().forEachRemaining(record -> {
+                            require(record.hasKey(), "Mirror log's key should not be null");
+                            short version = record.key().getShort();
+                            if (version == CoordinatorRecordType.LAST_MIRROR_EPOCHS.id()) {
+                                String clusterName = readMirrorNameFromKey(record.key());
+                                Map<String, Map<Integer, Integer>> offsets = readLastMirrorEpochsValue(record.value());
+                                metadataManager.updateLastMirrorEpochs(clusterName, offsets, Map.of());
+                            } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
+                                String clusterName = readMirrorNameFromKey(record.key());
+                                ClusterMirrorUtils.PartitionStateLogEntry value = readMirrorPartitionStateValue(record.value());
+                                ClusterMirrorUtils.PartitionKey pk = new ClusterMirrorUtils.PartitionKey(
+                                        clusterName, value.topic(), value.partition());
+                                metadataManager.updatePartitionState(pk, value.state());
+                                TopicPartition tp = new TopicPartition(value.topic(), value.partition());
+                                if (value.state() == MirrorPartitionState.FAILED && value.retryAttempt() > 0) {
+                                    metadataManager.failedRetryAttempts().put(tp, value.retryAttempt());
+                                    metadataManager.partitionPreviousStates().put(pk, value.previousState());
+                                } else {
+                                    metadataManager.failedRetryAttempts().remove(tp);
+                                    metadataManager.partitionPreviousStates().remove(pk);
+                                }
+                            } else {
+                                throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);
+                            }
+
+                        });
+                        currOffset = batch.nextOffset();
+                    }
+                }
+            } catch (Throwable t) {
+                log.error("Error loading mirrors from mirror state log {}", topicPartition, t);
+            }
+
+            // we've read all the mirrored records, transition the state for each topic partitions
+            metadataManager.applyLoadedPartitionStates(this::handleStateTransition);
+
+            return null;
+        });
+    }
+
+    /** Executes the appropriate actions for a state transition. */
     private void handleStateTransition(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
         switch (newState) {
             case LOG_TRUNCATION:
@@ -182,7 +327,7 @@ public class ClusterMirrorCoordinator {
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
                 collectAndUpdateLastMirrorEpochs(mirrorName, topicPartitions)
                     .thenCompose(v -> metadataManager.sendBumpLeaderEpochs(
-                            metadataManager.buildLocalEpochBumpTargets(replicaManager.logManager(), topicPartitions)))
+                            metadataManager.getLatestLocalEpochs(replicaManager.logManager(), topicPartitions)))
                     .thenCompose(v -> abortOngoingTransactions(topicPartitions))
                     .thenAccept(v -> writeMirrorPidResetAndStop(mirrorName, topicPartitions))
                     .exceptionally(ex -> {
@@ -204,6 +349,7 @@ public class ClusterMirrorCoordinator {
         }
     }
 
+    /** Tracks retry attempts and previous state for FAILED transitions; clears them on STOPPED/PAUSED. */
     private void updateRetryAttemptsAndPrevState(String mirrorName, TopicPartition tp, MirrorPartitionState currentState, MirrorPartitionState newState) {
         ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
         if (newState == MirrorPartitionState.FAILED) {
@@ -216,6 +362,7 @@ public class ClusterMirrorCoordinator {
         }
     }
 
+    /** Schedules retries with exponential backoff for partitions in FAILED state, restoring their previous state. */
     private void scheduleFailedRetries(String mirrorName, Set<TopicPartition> topicPartitions) {
         int maxAttempts = brokerConfig.mirrorConfig().failedRetryMaxAttempts();
         topicPartitions.forEach(tp -> {
@@ -224,6 +371,13 @@ public class ClusterMirrorCoordinator {
                 log.error("Partition {} exceeded max retry attempts ({}), requires manual intervention.", tp, maxAttempts);
                 return;
             }
+            // Exponential backoff for FAILED state retries with 20% jitter.
+            // With defaults (initial=1s, max=300s): attempt 0 ~1s, attempt 1 ~2s, attempt 2 ~4s, ..., attempt 8+ ~300s.
+            ExponentialBackoff failedRetryBackoff = new ExponentialBackoff(
+                    brokerConfig.mirrorConfig().failedRetryInitialBackoffMs(),
+                    CommonClientConfigs.RETRY_BACKOFF_EXP_BASE,
+                    brokerConfig.mirrorConfig().failedRetryMaxBackoffMs(),
+                    CommonClientConfigs.RETRY_BACKOFF_JITTER);
             long delay = failedRetryBackoff.backoff(attempt);
             MirrorPartitionState targetState = metadataManager.partitionPreviousStates()
                     .getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
@@ -278,11 +432,7 @@ public class ClusterMirrorCoordinator {
         });
     }
 
-    /**
-     * {@link kafka.server.ReplicaManager#appendRecords} allows only one record batch per partition per call,
-     * otherwise, the LogValidator#getFirstBatchAndMaybeValidateNoMoreBatches will throw exception.
-     * So we append in multiple rounds when needed.
-     */
+    /** Appends abort markers for all ongoing transactions on the given partitions, one batch per appendRecords call. */
     private CompletableFuture<Void> abortOngoingTransactions(Set<TopicPartition> topicPartitions) {
         Map<TopicPartition, List<MemoryRecords>> recordsByPartition = new HashMap<>();
         topicPartitions.forEach(tp -> {
@@ -299,56 +449,51 @@ public class ClusterMirrorCoordinator {
         log.debug("Appending abort markers for partitions: {}", recordsByPartition.keySet());
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         while (!recordsByPartition.isEmpty()) {
-            Map<TopicIdPartition, MemoryRecords> records = new HashMap<>();
+            Map<TopicIdPartition, MemoryRecords> batch = new HashMap<>();
             recordsByPartition.entrySet().removeIf(entry -> {
                 TopicPartition tp = entry.getKey();
                 List<MemoryRecords> recordsList = entry.getValue();
                 Iterator<MemoryRecords> it = recordsList.iterator();
                 if (it.hasNext()) {
                     MemoryRecords record = it.next();
-                    records.put(replicaManager.topicIdPartition(tp), record);
+                    batch.put(replicaManager.topicIdPartition(tp), record);
                     it.remove();
                 }
                 return recordsList.isEmpty();
             });
-            futures.add(appendAbortMarkers(records));
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            replicaManager.appendRecords(
+                // TODO: replace this with Cluster Mirror specific timeout
+                Duration.ofSeconds(5).toMillis(),
+                (short) -1,
+                true,
+                AppendOrigin.COORDINATOR,
+                CollectionConverters.asScala(batch),
+                partitionResponses -> {
+                    partitionResponses.foreach(partitionRes -> {
+                        ProduceResponse.PartitionResponse pr = partitionRes._2;
+                        if (pr.error.code() != Errors.NONE.code()) {
+                            // TODO: retry logic
+                            log.error("Failed to append abort marker for {}: {}", partitionRes._1.topicPartition(), pr.error.message());
+                        }
+                        return null;
+                    });
+                    future.complete(null);
+                    return null;
+                },
+                ignored -> null,
+                RequestLocal.noCaching(),
+                CollectionConverters.asScala(Map.of())
+            );
+            futures.add(future);
         }
         return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
-    private CompletableFuture<Void> appendAbortMarkers(Map<TopicIdPartition, MemoryRecords> records) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        replicaManager.appendRecords(
-            // TODO: replace this with Cluster Mirror specific timeout
-            Duration.ofSeconds(5).toMillis(),
-            (short) -1,
-            true,
-            AppendOrigin.COORDINATOR,
-            CollectionConverters.asScala(records),
-            partitionResponses -> {
-                partitionResponses.foreach(partitionRes -> {
-                    ProduceResponse.PartitionResponse pr = partitionRes._2;
-                    if (pr.error.code() != Errors.NONE.code()) {
-                        // TODO: retry logic
-                        log.error("Failed to append abort marker for {}: {}", partitionRes._1.topicPartition(), pr.error.message());
-                    }
-                    return null;
-                });
-                future.complete(null);
-
-                return null;
-            },
-            ignored -> null,
-            RequestLocal.noCaching(),
-            CollectionConverters.asScala(Map.of())
-        );
-        return future;
-    }
-
-    /** Writes partition state and offset updates to the internal topic. */
-    public void writePartitionStateInfo(String mirrorName,
-                                        Map<String, Set<ClusterMirrorUtils.PartitionStateInfo>> topicMetadata,
-                                        Consumer<WriteMirrorStatesResponse> callback) {
+    /** Write partition state and offset updates to the internal topic. */
+    public void updateTopicMetadata(String mirrorName,
+                                    Map<String, Set<ClusterMirrorUtils.PartitionStateInfo>> topicMetadata,
+                                    Consumer<WriteMirrorStatesResponse> callback) {
         List<CompletableFuture<Optional<TopicPartition>>> updateMirrorPartitionStateFutures = new ArrayList<>();
 
         String updatedMirrorName = ClusterMirrorUtils.originalMirrorName(mirrorName);
@@ -370,7 +515,7 @@ public class ClusterMirrorCoordinator {
             tps.put(topic, partitionIndices);
         });
 
-        // execute in parallel for efficiency, but wait for all partition state updates first, THEN wait for LME update
+        // Execute in parallel for efficiency, but wait for all partition state updates first, THEN wait for LME update
         CompletableFuture<Void> updateLastMirrorEpochsFuture = updateLastMirrorEpochs(updatedMirrorName, offsets);
         CompletableFuture.allOf(updateMirrorPartitionStateFutures.toArray(CompletableFuture[]::new))
             .thenCompose(v -> updateLastMirrorEpochsFuture)
@@ -398,10 +543,11 @@ public class ClusterMirrorCoordinator {
             });
     }
 
-    public void getCachedPartitionMetadata(String mirrorName,
-                                           Map<String, Set<Integer>> partitions,
-                                           Consumer<ReadMirrorStatesResponse> callback) {
-        metadataManager.getCachedPartitionMetadata(mirrorName, partitions, callback);
+    /** Reads partition states for the given mirror from the coordinator. */
+    public void getTopicMetadata(String mirrorName,
+                                 Map<String, Set<Integer>> partitions,
+                                 Consumer<ReadMirrorStatesResponse> callback) {
+        metadataManager.getTopicMetadata(mirrorName, partitions, callback);
     }
 
     private CompletableFuture<Void> collectAndUpdateLastMirrorEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
@@ -419,13 +565,99 @@ public class ClusterMirrorCoordinator {
         });
 
         futures.add(updateLastMirrorEpochs(mirrorName, partitionOffsets));
-
         return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
-    private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(String mirrorName,
-                                                                                  TopicPartition topicPartition,
-                                                                                  MirrorPartitionState newState) {
+    /** Persists last mirror epochs to local or remote coordinators. */
+    public CompletableFuture<Void> updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        // Separate partitions into local and remote coordinator groups
+        Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
+        Map<String, Set<ClusterMirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
+
+        partitionOffsets.forEach((topic, offsetMap) -> {
+            offsetMap.forEach((par, off) -> {
+                if (isLocalCoordinator(mirrorName, topic, par)) {
+                    int coordPartition = getCoordinatorPartitionByKey(
+                            new ClusterMirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), par));
+                    localByCoordPartition
+                            .computeIfAbsent(coordPartition, k -> new HashSet<>())
+                            .add(new TopicPartition(topic, par));
+                } else {
+                    remoteTopicMetadata
+                            .computeIfAbsent(topic, k -> new HashSet<>())
+                            .add(new ClusterMirrorUtils.PartitionStateInfo(par, null, off));
+                }
+            });
+        });
+
+        // No partitions need updating (e.g. empty topic with no leader epoch)
+        if (localByCoordPartition.isEmpty() && remoteTopicMetadata.isEmpty()) {
+            future.complete(null);
+            return future;
+        }
+
+        // Update in-memory cache once with all offsets
+        var updatedOffsets = metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets, Map.of());
+
+        // Write to local coordinator partitions (one append per coordinator partition)
+        localByCoordPartition.forEach((coordPartition, tps) -> {
+            var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, coordPartition);
+            var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
+            var record = buildLastMirrorEpochsRecord(mirrorName, updatedOffsets);
+            var keyBytes = serde.serializeKey(record);
+            var valueBytes = serde.serializeValue(record);
+            var timestamp = time.milliseconds();
+            var memRecord = MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(timestamp, keyBytes, valueBytes));
+
+            replicaManager.appendRecords(
+                    // TODO: replace this with Cluster Mirror specific timeout
+                    Duration.ofSeconds(5).toMillis(),
+                    (short) -1, // request ack from all ISR
+                    true,
+                    AppendOrigin.COORDINATOR,
+                    CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
+                    response -> {
+                        response.foreach(res -> {
+                            ProduceResponse.PartitionResponse partitionRes = res._2;
+                            if (partitionRes.error.code() != Errors.NONE.code()) {
+                                // TODO: retry logic
+                                log.error("Failed to write last mirrored epochs to coordinator: {}", partitionRes.error.message());
+                                future.completeExceptionally(partitionRes.error.exception());
+                            } else {
+                                future.complete(null);
+                            }
+                            return null;
+                        });
+                        return null;
+                    },
+                    ignored -> null,
+                    RequestLocal.noCaching(),
+                    CollectionConverters.asScala(Map.of())
+            );
+        });
+
+        // Write to remote coordinator (batched by coordinator node internally)
+        if (!remoteTopicMetadata.isEmpty()) {
+            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
+                res.data().topics().forEach(topicResult -> {
+                    topicResult.partitions().forEach(partitionResult -> {
+                        if (partitionResult.errorCode() != Errors.NONE.code()) {
+                            log.error("Failed to write last mirrored epochs to remote coordinator: {}", partitionResult.errorCode());
+                            future.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
+                        } else {
+                            future.complete(null);
+                        }
+                    });
+                });
+            });
+        }
+
+        return future;
+    }
+
+    private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(
+            String mirrorName, TopicPartition topicPartition, MirrorPartitionState newState) {
         CompletableFuture<Optional<TopicPartition>> future = new CompletableFuture<>();
         // no need to write a record for the same state again
         if (metadataManager.getPartitionState(mirrorName, topicPartition) == newState) {
@@ -438,7 +670,7 @@ public class ClusterMirrorCoordinator {
                     getCoordinatorPartitionByKey(new ClusterMirrorRecordKey(
                             mirrorName, metadataCache.getTopicId(topicPartition.topic()), topicPartition.partition())));
             var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
-            var record = generateMirrorPartitionState(mirrorName, topicPartition, newState);
+            var record = buildPartitionStateRecord(mirrorName, topicPartition, newState);
             var keyBytes = serde.serializeKey(record);
             var valueBytes = serde.serializeValue(record);
             var timestamp = time.milliseconds();
@@ -489,38 +721,6 @@ public class ClusterMirrorCoordinator {
         return future;
     }
 
-    /**
-     * Starts the mirror coordinator and begins periodic metadata refresh from source clusters.
-     * Schedules background tasks to synchronize topic metadata, offsets, and ACLs.
-     */
-    public void startup() {
-        if (!isActive.compareAndSet(false, true)) {
-            log.warn("Is already running.");
-            return;
-        }
-
-        log.info("Starting up.");
-        numPartitions = brokerConfig.mirrorConfig().stateTopicNumPartitions();
-        failedRetryBackoff = new ExponentialBackoff(
-                brokerConfig.mirrorConfig().failedRetryInitialBackoffMs(),
-                CommonClientConfigs.RETRY_BACKOFF_EXP_BASE,
-                brokerConfig.mirrorConfig().failedRetryMaxBackoffMs(),
-                CommonClientConfigs.RETRY_BACKOFF_JITTER);
-        metadataManager.initialize(
-                (mirrorName, tp, state) -> transitionTo(mirrorName, Set.of(tp), state),
-                this::tombstoneMirrorRecords,
-                this::getCoordinatorPartitionByKey,
-                this::getCoordinatorPartitionByName);
-
-        scheduler.startup();
-
-        // periodically query source cluster to get the metadata
-        long metadataRefreshIntervalMs = brokerConfig.mirrorConfig().metadataRefreshIntervalMs();
-        scheduler.schedule("MirrorMetadataRefresh", metadataManager::periodicSync, 0, metadataRefreshIntervalMs);
-
-        log.info("Startup complete.");
-    }
-
     /** Schedules truncation to align replicas with last mirrored epoch. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
         final Consumer<TopicPartition> truncateCallback =
@@ -532,13 +732,13 @@ public class ClusterMirrorCoordinator {
                         .whenComplete((descriptions, error) -> {
                             if (error != null) {
                                 if (error instanceof UnsupportedVersionException) {
-                                    log.warn("Source cluster doesn't support DESCRIBE_CLUSTER_MIRRORS. " +
-                                        "Replication will be one-way without possible failback");
+                                    log.warn("Source cluster doesn't support DescribeClusterMirror API. " +
+                                        "Replication will be one-way without failback");
                                     Map<TopicPartition, Integer> epochs = topicPartitions.stream()
                                         .collect(Collectors.toMap(tp -> tp, tp -> -1));
                                     replicaManager.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
                                 } else {
-                                    log.warn("Failed to truncate to last mirrored offsets for mirror {}", mirrorName, error);
+                                    log.warn("Failed to truncate to last mirrored epoch for mirror {}", mirrorName, error);
                                     transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED);
                                 }
                                 return;
@@ -546,7 +746,7 @@ public class ClusterMirrorCoordinator {
 
                             ClusterMirrorDescription description = descriptions.get(mirrorName);
                             if (description == null) {
-                                log.warn("Mirror {} not found in source cluster. Replication will be one-way without possible failback",
+                                log.warn("Mirror {} not found in source cluster. Replication will be one-way without failback",
                                     mirrorName);
                                 Map<TopicPartition, Integer> epochs = topicPartitions.stream()
                                     .collect(Collectors.toMap(tp -> tp, tp -> -1));
@@ -574,24 +774,19 @@ public class ClusterMirrorCoordinator {
                                     partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING));
                         });
                 } catch (Exception e) {
-                    log.warn("Failed to truncate to last mirrored offsets for mirror {}", mirrorName, e);
+                    log.warn("Failed to truncate to last mirror epochs for mirror {}", mirrorName, e);
                     transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED);
                 }
             }, 0);
     }
 
-    /**
-     * After bump epoch and last-mirrored updates, writes the PID reset barrier per partition and transition to STOPPED state.
-     * Retry the failed partitions until success.
-     * TODO: handle failure, we can't retry forever
-     */
+    /** Writes a PID reset control record per partition and transitions to STOPPED, retrying failed partitions. */
     private void writeMirrorPidResetAndStop(String mirrorName, Set<TopicPartition> topicPartitions) {
-        writeMirrorPidResetBarrier(mirrorName, topicPartitions).whenComplete((responses, ex) -> {
+        writeMirrorPidReset(mirrorName, topicPartitions).whenComplete((responses, ex) -> {
             if (ex != null) {
-                log.error("Failed to write PID reset barrier for partitions {} in mirror {}", topicPartitions, mirrorName, ex);
-                scheduler.scheduleOnce("MirrorPidResetBarrierRetry",
-                    () -> writeMirrorPidResetAndStop(mirrorName, topicPartitions),
-                        RETRY_DELAY_MS);
+                log.error("Failed to write PID reset record for partitions {} in mirror {}", topicPartitions, mirrorName, ex);
+                // TODO: handle failure, we can't retry forever
+                scheduler.scheduleOnce("MirrorPidResetRetry", () -> writeMirrorPidResetAndStop(mirrorName, topicPartitions), 5000);
                 return;
             }
             Set<TopicPartition> succeeded = new HashSet<>();
@@ -613,22 +808,19 @@ public class ClusterMirrorCoordinator {
                 transitionTo(mirrorName, succeeded, MirrorPartitionState.STOPPED);
             }
             if (!failed.isEmpty()) {
-                scheduler.scheduleOnce("MirrorPidResetBarrierRetry",
-                    () -> writeMirrorPidResetAndStop(mirrorName, failed),
-                        RETRY_DELAY_MS);
+                scheduler.scheduleOnce("MirrorPidResetRetry", () -> writeMirrorPidResetAndStop(mirrorName, failed), 5000);
             }
         });
     }
 
-    private CompletableFuture<Map<TopicPartition, ProduceResponse.PartitionResponse>> writeMirrorPidResetBarrier(
-            String mirrorName,
-            Set<TopicPartition> topicPartitions) {
-        CompletableFuture<Map<TopicPartition, ProduceResponse.PartitionResponse>> writePidResetBarrierFuture = new CompletableFuture<>();
+    private CompletableFuture<Map<TopicPartition, ProduceResponse.PartitionResponse>> writeMirrorPidReset(
+            String mirrorName, Set<TopicPartition> topicPartitions) {
+        CompletableFuture<Map<TopicPartition, ProduceResponse.PartitionResponse>> writePidResetFuture = new CompletableFuture<>();
         Uuid sourceClusterId = metadataManager.getSourceClusterId(mirrorName);
         if (sourceClusterId == null) {
             log.warn("Source cluster ID not available for mirror {}. Skipping PID reset barrier.", mirrorName);
-            writePidResetBarrierFuture.complete(Map.of());
-            return writePidResetBarrierFuture;
+            writePidResetFuture.complete(Map.of());
+            return writePidResetFuture;
         }
         MirrorPidResetRecord record = new MirrorPidResetRecord()
             .setVersion(ControlRecordUtils.MIRROR_PID_RESET_CURRENT_VERSION)
@@ -660,7 +852,7 @@ public class ClusterMirrorCoordinator {
                             result.put(tp, pr);
                             return null;
                         });
-                        writePidResetBarrierFuture.complete(result);
+                        writePidResetFuture.complete(result);
                         return null;
                     },
                     ignored -> null,
@@ -669,115 +861,18 @@ public class ClusterMirrorCoordinator {
                 );
             } catch (Exception e) {
                 log.error("Failed to write PID reset barrier for partition {} in mirror {}", tp, mirrorName, e);
-                writePidResetBarrierFuture.completeExceptionally(e);
+                writePidResetFuture.completeExceptionally(e);
             }
         }
-        return writePidResetBarrierFuture;
+        return writePidResetFuture;
     }
 
-    private Map<String, Map<Integer, Integer>> lastMirrorEpochsToCoordinatorRecords(Map<ClusterMirrorUtils.PartitionKey, Integer> offsets) {
-        Map<String, Map<Integer, Integer>> results = new HashMap<>();
-        offsets.forEach((key, value) -> {
-            Map<Integer, Integer> partitionOffsets = results.getOrDefault(key.topic(), new HashMap<>());
-            partitionOffsets.put(key.partition(), value);
-            results.put(key.topic(), partitionOffsets);
-        });
-        return results;
-    }
-
+    /** Returns the cached last mirror epochs for the given mirror. */
     public Map<TopicPartition, Integer> getLastMirrorEpochs(String mirrorName) {
         return metadataManager.getLastMirrorEpochs(mirrorName);
     }
 
-    /** Persists offsets to local or remote coordinators. */
-    public CompletableFuture<Void> updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        // Separate partitions into local and remote coordinator groups
-        Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
-        Map<String, Set<ClusterMirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
-
-        partitionOffsets.forEach((topic, offsetMap) -> {
-            offsetMap.forEach((par, off) -> {
-                if (isLocalCoordinator(mirrorName, topic, par)) {
-                    int coordPartition = getCoordinatorPartitionByKey(
-                        new ClusterMirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), par));
-                    localByCoordPartition
-                        .computeIfAbsent(coordPartition, k -> new HashSet<>())
-                        .add(new TopicPartition(topic, par));
-                } else {
-                    remoteTopicMetadata
-                        .computeIfAbsent(topic, k -> new HashSet<>())
-                        .add(new ClusterMirrorUtils.PartitionStateInfo(par, null, off));
-                }
-            });
-        });
-
-        // No partitions need updating (e.g. empty topic with no leader epoch)
-        if (localByCoordPartition.isEmpty() && remoteTopicMetadata.isEmpty()) {
-            future.complete(null);
-            return future;
-        }
-
-        // Update in-memory cache once with all offsets
-        var updatedOffsets = metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets, Map.of());
-
-        // Write to local coordinator partitions (one append per coordinator partition)
-        localByCoordPartition.forEach((coordPartition, tps) -> {
-            var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, coordPartition);
-            var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
-            var record = generateLastMirrorEpochs(mirrorName, lastMirrorEpochsToCoordinatorRecords(updatedOffsets));
-            var keyBytes = serde.serializeKey(record);
-            var valueBytes = serde.serializeValue(record);
-            var timestamp = time.milliseconds();
-            var memRecord = MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(timestamp, keyBytes, valueBytes));
-
-            replicaManager.appendRecords(
-                    // TODO: replace this with Cluster Mirror specific timeout
-                    Duration.ofSeconds(5).toMillis(),
-                    (short) -1, // request ack from all ISR
-                    true,
-                    AppendOrigin.COORDINATOR,
-                    CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
-                    response -> {
-                        response.foreach(res -> {
-                            ProduceResponse.PartitionResponse partitionRes = res._2;
-                            if (partitionRes.error.code() != Errors.NONE.code()) {
-                                // TODO: retry logic
-                                log.error("Failed to write last mirrored offsets to coordinator: {}", partitionRes.error.message());
-                                future.completeExceptionally(partitionRes.error.exception());
-                            } else {
-                                future.complete(null);
-                            }
-                            return null;
-                        });
-                        return null;
-                    },
-                    ignored -> null,
-                    RequestLocal.noCaching(),
-                    CollectionConverters.asScala(Map.of())
-            );
-        });
-
-        // Write to remote coordinator (batched by coordinator node internally)
-        if (!remoteTopicMetadata.isEmpty()) {
-            metadataManager.writeStatesToRemoteCoordinator(mirrorName, remoteTopicMetadata, Set.of(), res -> {
-                res.data().topics().forEach(topicResult -> {
-                    topicResult.partitions().forEach(partitionResult -> {
-                        if (partitionResult.errorCode() != Errors.NONE.code()) {
-                            log.error("Failed to write last mirrored offsets to remote coordinator: {}", partitionResult.errorCode());
-                            future.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
-                        } else {
-                            future.complete(null);
-                        }
-                    });
-                });
-            });
-        }
-
-        return future;
-    }
-
-    private CoordinatorRecord generateMirrorPartitionState(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
+    private CoordinatorRecord buildPartitionStateRecord(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
         short retryAttempt = (state == MirrorPartitionState.FAILED)
                 ? metadataManager.failedRetryAttempts().getOrDefault(topicPartition, 0).shortValue()
                 : 0;
@@ -793,11 +888,14 @@ public class ClusterMirrorCoordinator {
         return CoordinatorRecord.record(key, apiVersion);
     }
 
-    private static CoordinatorRecord generateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> offsets) {
+    private static CoordinatorRecord buildLastMirrorEpochsRecord(String mirrorName, Map<ClusterMirrorUtils.PartitionKey, Integer> offsets) {
+        Map<String, Map<Integer, Integer>> grouped = new HashMap<>();
+        offsets.forEach((pk, value) -> grouped.computeIfAbsent(pk.topic(), k -> new HashMap<>()).put(pk.partition(), value));
+
         var key = new LastMirrorEpochsKey().setMirrorName(mirrorName);
         var val = new LastMirrorEpochsValue();
         var topics = new ArrayList<LastMirrorEpochsValue.Topic>();
-        offsets.forEach((topic, partitionOffsets) -> {
+        grouped.forEach((topic, partitionOffsets) -> {
             var top = new LastMirrorEpochsValue.Topic().setName(topic);
             List<LastMirrorEpochsValue.Partition> partitions = new ArrayList<>();
             partitionOffsets.forEach((partition, offset) ->
@@ -875,7 +973,7 @@ public class ClusterMirrorCoordinator {
                 offsets.put(t.name(), partitions);
             });
         } else {
-            throw new IllegalStateException("Unsupported last mirrored offsets value version: " + version);
+            throw new IllegalStateException("Unsupported last mirrored epochs value version: " + version);
         }
         return offsets;
     }
@@ -892,159 +990,43 @@ public class ClusterMirrorCoordinator {
         }
     }
 
-    // Replays the mirror state log to rebuild in-memory partition states, epochs, and retry metadata.
-    private void loadMirrorMetadata(TopicPartition topicPartition) {
-        log.info("Loading mirror metadata from {}.", topicPartition);
-        long logEndOffset = replicaManager.getLogEndOffset(topicPartition).getOrElse(() -> -1L);
-
-        replicaManager.getLog(topicPartition).foreach(partitionLog -> {
-            ByteBuffer buffer = ByteBuffer.allocate(0);
-
-            // loop breaks if leader changes at any time during the load, since logEndOffset is -1
-            long currOffset = partitionLog.logStartOffset();
-
-            // loop breaks if no records have been read, since the end of the log has been reached
-            boolean readAtLeastOneRecord = true;
-            int maxLength = 5 * 1024 * 1024;
-
-            try {
-                // might need a lock
-                while (currOffset < logEndOffset && readAtLeastOneRecord && isActive.get()) {
-                    log.debug("Reading mirror data from {} at offset {}.", topicPartition, currOffset);
-                    FetchDataInfo fetchDataInfo = partitionLog.read(currOffset, maxLength, FetchIsolation.LOG_END, true);
-
-                    readAtLeastOneRecord = fetchDataInfo.records.sizeInBytes() > 0;
-
-                    MemoryRecords memRecords;
-
-                    if (fetchDataInfo.records instanceof MemoryRecords) {
-                        memRecords = (MemoryRecords) fetchDataInfo.records;
-                    } else if (fetchDataInfo.records instanceof FileRecords fileRecords) {
-                        int sizeInBytes = fileRecords.sizeInBytes();
-                        int bytesNeeded = Math.max(maxLength, sizeInBytes);
-
-                        // minOneMessage = true in the above read means that the buffer may need to be grown to ensure progress can be made
-                        if (buffer.capacity() < bytesNeeded) {
-                            if (maxLength < bytesNeeded)
-                                log.warn("Loaded mirror data from {} with buffer larger ({} bytes) than " +
-                                        "{} bytes)", topicPartition, bytesNeeded, maxLength);
-
-                            buffer = ByteBuffer.allocate(bytesNeeded);
-                        }
-                        buffer.clear();
-                        fileRecords.readInto(buffer, 0);
-                        memRecords = MemoryRecords.readableRecords(buffer);
-                    } else {
-                        return null;
-                    }
-                    for (MutableRecordBatch batch : memRecords.batches()) {
-                        batch.iterator().forEachRemaining(record -> {
-                            require(record.hasKey(), "Mirror log's key should not be null");
-                            short version = record.key().getShort();
-                            if (version == CoordinatorRecordType.LAST_MIRROR_EPOCHS.id()) {
-                                String clusterName = readMirrorNameFromKey(record.key());
-                                Map<String, Map<Integer, Integer>> offsets = readLastMirrorEpochsValue(record.value());
-                                metadataManager.updateLastMirrorEpochs(clusterName, offsets, Map.of());
-                            } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
-                                String clusterName = readMirrorNameFromKey(record.key());
-                                ClusterMirrorUtils.PartitionStateLogEntry value = readMirrorPartitionStateValue(record.value());
-                                ClusterMirrorUtils.PartitionKey pk = new ClusterMirrorUtils.PartitionKey(
-                                        clusterName, value.topic(), value.partition());
-                                metadataManager.updatePartitionState(pk, value.state());
-                                TopicPartition tp = new TopicPartition(value.topic(), value.partition());
-                                if (value.state() == MirrorPartitionState.FAILED && value.retryAttempt() > 0) {
-                                    metadataManager.failedRetryAttempts().put(tp, value.retryAttempt());
-                                    metadataManager.partitionPreviousStates().put(pk, value.previousState());
-                                } else {
-                                    metadataManager.failedRetryAttempts().remove(tp);
-                                    metadataManager.partitionPreviousStates().remove(pk);
-                                }
-                            } else {
-                                throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);
-                            }
-
-                        });
-                        currOffset = batch.nextOffset();
-                    }
-                }
-            } catch (Throwable t) {
-                log.error("Error loading mirrors from mirror state log {}", topicPartition, t);
-            }
-
-            // we've read all the mirrored records, transition the state for each topic partitions
-            metadataManager.applyLoadedPartitionStates(this::handleStateTransition);
-
-            return null;
-        });
-    }
-
-    /** Loads metadata from __mirror_state on leadership election. */
-    public void onElection(
-            int partitionIndex,
-            int partitionLeaderEpoch
-    ) {
-        loadMirrorMetadata(new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, partitionIndex));
-    }
-
-    /** Clears cached metadata on leadership resignation. */
-    public void onResignation(
-            int partitionIndex,
-            OptionalInt partitionLeaderEpoch
-    ) {
-        metadataManager.clear();
-    }
-
+    /** Returns the set of all configured mirror names. */
     public Set<String> getConfiguredMirrors() {
         return metadataManager.getConfiguredMirrors();
     }
 
+    /** Returns the number of active mirrored topics for the given mirror. */
     public int getActiveTopicCount(String mirrorName) {
         return metadataManager.getActiveTopicCount(mirrorName);
     }
 
+    /** Returns the source cluster bootstrap servers for the given mirror. */
     public String getSourceBootstrap(String mirrorName) {
         return metadataManager.getSourceBootstrap(mirrorName);
     }
 
+    /** Returns the source cluster ID for the given mirror. */
     public Uuid getSourceClusterId(String mirrorName) {
         return metadataManager.getSourceClusterId(mirrorName);
     }
 
+    /** Returns the current partition states for all partitions in the given mirror. */
     public Map<TopicPartition, MirrorPartitionState> getMirrorStates(String mirrorName) {
         return metadataManager.getMirrorStates(mirrorName);
     }
 
-    public void shutdown() {
-        if (!isActive.compareAndSet(true, false)) {
-            log.warn("Is already shutting down.");
-            return;
-        }
-
-        log.info("Shutting down.");
-        // stop the coordinator's periodic scheduler to prevent tasks running after shutdown
-        try {
-            scheduler.shutdown();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.warn("Interrupted while shutting down scheduler", e);
-        }
-        Utils.closeQuietly(metrics, "ClusterMirrorCoordinator metrics");
-        log.info("Shutdown complete.");
-    }
-
+    /** Maps a mirror record key to a __mirror_state partition index. */
     public int getCoordinatorPartitionByKey(ClusterMirrorRecordKey key) {
-        throwIfNotActive();
-        return Utils.abs(key.asCoordinatorKey().hashCode()) % numPartitions;
+        if (!isRunning.get()) {
+            throw Errors.COORDINATOR_NOT_AVAILABLE.exception();
+        }
+        return Utils.abs(key.asCoordinatorKey().hashCode()) % brokerConfig.mirrorConfig().stateTopicNumPartitions();
     }
 
     private int getCoordinatorPartitionByName(String mirrorName) {
-        throwIfNotActive();
-        return Utils.abs(mirrorName.hashCode()) % numPartitions;
-    }
-
-    private void throwIfNotActive() {
-        if (!isActive.get()) {
+        if (!isRunning.get()) {
             throw Errors.COORDINATOR_NOT_AVAILABLE.exception();
         }
+        return Utils.abs(mirrorName.hashCode()) % brokerConfig.mirrorConfig().stateTopicNumPartitions();
     }
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -33,9 +33,10 @@ import org.apache.kafka.clients.admin.GroupListing;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
 import org.apache.kafka.clients.admin.ListGroupsOptions;
 import org.apache.kafka.clients.admin.ListShareGroupOffsetsSpec;
+import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.GroupState;
-import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -44,6 +45,7 @@ import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.BumpLeaderEpochsRequestData;
 import org.apache.kafka.common.message.CreateAclsRequestData;
@@ -58,7 +60,6 @@ import org.apache.kafka.common.message.StartMirrorTopicsRequestData;
 import org.apache.kafka.common.message.WriteMirrorStatesRequestData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.BumpLeaderEpochsRequest;
 import org.apache.kafka.common.requests.CreateAclsRequest;
 import org.apache.kafka.common.requests.CreatePartitionsRequest;
@@ -66,7 +67,6 @@ import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
-import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.ReadMirrorStatesRequest;
 import org.apache.kafka.common.requests.ReadMirrorStatesResponse;
@@ -140,10 +140,10 @@ import static org.apache.kafka.controller.ConfigurationControlManager.STOPPED_TO
  * and periodically syncs topic metadata, configs, consumer group offsets, and ACLs from source
  * clusters.
  *
- * Maintains in-memory caches of partition states and last mirrored offsets, populated from
- * the {@code __cluster_mirror_state} topic on coordinator election and cleared on resignation
- * or leadership loss. Routes state reads/writes to the appropriate coordinator broker, batching
- * requests per coordinator node to reduce network overhead.
+ * Maintains in-memory caches of partition states and last mirrored epochs, populated from
+ * the {@code __mirror_state} topic on coordinator election and cleared on resignation or
+ * leadership loss. Routes state reads/writes to the appropriate coordinator broker,
+ * batching requests per coordinator node to reduce network overhead.
  */
 @SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
 public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
@@ -818,39 +818,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         sourceSenders.put(mirrorName, senders);
     }
 
-    /** Creates Admin clients for source mirrors and the local destination, if not already initialized. */
-    private void createAdminClients(Set<String> mirrors) {
-        for (String mirrorName : mirrors) {
-            srcAdmins.computeIfAbsent(mirrorName, k -> {
-                Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
-                return Admin.create(props);
-            });
-        }
+    private Admin getOrCreateDestAdmin() {
         if (dstAdmin == null) {
             var endpoint = brokerConfig.effectiveAdvertisedBrokerListeners().head();
             Properties props = new Properties();
             props.put(BOOTSTRAP_SERVERS_CONFIG, endpoint.host() + ":" + endpoint.port());
             dstAdmin = Admin.create(props);
         }
-    }
-
-    /** Sends a request to the source cluster, iterating available senders with fallback on failure. */
-    private ClientResponse trySendSourceClusterRequest(String mirrorName, AbstractRequest.Builder<?> requestBuilder) {
-        // snapshot sender list to avoid concurrent modification during iteration
-        List<MirrorSourceSender> senders = List.copyOf(sourceSenders.getOrDefault(mirrorName, List.of()));
-        if (senders.isEmpty()) {
-            throw new IllegalStateException("No source senders available for mirror " + mirrorName);
-        }
-        Exception lastException = null;
-        for (MirrorSourceSender sender : senders) {
-            try {
-                return sender.sendRequest(requestBuilder);
-            } catch (Exception e) {
-                lastException = e;
-                log.warn("Failed to send request to {} for mirror {}: {}", sender.brokerEndPoint(), mirrorName, e.getMessage());
-            }
-        }
-        throw new KafkaException("Failed to send request to any source server for mirror " + mirrorName, lastException);
+        return dstAdmin;
     }
 
     /** Updates cached source leader for a specific partition. */
@@ -1005,14 +980,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         log.info("Syncing metadata for mirrors: {}", mirrors);
         mirrors.forEach(this::ensureConnection);
-        createAdminClients(mirrors);
 
         // snapshot keyset to avoid ConcurrentModificationException
         for (String mirrorName : Set.copyOf(sourceSenders.keySet())) {
             try {
                 discoverSourceBrokers(mirrorName);
-                var metadataResponse = syncSourceTopicState(mirrorName);
-                syncCoordinatorMetadata(mirrorName, metadataResponse);
+                var topicInfos = syncSourceTopicState(mirrorName);
+                syncCoordinatorMetadata(mirrorName, topicInfos);
             } catch (Exception e) {
                 log.error("Failed to sync metadata for mirror {}", mirrorName, e);
             }
@@ -1027,8 +1001,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         scheduler.scheduleOnce("bump-leader-epoch", () -> {
             ensureConnection(mirrorName);
             discoverSourceBrokers(mirrorName);
-            Optional<MetadataResponse> metadataResponse = syncSourceTopicState(mirrorName);
-            maybeBumpLeaderEpochs(mirrorName, metadataResponse, topicPartitions)
+            Optional<List<SourceTopicInfo>> topicInfos = syncSourceTopicState(mirrorName);
+            maybeBumpLeaderEpochs(mirrorName, topicInfos, topicPartitions)
                     .whenComplete((v, ex) -> {
                         if (ex != null) {
                             future.completeExceptionally(ex);
@@ -1040,9 +1014,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return future;
     }
 
-    private CompletableFuture<Void> maybeBumpLeaderEpochs(String mirrorName, Optional<MetadataResponse> metadataResponse, Set<TopicPartition> topicPartitions) {
-        if (metadataResponse.isPresent()) {
-            return sendBumpLeaderEpochs(buildSourceEpochBumpTargets(mirrorName, metadataResponse.get(), topicPartitions))
+    private CompletableFuture<Void> maybeBumpLeaderEpochs(String mirrorName, Optional<List<SourceTopicInfo>> topicInfos, Set<TopicPartition> topicPartitions) {
+        if (topicInfos.isPresent()) {
+            return sendBumpLeaderEpochs(buildSourceEpochBumpTargets(mirrorName, topicInfos.get(), topicPartitions))
                     .whenComplete((v, ex) -> {
                         if (ex != null) log.warn("Failed to bump leader epoch for mirror {}", mirrorName, ex);
                     });
@@ -1093,17 +1067,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return future;
     }
 
-    private Map<TopicPartition, Integer> buildSourceEpochBumpTargets(String mirrorName, MetadataResponse metadataResponse, Set<TopicPartition> topicPartitions) {
+    private Map<TopicPartition, Integer> buildSourceEpochBumpTargets(String mirrorName, List<SourceTopicInfo> topicInfos, Set<TopicPartition> topicPartitions) {
         Set<String> mirrorTopics = topicPartitions.isEmpty() ? getConfiguredTopics(mirrorName, false) : Set.of();
         Map<TopicPartition, Integer> leaderEpochFromMetadata = new HashMap<>();
-        for (MetadataResponse.TopicMetadata topicMetadata : metadataResponse.topicMetadata()) {
-            if (topicMetadata.error() != Errors.NONE) {
+        for (SourceTopicInfo ti : topicInfos) {
+            if (!ti.exists()) {
                 continue;
             }
-            if (!mirrorTopics.isEmpty() && !mirrorTopics.contains(topicMetadata.topic())) {
+            if (!mirrorTopics.isEmpty() && !mirrorTopics.contains(ti.topic())) {
                 continue;
             }
-            collectEpochBumpTargets(topicMetadata, topicPartitions, leaderEpochFromMetadata);
+            collectEpochBumpTargets(ti, topicPartitions, leaderEpochFromMetadata);
         }
         if (!leaderEpochFromMetadata.isEmpty()) {
             log.info("Bumping leader epoch for partitions {} to {}", topicPartitions, leaderEpochFromMetadata);
@@ -1111,22 +1085,22 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return leaderEpochFromMetadata;
     }
 
-    private void collectEpochBumpTargets(MetadataResponse.TopicMetadata topicMetadata,
+    private void collectEpochBumpTargets(SourceTopicInfo topicInfo,
                                          Set<TopicPartition> topicPartitions,
                                          Map<TopicPartition, Integer> leaderEpochFromMetadata) {
-        for (MetadataResponse.PartitionMetadata partitionMetadata : topicMetadata.partitionMetadata()) {
-            TopicPartition tp = partitionMetadata.topicPartition;
+        for (SourcePartitionInfo pi : topicInfo.partitions()) {
+            TopicPartition tp = pi.topicPartition();
             if (!topicPartitions.isEmpty() && !topicPartitions.contains(tp)) {
                 continue;
             }
-            if (partitionMetadata.leaderEpoch.isEmpty()) {
+            if (pi.leaderEpoch().isEmpty()) {
                 continue;
             }
             TopicImage topicImage = metadataImage.topics().getTopic(tp.topic());
             if (topicImage == null || topicImage.partitions().get(tp.partition()) == null) {
                 continue;
             }
-            int epoch = partitionMetadata.leaderEpoch.get();
+            int epoch = pi.leaderEpoch().get();
             int localEpoch = topicImage.partitions().get(tp.partition()).leaderEpoch;
             if (epoch > localEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
                 int newEpoch = Math.addExact(epoch, LEADER_EPOCH_BUMP_INCREMENT);
@@ -1170,24 +1144,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Sender cleanup only happens via {@link #onMetadataUpdate} or {@link #clear}.
      */
     private void discoverSourceBrokers(String mirrorName) {
-        var response = trySendSourceClusterRequest(mirrorName, MetadataRequest.Builder.allTopics());
-        if (!(response.responseBody() instanceof MetadataResponse metadataResponse)) {
-            return;
-        }
-
-        // Cross-cluster identity validation
-        String clusterId = metadataResponse.clusterId();
-        if (clusterId != null && !clusterId.isEmpty()) {
-            Uuid newClusterId = Uuid.fromString(clusterId);
-            Uuid previousClusterId = sourceClusterIds.put(mirrorName, newClusterId);
-            if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
-                throw new IllegalStateException("Source cluster ID changed for mirror " + mirrorName
-                    + ": expected " + previousClusterId + ", got " + newClusterId
-                    + ". This may indicate a misconfiguration or that the source cluster has been replaced.");
-            }
-        }
-
-        Collection<Node> discoveredBrokers = metadataResponse.brokers();
+        Collection<Node> discoveredBrokers = describeSourceClusterNodes(mirrorName);
         if (discoveredBrokers.isEmpty()) {
             return;
         }
@@ -1235,82 +1192,137 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         sourceSenders.put(mirrorName, merged);
     }
 
+    private Admin getOrCreateSourceAdmin(String mirrorName) {
+        return srcAdmins.computeIfAbsent(mirrorName, k -> {
+            Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
+            return Admin.create(props);
+        });
+    }
+
+    private Collection<Node> describeSourceClusterNodes(String mirrorName) {
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
+        try {
+            var clusterResult = srcAdmin.describeCluster();
+            String clusterId = clusterResult.clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            Collection<Node> nodes = clusterResult.nodes().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            validateSourceClusterId(mirrorName, clusterId);
+            return nodes;
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Failed to describe source cluster for mirror {}", mirrorName, e);
+            return List.of();
+        }
+    }
+
+    private void validateSourceClusterId(String mirrorName, String clusterId) {
+        if (clusterId != null && !clusterId.isEmpty()) {
+            Uuid newClusterId = Uuid.fromString(clusterId);
+            Uuid previousClusterId = sourceClusterIds.put(mirrorName, newClusterId);
+            if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
+                throw new IllegalStateException("Source cluster ID changed for mirror " + mirrorName
+                    + ": expected " + previousClusterId + ", got " + newClusterId
+                    + ". This may indicate a misconfiguration or that the source cluster has been replaced.");
+            }
+        }
+    }
+
     /**
-     * Fetches topic metadata from the source cluster.
-     * Runs on every broker to keep partition leaders, topic creation, deletion, and partition counts in sync.
+     * Fetches topic metadata from the source cluster via Admin.describeTopics.
+     * Runs on every broker to keep partition leaders, topic creation, topic deletion, and partition counts in sync.
+     *
+     * Against older source clusters (e.g. 2.1.1 with ZK) the Admin client first attempts the
+     * DescribeTopicPartitions API, gets UnsupportedVersionException, then falls back to a
+     * MetadataRequest. The extra round trips widen the window between topic creation on the
+     * destination and source leader population in sourceLeaders. The maybeStartMissedPartitions
+     * call at the end of processTopicMetadata closes that gap.
      */
-    private Optional<MetadataResponse> syncSourceTopicState(String mirrorName) {
+    private Optional<List<SourceTopicInfo>> syncSourceTopicState(String mirrorName) {
         log.info("Syncing source topic state for mirror {}", mirrorName);
         Set<String> topics = getConfiguredTopics(mirrorName, false);
         if (topics.isEmpty()) {
             return Optional.empty();
         }
-        var response = trySendSourceClusterRequest(mirrorName,
-                MetadataRequest.Builder.forTopicNames(topics.stream().toList(), false)
-        );
 
-        if (response.responseBody() instanceof MetadataResponse metadataResponse) {
-            log.debug("Periodic metadata response: {}", metadataResponse);
-            Map<Integer, Node> brokerNodes = new HashMap<>();
-            metadataResponse.brokers().forEach(broker -> brokerNodes.put(broker.id(), broker));
-            processTopicMetadata(mirrorName, metadataResponse.topicMetadata(), brokerNodes);
-            return Optional.of(metadataResponse);
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
+
+        try {
+            Map<String, KafkaFuture<TopicDescription>> futures = srcAdmin.describeTopics(topics).topicNameValues();
+            List<SourceTopicInfo> result = new ArrayList<>();
+
+            for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : futures.entrySet()) {
+                try {
+                    TopicDescription td = entry.getValue().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                    List<SourcePartitionInfo> partitions = td.partitions().stream()
+                            .map(pi -> new SourcePartitionInfo(
+                                    new TopicPartition(td.name(), pi.partition()),
+                                    pi.leader(),
+                                    pi.leaderEpoch()))
+                            .toList();
+                    result.add(new SourceTopicInfo(td.name(), td.topicId(), true, partitions));
+                } catch (ExecutionException e) {
+                    if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                        result.add(new SourceTopicInfo(entry.getKey(), Uuid.ZERO_UUID, false, List.of()));
+                    } else {
+                        log.warn("Failed to describe topic {} for mirror {}", entry.getKey(), mirrorName, e.getCause());
+                    }
+                }
+            }
+
+            processTopicMetadata(mirrorName, result);
+            return Optional.of(result);
+        } catch (Exception e) {
+            log.warn("Failed to sync source topic state for mirror {}", mirrorName, e);
+            return Optional.empty();
         }
-        return Optional.empty();
     }
 
-    /** Processes topic metadata: updates source leaders, creates missing topics, scales partitions and stops deleted topics. */
-    private void processTopicMetadata(
-            String mirrorName, Collection<MetadataResponse.TopicMetadata> topicMetadata, Map<Integer, Node> brokerNodes) {
+    private void processTopicMetadata(String mirrorName, List<SourceTopicInfo> topicInfos) {
         var creatableTopics = new ArrayList<CreateTopicsRequestData.CreatableTopic>();
         var createPartitionsTopics = new CreatePartitionsRequestData.CreatePartitionsTopicCollection();
 
-        topicMetadata.forEach(tm -> {
+        topicInfos.forEach(ti -> {
             // use ConcurrentHashMap for thread-safe access from scheduler and fetcher threads
             var partitionLeaders = sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
 
-            // Count partitions for this specific topic only
-            int sourcePartitionCount = tm.partitionMetadata().size();
+            int sourcePartitionCount = ti.partitions().size();
 
             // skip partitions with no leader (source broker may be restarting)
-            tm.partitionMetadata().forEach(partitionMetadata -> {
-                if (partitionMetadata.leaderId.isPresent()) {
-                    Node leader = brokerNodes.get(partitionMetadata.leaderId.get());
-                    if (leader != null) {
-                        // set leaderEpoch to 0 if unknown to trigger source epoch discovery through fencing
-                        partitionLeaders.put(partitionMetadata.topicPartition, new ClusterMirrorUtils.LeaderInfo(leader, partitionMetadata.leaderEpoch.orElse(0)));
-                    }
+            ti.partitions().forEach(pi -> {
+                if (pi.leader() != null) {
+                    partitionLeaders.put(pi.topicPartition(),
+                            new ClusterMirrorUtils.LeaderInfo(pi.leader(), pi.leaderEpoch().orElse(0)));
                 }
             });
 
             // Pre-KIP-516 sources (Kafka < 2.8) return ZERO_UUID; fall back to name-based lookup
-            TopicImage destTopic = !tm.topicId().equals(Uuid.ZERO_UUID)
-                    ? metadataImage.topics().getTopic(tm.topicId())
-                    : metadataImage.topics().getTopic(tm.topic());
+            TopicImage destTopic = !ti.topicId().equals(Uuid.ZERO_UUID)
+                    ? metadataImage.topics().getTopic(ti.topicId())
+                    : metadataImage.topics().getTopic(ti.topic());
 
             if (destTopic != null && destTopic.partitions().size() < sourcePartitionCount) {
                 createPartitionsTopics.add(new CreatePartitionsRequestData.CreatePartitionsTopic()
-                        .setName(tm.topic())
+                        .setName(ti.topic())
                         .setCount(sourcePartitionCount)
                         .setAssignments(null)
                 );
             } else if (destTopic == null &&
-                    metadataImage.topics().getTopic(tm.topic()) == null &&
-                    tm.error() == Errors.NONE && sourcePartitionCount > 0) {
-                if (pendingTopicCreations.add(tm.topic())) {
+                    metadataImage.topics().getTopic(ti.topic()) == null &&
+                    ti.exists() && sourcePartitionCount > 0) {
+                if (pendingTopicCreations.add(ti.topic())) {
                     creatableTopics.add(new CreateTopicsRequestData.CreatableTopic()
-                            .setName(tm.topic())
+                            .setName(ti.topic())
                             .setNumPartitions(sourcePartitionCount)
                             .setReplicationFactor(CreateTopicsRequest.NO_REPLICATION_FACTOR)
                             .setMirrorInfo(new CreateTopicsRequestData.MirrorInfo().setTopicId(
-                                    tm.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : tm.topicId())));
+                                    ti.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : ti.topicId())));
                 }
             } else if (destTopic == null &&
-                    metadataImage.topics().getTopic(tm.topic()) != null &&
-                    tm.error() == Errors.NONE) {
+                    metadataImage.topics().getTopic(ti.topic()) != null &&
+                    ti.exists()) {
                 log.error("Mirror topic {} exists on destination with TopicId {} but source has TopicId {}. "
                         + "Delete the topic on destination and let auto-creation recreate it with the correct TopicId.",
-                        tm.topic(), metadataImage.topics().getTopic(tm.topic()).id(), tm.topicId());
+                        ti.topic(), metadataImage.topics().getTopic(ti.topic()).id(), ti.topicId());
             }
         });
 
@@ -1318,8 +1330,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             createMirrorTopics(creatableTopics);
         }
 
+        maybeStartMissedPartitions(mirrorName);
         maybeScalePartitions(createPartitionsTopics);
-        maybeStopDeletedTopics(mirrorName, topicMetadata);
+        maybeStopDeletedTopics(mirrorName, topicInfos);
     }
 
     /**
@@ -1371,10 +1384,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    private void maybeStopDeletedTopics(String mirrorName, Collection<MetadataResponse.TopicMetadata> topicMetadata) {
-        List<String> deletedSourceTopicNames = new ArrayList<>(topicMetadata.stream()
-                .filter(tm -> tm.error() == Errors.UNKNOWN_TOPIC_OR_PARTITION)
-                .map(MetadataResponse.TopicMetadata::topic).toList());
+    private void maybeStopDeletedTopics(String mirrorName, List<SourceTopicInfo> topicInfos) {
+        List<String> deletedSourceTopicNames = new ArrayList<>(topicInfos.stream()
+                .filter(ti -> !ti.exists())
+                .map(SourceTopicInfo::topic).toList());
 
         if (deletedSourceTopicNames.isEmpty()) {
             return;
@@ -1382,11 +1395,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         // In old cluster, it is possible the broker metadata update in progress, and the returned metadata response is stale.
         // list topic again to make sure it is indeed deleted.
-        Admin srcAdmin = srcAdmins.get(mirrorName);
-        if (srcAdmin == null) {
-            log.error("Source admin client not initialized for mirror {}, skipping config sync", mirrorName);
-            return;
-        }
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
         try {
             Set<String> allTopics = srcAdmin.listTopics().names().get();
             log.debug("Source topic name list: {}", allTopics);
@@ -1408,10 +1417,59 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
+     * Catches partitions that onMetadataUpdate could not start because their source leader
+     * was not yet known. This happens when the source cluster has not elected a leader for
+     * a partition at the time processTopicMetadata first runs: the partition is skipped in
+     * sourceLeaders, but the destination topic is still created, triggering onMetadataUpdate
+     * which finds no source leader and leaves the partition in UNKNOWN state. Since
+     * onMetadataUpdate only reacts to destination metadata changes, it never retries on its
+     * own. This method runs after each source metadata sync and transitions any UNKNOWN
+     * partitions whose source leader has since been discovered.
+     */
+    private void maybeStartMissedPartitions(String mirrorName) {
+        var partitionLeaders = sourceLeaders.get(mirrorName);
+        if (partitionLeaders == null) {
+            return;
+        }
+        partitionLeaders.keySet().forEach(tp -> {
+            ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
+            if (partitionStates.getOrDefault(key, MirrorPartitionState.UNKNOWN) != MirrorPartitionState.UNKNOWN) {
+                return;
+            }
+            TopicImage topicImage = metadataImage.topics().getTopic(tp.topic());
+            if (topicImage == null) {
+                return;
+            }
+            var partition = topicImage.partitions().get(tp.partition());
+            if (partition != null && partition.leader == nodeId) {
+                log.info("Source leader for {} discovered after initial onMetadataUpdate, transitioning to LOG_TRUNCATION", tp);
+                stateTransitioner.ifPresent(t -> t.transitionTo(mirrorName, tp, MirrorPartitionState.LOG_TRUNCATION));
+            }
+        });
+    }
+
+    /**
+     * Pre-populates sourceLeaders for discovered topics so that when onMetadataUpdate fires
+     * after the destination topic is created, the fetcher can connect to the correct source
+     * broker immediately. Without this, the fetcher starts with a bootstrap broker, gets a
+     * redirect it cannot resolve, and cycles through FAILED/retry until the next periodic
+     * syncSourceTopicState populates the cache.
+     */
+    private void cacheSourceLeaders(String mirrorName, Collection<TopicDescription> descriptions) {
+        var partitionLeaders = sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
+        descriptions.forEach(td -> td.partitions().forEach(pi -> {
+            if (pi.leader() != null) {
+                partitionLeaders.put(new TopicPartition(td.name(), pi.partition()),
+                        new ClusterMirrorUtils.LeaderInfo(pi.leader(), pi.leaderEpoch().orElse(0)));
+            }
+        }));
+    }
+
+    /**
      * Syncs configurations, consumer group offsets, ACLs, and topic patterns from source clusters.
      * Runs only on the coordinator broker for each mirror.
      */
-    void syncCoordinatorMetadata(String mirrorName, Optional<MetadataResponse> metadataResponse) {
+    private void syncCoordinatorMetadata(String mirrorName, Optional<List<SourceTopicInfo>> topicInfos) {
         if (!isLocalCoordinator(mirrorName)) {
             return;
         }
@@ -1425,7 +1483,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             syncTopicConfigurations(mirrorName, mirrorConfig);
             syncGroupOffsets(mirrorName, mirrorConfig);
             syncAccessControlLists(mirrorName, mirrorConfig);
-            maybeBumpLeaderEpochs(mirrorName, metadataResponse, Set.of());
+            maybeBumpLeaderEpochs(mirrorName, topicInfos, Set.of());
             discoverTopicsByPattern(mirrorName, mirrorConfig);
             enforceExcludePatterns(mirrorName, mirrorConfig);
         } catch (Exception e) {
@@ -1434,11 +1492,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     private void syncTopicConfigurations(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Admin srcAdmin = srcAdmins.get(mirrorName);
-        if (srcAdmin == null) {
-            log.error("Source admin client not initialized for mirror {}, skipping config sync", mirrorName);
-            return;
-        }
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
 
         Set<String> topics = getConfiguredTopics(mirrorName, false);
         log.debug("Describing topic configs for topics: {}", topics);
@@ -1531,11 +1585,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * the same name on the destination (or vice versa).
      */
     private void syncGroupOffsets(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Admin srcAdmin = srcAdmins.get(mirrorName);
-        if (srcAdmin == null || dstAdmin == null) {
-            log.error("Admin clients not initialized for mirror {}, skipping offset sync", mirrorName);
-            return;
-        }
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
 
         Set<String> mirrorTopics = getConfiguredTopics(mirrorName, false);
         if (mirrorTopics.isEmpty()) {
@@ -1620,7 +1670,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
                 try {
                     log.debug("Committing consumer group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
-                    dstAdmin.alterConsumerGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                    getOrCreateDestAdmin().alterConsumerGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
                 } catch (Exception e) {
                     log.warn("Failed to commit consumer group offsets for group {} in mirror {}: {}", groupId, mirrorName, e.getMessage());
                 }
@@ -1691,7 +1741,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
                 try {
                     log.debug("Committing share group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
-                    dstAdmin.alterShareGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                    getOrCreateDestAdmin().alterShareGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
                 } catch (Exception e) {
                     log.warn("Failed to commit share group offsets for group {} in mirror {}: {}", groupId, mirrorName, e);
                 }
@@ -1721,7 +1771,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     GroupState.ASSIGNING,
                     GroupState.RECONCILING,
                     GroupState.EMPTY));
-            return Optional.of(dstAdmin.listGroups(options).all()
+            return Optional.of(getOrCreateDestAdmin().listGroups(options).all()
                     .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
                     .map(GroupListing::groupId)
                     .collect(Collectors.toSet()));
@@ -1739,11 +1789,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         // TODO: How do we disambiguate ACLs that reference the same resource name
         //       when multiple cluster mirrors exist?
 
-        Admin srcAdmin = srcAdmins.get(mirrorName);
-        if (srcAdmin == null) {
-            log.error("Source admin client not initialized for mirror {}, skipping ACL sync", mirrorName);
-            return;
-        }
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
 
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         aclSyncError.incrementAndGet();
@@ -1833,33 +1879,47 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    private record ACLChanges(List<AclBinding> aclsToAdd, List<AclBinding> aclsToDelete) { }
-
     private void discoverTopicsByPattern(String mirrorName, ClusterMirrorConfig mirrorConfig) {
         final Pattern topicsIncludePattern = mirrorConfig.topicsIncludePattern();
         if (topicsIncludePattern == null) {
             return;
         }
 
-        var response = trySendSourceClusterRequest(mirrorName, MetadataRequest.Builder.allTopics());
-        if (!(response.responseBody() instanceof MetadataResponse metadataResponse)) {
-            log.warn("Unexpected metadata response type from source cluster for topic discovery: {}", response);
-            return;
-        }
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
 
         Set<String> configuredTopics = getConfiguredTopics(mirrorName, true);
         final Pattern topicsExcludePattern = mirrorConfig.topicsExcludePattern();
 
-        List<StartMirrorTopicsRequestData.TopicData> newTopics = metadataResponse.topicMetadata().stream()
-                .filter(tm -> tm.error() == Errors.NONE)
-                .filter(tm -> topicsIncludePattern.matcher(tm.topic()).matches())
-                .filter(tm -> topicsExcludePattern == null || !topicsExcludePattern.matcher(tm.topic()).matches())
-                .filter(tm -> !configuredTopics.contains(tm.topic()))
-                .map(tm -> new StartMirrorTopicsRequestData.TopicData()
-                        .setTopicName(tm.topic())
-                        .setTopicId(tm.topicId())
-                        .setNumPartitions(tm.partitionMetadata().size()))
-                .toList();
+        List<StartMirrorTopicsRequestData.TopicData> newTopics;
+        try {
+            Set<String> allSourceTopics = srcAdmin.listTopics()
+                    .names().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            List<String> candidates = allSourceTopics.stream()
+                    .filter(name -> topicsIncludePattern.matcher(name).matches())
+                    .filter(name -> topicsExcludePattern == null || !topicsExcludePattern.matcher(name).matches())
+                    .filter(name -> !configuredTopics.contains(name))
+                    .toList();
+
+            if (candidates.isEmpty()) {
+                return;
+            }
+
+            Map<String, TopicDescription> descriptions = srcAdmin.describeTopics(candidates)
+                    .allTopicNames().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            cacheSourceLeaders(mirrorName, descriptions.values());
+
+            newTopics = descriptions.values().stream()
+                    .map(td -> new StartMirrorTopicsRequestData.TopicData()
+                            .setTopicName(td.name())
+                            .setTopicId(td.topicId())
+                            .setNumPartitions(td.partitions().size()))
+                    .toList();
+        } catch (Exception e) {
+            log.warn("Failed to discover topics by pattern for mirror {}", mirrorName, e);
+            return;
+        }
 
         if (newTopics.isEmpty()) {
             return;
@@ -1881,7 +1941,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
-     * Checks if any active mirroring topics now match the exclude pattern and sends
+     * Checks if any active mirror topics now match the exclude pattern and sends
      * StopMirrorTopicsRequest to stop them. Catches cases where exclude was updated
      * via incrementalAlterConfigs outside of the startMirrorTopics/stopMirrorTopics flow.
      */
@@ -1957,12 +2017,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (cached != null) {
             return cached;
         }
-        // lazily create the admin client
-        // handles the edge case where getSourceClusterId is called before periodicSync
-        Admin srcAdmin = srcAdmins.computeIfAbsent(mirrorName, k -> {
-            Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
-            return Admin.create(props);
-        });
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
         try {
             String clusterId = srcAdmin.describeCluster()
                 .clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
@@ -2008,4 +2063,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             log.debug("Controller request completed: {}", response);
         }
     }
+
+    private record SourceTopicInfo(String topic, Uuid topicId, boolean exists, List<SourcePartitionInfo> partitions) { }
+    private record SourcePartitionInfo(TopicPartition topicPartition, Node leader, Optional<Integer> leaderEpoch) { }
+
+    private record ACLChanges(List<AclBinding> aclsToAdd, List<AclBinding> aclsToDelete) { }
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -832,14 +832,21 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
-     * Catches partitions that onMetadataUpdate could not start because their source leader
-     * was not yet known. This happens when the source cluster has not elected a leader for
-     * a partition at the time processTopicMetadata first runs: the partition is skipped in
-     * sourceLeaders, but the destination topic is still created, triggering onMetadataUpdate
-     * which finds no source leader and leaves the partition in UNKNOWN state. Since
-     * onMetadataUpdate only reacts to destination metadata changes, it never retries on its
-     * own. This method runs after each source metadata sync and transitions any UNKNOWN
-     * partitions whose source leader has since been discovered.
+     * Transitions partitions stuck in UNKNOWN because their source leader was not yet known
+     * when onMetadataUpdate first ran.
+     *
+     * The race: processTopicMetadata creates a mirror topic on the destination, which
+     * triggers onMetadataUpdate. That callback needs the source leader in sourceLeaders to
+     * transition the partition to LOG_TRUNCATION. If the source has not elected a leader yet
+     * (or the Admin describeTopics response arrived without one), the partition stays in
+     * UNKNOWN. Since onMetadataUpdate only fires on destination metadata changes, it will
+     * not retry on its own.
+     *
+     * This is more likely against older source clusters (e.g. Kafka 2.1 with ZK) where
+     * Admin.describeTopics goes through three round trips before returning topic metadata:
+     * describeCluster (node discovery), DescribeTopicPartitions (rejected with
+     * UnsupportedVersionException), then MetadataRequest (fallback). The extra latency
+     * widens the window in which the source leader is not yet known.
      */
     private void maybeStartMissedPartitions(String mirrorName) {
         var partitionLeaders = sourceLeaders.get(mirrorName);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -747,6 +747,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         maybeScalePartitions(createPartitionsTopics);
         maybeStopDeletedTopics(mirrorName, topicInfos);
+        maybeStartMissedPartitions(mirrorName);
     }
 
     /**
@@ -826,6 +827,38 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         .filter(key -> key.mirrorName().equals(mirrorName) && key.topic().equals(name))
                         .forEach(key -> stateTransitioner.ifPresent(t ->
                                 t.transitionTo(mirrorName, new TopicPartition(key.topic(), key.partition()), MirrorPartitionState.STOPPING)));
+            }
+        });
+    }
+
+    /**
+     * Catches partitions that onMetadataUpdate could not start because their source leader
+     * was not yet known. This happens when the source cluster has not elected a leader for
+     * a partition at the time processTopicMetadata first runs: the partition is skipped in
+     * sourceLeaders, but the destination topic is still created, triggering onMetadataUpdate
+     * which finds no source leader and leaves the partition in UNKNOWN state. Since
+     * onMetadataUpdate only reacts to destination metadata changes, it never retries on its
+     * own. This method runs after each source metadata sync and transitions any UNKNOWN
+     * partitions whose source leader has since been discovered.
+     */
+    private void maybeStartMissedPartitions(String mirrorName) {
+        var partitionLeaders = sourceLeaders.get(mirrorName);
+        if (partitionLeaders == null) {
+            return;
+        }
+        partitionLeaders.keySet().forEach(tp -> {
+            ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
+            if (partitionStates.getOrDefault(key, MirrorPartitionState.UNKNOWN) != MirrorPartitionState.UNKNOWN) {
+                return;
+            }
+            TopicImage topicImage = metadataImage.topics().getTopic(tp.topic());
+            if (topicImage == null) {
+                return;
+            }
+            var partition = topicImage.partitions().get(tp.partition());
+            if (partition != null && partition.leader == nodeId) {
+                log.info("Source leader for {} discovered after initial onMetadataUpdate, transitioning to LOG_TRUNCATION", tp);
+                stateTransitioner.ifPresent(t -> t.transitionTo(mirrorName, tp, MirrorPartitionState.LOG_TRUNCATION));
             }
         });
     }
@@ -1801,7 +1834,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             collectEpochBumpTargets(ts, topicPartitions, leaderEpochFromMetadata);
         }
         if (!leaderEpochFromMetadata.isEmpty()) {
-            log.info("Bumping leader epoch for partitions {} to {}", topicPartitions, leaderEpochFromMetadata);
+            log.info("Bumping leader epoch for partitions {}", leaderEpochFromMetadata);
         }
         return leaderEpochFromMetadata;
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -135,40 +135,35 @@ import static org.apache.kafka.controller.ConfigurationControlManager.STOPPED_TO
  * Bridges the local destination cluster and remote source clusters for Cluster Mirroring.
  *
  * Implements {@link MetadataPublisher} to detect leadership and config changes, triggering
- * partition state transitions (LOG_TRUNCATION, MIRRORING, STOPPING, STOPPED) via the
- * {@link ClusterMirrorCoordinator}. Manages remote cluster connections using {@link MirrorSourceSender}
- * and periodically syncs topic metadata, configs, consumer group offsets, and ACLs from source
- * clusters.
+ * partition state transitions. Manages remote cluster connections using {@link MirrorSourceSender}
+ * and periodically syncs topic metadata, configs, group offsets, and ACLs from source clusters.
+ * Maintains in-memory caches of partition states and last mirror epochs. Routes state reads/writes
+ * to the appropriate coordinator broker.
  *
- * Maintains in-memory caches of partition states and last mirrored epochs, populated from
- * the {@code __mirror_state} topic on coordinator election and cleared on resignation or
- * leadership loss. Routes state reads/writes to the appropriate coordinator broker,
- * batching requests per coordinator node to reduce network overhead.
+ * Source topic metadata and broker discovery run on every broker so that all brokers keep an
+ * up to date view of source partition leaders. Coordinator level sync (topic configs, group
+ * offsets, ACLs, pattern discovery, and exclude enforcement) runs only on the broker that
+ * leads the {@code __mirror_state} partition for a given mirror name.
  */
 @SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
 public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
-    private final String name;
     private final Logger log;
-    private final KafkaConfig brokerConfig;
+    private volatile boolean isInitialized = false;
+    private final String name;
     private final int nodeId;
-    private final Metrics metrics;
-    private final Time time;
-    private final Random random;
 
-    // volatile for cross-thread visibility (written by KRaft thread, read by scheduler and fetcher threads)
-    private volatile MetadataImage metadataImage;
-    private final MetadataCache metadataCache;
-
-    private volatile ClusterMirrorStateSender mirrorStateSender;
-    private volatile boolean initialized = false;
+    private final KafkaConfig brokerConfig;
     private final NodeToControllerChannelManager channelManager;
     private final Supplier<ReplicaManager> replicaManagerSupplier;
-    private Optional<ClusterMirrorUtils.StateTransitioner> stateTransitioner = Optional.empty();
-    private Optional<Consumer<String>> mirrorDeletionHandler = Optional.empty();
-    private Optional<Function<ClusterMirrorRecordKey, Integer>> coordinatorPartitionFinder = Optional.empty();
-    private Optional<Function<String, Integer>> coordinatorPartitionByNameFinder = Optional.empty();
+    private final MetadataCache metadataCache;
     private final KafkaScheduler scheduler;
+    private final Metrics metrics;
+    private final Time time;
 
+    private final Random random = new Random();
+    private volatile MetadataImage metadataImage = MetadataImage.EMPTY;
+
+    private volatile MirrorStateSender mirrorStateSender;
     private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>();
     private volatile Admin dstAdmin;
 
@@ -177,17 +172,22 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Map<String, Map<TopicPartition, ClusterMirrorUtils.LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
     private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates = new ConcurrentHashMap<>();
-    private final Map<MirrorPartitionState, AtomicLong> partitionStateCounts = new ConcurrentHashMap<>();
     private final Map<ClusterMirrorUtils.PartitionKey, Integer> lastMirrorEpochs = new ConcurrentHashMap<>();
+    private final Map<MirrorPartitionState, AtomicLong> partitionStateCounts = new ConcurrentHashMap<>();
 
-    // Leader epoch bumps require a request to the controller followed by a metadata log fetch.
-    // The bump must be confirmed on the broker side before we can write the PID reset record.
-    private final Set<ClusterMirrorUtils.LeaderEpochBump> pendingLeaderEpochBumps = ConcurrentHashMap.newKeySet();
+    private Optional<ClusterMirrorUtils.StateTransitioner> stateTransitioner = Optional.empty();
+    private Optional<Consumer<String>> mirrorDeletionHandler = Optional.empty();
+    private Optional<Function<ClusterMirrorRecordKey, Integer>> coordPartitionFinderByKey = Optional.empty();
+    private Optional<Function<String, Integer>> coordPartitionFinderByName = Optional.empty();
 
     // lets the transition handler skip partitions that are already being processed
     private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
     private final Map<TopicPartition, Integer> failedRetryAttempts = new ConcurrentHashMap<>();
     private final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
+
+    // Leader epoch bumps require a request to the controller followed by a metadata log fetch.
+    // The bump must be confirmed on the broker side before we can write the PID reset record.
+    private final Set<ClusterMirrorUtils.LeaderEpochBump> pendingLeaderEpochBumps = ConcurrentHashMap.newKeySet();
 
     private final AtomicLong metadataRefreshError;
     private final AtomicLong topicConfigSyncError;
@@ -197,27 +197,26 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public MirrorMetadataManager(
         KafkaConfig brokerConfig,
-        Metrics metrics,
-        Time time,
-        MetadataCache metadataCache,
         NodeToControllerChannelManager channelManager,
         Supplier<ReplicaManager> replicaManagerSupplier,
-        KafkaScheduler scheduler
+        MetadataCache metadataCache,
+        KafkaScheduler scheduler,
+        Metrics metrics,
+        Time time
     ) {
+        this.brokerConfig = brokerConfig;
         this.name = "[" + MirrorMetadataManager.class.getSimpleName() + " id=" + brokerConfig.nodeId() + "] ";
         this.log = new LogContext(name).logger(MirrorMetadataManager.class);
-        this.brokerConfig = brokerConfig;
         this.nodeId = brokerConfig.nodeId();
-        this.metrics = metrics;
-        this.time = time;
-        this.random = new Random();
+
         this.channelManager = channelManager;
         this.replicaManagerSupplier = replicaManagerSupplier;
-        this.metadataImage = MetadataImage.EMPTY;
         this.metadataCache = metadataCache;
-        this.scheduler = scheduler;
 
-        // metrics
+        this.scheduler = scheduler;
+        this.metrics = metrics;
+        this.time = time;
+
         KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(this.getClass());
         this.metadataRefreshError = new AtomicLong();
         this.topicConfigSyncError = new AtomicLong();
@@ -240,6 +239,62 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         metricsGroup.newGauge("FailedPartitionState", () -> partitionStateCount(MirrorPartitionState.FAILED));
     }
 
+    private boolean isLocalCoordinator(String mirrorName) {
+        if (coordPartitionFinderByName.isPresent()) {
+            int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
+                    .partitions().get(coordPartitionFinderByName.get().apply(mirrorName)).leader;
+            return activeCoordinator == brokerConfig.nodeId();
+        }
+        return false;
+    }
+
+    private boolean isLocalCoordinator(String mirrorName, String topic, int partition) {
+        if (coordPartitionFinderByKey.isPresent()) {
+            int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
+                    .partitions().get(coordPartitionFinderByKey.get().apply(
+                            new ClusterMirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), partition))).leader;
+            return activeCoordinator == brokerConfig.nodeId();
+        }
+        return false;
+    }
+
+    /** Wires in the state transitioner, tombstone handler, and coordinator partition finders. */
+    public void initialize(ClusterMirrorUtils.StateTransitioner stateTransitioner,
+                           Consumer<String> tombStoneHandler,
+                           Function<ClusterMirrorRecordKey, Integer> coordinatorPartitionByKeyFinder,
+                           Function<String, Integer> coordinatorPartitionByNameFinder) {
+        if (mirrorStateSender == null) {
+            mirrorStateSender = new MirrorStateSender(MirrorStateSender.class.getSimpleName(),
+                    NetworkUtils.buildNetworkClient(MirrorMetadataManager.class.getSimpleName(), brokerConfig, metrics, time, new LogContext(name())),
+                    brokerConfig.requestTimeoutMs(), Time.SYSTEM);
+            mirrorStateSender.start();
+        }
+
+        this.stateTransitioner = Optional.of(stateTransitioner);
+        this.mirrorDeletionHandler = Optional.of(tombStoneHandler);
+        this.coordPartitionFinderByKey = Optional.of(coordinatorPartitionByKeyFinder);
+        this.coordPartitionFinderByName = Optional.of(coordinatorPartitionByNameFinder);
+
+        this.isInitialized = true;
+    }
+
+    private Admin getOrCreateSourceAdmin(String mirrorName) {
+        return srcAdmins.computeIfAbsent(mirrorName, k -> {
+            Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
+            return Admin.create(props);
+        });
+    }
+
+    private Admin getOrCreateDestAdmin() {
+        if (dstAdmin == null) {
+            var endpoint = brokerConfig.effectiveAdvertisedBrokerListeners().head();
+            Properties props = new Properties();
+            props.put(BOOTSTRAP_SERVERS_CONFIG, endpoint.host() + ":" + endpoint.port());
+            dstAdmin = Admin.create(props);
+        }
+        return dstAdmin;
+    }
+
     @Override
     public String name() {
         return name;
@@ -255,18 +310,19 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      */
     @Override
     public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage, LoaderManifest manifest) {
-        if (!initialized) {
+        if (!isInitialized) {
             return;
         }
-        // caching the image for query purpose
+
+        // Caching the metadata image for query purpose
         this.metadataImage = newImage;
 
-        Set<String> reconnectedMirrors = maybeRecreateConnection(delta, newImage);
+        Set<String> reconnectedMirrors = maybeRecreateSourceConnection(delta, newImage);
 
-        // get all mirror partition leaders on this node based on the delta
+        // Get all mirror partition leaders on this node based on the delta
         Set<TopicPartition> mirrorLeaders = getMirrorLeadersAndClearFollowerStates(delta, newImage);
 
-        // after a connection config change (e.g. bootstrap.servers), fetchers were removed
+        // After a connection config change (e.g. bootstrap.servers), fetchers were removed
         // and must be recreated by re-evaluating MIRRORING partitions for the affected mirrors
         if (!reconnectedMirrors.isEmpty()) {
             partitionStates.forEach((key, state) -> {
@@ -302,15 +358,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             } else {
                 // Collect for batched remote read
                 remotePartitionsByMirror
-                    .computeIfAbsent(mirrorName, k -> new HashMap<>())
-                    .computeIfAbsent(tp.topic(), k -> new HashSet<>())
-                    .add(tp.partition());
+                        .computeIfAbsent(mirrorName, k -> new HashMap<>())
+                        .computeIfAbsent(tp.topic(), k -> new HashSet<>())
+                        .add(tp.partition());
                 remoteStopFlags
-                    .computeIfAbsent(mirrorName, k -> new HashMap<>())
-                    .put(tp, stopRequested);
+                        .computeIfAbsent(mirrorName, k -> new HashMap<>())
+                        .put(tp, stopRequested);
                 remotePauseFlags
-                    .computeIfAbsent(mirrorName, k -> new HashMap<>())
-                    .put(tp, pauseRequested);
+                        .computeIfAbsent(mirrorName, k -> new HashMap<>())
+                        .put(tp, pauseRequested);
             }
         });
 
@@ -319,19 +375,19 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             Map<TopicPartition, Boolean> stopFlags = remoteStopFlags.get(mirrorName);
             Map<TopicPartition, Boolean> pauseFlags = remotePauseFlags.get(mirrorName);
             readStatesFromRemoteCoordinator(mirrorName, partitions, res ->
-                res.data().topics().forEach(topic ->
-                    topic.partitions().forEach(partition -> {
-                        TopicPartition resTp = new TopicPartition(topic.name(), partition.partitionIndex());
-                        // treat unrecorded state (-1) as UNKNOWN so the partition can transition to LOG_TRUNCATION
-                        MirrorPartitionState state = partition.state() != -1
-                                ? MirrorPartitionState.fromValue(partition.state())
-                                : MirrorPartitionState.UNKNOWN;
-                        boolean stopRequested = stopFlags.getOrDefault(resTp, false);
-                        boolean pauseRequested = pauseFlags.getOrDefault(resTp, false);
-                        ClusterMirrorUtils.PartitionKey mpk = new ClusterMirrorUtils.PartitionKey(mirrorName, resTp.topic(), resTp.partition());
-                        MirrorPartitionState curState = partitionStates.getOrDefault(mpk, MirrorPartitionState.UNKNOWN);
-                        applyMirrorStateTransition(mirrorName, resTp, curState, state, stopRequested, pauseRequested);
-                    })));
+                    res.data().topics().forEach(topic ->
+                            topic.partitions().forEach(partition -> {
+                                TopicPartition resTp = new TopicPartition(topic.name(), partition.partitionIndex());
+                                // treat unrecorded state (-1) as UNKNOWN so the partition can transition to LOG_TRUNCATION
+                                MirrorPartitionState state = partition.state() != -1
+                                        ? MirrorPartitionState.fromValue(partition.state())
+                                        : MirrorPartitionState.UNKNOWN;
+                                boolean stopRequested = stopFlags.getOrDefault(resTp, false);
+                                boolean pauseRequested = pauseFlags.getOrDefault(resTp, false);
+                                ClusterMirrorUtils.PartitionKey mpk = new ClusterMirrorUtils.PartitionKey(mirrorName, resTp.topic(), resTp.partition());
+                                MirrorPartitionState curState = partitionStates.getOrDefault(mpk, MirrorPartitionState.UNKNOWN);
+                                applyMirrorStateTransition(mirrorName, resTp, curState, state, stopRequested, pauseRequested);
+                            })));
         });
 
         if (delta.topicsDelta() != null) {
@@ -349,50 +405,45 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (dstAdmin != null) {
             dstAdmin.close();
         }
-        closeSourceSenders();
+        clearCache();
     }
 
+    void clearCache() {
+        failedRetryAttempts.clear();
+        partitionStates.clear();
+        partitionPreviousStates.clear();
+        partitionStateCounts.clear();
+        lastMirrorEpochs.clear();
+        sourceClusterIds.clear();
+
+        // snapshot and clear first, then close to avoid use-after-close races
+        Map<String, List<MirrorSourceSender>> snapshot = new HashMap<>(sourceSenders);
+        sourceSenders.clear();
+        snapshot.values().forEach(senders -> senders.forEach(MirrorSourceSender::close));
+
+        sourceLeaders.clear();
+        pendingLeaderEpochBumps.clear();
+        pendingPartitionStates.clear();
+    }
+
+    /** Returns partition states pending coordinator write. */
     public Map<TopicPartition, MirrorPartitionState> pendingPartitionStates() {
         return pendingPartitionStates;
     }
 
+    /** Returns the per-partition count of consecutive failed retry attempts. */
     public Map<TopicPartition, Integer> failedRetryAttempts() {
         return failedRetryAttempts;
     }
 
+    /** Returns the previous state of each partition before its last transition. */
     public Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates() {
         return partitionPreviousStates;
     }
 
-    public void initialize(ClusterMirrorUtils.StateTransitioner stateTransitioner,
-                           Consumer<String> tombStoneHandler,
-                           Function<ClusterMirrorRecordKey, Integer> coordinatorPartitionByKeyFinder,
-                           Function<String, Integer> coordinatorPartitionByNameFinder) {
-        if (mirrorStateSender == null) {
-            mirrorStateSender = new ClusterMirrorStateSender(ClusterMirrorStateSender.class.getSimpleName(),
-                    NetworkUtils.buildNetworkClient(MirrorMetadataManager.class.getSimpleName(), brokerConfig, metrics, time, new LogContext(name())),
-                    brokerConfig.requestTimeoutMs(), Time.SYSTEM);
-            mirrorStateSender.start();
-        }
-
-        this.stateTransitioner = Optional.of(stateTransitioner);
-        this.mirrorDeletionHandler = Optional.of(tombStoneHandler);
-        this.coordinatorPartitionFinder = Optional.of(coordinatorPartitionByKeyFinder);
-        this.coordinatorPartitionByNameFinder = Optional.of(coordinatorPartitionByNameFinder);
-
-        initialized = true;
-    }
-
+    /** Transitions a mirror partition to the given state via the configured state transitioner. */
     public void transitionTo(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
         stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state));
-    }
-
-    // immediately update the source cluster metadata
-    public void scheduleRediscoverSource(String mirrorName) {
-        scheduler.scheduleOnce("rediscover-source", () -> {
-            discoverSourceBrokers(mirrorName);
-            syncSourceTopicState(mirrorName);
-        });
     }
 
     private static final Set<String> NON_CONNECTION_CONFIGS = Set.of(
@@ -400,43 +451,883 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             ClusterMirrorConfig.MIRROR_GROUPS_INCLUDE_CONFIG, ClusterMirrorConfig.MIRROR_GROUPS_EXCLUDE_CONFIG,
             ClusterMirrorConfig.MIRROR_ACL_INCLUDE_CONFIG);
 
-    private Set<String> maybeRecreateConnection(MetadataDelta delta, MetadataImage newImage) {
+    private Set<String> maybeRecreateSourceConnection(MetadataDelta delta, MetadataImage newImage) {
         Set<String> reconnectedMirrors = new HashSet<>();
         if (delta.configsDelta() != null) {
             delta.configsDelta().changes().entrySet().stream()
-                .filter(e -> e.getKey().type() == ConfigResource.Type.CLUSTER_MIRROR)
-                .forEach(e -> {
-                    String mirrorName = e.getKey().name();
-                    boolean mirrorDeleted = newImage.configs()
-                            .configProperties(e.getKey()).isEmpty();
-                    if (mirrorDeleted) {
-                        log.info("Mirror '{}' has been deleted. Writing tombstone records.", mirrorName);
-                        mirrorDeletionHandler.ifPresent(h -> h.accept(mirrorName));
+                    .filter(e -> e.getKey().type() == ConfigResource.Type.CLUSTER_MIRROR)
+                    .forEach(e -> {
+                        String mirrorName = e.getKey().name();
+                        boolean mirrorDeleted = newImage.configs()
+                                .configProperties(e.getKey()).isEmpty();
+                        if (mirrorDeleted) {
+                            log.info("Mirror '{}' has been deleted. Writing tombstone records.", mirrorName);
+                            mirrorDeletionHandler.ifPresent(h -> h.accept(mirrorName));
+                        }
+
+                        boolean connectionConfigChanged = e.getValue().changes().keySet().stream()
+                                .anyMatch(key -> !NON_CONNECTION_CONFIGS.contains(key));
+
+                        if (connectionConfigChanged || mirrorDeleted) {
+                            sourceLeaders.remove(mirrorName);
+                            List<MirrorSourceSender> senders = sourceSenders.remove(mirrorName);
+                            if (senders != null) {
+                                log.info("Mirror config changed for '{}'. Closing existing connections "
+                                        + "to trigger reconnection with updated configuration.", mirrorName);
+                                senders.forEach(MirrorSourceSender::close);
+                            }
+                            Admin admin = srcAdmins.remove(mirrorName);
+                            if (admin != null) {
+                                admin.close();
+                            }
+                            replicaManagerSupplier.get().mirrorFetcherManager().removeFetchersForMirror(mirrorName);
+                            if (!mirrorDeleted) {
+                                reconnectedMirrors.add(mirrorName);
+                            }
+                        }
+                    });
+        }
+        return reconnectedMirrors;
+    }
+
+    /**
+     * Applies the appropriate state transition based on current state and stop flag.
+     *
+     * stopRequested: it means the partition should head to STOPPED state. When it is true (i.e. users stopMirrorTopics):
+     *   1. if it's already in STOPPED state, then keep the state
+     *   2. else, move the state to STOPPING state
+     *
+     * pauseRequested: it means the partition should head to PAUSED state. When it is true (i.e. users pause it):
+     *   1. if it's already in PAUSED state, then keep the state
+     *   2. else, move the state to PAUSING state
+     *
+     * When stopRequested=false and pauseRequested=false:
+     *   1. if it's in PAUSED state, we should move it to MIRRORING state. It will happen when users resume mirroring
+     *   2. if it's in UNKNOWN or STOPPED state, we should move it to LOG_TRUNCATION state. It will happen when users startMirrorTopics
+     *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should continue to complete the process in previous leader
+     */
+    private void applyMirrorStateTransition(String mirrorName, TopicPartition tp,
+                                            MirrorPartitionState curState, MirrorPartitionState fetchedState,
+                                            boolean stopRequested, boolean pauseRequested) {
+        stateTransitioner.ifPresent(t -> {
+            if (stopRequested) {
+                if (curState != MirrorPartitionState.STOPPED) {
+                    t.transitionTo(mirrorName, tp, MirrorPartitionState.STOPPING);
+                } else {
+                    t.transitionTo(mirrorName, tp, MirrorPartitionState.STOPPED);
+                }
+            } else if (pauseRequested) {
+                if (curState != MirrorPartitionState.PAUSED) {
+                    t.transitionTo(mirrorName, tp, MirrorPartitionState.PAUSING);
+                } else {
+                    t.transitionTo(mirrorName, tp, MirrorPartitionState.PAUSED);
+                }
+            } else if (curState == MirrorPartitionState.PAUSED) {
+                t.transitionTo(mirrorName, tp, MirrorPartitionState.MIRRORING);
+            } else if (curState == MirrorPartitionState.UNKNOWN
+                    || curState == MirrorPartitionState.STOPPED) {
+                t.transitionTo(mirrorName, tp, MirrorPartitionState.LOG_TRUNCATION);
+            } else {
+                t.transitionTo(mirrorName, tp, fetchedState != null ? fetchedState : curState);
+            }
+        });
+    }
+
+
+    /** Periodic metadata sync entry point. */
+    void periodicSync() {
+        Set<String> mirrors = getConfiguredMirrors();
+        if (mirrors.isEmpty()) {
+            return;
+        }
+
+        log.info("Syncing metadata for mirrors: {}", mirrors);
+        mirrors.forEach(this::ensureConnection);
+
+        // Snapshot keyset to avoid ConcurrentModificationException
+        for (String mirrorName : Set.copyOf(sourceSenders.keySet())) {
+            try {
+                discoverSourceBrokers(mirrorName);
+                var topicsState = syncSourceTopicsState(mirrorName);
+                syncCoordinatorMetadata(mirrorName, topicsState);
+            } catch (Exception e) {
+                log.error("Failed to sync metadata for mirror {}", mirrorName, e);
+            }
+        }
+
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        metadataRefreshError.incrementAndGet();
+    }
+
+    /** Schedules a source cluster metadata update. */
+    public void scheduleSourceClusterMetadataUpdate(String mirrorName) {
+        scheduler.scheduleOnce("SourceClusterMetadataUpdate", () -> {
+            discoverSourceBrokers(mirrorName);
+            syncSourceTopicsState(mirrorName);
+        });
+    }
+
+    /**
+     * Discovers source cluster brokers via metadata and adds senders for any newly found brokers.
+     * Sender cleanup only happens via {@link #onMetadataUpdate} or {@link #clearCache}.
+     */
+    private void discoverSourceBrokers(String mirrorName) {
+        Collection<Node> discoveredBrokers = describeSourceClusterNodes(mirrorName);
+        if (discoveredBrokers.isEmpty()) {
+            return;
+        }
+        List<MirrorSourceSender> currentSenders = sourceSenders.get(mirrorName);
+        if (currentSenders == null) {
+            return;
+        }
+
+        Set<String> currentEndpoints = currentSenders.stream()
+                .map(s -> s.brokerEndPoint().host() + ":" + s.brokerEndPoint().port())
+                .collect(Collectors.toSet());
+
+        List<Node> newBrokers = discoveredBrokers.stream()
+                .filter(n -> !currentEndpoints.contains(n.host() + ":" + n.port()))
+                .toList();
+
+        if (newBrokers.isEmpty()) {
+            return;
+        }
+
+        Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName));
+        ClusterMirrorConfig mirrorConfig = ClusterMirrorConfig.fromProperties(props);
+
+        List<MirrorSourceSender> addedSenders = new ArrayList<>();
+        for (Node broker : newBrokers) {
+            try {
+                BrokerEndPoint endpoint = new BrokerEndPoint(broker.id(), broker.host(), broker.port());
+                String clientId = "nodeId-" + nodeId + "-" + mirrorName + "-" + broker.host() + "-" + broker.port();
+                LogContext logContext = new LogContext("[" + MirrorMetadataManager.class.getSimpleName() + "Sender id=" + nodeId + " clientId=" + clientId + "] ");
+                addedSenders.add(ClusterMirrorUtils.createSender(endpoint, mirrorConfig, brokerConfig, metrics, time, clientId, logContext));
+            } catch (Exception e) {
+                log.warn("Failed to create sender for broker {} in mirror {}", broker, mirrorName, e);
+            }
+        }
+
+        if (addedSenders.isEmpty()) {
+            return;
+        }
+
+        List<MirrorSourceSender> merged = new ArrayList<>(currentSenders);
+        merged.addAll(addedSenders);
+        log.info("Adding {} discovered broker(s) to source senders for mirror {}: {}",
+                addedSenders.size(), mirrorName,
+                addedSenders.stream().map(s -> s.brokerEndPoint().toString()).collect(Collectors.joining(", ")));
+        sourceSenders.put(mirrorName, merged);
+    }
+
+    private Collection<Node> describeSourceClusterNodes(String mirrorName) {
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
+        try {
+            var clusterResult = srcAdmin.describeCluster();
+            String clusterId = clusterResult.clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            Collection<Node> nodes = clusterResult.nodes().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            validateSourceClusterId(mirrorName, clusterId);
+            return nodes;
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Failed to describe source cluster for mirror {}", mirrorName, e);
+            return List.of();
+        }
+    }
+
+    private void validateSourceClusterId(String mirrorName, String clusterId) {
+        if (clusterId != null && !clusterId.isEmpty()) {
+            Uuid newClusterId = Uuid.fromString(clusterId);
+            Uuid previousClusterId = sourceClusterIds.put(mirrorName, newClusterId);
+            if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
+                throw new IllegalStateException("Source cluster ID changed for mirror " + mirrorName
+                        + ": expected " + previousClusterId + ", got " + newClusterId
+                        + ". This may indicate a misconfiguration or that the source cluster has been replaced.");
+            }
+        }
+    }
+
+    /**
+     * Fetches topics metadata from the source cluster via Admin.describeTopics.
+     * Runs on every broker to keep partition leaders, topic creation, topic deletion, and partition counts in sync.
+     */
+    private Optional<List<SourceTopicState>> syncSourceTopicsState(String mirrorName) {
+        log.info("Syncing source topic state for mirror {}", mirrorName);
+        Set<String> topics = getConfiguredTopics(mirrorName, false);
+        if (topics.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
+
+        try {
+            Map<String, KafkaFuture<TopicDescription>> futures = srcAdmin.describeTopics(topics).topicNameValues();
+            List<SourceTopicState> result = new ArrayList<>();
+
+            for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : futures.entrySet()) {
+                try {
+                    TopicDescription td = entry.getValue().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                    List<SourcePartitionState> partitions = td.partitions().stream()
+                            .map(pi -> new SourcePartitionState(
+                                    new TopicPartition(td.name(), pi.partition()),
+                                    pi.leader(),
+                                    pi.leaderEpoch()))
+                            .toList();
+                    result.add(new SourceTopicState(td.name(), td.topicId(), true, partitions));
+                } catch (ExecutionException e) {
+                    if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                        result.add(new SourceTopicState(entry.getKey(), Uuid.ZERO_UUID, false, List.of()));
+                    } else {
+                        log.warn("Failed to describe topic {} for mirror {}", entry.getKey(), mirrorName, e.getCause());
                     }
+                }
+            }
 
-                    boolean connectionConfigChanged = e.getValue().changes().keySet().stream()
-                            .anyMatch(key -> !NON_CONNECTION_CONFIGS.contains(key));
+            processTopicMetadata(mirrorName, result);
+            return Optional.of(result);
+        } catch (Exception e) {
+            log.warn("Failed to sync source topic state for mirror {}", mirrorName, e);
+            return Optional.empty();
+        }
+    }
 
-                    if (connectionConfigChanged || mirrorDeleted) {
-                        sourceLeaders.remove(mirrorName);
-                        List<MirrorSourceSender> senders = sourceSenders.remove(mirrorName);
-                        if (senders != null) {
-                            log.info("Mirror config changed for '{}'. Closing existing connections "
-                                    + "to trigger reconnection with updated configuration.", mirrorName);
-                            senders.forEach(MirrorSourceSender::close);
+    private void processTopicMetadata(String mirrorName, List<SourceTopicState> topicInfos) {
+        var creatableTopics = new ArrayList<CreateTopicsRequestData.CreatableTopic>();
+        var createPartitionsTopics = new CreatePartitionsRequestData.CreatePartitionsTopicCollection();
+
+        topicInfos.forEach(ti -> {
+            // use ConcurrentHashMap for thread-safe access from scheduler and fetcher threads
+            var partitionLeaders = sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
+
+            int sourcePartitionCount = ti.partitions().size();
+
+            // skip partitions with no leader (source broker may be restarting)
+            ti.partitions().forEach(pi -> {
+                if (pi.leader() != null) {
+                    partitionLeaders.put(pi.topicPartition(),
+                            new ClusterMirrorUtils.LeaderInfo(pi.leader(), pi.leaderEpoch().orElse(0)));
+                }
+            });
+
+            // Pre-KIP-516 sources (Kafka < 2.8) return ZERO_UUID; fall back to name-based lookup
+            TopicImage destTopic = !ti.topicId().equals(Uuid.ZERO_UUID)
+                    ? metadataImage.topics().getTopic(ti.topicId())
+                    : metadataImage.topics().getTopic(ti.topic());
+
+            if (destTopic != null && destTopic.partitions().size() < sourcePartitionCount) {
+                createPartitionsTopics.add(new CreatePartitionsRequestData.CreatePartitionsTopic()
+                        .setName(ti.topic())
+                        .setCount(sourcePartitionCount)
+                        .setAssignments(null)
+                );
+            } else if (destTopic == null &&
+                    metadataImage.topics().getTopic(ti.topic()) == null &&
+                    ti.exists() && sourcePartitionCount > 0) {
+                if (pendingTopicCreations.add(ti.topic())) {
+                    creatableTopics.add(new CreateTopicsRequestData.CreatableTopic()
+                            .setName(ti.topic())
+                            .setNumPartitions(sourcePartitionCount)
+                            .setReplicationFactor(CreateTopicsRequest.NO_REPLICATION_FACTOR)
+                            .setMirrorInfo(new CreateTopicsRequestData.MirrorInfo().setTopicId(
+                                    ti.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : ti.topicId())));
+                }
+            } else if (destTopic == null &&
+                    metadataImage.topics().getTopic(ti.topic()) != null &&
+                    ti.exists()) {
+                log.error("Mirror topic {} exists on destination with TopicId {} but source has TopicId {}. "
+                                + "Delete the topic on destination and let auto-creation recreate it with the correct TopicId.",
+                        ti.topic(), metadataImage.topics().getTopic(ti.topic()).id(), ti.topicId());
+            }
+        });
+
+        if (!creatableTopics.isEmpty()) {
+            createMirrorTopics(creatableTopics);
+        }
+
+        maybeScalePartitions(createPartitionsTopics);
+        maybeStopDeletedTopics(mirrorName, topicInfos);
+    }
+
+    /**
+     * Creates mirror topics on the destination with the source's TopicId,
+     * preserving topic identity across clusters. Called during periodic metadata
+     * sync when topics have mirror.name config but don't exist on the destination yet.
+     * Once created, onMetadataUpdate will detect them and start the mirror state machine.
+     */
+    private void createMirrorTopics(List<CreateTopicsRequestData.CreatableTopic> creatableTopics) {
+        var topicNames = creatableTopics.stream().map(CreateTopicsRequestData.CreatableTopic::name).toList();
+        creatableTopics.forEach(t -> log.info("Creating mirror topic {} on destination (partitions={}, topicId={})",
+                t.name(), t.numPartitions(), t.mirrorInfo().topicId()));
+        var createTopicsData = new CreateTopicsRequestData().setTimeoutMs(brokerConfig.requestTimeoutMs());
+        creatableTopics.forEach(createTopicsData.topics()::add);
+        ControllerRequestCompletionHandler requestCompletionHandler = new ControllerRequestCompletionHandler() {
+            @Override
+            public void onTimeout() {
+                topicNames.forEach(pendingTopicCreations::remove);
+                log.warn("Create mirror topics timed out for {}", topicNames);
+            }
+
+            @Override
+            public void onComplete(ClientResponse response) {
+                topicNames.forEach(pendingTopicCreations::remove);
+                if (response.responseBody() instanceof CreateTopicsResponse createTopicsResponse) {
+                    createTopicsResponse.data().topics().forEach(topic -> {
+                        Errors error = Errors.forCode(topic.errorCode());
+                        if (error != Errors.NONE) {
+                            log.warn("Failed to create mirror topic {}: {}", topic.name(), error.message());
                         }
-                        Admin admin = srcAdmins.remove(mirrorName);
-                        if (admin != null) {
-                            admin.close();
-                        }
-                        replicaManagerSupplier.get().mirrorFetcherManager().removeFetchersForMirror(mirrorName);
-                        if (!mirrorDeleted) {
-                            reconnectedMirrors.add(mirrorName);
+                    });
+                }
+            }
+        };
+        channelManager.sendRequest(
+                new CreateTopicsRequest.Builder(createTopicsData),
+                requestCompletionHandler);
+    }
+
+    private void maybeScalePartitions(CreatePartitionsRequestData.CreatePartitionsTopicCollection topics) {
+        if (!topics.isEmpty()) {
+            log.debug("Detected partition count change, sending CreatePartitionsRequest: {}", topics);
+            channelManager.sendRequest(new CreatePartitionsRequest.Builder(
+                    new CreatePartitionsRequestData()
+                            .setTopics(topics)
+                            .setValidateOnly(false)
+                            .setTimeoutMs(3000)
+            ), new TimeoutHandler(log));
+        }
+    }
+
+    private void maybeStopDeletedTopics(String mirrorName, List<SourceTopicState> topicInfos) {
+        List<String> deletedSourceTopicNames = new ArrayList<>(topicInfos.stream()
+                .filter(ti -> !ti.exists())
+                .map(SourceTopicState::topic).toList());
+
+        if (deletedSourceTopicNames.isEmpty()) {
+            return;
+        }
+
+        // In old cluster, it is possible the broker metadata update in progress, and the returned metadata response is stale.
+        // list topic again to make sure it is indeed deleted.
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
+        try {
+            Set<String> allTopics = srcAdmin.listTopics().names().get();
+            log.debug("Source topic name list: {}", allTopics);
+            deletedSourceTopicNames.removeAll(allTopics);
+        } catch (Exception e) {
+            log.warn("Failed to describe topic for mirror {}: {}", mirrorName, e.getMessage());
+        }
+
+        getConfiguredTopics(mirrorName, true).forEach(name -> {
+            if (deletedSourceTopicNames.contains(name)) {
+                log.info("Detected topic {} deleted in remote cluster {}, stopping mirror partitions", name, mirrorName);
+                // snapshot keyset to avoid skipping entries during concurrent modification
+                Set.copyOf(partitionStates.keySet()).stream()
+                        .filter(key -> key.mirrorName().equals(mirrorName) && key.topic().equals(name))
+                        .forEach(key -> stateTransitioner.ifPresent(t ->
+                                t.transitionTo(mirrorName, new TopicPartition(key.topic(), key.partition()), MirrorPartitionState.STOPPING)));
+            }
+        });
+    }
+
+    /**
+     * Syncs configurations, consumer group offsets, ACLs, and topic patterns from source clusters.
+     * Runs only on the coordinator broker for each mirror.
+     */
+    private void syncCoordinatorMetadata(String mirrorName, Optional<List<SourceTopicState>> topicInfos) {
+        if (!isLocalCoordinator(mirrorName)) {
+            return;
+        }
+
+        log.info("Syncing coordinator metadata for mirror {}", mirrorName);
+        ensureConnection(mirrorName);
+
+        try {
+            ClusterMirrorConfig mirrorConfig = ClusterMirrorConfig.fromProperties(
+                    metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName)));
+            syncTopicConfigs(mirrorName, mirrorConfig);
+            syncGroupOffsets(mirrorName, mirrorConfig);
+            syncAcls(mirrorName, mirrorConfig);
+            maybeBumpLeaderEpochs(mirrorName, topicInfos, Set.of());
+            discoverTopicsByPattern(mirrorName, mirrorConfig);
+            enforceExcludePatterns(mirrorName, mirrorConfig);
+        } catch (Exception e) {
+            log.error("Failed to sync mirror metadata for mirror {}", mirrorName, e);
+        }
+    }
+
+    private void syncTopicConfigs(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
+
+        Set<String> topics = getConfiguredTopics(mirrorName, false);
+        log.debug("Describing topic configs for topics: {}", topics);
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        topicConfigSyncError.incrementAndGet();
+
+        Collection<ConfigResource> resources = topics.stream()
+                .map(topic -> new ConfigResource(ConfigResource.Type.TOPIC, topic))
+                .toList();
+
+        try {
+            Map<ConfigResource, Config> sourceConfigs = srcAdmin.describeConfigs(resources)
+                    .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(sourceConfigs, mirrorConfig);
+            applyConfigurationChanges(configsToChange);
+        } catch (Exception e) {
+            log.warn("Failed to describe topic configs for mirror {}: {}", mirrorName, e.getMessage());
+        }
+    }
+
+    private Map<String, Map<String, String>> detectConfigurationChanges(
+            Map<ConfigResource, Config> sourceConfigs, ClusterMirrorConfig mirrorConfig) {
+        Map<String, Map<String, String>> configsToChange = new HashMap<>();
+        Pattern excludePattern = mirrorConfig.topicPropertiesExcludePattern();
+
+        sourceConfigs.forEach((resource, config) -> {
+            if (resource.type() == ConfigResource.Type.TOPIC) {
+                Properties props = metadataCache.topicConfig(resource.name());
+                Map<String, String> conChange = new HashMap<>();
+
+                config.entries().forEach(entry -> {
+                    if (entry.source() == ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG
+                            && !entry.name().equals(TopicConfig.MIRROR_NAME_CONFIG)
+                            && (excludePattern == null || !excludePattern.matcher(entry.name()).matches())) {
+                        if (props.containsKey(entry.name())) {
+                            if (!props.get(entry.name()).equals(entry.value())) {
+                                conChange.put(entry.name(), entry.value());
+                            }
+                        } else {
+                            conChange.put(entry.name(), entry.value());
                         }
                     }
                 });
+
+                if (!conChange.isEmpty()) {
+                    configsToChange.put(resource.name(), conChange);
+                }
+            }
+        });
+
+        return configsToChange;
+    }
+
+    private void applyConfigurationChanges(Map<String, Map<String, String>> configsToChange) {
+        log.debug("Applying config change: {}", configsToChange);
+
+        Map<ConfigResource, Collection<AlterConfigOp>> configOps = new HashMap<>();
+        configsToChange.forEach((name, changes) -> {
+            var changeList = changes.entrySet().stream()
+                    .map(entry -> new AlterConfigOp(new ConfigEntry(entry.getKey(), entry.getValue()), AlterConfigOp.OpType.SET))
+                    .toList();
+            configOps.put(new ConfigResource(ConfigResource.Type.TOPIC, name), changeList);
+        });
+
+        if (!configOps.isEmpty()) {
+            IncrementalAlterConfigsRequestData data = new IncrementalAlterConfigsRequestData().setValidateOnly(false);
+            for (Map.Entry<ConfigResource, Collection<AlterConfigOp>> entry : configOps.entrySet()) {
+                ConfigResource resource = entry.getKey();
+                IncrementalAlterConfigsRequestData.AlterableConfigCollection alterableConfigSet =
+                        new IncrementalAlterConfigsRequestData.AlterableConfigCollection();
+                for (AlterConfigOp configEntry : configOps.get(resource))
+                    alterableConfigSet.add(new IncrementalAlterConfigsRequestData.AlterableConfig()
+                            .setName(configEntry.configEntry().name())
+                            .setValue(configEntry.configEntry().value())
+                            .setConfigOperation(configEntry.opType().id()));
+                IncrementalAlterConfigsRequestData.AlterConfigsResource alterConfigsResource =
+                        new IncrementalAlterConfigsRequestData.AlterConfigsResource();
+                alterConfigsResource.setResourceType(resource.type().id())
+                        .setResourceName(resource.name()).setConfigs(alterableConfigSet);
+                data.resources().add(alterConfigsResource);
+            }
+            channelManager.sendRequest(new IncrementalAlterConfigsRequest.Builder(data), new TimeoutHandler(log));
         }
-        return reconnectedMirrors;
+    }
+
+    /**
+     * Syncs group offsets from the source cluster to the destination in two phases:
+     * consumer groups first, then share groups. Keeping them separate avoids cross-type
+     * conflicts where a consumer group on the source could overwrite a share group with
+     * the same name on the destination (or vice versa).
+     */
+    private void syncGroupOffsets(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
+
+        Set<String> mirrorTopics = getConfiguredTopics(mirrorName, false);
+        if (mirrorTopics.isEmpty()) {
+            return;
+        }
+
+        Pattern groupsIncludePattern = mirrorConfig.groupsIncludePattern();
+        Pattern groupsExcludePattern = mirrorConfig.groupsExcludePattern();
+
+        syncConsumerGroupOffsets(srcAdmin, mirrorName, mirrorTopics, groupsIncludePattern, groupsExcludePattern);
+        syncShareGroupOffsets(srcAdmin, mirrorName, mirrorTopics, groupsIncludePattern, groupsExcludePattern);
+    }
+
+    private void syncConsumerGroupOffsets(Admin srcAdmin, String mirrorName, Set<String> mirrorTopics,
+                                          Pattern groupsIncludePattern, Pattern groupsExcludePattern) {
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        consumerGroupOffsetSyncError.incrementAndGet();
+        try {
+            List<String> sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forConsumerGroups(),
+                    groupsIncludePattern, groupsExcludePattern);
+            if (sourceGroupIds.isEmpty()) {
+                return;
+            }
+            log.info("Syncing consumer group offsets for mirror {}, groups={}", mirrorName, sourceGroupIds);
+
+            Map<String, ListConsumerGroupOffsetsSpec> groupSpecs = sourceGroupIds.stream()
+                    .collect(Collectors.toMap(id -> id, id -> new ListConsumerGroupOffsetsSpec()));
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets = srcAdmin
+                    .listConsumerGroupOffsets(groupSpecs).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            Optional<Set<String>> activeDestGroups = getNonSyncableDestinationGroupIds(ListGroupsOptions.forConsumerGroups());
+            if (activeDestGroups.isEmpty()) {
+                return;
+            }
+
+            for (var entry : allOffsets.entrySet()) {
+                String groupId = entry.getKey();
+                if (activeDestGroups.get().contains(groupId)) {
+                    log.debug("Skipping consumer group offset sync for group {} in mirror {}: active on destination", groupId, mirrorName);
+                    continue;
+                }
+
+                Map<TopicPartition, OffsetAndMetadata> filtered = new HashMap<>();
+                entry.getValue().entrySet().stream()
+                        .filter(e -> mirrorTopics.contains(e.getKey().topic()))
+                        .forEach(ent -> {
+                            TopicPartition topicPartition = ent.getKey();
+                            Option<Long> logStartOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
+                            Option<Long> logEndOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
+                            if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
+                                log.debug("Cannot get the log start offset or log end offset for partition {}, skip consumer group sync for it.", topicPartition);
+                                return;
+                            }
+                            OffsetAndMetadata sourceGroupOffsetAndMetadata = ent.getValue();
+
+                            // Committing to the range [local logStartOffset ~ local logEndOffset]
+                            long finalOffset = Math.max(logStartOffset.get(), Math.min(sourceGroupOffsetAndMetadata.offset(), logEndOffset.get()));
+
+                            if (finalOffset == sourceGroupOffsetAndMetadata.offset()) {
+                                filtered.put(topicPartition, sourceGroupOffsetAndMetadata);
+                            } else if (finalOffset == logEndOffset.get()) {
+                                int logEndEpoch = replicaManagerSupplier.get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logEndOffset.get())).getOrElse(() -> -1);
+                                if (logEndEpoch < 0) {
+                                    log.debug("Cannot get the log end epoch for partition {}, skip consumer group sync for it.", topicPartition);
+                                } else {
+                                    filtered.put(topicPartition, new OffsetAndMetadata(logEndOffset.get(), Optional.of(logEndEpoch), ""));
+                                }
+                            } else {
+                                // finalOffset == logStartOffset
+                                int logStartEpoch = replicaManagerSupplier.get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logStartOffset.get())).getOrElse(() -> -1);
+                                if (logStartEpoch < 0) {
+                                    log.debug("Cannot get the log start epoch for partition {}, skip consumer group sync for it.", topicPartition);
+                                } else {
+                                    filtered.put(topicPartition, new OffsetAndMetadata(logStartOffset.get(), Optional.of(logStartEpoch), ""));
+                                }
+                            }
+                        });
+
+                if (filtered.isEmpty()) {
+                    continue;
+                }
+
+                try {
+                    log.debug("Committing consumer group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
+                    getOrCreateDestAdmin().alterConsumerGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                } catch (Exception e) {
+                    log.warn("Failed to commit consumer group offsets for group {} in mirror {}: {}", groupId, mirrorName, e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to sync consumer group offsets for mirror {}: {}", mirrorName, e.getMessage());
+        }
+    }
+
+    private void syncShareGroupOffsets(Admin srcAdmin, String mirrorName, Set<String> mirrorTopics,
+                                       Pattern groupsIncludePattern, Pattern groupsExcludePattern) {
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        shareGroupOffsetSyncError.incrementAndGet();
+        try {
+            List<String> sourceGroupIds;
+            try {
+                sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forShareGroups(),
+                        groupsIncludePattern, groupsExcludePattern);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnsupportedVersionException) {
+                    log.debug("The source cluster doesn't support share group, skipping share group offset sync");
+                    return;
+                } else {
+                    throw e;
+                }
+            }
+            if (sourceGroupIds.isEmpty()) {
+                return;
+            }
+            log.info("Syncing share group offsets for mirror {}, groups={}", mirrorName, sourceGroupIds);
+
+            Map<String, ListShareGroupOffsetsSpec> groupSpecs = sourceGroupIds.stream()
+                    .collect(Collectors.toMap(id -> id, id -> new ListShareGroupOffsetsSpec()));
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets = srcAdmin
+                    .listShareGroupOffsets(groupSpecs).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            Optional<Set<String>> activeDestGroups = getNonSyncableDestinationGroupIds(ListGroupsOptions.forShareGroups());
+            if (activeDestGroups.isEmpty()) {
+                return;
+            }
+
+            for (var entry : allOffsets.entrySet()) {
+                String groupId = entry.getKey();
+                if (activeDestGroups.get().contains(groupId)) {
+                    log.debug("Skipping share group offset sync for group {} in mirror {}: active on destination", groupId, mirrorName);
+                    continue;
+                }
+
+                Map<TopicPartition, Long> filtered = new  HashMap<>();
+                entry.getValue().entrySet().stream()
+                        .filter(e -> mirrorTopics.contains(e.getKey().topic()))
+                        .forEach(ent -> {
+                            TopicPartition topicPartition = ent.getKey();
+                            Option<Long> logStartOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
+                            Option<Long> logEndOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
+                            if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
+                                log.debug("Cannot get the log start offset or log end offset for partition {}, skip share group offset sync for it.", topicPartition);
+                                return;
+                            }
+                            OffsetAndMetadata sourceGroupOffsetAndMetadata = ent.getValue();
+                            // Committing to the range [local logStartOffset ~ local logEndOffset]
+                            long finalOffset = Math.max(logStartOffset.get(), Math.min(sourceGroupOffsetAndMetadata.offset(), logEndOffset.get()));
+                            filtered.put(topicPartition, finalOffset);
+                        });
+                if (filtered.isEmpty()) {
+                    continue;
+                }
+
+                try {
+                    log.debug("Committing share group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
+                    getOrCreateDestAdmin().alterShareGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                } catch (Exception e) {
+                    log.warn("Failed to commit share group offsets for group {} in mirror {}: {}", groupId, mirrorName, e);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to sync share group offsets for mirror {}: {}", mirrorName, e);
+        }
+    }
+
+    private List<String> listSourceGroupIds(Admin srcAdmin, ListGroupsOptions options,
+                                            Pattern groupsIncludePattern, Pattern groupsExcludePattern) throws Exception {
+        return srcAdmin.listGroups(options).all()
+                .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
+                .map(GroupListing::groupId)
+                .filter(id -> groupsIncludePattern == null || groupsIncludePattern.matcher(id).matches())
+                .filter(id -> groupsExcludePattern == null || !groupsExcludePattern.matcher(id).matches())
+                .toList();
+    }
+
+    /** Returns empty Optional on failure so the caller can skip the sync cycle. */
+    private Optional<Set<String>> getNonSyncableDestinationGroupIds(ListGroupsOptions typeFilter) {
+        try {
+            var options = typeFilter.inGroupStates(Set.of(
+                    GroupState.STABLE,
+                    GroupState.PREPARING_REBALANCE,
+                    GroupState.COMPLETING_REBALANCE,
+                    GroupState.ASSIGNING,
+                    GroupState.RECONCILING,
+                    GroupState.EMPTY));
+            return Optional.of(getOrCreateDestAdmin().listGroups(options).all()
+                    .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
+                    .map(GroupListing::groupId)
+                    .collect(Collectors.toSet()));
+        } catch (Exception e) {
+            log.warn("Failed to list destination groups, skipping offset sync cycle.", e);
+            return Optional.empty();
+        }
+    }
+
+    private void syncAcls(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        // TODO: We currently mirror all ACLs from the source to the target.
+        //       Any ACLs added/removed directly on the target will be overwritten
+        //       on the next sync to match the source.
+        //
+        // TODO: How do we disambiguate ACLs that reference the same resource name
+        //       when multiple cluster mirrors exist?
+
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
+
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        aclSyncError.incrementAndGet();
+
+        try {
+            Collection<AclBinding> sourceAcls = srcAdmin.describeAcls(AclBindingFilter.ANY)
+                    .values().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            log.debug("Describe ACLs response from remote cluster {}: {}", mirrorName, sourceAcls);
+
+            List<ClusterMirrorConfig.AclRule> aclIncludeRules = mirrorConfig.aclIncludeRules();
+            var allRemoteAcls = sourceAcls.stream()
+                    .filter(acl -> aclIncludeRules.stream().anyMatch(rule -> rule.matches(acl)))
+                    .toList();
+            var aclChanges = detectAclChanges(allRemoteAcls);
+            applyAclChanges(mirrorName, aclChanges);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof SecurityDisabledException) {
+                log.debug("ACL sync skipped for mirror {}: {}", mirrorName, e.getCause().getMessage());
+            } else {
+                log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
+        }
+    }
+
+    private SourceAclChanges detectAclChanges(List<AclBinding> sourceAcls) {
+        var addACLsList = new ArrayList<AclBinding>();
+        var deleteACLsList = new ArrayList<AclBinding>();
+        var current = metadataImage.acls().acls().values();
+
+        // collect missing acls list
+        sourceAcls.forEach(acl -> {
+            if (current.stream().map(StandardAcl::toBinding).noneMatch(a -> a.equals(acl))) {
+                addACLsList.add(acl);
+            }
+        });
+
+        // collect remove acls list (skip CLUSTER_MIRROR ACLs as they are destination-specific)
+        metadataImage.acls().acls().values().forEach(acl -> {
+            if (acl.resourceType() != ResourceType.CLUSTER_MIRROR && !sourceAcls.contains(acl.toBinding())) {
+                deleteACLsList.add(acl.toBinding());
+            }
+        });
+
+        return new SourceAclChanges(addACLsList, deleteACLsList);
+    }
+
+    private void applyAclChanges(String mirrorName, SourceAclChanges aclChanges) {
+        // send createAcls request
+        if (!aclChanges.aclsToAdd().isEmpty()) {
+            log.debug("Adding {} ACLs from remote cluster {}", aclChanges.aclsToAdd().size(), mirrorName);
+            var requestData = aclChanges.aclsToAdd().stream().map(
+                            aclBinding -> new CreateAclsRequestData.AclCreation()
+                                    .setResourceType(aclBinding.pattern().resourceType().code())
+                                    .setResourceName(aclBinding.pattern().name())
+                                    .setResourcePatternType(aclBinding.pattern().patternType().code())
+                                    .setPrincipal(aclBinding.entry().principal())
+                                    .setHost(aclBinding.entry().host())
+                                    .setOperation(aclBinding.entry().operation().code())
+                                    .setPermissionType(aclBinding.entry().permissionType().code()))
+                    .toList();
+            channelManager.sendRequest(
+                    new CreateAclsRequest.Builder(new CreateAclsRequestData().setCreations(requestData)),
+                    new TimeoutHandler(log)
+            );
+        }
+
+        // send deleteAcls request
+        if (!aclChanges.aclsToDelete().isEmpty()) {
+            log.debug("Removing {} ACLs from remote cluster {}", aclChanges.aclsToDelete().size(), mirrorName);
+            var requestData = aclChanges.aclsToDelete().stream().map(
+                            aclBinding -> new DeleteAclsRequestData.DeleteAclsFilter()
+                                    .setResourceTypeFilter(aclBinding.pattern().resourceType().code())
+                                    .setResourceNameFilter(aclBinding.pattern().name())
+                                    .setPatternTypeFilter(aclBinding.pattern().patternType().code())
+                                    .setPrincipalFilter(aclBinding.entry().principal())
+                                    .setHostFilter(aclBinding.entry().host())
+                                    .setOperation(aclBinding.entry().operation().code())
+                                    .setPermissionType(aclBinding.entry().permissionType().code()))
+                    .toList();
+            channelManager.sendRequest(
+                    new DeleteAclsRequest.Builder(new DeleteAclsRequestData().setFilters(requestData)),
+                    new TimeoutHandler(log)
+            );
+        }
+    }
+
+    private void discoverTopicsByPattern(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        final Pattern topicsIncludePattern = mirrorConfig.topicsIncludePattern();
+        if (topicsIncludePattern == null) {
+            return;
+        }
+
+        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
+
+        Set<String> configuredTopics = getConfiguredTopics(mirrorName, true);
+        final Pattern topicsExcludePattern = mirrorConfig.topicsExcludePattern();
+
+        List<StartMirrorTopicsRequestData.TopicData> newTopics;
+        try {
+            Set<String> allSourceTopics = srcAdmin.listTopics()
+                    .names().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            List<String> candidates = allSourceTopics.stream()
+                    .filter(name -> topicsIncludePattern.matcher(name).matches())
+                    .filter(name -> topicsExcludePattern == null || !topicsExcludePattern.matcher(name).matches())
+                    .filter(name -> !configuredTopics.contains(name))
+                    .toList();
+
+            if (candidates.isEmpty()) {
+                return;
+            }
+
+            Map<String, TopicDescription> descriptions = srcAdmin.describeTopics(candidates)
+                    .allTopicNames().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            cacheSourceLeaders(mirrorName, descriptions.values());
+
+            newTopics = descriptions.values().stream()
+                    .map(td -> new StartMirrorTopicsRequestData.TopicData()
+                            .setTopicName(td.name())
+                            .setTopicId(td.topicId())
+                            .setNumPartitions(td.partitions().size()))
+                    .toList();
+        } catch (Exception e) {
+            log.warn("Failed to discover topics by pattern for mirror {}", mirrorName, e);
+            return;
+        }
+
+        if (newTopics.isEmpty()) {
+            return;
+        }
+
+        log.info("Discovered {} new topic(s) matching mirror.topics.include pattern for mirror {}: {}",
+                newTopics.size(), mirrorName, newTopics.stream().map(StartMirrorTopicsRequestData.TopicData::topicName).toList());
+
+        StartMirrorTopicsRequestData data = new StartMirrorTopicsRequestData();
+        data.setMirrorName(mirrorName);
+        newTopics.forEach(topic -> data.topics().add(topic));
+
+        // TODO: creation failures from auto-discovery are silently lost here (fire-and-forget).
+        //  Add per-topic status tracking so describeMirror can surface failed topics to users.
+        channelManager.sendRequest(
+                new StartMirrorTopicsRequest.Builder(data),
+                new TimeoutHandler(log)
+        );
+    }
+
+    /**
+     * Checks if any active mirror topics now match the exclude pattern and sends
+     * StopMirrorTopicsRequest to stop them. Catches cases where exclude was updated
+     * via incrementalAlterConfigs outside of the startMirrorTopics/stopMirrorTopics flow.
+     */
+    private void enforceExcludePatterns(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        Pattern excludePattern = mirrorConfig.topicsExcludePattern();
+        if (excludePattern == null) return;
+
+        Set<String> activeTopics = getConfiguredTopics(mirrorName, false, false);
+        Set<String> excludedTopics = activeTopics.stream()
+                .filter(topic -> excludePattern.matcher(topic).matches())
+                .collect(Collectors.toSet());
+
+        if (excludedTopics.isEmpty()) return;
+
+        log.info("Stopping {} topic(s) matching mirror.topics.exclude for mirror {}: {}",
+                excludedTopics.size(), mirrorName, excludedTopics);
+
+        channelManager.sendRequest(
+                new StopMirrorTopicsRequest.Builder(mirrorName, excludedTopics),
+                new TimeoutHandler(log)
+        );
     }
 
     /** Returns mirror partitions led by this broker, detecting both leadership and config changes */
@@ -505,49 +1396,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return mirrorLeaderPartitions;
     }
 
-    /**
-     * Applies the appropriate state transition based on current state and stop flag.
-     *
-     * Possible cases:
-     * stopRequested: it means the partition should head to STOPPED state. When it is true (i.e. users stopMirrorTopics):
-     *   1. if it's already in STOPPED state, then keep the state
-     *   2. else, move the state to STOPPING state
-     * pauseRequested: it means the partition should head to PAUSED state. When it is true (i.e. users pause it):
-     *   1. if it's already in PAUSED state, then keep the state
-     *   2. else, move the state to PAUSING state
-     * When stopRequested=false and pauseRequested=false:
-     *   1. if it's in PAUSED state, we should move it to MIRRORING state. It will happen when users resume mirroring
-     *   2. if it's in UNKNOWN or STOPPED state, we should move it to LOG_TRUNCATION state. It will happen when users startMirrorTopics.
-     *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should continue to complete the process in previous leader.
-     */
-    private void applyMirrorStateTransition(String mirrorName, TopicPartition tp,
-                                            MirrorPartitionState curState, MirrorPartitionState fetchedState,
-                                            boolean stopRequested, boolean pauseRequested) {
-        stateTransitioner.ifPresent(t -> {
-            if (stopRequested) {
-                if (curState != MirrorPartitionState.STOPPED) {
-                    t.transitionTo(mirrorName, tp, MirrorPartitionState.STOPPING);
-                } else {
-                    t.transitionTo(mirrorName, tp, MirrorPartitionState.STOPPED);
-                }
-            } else if (pauseRequested) {
-                if (curState != MirrorPartitionState.PAUSED) {
-                    t.transitionTo(mirrorName, tp, MirrorPartitionState.PAUSING);
-                } else {
-                    t.transitionTo(mirrorName, tp, MirrorPartitionState.PAUSED);
-                }
-            } else if (curState == MirrorPartitionState.PAUSED) {
-                t.transitionTo(mirrorName, tp, MirrorPartitionState.MIRRORING);
-            } else if (curState == MirrorPartitionState.UNKNOWN
-                    || curState == MirrorPartitionState.STOPPED) {
-                t.transitionTo(mirrorName, tp, MirrorPartitionState.LOG_TRUNCATION);
-            } else {
-                t.transitionTo(mirrorName, tp, fetchedState != null ? fetchedState : curState);
-            }
-        });
-    }
-
-    // Clears mirror state for partitions where this broker lost leadership, unless it is the coordinator
+    /** Clears state for partitions where this broker lost leadership, unless it is the coordinator */
     private void clearFollowersState(Set<TopicPartition> followerDelta, MetadataImage newImage) {
         followerDelta.forEach(followerTp -> {
             String mirrorName = (String) newImage.configs()
@@ -562,26 +1411,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    private boolean isLocalCoordinator(String mirrorName, String topic, int partition) {
-        if (coordinatorPartitionFinder.isPresent()) {
-            int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
-                    .partitions().get(coordinatorPartitionFinder.get().apply(
-                            new ClusterMirrorRecordKey(mirrorName, metadataCache.getTopicId(topic), partition))).leader;
-            return activeCoordinator == brokerConfig.nodeId();
-        }
-        return false;
-    }
-
-    private boolean isLocalCoordinator(String mirrorName) {
-        if (coordinatorPartitionByNameFinder.isPresent()) {
-            int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
-                    .partitions().get(coordinatorPartitionByNameFinder.get().apply(mirrorName)).leader;
-            return activeCoordinator == brokerConfig.nodeId();
-        }
-        return false;
-    }
-
-    // Finds the coordinator node (leader of the __mirror_state partition) for a mirror record key
+    /** Finds the coordinator node (leader of the __mirror_state partition) for a mirror record key */
     private Node findCoordinatorNode(ClusterMirrorRecordKey key) {
         try {
             if (metadataCache.contains(MIRROR_STATE_TOPIC_NAME)) {
@@ -600,10 +1430,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 if (topicMetadata == null || topicMetadata.isEmpty() || topicMetadata.get(0).errorCode() != Errors.NONE.code()) {
                     return Node.noNode();
                 } else {
-                    if (coordinatorPartitionFinder.isEmpty()) {
+                    if (coordPartitionFinderByKey.isEmpty()) {
                         return Node.noNode();
                     }
-                    int partition = coordinatorPartitionFinder.get().apply(key);
+                    int partition = coordPartitionFinderByKey.get().apply(key);
                     Optional<MetadataResponseData.MetadataResponsePartition> response = topicMetadata.get(0).partitions().stream()
                             .filter(responsePart -> responsePart.partitionIndex() == partition
                                     && responsePart.leaderId() != MetadataResponse.NO_LEADER_ID)
@@ -759,9 +1589,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /** Reads partition states and offsets from local cache. Used when this broker is the coordinator. */
-    void getCachedPartitionMetadata(String mirrorName,
-                                    Map<String, Set<Integer>> partitions,
-                                    Consumer<ReadMirrorStatesResponse> responseCallback) {
+    void getTopicMetadata(String mirrorName,
+                          Map<String, Set<Integer>> partitions,
+                          Consumer<ReadMirrorStatesResponse> responseCallback) {
         ReadMirrorStatesResponseData data = new ReadMirrorStatesResponseData();
         List<ReadMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
         partitions.forEach((tp, parts) -> {
@@ -818,16 +1648,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         sourceSenders.put(mirrorName, senders);
     }
 
-    private Admin getOrCreateDestAdmin() {
-        if (dstAdmin == null) {
-            var endpoint = brokerConfig.effectiveAdvertisedBrokerListeners().head();
-            Properties props = new Properties();
-            props.put(BOOTSTRAP_SERVERS_CONFIG, endpoint.host() + ":" + endpoint.port());
-            dstAdmin = Admin.create(props);
-        }
-        return dstAdmin;
-    }
-
     /** Updates cached source leader for a specific partition. */
     public void updateSourceLeader(String mirrorName, TopicPartition tp, ClusterMirrorUtils.LeaderInfo leader) {
         sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>()).put(tp, leader);
@@ -859,7 +1679,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         throw new IllegalStateException("No source senders available for mirror " + mirrorName);
     }
 
-    // atomic per-key update to keep partition state counts consistent
+    // Atomic per-key update to keep partition state counts consistent
     void updatePartitionState(ClusterMirrorUtils.PartitionKey key, MirrorPartitionState newState) {
         partitionStates.compute(key, (k, oldState) -> {
             if (oldState != null && oldState != newState) {
@@ -872,7 +1692,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    // atomic remove + counter decrement to keep partition state counts consistent
+    // Atomic remove + counter decrement to keep partition state counts consistent
     void removePartitionState(ClusterMirrorUtils.PartitionKey key) {
         partitionStates.computeIfPresent(key, (k, oldState) -> {
             partitionStateCounts.computeIfAbsent(oldState, s -> new AtomicLong()).decrementAndGet();
@@ -895,114 +1715,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return partitionStates.get(new ClusterMirrorUtils.PartitionKey(updatedMirrorName, topicPartition.topic(), topicPartition.partition()));
     }
 
-    /** Groups loaded partition states by mirror and state, then invokes the callback for each group. */
-    void applyLoadedPartitionStates(ClusterMirrorUtils.StateTransitionCallback callback) {
-        Map<String, Map<MirrorPartitionState, Set<TopicPartition>>> statesToPartitionsToOperate = new HashMap<>();
-        partitionStates.forEach((key, value) -> {
-            log.debug("Applying loaded partition state: {} {}", key, value);
-            metadataCache.getLeaderAndIsr(key.topic(), key.partition()).ifPresent(metadata -> {
-                // only operate when this node is the leader of the partition
-                if (metadata.leader() == nodeId) {
-                    statesToPartitionsToOperate.compute(key.mirrorName(), (k, v) -> {
-                        if (v == null) {
-                            Map<MirrorPartitionState, Set<TopicPartition>> map = new HashMap<>();
-                            map.put(value, Set.of(new TopicPartition(key.topic(), key.partition())));
-                            return map;
-                        }
-                        v.compute(value, (state, prevTps) -> {
-                            if (prevTps == null) {
-                                Set<TopicPartition> set = new HashSet<>();
-                                set.add(new TopicPartition(key.topic(), key.partition()));
-                                return set;
-                            } else {
-                                Set<TopicPartition> result = new HashSet<>(prevTps);
-                                result.add(new TopicPartition(key.topic(), key.partition()));
-                                return result;
-                            }
-                        });
-                        return v;
-                    });
-                }
-            });
-        });
-
-        statesToPartitionsToOperate.forEach((mirrorName, statesToPartitionsMap) -> {
-            statesToPartitionsMap.forEach((state, tps) -> {
-                callback.onStateLoaded(mirrorName, tps, state);
-            });
-        });
-    }
-
-    Map<TopicPartition, Integer> getLastMirrorEpochs(String clusterName) {
-        Map<TopicPartition, Integer> result = new HashMap<>();
-        lastMirrorEpochs.forEach((key, epoch) -> {
-            if (key.mirrorName().equals(clusterName)) {
-                result.put(new TopicPartition(key.topic(), key.partition()), epoch);
-            }
-        });
-        return result;
-    }
-
-    Map<ClusterMirrorUtils.PartitionKey, Integer> updateLastMirrorEpochs(String clusterName,
-                                                                  Map<String, Map<Integer, Integer>> addedEpochs,
-                                                                  Map<String, Map<Integer, Integer>> stoppedEpochs) {
-        stoppedEpochs.forEach((topic, partitionOffsets) -> {
-            partitionOffsets.forEach((partition, offset) -> {
-                lastMirrorEpochs.remove(new ClusterMirrorUtils.PartitionKey(clusterName, topic, partition));
-            });
-        });
-        addedEpochs.forEach((topic, partitionOffsets) -> {
-            partitionOffsets.forEach((partition, offset) -> {
-                lastMirrorEpochs.put(new ClusterMirrorUtils.PartitionKey(clusterName, topic, partition), offset);
-            });
-        });
-        return lastMirrorEpochs;
-    }
-
-    /** Truncates local replicas using last mirrored leader epochs from this broker's coordinator cache. */
-    CompletionStage<Map<String, ClusterMirrorDescription>> truncateToLastMirrorEpochs(String mirrorName,
-                                                                               Set<TopicPartition> topicPartitionSet) {
-        log.info("Truncating to last mirrored epochs from local state for mirror {}: {}", mirrorName, topicPartitionSet);
-        Admin admin = srcAdmins.computeIfAbsent(mirrorName, k -> {
-            Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
-            return Admin.create(props);
-        });
-        DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName));
-        return result.allDescriptions().toCompletionStage();
-    }
-
-    /** Periodic sync entry point. */
-    void periodicSync() {
-        Set<String> mirrors = getConfiguredMirrors();
-        if (mirrors.isEmpty()) {
-            return;
-        }
-
-        log.info("Syncing metadata for mirrors: {}", mirrors);
-        mirrors.forEach(this::ensureConnection);
-
-        // snapshot keyset to avoid ConcurrentModificationException
-        for (String mirrorName : Set.copyOf(sourceSenders.keySet())) {
-            try {
-                discoverSourceBrokers(mirrorName);
-                var topicInfos = syncSourceTopicState(mirrorName);
-                syncCoordinatorMetadata(mirrorName, topicInfos);
-            } catch (Exception e) {
-                log.error("Failed to sync metadata for mirror {}", mirrorName, e);
-            }
-        }
-
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        metadataRefreshError.incrementAndGet();
-    }
-
+    /** Schedules a source metadata sync followed by a leader epoch bump request. */
     public CompletableFuture<Void> scheduleBumpLeaderEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         scheduler.scheduleOnce("bump-leader-epoch", () -> {
             ensureConnection(mirrorName);
             discoverSourceBrokers(mirrorName);
-            Optional<List<SourceTopicInfo>> topicInfos = syncSourceTopicState(mirrorName);
-            maybeBumpLeaderEpochs(mirrorName, topicInfos, topicPartitions)
+            Optional<List<SourceTopicState>> topics = syncSourceTopicsState(mirrorName);
+            maybeBumpLeaderEpochs(mirrorName, topics, topicPartitions)
                     .whenComplete((v, ex) -> {
                         if (ex != null) {
                             future.completeExceptionally(ex);
@@ -1014,7 +1734,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return future;
     }
 
-    private CompletableFuture<Void> maybeBumpLeaderEpochs(String mirrorName, Optional<List<SourceTopicInfo>> topicInfos, Set<TopicPartition> topicPartitions) {
+    private CompletableFuture<Void> maybeBumpLeaderEpochs(String mirrorName, Optional<List<SourceTopicState>> topicInfos, Set<TopicPartition> topicPartitions) {
         if (topicInfos.isPresent()) {
             return sendBumpLeaderEpochs(buildSourceEpochBumpTargets(mirrorName, topicInfos.get(), topicPartitions))
                     .whenComplete((v, ex) -> {
@@ -1024,6 +1744,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return CompletableFuture.completedFuture(null);
     }
 
+    /** Sends an AlterPartition request to bump leader epochs on the destination. */
     public CompletableFuture<Void> sendBumpLeaderEpochs(Map<TopicPartition, Integer> partitionMinEpochs) {
         if (partitionMinEpochs.isEmpty()) {
             return CompletableFuture.completedFuture(null);
@@ -1067,17 +1788,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return future;
     }
 
-    private Map<TopicPartition, Integer> buildSourceEpochBumpTargets(String mirrorName, List<SourceTopicInfo> topicInfos, Set<TopicPartition> topicPartitions) {
+    private Map<TopicPartition, Integer> buildSourceEpochBumpTargets(String mirrorName, List<SourceTopicState> topicInfos, Set<TopicPartition> topicPartitions) {
         Set<String> mirrorTopics = topicPartitions.isEmpty() ? getConfiguredTopics(mirrorName, false) : Set.of();
         Map<TopicPartition, Integer> leaderEpochFromMetadata = new HashMap<>();
-        for (SourceTopicInfo ti : topicInfos) {
-            if (!ti.exists()) {
+        for (SourceTopicState ts : topicInfos) {
+            if (!ts.exists()) {
                 continue;
             }
-            if (!mirrorTopics.isEmpty() && !mirrorTopics.contains(ti.topic())) {
+            if (!mirrorTopics.isEmpty() && !mirrorTopics.contains(ts.topic())) {
                 continue;
             }
-            collectEpochBumpTargets(ti, topicPartitions, leaderEpochFromMetadata);
+            collectEpochBumpTargets(ts, topicPartitions, leaderEpochFromMetadata);
         }
         if (!leaderEpochFromMetadata.isEmpty()) {
             log.info("Bumping leader epoch for partitions {} to {}", topicPartitions, leaderEpochFromMetadata);
@@ -1085,22 +1806,22 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return leaderEpochFromMetadata;
     }
 
-    private void collectEpochBumpTargets(SourceTopicInfo topicInfo,
+    private void collectEpochBumpTargets(SourceTopicState topicInfo,
                                          Set<TopicPartition> topicPartitions,
                                          Map<TopicPartition, Integer> leaderEpochFromMetadata) {
-        for (SourcePartitionInfo pi : topicInfo.partitions()) {
-            TopicPartition tp = pi.topicPartition();
+        for (SourcePartitionState ps : topicInfo.partitions()) {
+            TopicPartition tp = ps.topicPartition();
             if (!topicPartitions.isEmpty() && !topicPartitions.contains(tp)) {
                 continue;
             }
-            if (pi.leaderEpoch().isEmpty()) {
+            if (ps.leaderEpoch().isEmpty()) {
                 continue;
             }
             TopicImage topicImage = metadataImage.topics().getTopic(tp.topic());
             if (topicImage == null || topicImage.partitions().get(tp.partition()) == null) {
                 continue;
             }
-            int epoch = pi.leaderEpoch().get();
+            int epoch = ps.leaderEpoch().get();
             int localEpoch = topicImage.partitions().get(tp.partition()).leaderEpoch;
             if (epoch > localEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
                 int newEpoch = Math.addExact(epoch, LEADER_EPOCH_BUMP_INCREMENT);
@@ -1109,7 +1830,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    public Map<TopicPartition, Integer> buildLocalEpochBumpTargets(LogManager logManager, Set<TopicPartition> topicPartitions) {
+    /** Reads the latest epoch from local logs for each partition. */
+    public Map<TopicPartition, Integer> getLatestLocalEpochs(LogManager logManager, Set<TopicPartition> topicPartitions) {
         Map<TopicPartition, Integer> partitionMinEpochs = new HashMap<>();
         topicPartitions.forEach(tp -> {
             int epoch = logManager.getLog(tp, false).get().latestEpoch().orElse(-1);
@@ -1140,315 +1862,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
-     * Discovers source cluster brokers via metadata and adds senders for any newly found brokers.
-     * Sender cleanup only happens via {@link #onMetadataUpdate} or {@link #clear}.
-     */
-    private void discoverSourceBrokers(String mirrorName) {
-        Collection<Node> discoveredBrokers = describeSourceClusterNodes(mirrorName);
-        if (discoveredBrokers.isEmpty()) {
-            return;
-        }
-        List<MirrorSourceSender> currentSenders = sourceSenders.get(mirrorName);
-        if (currentSenders == null) {
-            return;
-        }
-
-        Set<String> currentEndpoints = currentSenders.stream()
-                .map(s -> s.brokerEndPoint().host() + ":" + s.brokerEndPoint().port())
-                .collect(Collectors.toSet());
-
-        List<Node> newBrokers = discoveredBrokers.stream()
-                .filter(n -> !currentEndpoints.contains(n.host() + ":" + n.port()))
-                .toList();
-
-        if (newBrokers.isEmpty()) {
-            return;
-        }
-
-        Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName));
-        ClusterMirrorConfig mirrorConfig = ClusterMirrorConfig.fromProperties(props);
-
-        List<MirrorSourceSender> addedSenders = new ArrayList<>();
-        for (Node broker : newBrokers) {
-            try {
-                BrokerEndPoint endpoint = new BrokerEndPoint(broker.id(), broker.host(), broker.port());
-                String clientId = "nodeId-" + nodeId + "-" + mirrorName + "-" + broker.host() + "-" + broker.port();
-                LogContext logContext = new LogContext("[" + MirrorMetadataManager.class.getSimpleName() + "Sender id=" + nodeId + " clientId=" + clientId + "] ");
-                addedSenders.add(ClusterMirrorUtils.createSender(endpoint, mirrorConfig, brokerConfig, metrics, time, clientId, logContext));
-            } catch (Exception e) {
-                log.warn("Failed to create sender for broker {} in mirror {}", broker, mirrorName, e);
-            }
-        }
-
-        if (addedSenders.isEmpty()) {
-            return;
-        }
-
-        List<MirrorSourceSender> merged = new ArrayList<>(currentSenders);
-        merged.addAll(addedSenders);
-        log.info("Adding {} discovered broker(s) to source senders for mirror {}: {}",
-                addedSenders.size(), mirrorName,
-                addedSenders.stream().map(s -> s.brokerEndPoint().toString()).collect(Collectors.joining(", ")));
-        sourceSenders.put(mirrorName, merged);
-    }
-
-    private Admin getOrCreateSourceAdmin(String mirrorName) {
-        return srcAdmins.computeIfAbsent(mirrorName, k -> {
-            Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
-            return Admin.create(props);
-        });
-    }
-
-    private Collection<Node> describeSourceClusterNodes(String mirrorName) {
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-        try {
-            var clusterResult = srcAdmin.describeCluster();
-            String clusterId = clusterResult.clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-            Collection<Node> nodes = clusterResult.nodes().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-            validateSourceClusterId(mirrorName, clusterId);
-            return nodes;
-        } catch (IllegalStateException e) {
-            throw e;
-        } catch (Exception e) {
-            log.warn("Failed to describe source cluster for mirror {}", mirrorName, e);
-            return List.of();
-        }
-    }
-
-    private void validateSourceClusterId(String mirrorName, String clusterId) {
-        if (clusterId != null && !clusterId.isEmpty()) {
-            Uuid newClusterId = Uuid.fromString(clusterId);
-            Uuid previousClusterId = sourceClusterIds.put(mirrorName, newClusterId);
-            if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
-                throw new IllegalStateException("Source cluster ID changed for mirror " + mirrorName
-                    + ": expected " + previousClusterId + ", got " + newClusterId
-                    + ". This may indicate a misconfiguration or that the source cluster has been replaced.");
-            }
-        }
-    }
-
-    /**
-     * Fetches topic metadata from the source cluster via Admin.describeTopics.
-     * Runs on every broker to keep partition leaders, topic creation, topic deletion, and partition counts in sync.
-     *
-     * Against older source clusters (e.g. 2.1.1 with ZK) the Admin client first attempts the
-     * DescribeTopicPartitions API, gets UnsupportedVersionException, then falls back to a
-     * MetadataRequest. The extra round trips widen the window between topic creation on the
-     * destination and source leader population in sourceLeaders. The maybeStartMissedPartitions
-     * call at the end of processTopicMetadata closes that gap.
-     */
-    private Optional<List<SourceTopicInfo>> syncSourceTopicState(String mirrorName) {
-        log.info("Syncing source topic state for mirror {}", mirrorName);
-        Set<String> topics = getConfiguredTopics(mirrorName, false);
-        if (topics.isEmpty()) {
-            return Optional.empty();
-        }
-
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        try {
-            Map<String, KafkaFuture<TopicDescription>> futures = srcAdmin.describeTopics(topics).topicNameValues();
-            List<SourceTopicInfo> result = new ArrayList<>();
-
-            for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : futures.entrySet()) {
-                try {
-                    TopicDescription td = entry.getValue().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-                    List<SourcePartitionInfo> partitions = td.partitions().stream()
-                            .map(pi -> new SourcePartitionInfo(
-                                    new TopicPartition(td.name(), pi.partition()),
-                                    pi.leader(),
-                                    pi.leaderEpoch()))
-                            .toList();
-                    result.add(new SourceTopicInfo(td.name(), td.topicId(), true, partitions));
-                } catch (ExecutionException e) {
-                    if (e.getCause() instanceof UnknownTopicOrPartitionException) {
-                        result.add(new SourceTopicInfo(entry.getKey(), Uuid.ZERO_UUID, false, List.of()));
-                    } else {
-                        log.warn("Failed to describe topic {} for mirror {}", entry.getKey(), mirrorName, e.getCause());
-                    }
-                }
-            }
-
-            processTopicMetadata(mirrorName, result);
-            return Optional.of(result);
-        } catch (Exception e) {
-            log.warn("Failed to sync source topic state for mirror {}", mirrorName, e);
-            return Optional.empty();
-        }
-    }
-
-    private void processTopicMetadata(String mirrorName, List<SourceTopicInfo> topicInfos) {
-        var creatableTopics = new ArrayList<CreateTopicsRequestData.CreatableTopic>();
-        var createPartitionsTopics = new CreatePartitionsRequestData.CreatePartitionsTopicCollection();
-
-        topicInfos.forEach(ti -> {
-            // use ConcurrentHashMap for thread-safe access from scheduler and fetcher threads
-            var partitionLeaders = sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
-
-            int sourcePartitionCount = ti.partitions().size();
-
-            // skip partitions with no leader (source broker may be restarting)
-            ti.partitions().forEach(pi -> {
-                if (pi.leader() != null) {
-                    partitionLeaders.put(pi.topicPartition(),
-                            new ClusterMirrorUtils.LeaderInfo(pi.leader(), pi.leaderEpoch().orElse(0)));
-                }
-            });
-
-            // Pre-KIP-516 sources (Kafka < 2.8) return ZERO_UUID; fall back to name-based lookup
-            TopicImage destTopic = !ti.topicId().equals(Uuid.ZERO_UUID)
-                    ? metadataImage.topics().getTopic(ti.topicId())
-                    : metadataImage.topics().getTopic(ti.topic());
-
-            if (destTopic != null && destTopic.partitions().size() < sourcePartitionCount) {
-                createPartitionsTopics.add(new CreatePartitionsRequestData.CreatePartitionsTopic()
-                        .setName(ti.topic())
-                        .setCount(sourcePartitionCount)
-                        .setAssignments(null)
-                );
-            } else if (destTopic == null &&
-                    metadataImage.topics().getTopic(ti.topic()) == null &&
-                    ti.exists() && sourcePartitionCount > 0) {
-                if (pendingTopicCreations.add(ti.topic())) {
-                    creatableTopics.add(new CreateTopicsRequestData.CreatableTopic()
-                            .setName(ti.topic())
-                            .setNumPartitions(sourcePartitionCount)
-                            .setReplicationFactor(CreateTopicsRequest.NO_REPLICATION_FACTOR)
-                            .setMirrorInfo(new CreateTopicsRequestData.MirrorInfo().setTopicId(
-                                    ti.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : ti.topicId())));
-                }
-            } else if (destTopic == null &&
-                    metadataImage.topics().getTopic(ti.topic()) != null &&
-                    ti.exists()) {
-                log.error("Mirror topic {} exists on destination with TopicId {} but source has TopicId {}. "
-                        + "Delete the topic on destination and let auto-creation recreate it with the correct TopicId.",
-                        ti.topic(), metadataImage.topics().getTopic(ti.topic()).id(), ti.topicId());
-            }
-        });
-
-        if (!creatableTopics.isEmpty()) {
-            createMirrorTopics(creatableTopics);
-        }
-
-        maybeStartMissedPartitions(mirrorName);
-        maybeScalePartitions(createPartitionsTopics);
-        maybeStopDeletedTopics(mirrorName, topicInfos);
-    }
-
-    /**
-     * Creates mirror topics on the destination with the source's TopicId,
-     * preserving topic identity across clusters. Called during periodic metadata
-     * sync when topics have mirror.name config but don't exist on the destination yet.
-     * Once created, onMetadataUpdate will detect them and start the mirror state machine.
-     */
-    private void createMirrorTopics(List<CreateTopicsRequestData.CreatableTopic> creatableTopics) {
-        var topicNames = creatableTopics.stream().map(CreateTopicsRequestData.CreatableTopic::name).toList();
-        creatableTopics.forEach(t -> log.info("Creating mirror topic {} on destination (partitions={}, topicId={})",
-                t.name(), t.numPartitions(), t.mirrorInfo().topicId()));
-        var createTopicsData = new CreateTopicsRequestData().setTimeoutMs(brokerConfig.requestTimeoutMs());
-        creatableTopics.forEach(createTopicsData.topics()::add);
-        ControllerRequestCompletionHandler requestCompletionHandler = new ControllerRequestCompletionHandler() {
-            @Override
-            public void onTimeout() {
-                topicNames.forEach(pendingTopicCreations::remove);
-                log.warn("Create mirror topics timed out for {}", topicNames);
-            }
-
-            @Override
-            public void onComplete(ClientResponse response) {
-                topicNames.forEach(pendingTopicCreations::remove);
-                if (response.responseBody() instanceof CreateTopicsResponse createTopicsResponse) {
-                    createTopicsResponse.data().topics().forEach(topic -> {
-                        Errors error = Errors.forCode(topic.errorCode());
-                        if (error != Errors.NONE) {
-                            log.warn("Failed to create mirror topic {}: {}", topic.name(), error.message());
-                        }
-                    });
-                }
-            }
-        };
-        channelManager.sendRequest(
-                new CreateTopicsRequest.Builder(createTopicsData),
-                requestCompletionHandler);
-    }
-
-    private void maybeScalePartitions(CreatePartitionsRequestData.CreatePartitionsTopicCollection topics) {
-        if (!topics.isEmpty()) {
-            log.debug("Detected partition count change, sending CreatePartitionsRequest: {}", topics);
-            channelManager.sendRequest(new CreatePartitionsRequest.Builder(
-                    new CreatePartitionsRequestData()
-                            .setTopics(topics)
-                            .setValidateOnly(false)
-                            .setTimeoutMs(3000)
-            ), new TimeoutHandler(log));
-        }
-    }
-
-    private void maybeStopDeletedTopics(String mirrorName, List<SourceTopicInfo> topicInfos) {
-        List<String> deletedSourceTopicNames = new ArrayList<>(topicInfos.stream()
-                .filter(ti -> !ti.exists())
-                .map(SourceTopicInfo::topic).toList());
-
-        if (deletedSourceTopicNames.isEmpty()) {
-            return;
-        }
-
-        // In old cluster, it is possible the broker metadata update in progress, and the returned metadata response is stale.
-        // list topic again to make sure it is indeed deleted.
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-        try {
-            Set<String> allTopics = srcAdmin.listTopics().names().get();
-            log.debug("Source topic name list: {}", allTopics);
-            deletedSourceTopicNames.removeAll(allTopics);
-        } catch (Exception e) {
-            log.warn("Failed to describe topic for mirror {}: {}", mirrorName, e.getMessage());
-        }
-
-        getConfiguredTopics(mirrorName, true).forEach(name -> {
-            if (deletedSourceTopicNames.contains(name)) {
-                log.info("Detected topic {} deleted in remote cluster {}, stopping mirror partitions", name, mirrorName);
-                // snapshot keyset to avoid skipping entries during concurrent modification
-                Set.copyOf(partitionStates.keySet()).stream()
-                        .filter(key -> key.mirrorName().equals(mirrorName) && key.topic().equals(name))
-                        .forEach(key -> stateTransitioner.ifPresent(t ->
-                                t.transitionTo(mirrorName, new TopicPartition(key.topic(), key.partition()), MirrorPartitionState.STOPPING)));
-            }
-        });
-    }
-
-    /**
-     * Catches partitions that onMetadataUpdate could not start because their source leader
-     * was not yet known. This happens when the source cluster has not elected a leader for
-     * a partition at the time processTopicMetadata first runs: the partition is skipped in
-     * sourceLeaders, but the destination topic is still created, triggering onMetadataUpdate
-     * which finds no source leader and leaves the partition in UNKNOWN state. Since
-     * onMetadataUpdate only reacts to destination metadata changes, it never retries on its
-     * own. This method runs after each source metadata sync and transitions any UNKNOWN
-     * partitions whose source leader has since been discovered.
-     */
-    private void maybeStartMissedPartitions(String mirrorName) {
-        var partitionLeaders = sourceLeaders.get(mirrorName);
-        if (partitionLeaders == null) {
-            return;
-        }
-        partitionLeaders.keySet().forEach(tp -> {
-            ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
-            if (partitionStates.getOrDefault(key, MirrorPartitionState.UNKNOWN) != MirrorPartitionState.UNKNOWN) {
-                return;
-            }
-            TopicImage topicImage = metadataImage.topics().getTopic(tp.topic());
-            if (topicImage == null) {
-                return;
-            }
-            var partition = topicImage.partitions().get(tp.partition());
-            if (partition != null && partition.leader == nodeId) {
-                log.info("Source leader for {} discovered after initial onMetadataUpdate, transitioning to LOG_TRUNCATION", tp);
-                stateTransitioner.ifPresent(t -> t.transitionTo(mirrorName, tp, MirrorPartitionState.LOG_TRUNCATION));
-            }
-        });
-    }
-
-    /**
      * Pre-populates sourceLeaders for discovered topics so that when onMetadataUpdate fires
      * after the destination topic is created, the fetcher can connect to the correct source
      * broker immediately. Without this, the fetcher starts with a bootstrap broker, gets a
@@ -1463,506 +1876,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         new ClusterMirrorUtils.LeaderInfo(pi.leader(), pi.leaderEpoch().orElse(0)));
             }
         }));
-    }
-
-    /**
-     * Syncs configurations, consumer group offsets, ACLs, and topic patterns from source clusters.
-     * Runs only on the coordinator broker for each mirror.
-     */
-    private void syncCoordinatorMetadata(String mirrorName, Optional<List<SourceTopicInfo>> topicInfos) {
-        if (!isLocalCoordinator(mirrorName)) {
-            return;
-        }
-
-        log.info("Syncing coordinator metadata for mirror {}", mirrorName);
-        ensureConnection(mirrorName);
-
-        try {
-            ClusterMirrorConfig mirrorConfig = ClusterMirrorConfig.fromProperties(
-                    metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName)));
-            syncTopicConfigurations(mirrorName, mirrorConfig);
-            syncGroupOffsets(mirrorName, mirrorConfig);
-            syncAccessControlLists(mirrorName, mirrorConfig);
-            maybeBumpLeaderEpochs(mirrorName, topicInfos, Set.of());
-            discoverTopicsByPattern(mirrorName, mirrorConfig);
-            enforceExcludePatterns(mirrorName, mirrorConfig);
-        } catch (Exception e) {
-            log.error("Failed to sync mirror metadata for mirror {}", mirrorName, e);
-        }
-    }
-
-    private void syncTopicConfigurations(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        Set<String> topics = getConfiguredTopics(mirrorName, false);
-        log.debug("Describing topic configs for topics: {}", topics);
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        topicConfigSyncError.incrementAndGet();
-
-        Collection<ConfigResource> resources = topics.stream()
-            .map(topic -> new ConfigResource(ConfigResource.Type.TOPIC, topic))
-            .toList();
-
-        try {
-            Map<ConfigResource, Config> sourceConfigs = srcAdmin.describeConfigs(resources)
-                .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-            Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(sourceConfigs, mirrorConfig);
-            applyConfigurationChanges(configsToChange);
-        } catch (Exception e) {
-            log.warn("Failed to describe topic configs for mirror {}: {}", mirrorName, e.getMessage());
-        }
-    }
-
-    private Map<String, Map<String, String>> detectConfigurationChanges(
-            Map<ConfigResource, Config> sourceConfigs, ClusterMirrorConfig mirrorConfig) {
-        Map<String, Map<String, String>> configsToChange = new HashMap<>();
-        Pattern excludePattern = mirrorConfig.topicPropertiesExcludePattern();
-
-        sourceConfigs.forEach((resource, config) -> {
-            if (resource.type() == ConfigResource.Type.TOPIC) {
-                Properties props = metadataCache.topicConfig(resource.name());
-                Map<String, String> conChange = new HashMap<>();
-
-                config.entries().forEach(entry -> {
-                    if (entry.source() == ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG
-                            && !entry.name().equals(TopicConfig.MIRROR_NAME_CONFIG)
-                            && (excludePattern == null || !excludePattern.matcher(entry.name()).matches())) {
-                        if (props.containsKey(entry.name())) {
-                            if (!props.get(entry.name()).equals(entry.value())) {
-                                conChange.put(entry.name(), entry.value());
-                            }
-                        } else {
-                            conChange.put(entry.name(), entry.value());
-                        }
-                    }
-                });
-
-                if (!conChange.isEmpty()) {
-                    configsToChange.put(resource.name(), conChange);
-                }
-            }
-        });
-
-        return configsToChange;
-    }
-
-    private void applyConfigurationChanges(Map<String, Map<String, String>> configsToChange) {
-        log.debug("Applying config change: {}", configsToChange);
-
-        Map<ConfigResource, Collection<AlterConfigOp>> configOps = new HashMap<>();
-        configsToChange.forEach((name, changes) -> {
-            var changeList = changes.entrySet().stream()
-                .map(entry -> new AlterConfigOp(new ConfigEntry(entry.getKey(), entry.getValue()), AlterConfigOp.OpType.SET))
-                .toList();
-            configOps.put(new ConfigResource(ConfigResource.Type.TOPIC, name), changeList);
-        });
-
-        if (!configOps.isEmpty()) {
-            IncrementalAlterConfigsRequestData data = new IncrementalAlterConfigsRequestData().setValidateOnly(false);
-            for (Map.Entry<ConfigResource, Collection<AlterConfigOp>> entry : configOps.entrySet()) {
-                ConfigResource resource = entry.getKey();
-                IncrementalAlterConfigsRequestData.AlterableConfigCollection alterableConfigSet =
-                        new IncrementalAlterConfigsRequestData.AlterableConfigCollection();
-                for (AlterConfigOp configEntry : configOps.get(resource))
-                    alterableConfigSet.add(new IncrementalAlterConfigsRequestData.AlterableConfig()
-                            .setName(configEntry.configEntry().name())
-                            .setValue(configEntry.configEntry().value())
-                            .setConfigOperation(configEntry.opType().id()));
-                IncrementalAlterConfigsRequestData.AlterConfigsResource alterConfigsResource =
-                    new IncrementalAlterConfigsRequestData.AlterConfigsResource();
-                alterConfigsResource.setResourceType(resource.type().id())
-                        .setResourceName(resource.name()).setConfigs(alterableConfigSet);
-                data.resources().add(alterConfigsResource);
-            }
-            channelManager.sendRequest(new IncrementalAlterConfigsRequest.Builder(data), new TimeoutHandler(log));
-        }
-    }
-
-    /**
-     * Syncs group offsets from the source cluster to the destination in two phases:
-     * consumer groups first, then share groups. Keeping them separate avoids cross-type
-     * conflicts where a consumer group on the source could overwrite a share group with
-     * the same name on the destination (or vice versa).
-     */
-    private void syncGroupOffsets(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        Set<String> mirrorTopics = getConfiguredTopics(mirrorName, false);
-        if (mirrorTopics.isEmpty()) {
-            return;
-        }
-
-        Pattern groupsIncludePattern = mirrorConfig.groupsIncludePattern();
-        Pattern groupsExcludePattern = mirrorConfig.groupsExcludePattern();
-
-        syncConsumerGroupOffsets(srcAdmin, mirrorName, mirrorTopics, groupsIncludePattern, groupsExcludePattern);
-        syncShareGroupOffsets(srcAdmin, mirrorName, mirrorTopics, groupsIncludePattern, groupsExcludePattern);
-    }
-
-    private void syncConsumerGroupOffsets(Admin srcAdmin, String mirrorName, Set<String> mirrorTopics,
-                                          Pattern groupsIncludePattern, Pattern groupsExcludePattern) {
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        consumerGroupOffsetSyncError.incrementAndGet();
-        try {
-            List<String> sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forConsumerGroups(),
-                    groupsIncludePattern, groupsExcludePattern);
-            if (sourceGroupIds.isEmpty()) {
-                return;
-            }
-            log.info("Syncing consumer group offsets for mirror {}, groups={}", mirrorName, sourceGroupIds);
-
-            Map<String, ListConsumerGroupOffsetsSpec> groupSpecs = sourceGroupIds.stream()
-                    .collect(Collectors.toMap(id -> id, id -> new ListConsumerGroupOffsetsSpec()));
-            Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets = srcAdmin
-                    .listConsumerGroupOffsets(groupSpecs).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            Optional<Set<String>> activeDestGroups = getNonSyncableDestinationGroupIds(ListGroupsOptions.forConsumerGroups());
-            if (activeDestGroups.isEmpty()) {
-                return;
-            }
-
-            for (var entry : allOffsets.entrySet()) {
-                String groupId = entry.getKey();
-                if (activeDestGroups.get().contains(groupId)) {
-                    log.debug("Skipping consumer group offset sync for group {} in mirror {}: active on destination", groupId, mirrorName);
-                    continue;
-                }
-
-                Map<TopicPartition, OffsetAndMetadata> filtered = new HashMap<>();
-                entry.getValue().entrySet().stream()
-                    .filter(e -> mirrorTopics.contains(e.getKey().topic()))
-                    .forEach(ent -> {
-                        TopicPartition topicPartition = ent.getKey();
-                        Option<Long> logStartOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
-                        Option<Long> logEndOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
-                        if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
-                            log.debug("Cannot get the log start offset or log end offset for partition {}, skip consumer group sync for it.", topicPartition);
-                            return;
-                        }
-                        OffsetAndMetadata sourceGroupOffsetAndMetadata = ent.getValue();
-
-                        // Committing to the range [local logStartOffset ~ local logEndOffset]
-                        long finalOffset = Math.max(logStartOffset.get(), Math.min(sourceGroupOffsetAndMetadata.offset(), logEndOffset.get()));
-
-                        if (finalOffset == sourceGroupOffsetAndMetadata.offset()) {
-                            filtered.put(topicPartition, sourceGroupOffsetAndMetadata);
-                        } else if (finalOffset == logEndOffset.get()) {
-                            int logEndEpoch = replicaManagerSupplier.get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logEndOffset.get())).getOrElse(() -> -1);
-                            if (logEndEpoch < 0) {
-                                log.debug("Cannot get the log end epoch for partition {}, skip consumer group sync for it.", topicPartition);
-                            } else {
-                                filtered.put(topicPartition, new OffsetAndMetadata(logEndOffset.get(), Optional.of(logEndEpoch), ""));
-                            }
-                        } else {
-                            // finalOffset == logStartOffset
-                            int logStartEpoch = replicaManagerSupplier.get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logStartOffset.get())).getOrElse(() -> -1);
-                            if (logStartEpoch < 0) {
-                                log.debug("Cannot get the log start epoch for partition {}, skip consumer group sync for it.", topicPartition);
-                            } else {
-                                filtered.put(topicPartition, new OffsetAndMetadata(logStartOffset.get(), Optional.of(logStartEpoch), ""));
-                            }
-                        }
-                    });
-
-                if (filtered.isEmpty()) {
-                    continue;
-                }
-
-                try {
-                    log.debug("Committing consumer group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
-                    getOrCreateDestAdmin().alterConsumerGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-                } catch (Exception e) {
-                    log.warn("Failed to commit consumer group offsets for group {} in mirror {}: {}", groupId, mirrorName, e.getMessage());
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Failed to sync consumer group offsets for mirror {}: {}", mirrorName, e.getMessage());
-        }
-    }
-
-    private void syncShareGroupOffsets(Admin srcAdmin, String mirrorName, Set<String> mirrorTopics,
-                                       Pattern groupsIncludePattern, Pattern groupsExcludePattern) {
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        shareGroupOffsetSyncError.incrementAndGet();
-        try {
-            List<String> sourceGroupIds;
-            try {
-                sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forShareGroups(),
-                        groupsIncludePattern, groupsExcludePattern);
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnsupportedVersionException) {
-                    log.debug("The source cluster doesn't support share group, skipping share group offset sync");
-                    return;
-                } else {
-                    throw e;
-                }
-            }
-            if (sourceGroupIds.isEmpty()) {
-                return;
-            }
-            log.info("Syncing share group offsets for mirror {}, groups={}", mirrorName, sourceGroupIds);
-
-            Map<String, ListShareGroupOffsetsSpec> groupSpecs = sourceGroupIds.stream()
-                    .collect(Collectors.toMap(id -> id, id -> new ListShareGroupOffsetsSpec()));
-            Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets = srcAdmin
-                    .listShareGroupOffsets(groupSpecs).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            Optional<Set<String>> activeDestGroups = getNonSyncableDestinationGroupIds(ListGroupsOptions.forShareGroups());
-            if (activeDestGroups.isEmpty()) {
-                return;
-            }
-
-            for (var entry : allOffsets.entrySet()) {
-                String groupId = entry.getKey();
-                if (activeDestGroups.get().contains(groupId)) {
-                    log.debug("Skipping share group offset sync for group {} in mirror {}: active on destination", groupId, mirrorName);
-                    continue;
-                }
-
-                Map<TopicPartition, Long> filtered = new  HashMap<>();
-                entry.getValue().entrySet().stream()
-                    .filter(e -> mirrorTopics.contains(e.getKey().topic()))
-                    .forEach(ent -> {
-                        TopicPartition topicPartition = ent.getKey();
-                        Option<Long> logStartOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
-                        Option<Long> logEndOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
-                        if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
-                            log.debug("Cannot get the log start offset or log end offset for partition {}, skip share group offset sync for it.", topicPartition);
-                            return;
-                        }
-                        OffsetAndMetadata sourceGroupOffsetAndMetadata = ent.getValue();
-                        // Committing to the range [local logStartOffset ~ local logEndOffset]
-                        long finalOffset = Math.max(logStartOffset.get(), Math.min(sourceGroupOffsetAndMetadata.offset(), logEndOffset.get()));
-                        filtered.put(topicPartition, finalOffset);
-                    });
-                if (filtered.isEmpty()) {
-                    continue;
-                }
-
-                try {
-                    log.debug("Committing share group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
-                    getOrCreateDestAdmin().alterShareGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-                } catch (Exception e) {
-                    log.warn("Failed to commit share group offsets for group {} in mirror {}: {}", groupId, mirrorName, e);
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Failed to sync share group offsets for mirror {}: {}", mirrorName, e);
-        }
-    }
-
-    private List<String> listSourceGroupIds(Admin srcAdmin, ListGroupsOptions options,
-                                            Pattern groupsIncludePattern, Pattern groupsExcludePattern) throws Exception {
-        return srcAdmin.listGroups(options).all()
-                .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
-                .map(GroupListing::groupId)
-                .filter(id -> groupsIncludePattern == null || groupsIncludePattern.matcher(id).matches())
-                .filter(id -> groupsExcludePattern == null || !groupsExcludePattern.matcher(id).matches())
-                .toList();
-    }
-
-    /** Returns empty Optional on failure so the caller can skip the sync cycle. */
-    private Optional<Set<String>> getNonSyncableDestinationGroupIds(ListGroupsOptions typeFilter) {
-        try {
-            var options = typeFilter.inGroupStates(Set.of(
-                    GroupState.STABLE,
-                    GroupState.PREPARING_REBALANCE,
-                    GroupState.COMPLETING_REBALANCE,
-                    GroupState.ASSIGNING,
-                    GroupState.RECONCILING,
-                    GroupState.EMPTY));
-            return Optional.of(getOrCreateDestAdmin().listGroups(options).all()
-                    .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
-                    .map(GroupListing::groupId)
-                    .collect(Collectors.toSet()));
-        } catch (Exception e) {
-            log.warn("Failed to list destination groups, skipping offset sync cycle.", e);
-            return Optional.empty();
-        }
-    }
-
-    private void syncAccessControlLists(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        // TODO: We currently mirror all ACLs from the source to the target.
-        //       Any ACLs added/removed directly on the target will be overwritten
-        //       on the next sync to match the source.
-        //
-        // TODO: How do we disambiguate ACLs that reference the same resource name
-        //       when multiple cluster mirrors exist?
-
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        aclSyncError.incrementAndGet();
-
-        try {
-            Collection<AclBinding> remoteAcls = srcAdmin.describeAcls(AclBindingFilter.ANY)
-                .values().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            log.debug("Describe ACLs response from remote cluster {}: {}", mirrorName, remoteAcls);
-
-            List<ClusterMirrorConfig.AclRule> aclIncludeRules = mirrorConfig.aclIncludeRules();
-            var allRemoteAcls = remoteAcls.stream()
-                    .filter(acl -> aclIncludeRules.stream().anyMatch(rule -> rule.matches(acl)))
-                    .toList();
-            var aclChanges = detectAccessControlListsChanges(allRemoteAcls);
-            applyAccessControlListChanges(mirrorName, aclChanges);
-        } catch (ExecutionException e) {
-            if (e.getCause() instanceof SecurityDisabledException) {
-                log.debug("ACL sync skipped for mirror {}: {}", mirrorName, e.getCause().getMessage());
-            } else {
-                log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
-            }
-        } catch (Exception e) {
-            log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
-        }
-    }
-
-    private ACLChanges detectAccessControlListsChanges(List<AclBinding> allRemoteAcls) {
-        var addACLsList = new ArrayList<AclBinding>();
-        var deleteACLsList = new ArrayList<AclBinding>();
-        var current = metadataImage.acls().acls().values();
-
-        // collect missing acls list
-        allRemoteAcls.forEach(acl -> {
-            if (current.stream().map(StandardAcl::toBinding).noneMatch(a -> a.equals(acl))) {
-                addACLsList.add(acl);
-            }
-        });
-
-        // collect remove acls list (skip CLUSTER_MIRROR ACLs as they are destination-specific)
-        metadataImage.acls().acls().values().forEach(acl -> {
-            if (acl.resourceType() != ResourceType.CLUSTER_MIRROR && !allRemoteAcls.contains(acl.toBinding())) {
-                deleteACLsList.add(acl.toBinding());
-            }
-        });
-
-        return new ACLChanges(addACLsList, deleteACLsList);
-    }
-
-    private void applyAccessControlListChanges(String mirrorName, ACLChanges aclChanges) {
-        // send createAcls request
-        if (!aclChanges.aclsToAdd().isEmpty()) {
-            log.debug("Adding {} ACLs from remote cluster {}", aclChanges.aclsToAdd().size(), mirrorName);
-            var requestData = aclChanges.aclsToAdd().stream().map(
-                    aclBinding -> new CreateAclsRequestData.AclCreation()
-                            .setResourceType(aclBinding.pattern().resourceType().code())
-                            .setResourceName(aclBinding.pattern().name())
-                            .setResourcePatternType(aclBinding.pattern().patternType().code())
-                            .setPrincipal(aclBinding.entry().principal())
-                            .setHost(aclBinding.entry().host())
-                            .setOperation(aclBinding.entry().operation().code())
-                            .setPermissionType(aclBinding.entry().permissionType().code()))
-                    .toList();
-            channelManager.sendRequest(
-                    new CreateAclsRequest.Builder(new CreateAclsRequestData().setCreations(requestData)),
-                    new TimeoutHandler(log)
-            );
-        }
-
-        // send deleteAcls request
-        if (!aclChanges.aclsToDelete().isEmpty()) {
-            log.debug("Removing {} ACLs from remote cluster {}", aclChanges.aclsToDelete().size(), mirrorName);
-            var requestData = aclChanges.aclsToDelete().stream().map(
-                    aclBinding -> new DeleteAclsRequestData.DeleteAclsFilter()
-                            .setResourceTypeFilter(aclBinding.pattern().resourceType().code())
-                            .setResourceNameFilter(aclBinding.pattern().name())
-                            .setPatternTypeFilter(aclBinding.pattern().patternType().code())
-                            .setPrincipalFilter(aclBinding.entry().principal())
-                            .setHostFilter(aclBinding.entry().host())
-                            .setOperation(aclBinding.entry().operation().code())
-                            .setPermissionType(aclBinding.entry().permissionType().code()))
-                    .toList();
-            channelManager.sendRequest(
-                    new DeleteAclsRequest.Builder(new DeleteAclsRequestData().setFilters(requestData)),
-                    new TimeoutHandler(log)
-            );
-        }
-    }
-
-    private void discoverTopicsByPattern(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        final Pattern topicsIncludePattern = mirrorConfig.topicsIncludePattern();
-        if (topicsIncludePattern == null) {
-            return;
-        }
-
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        Set<String> configuredTopics = getConfiguredTopics(mirrorName, true);
-        final Pattern topicsExcludePattern = mirrorConfig.topicsExcludePattern();
-
-        List<StartMirrorTopicsRequestData.TopicData> newTopics;
-        try {
-            Set<String> allSourceTopics = srcAdmin.listTopics()
-                    .names().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            List<String> candidates = allSourceTopics.stream()
-                    .filter(name -> topicsIncludePattern.matcher(name).matches())
-                    .filter(name -> topicsExcludePattern == null || !topicsExcludePattern.matcher(name).matches())
-                    .filter(name -> !configuredTopics.contains(name))
-                    .toList();
-
-            if (candidates.isEmpty()) {
-                return;
-            }
-
-            Map<String, TopicDescription> descriptions = srcAdmin.describeTopics(candidates)
-                    .allTopicNames().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            cacheSourceLeaders(mirrorName, descriptions.values());
-
-            newTopics = descriptions.values().stream()
-                    .map(td -> new StartMirrorTopicsRequestData.TopicData()
-                            .setTopicName(td.name())
-                            .setTopicId(td.topicId())
-                            .setNumPartitions(td.partitions().size()))
-                    .toList();
-        } catch (Exception e) {
-            log.warn("Failed to discover topics by pattern for mirror {}", mirrorName, e);
-            return;
-        }
-
-        if (newTopics.isEmpty()) {
-            return;
-        }
-
-        log.info("Discovered {} new topic(s) matching mirror.topics.include pattern for mirror {}: {}",
-                newTopics.size(), mirrorName, newTopics.stream().map(StartMirrorTopicsRequestData.TopicData::topicName).toList());
-
-        StartMirrorTopicsRequestData data = new StartMirrorTopicsRequestData();
-        data.setMirrorName(mirrorName);
-        newTopics.forEach(topic -> data.topics().add(topic));
-
-        // TODO: creation failures from auto-discovery are silently lost here (fire-and-forget).
-        //  Add per-topic status tracking so describeMirror can surface failed topics to users.
-        channelManager.sendRequest(
-                new StartMirrorTopicsRequest.Builder(data),
-                new TimeoutHandler(log)
-        );
-    }
-
-    /**
-     * Checks if any active mirror topics now match the exclude pattern and sends
-     * StopMirrorTopicsRequest to stop them. Catches cases where exclude was updated
-     * via incrementalAlterConfigs outside of the startMirrorTopics/stopMirrorTopics flow.
-     */
-    private void enforceExcludePatterns(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Pattern excludePattern = mirrorConfig.topicsExcludePattern();
-        if (excludePattern == null) return;
-
-        Set<String> activeTopics = getConfiguredTopics(mirrorName, false, false);
-        Set<String> excludedTopics = activeTopics.stream()
-                .filter(topic -> excludePattern.matcher(topic).matches())
-                .collect(Collectors.toSet());
-
-        if (excludedTopics.isEmpty()) return;
-
-        log.info("Stopping {} topic(s) matching mirror.topics.exclude for mirror {}: {}",
-                excludedTopics.size(), mirrorName, excludedTopics);
-
-        channelManager.sendRequest(
-                new StopMirrorTopicsRequest.Builder(mirrorName, excludedTopics),
-                new TimeoutHandler(log)
-        );
     }
 
     Set<String> getConfiguredMirrors() {
@@ -2032,24 +1945,80 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return null;
     }
 
-    void clear() {
-        failedRetryAttempts.clear();
-        partitionStates.clear();
-        partitionPreviousStates.clear();
-        partitionStateCounts.clear();
-        lastMirrorEpochs.clear();
-        sourceClusterIds.clear();
-        closeSourceSenders();
-        sourceLeaders.clear();
-        pendingLeaderEpochBumps.clear();
-        pendingPartitionStates.clear();
+    /** Groups loaded partition states by mirror and state, then invokes the callback for each group. */
+    void applyLoadedPartitionStates(ClusterMirrorUtils.StateTransitionCallback callback) {
+        Map<String, Map<MirrorPartitionState, Set<TopicPartition>>> statesToPartitionsToOperate = new HashMap<>();
+        partitionStates.forEach((key, value) -> {
+            log.debug("Applying loaded partition state: {} {}", key, value);
+            metadataCache.getLeaderAndIsr(key.topic(), key.partition()).ifPresent(metadata -> {
+                // only operate when this node is the leader of the partition
+                if (metadata.leader() == nodeId) {
+                    statesToPartitionsToOperate.compute(key.mirrorName(), (k, v) -> {
+                        if (v == null) {
+                            Map<MirrorPartitionState, Set<TopicPartition>> map = new HashMap<>();
+                            map.put(value, Set.of(new TopicPartition(key.topic(), key.partition())));
+                            return map;
+                        }
+                        v.compute(value, (state, prevTps) -> {
+                            if (prevTps == null) {
+                                Set<TopicPartition> set = new HashSet<>();
+                                set.add(new TopicPartition(key.topic(), key.partition()));
+                                return set;
+                            } else {
+                                Set<TopicPartition> result = new HashSet<>(prevTps);
+                                result.add(new TopicPartition(key.topic(), key.partition()));
+                                return result;
+                            }
+                        });
+                        return v;
+                    });
+                }
+            });
+        });
+
+        statesToPartitionsToOperate.forEach((mirrorName, statesToPartitionsMap) -> {
+            statesToPartitionsMap.forEach((state, tps) -> {
+                callback.onStateLoaded(mirrorName, tps, state);
+            });
+        });
     }
 
-    private void closeSourceSenders() {
-        // snapshot and clear first, then close to avoid use-after-close races
-        Map<String, List<MirrorSourceSender>> snapshot = new HashMap<>(sourceSenders);
-        sourceSenders.clear();
-        snapshot.values().forEach(senders -> senders.forEach(MirrorSourceSender::close));
+    Map<TopicPartition, Integer> getLastMirrorEpochs(String clusterName) {
+        Map<TopicPartition, Integer> result = new HashMap<>();
+        lastMirrorEpochs.forEach((key, epoch) -> {
+            if (key.mirrorName().equals(clusterName)) {
+                result.put(new TopicPartition(key.topic(), key.partition()), epoch);
+            }
+        });
+        return result;
+    }
+
+    /** Truncates local replicas using last mirrored leader epochs from this broker's coordinator cache. */
+    CompletionStage<Map<String, ClusterMirrorDescription>> truncateToLastMirrorEpochs(
+            String mirrorName, Set<TopicPartition> topicPartitionSet) {
+        log.info("Truncating to last mirrored epochs from local state for mirror {}: {}", mirrorName, topicPartitionSet);
+        Admin admin = srcAdmins.computeIfAbsent(mirrorName, k -> {
+            Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
+            return Admin.create(props);
+        });
+        DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName));
+        return result.allDescriptions().toCompletionStage();
+    }
+
+    /** Removes stopped partition epochs and upserts added ones, returning the full epoch map for record serialization. */
+    Map<ClusterMirrorUtils.PartitionKey, Integer> updateLastMirrorEpochs(
+            String clusterName, Map<String, Map<Integer, Integer>> addedEpochs, Map<String, Map<Integer, Integer>> stoppedEpochs) {
+        stoppedEpochs.forEach((topic, partitionOffsets) -> {
+            partitionOffsets.forEach((partition, offset) -> {
+                lastMirrorEpochs.remove(new ClusterMirrorUtils.PartitionKey(clusterName, topic, partition));
+            });
+        });
+        addedEpochs.forEach((topic, partitionOffsets) -> {
+            partitionOffsets.forEach((partition, offset) -> {
+                lastMirrorEpochs.put(new ClusterMirrorUtils.PartitionKey(clusterName, topic, partition), offset);
+            });
+        });
+        return lastMirrorEpochs;
     }
 
     private record TimeoutHandler(Logger log) implements ControllerRequestCompletionHandler {
@@ -2064,8 +2033,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    private record SourceTopicInfo(String topic, Uuid topicId, boolean exists, List<SourcePartitionInfo> partitions) { }
-    private record SourcePartitionInfo(TopicPartition topicPartition, Node leader, Optional<Integer> leaderEpoch) { }
-
-    private record ACLChanges(List<AclBinding> aclsToAdd, List<AclBinding> aclsToDelete) { }
+    private record SourceTopicState(String topic, Uuid topicId, boolean exists, List<SourcePartitionState> partitions) { }
+    private record SourcePartitionState(TopicPartition topicPartition, Node leader, Optional<Integer> leaderEpoch) { }
+    private record SourceAclChanges(List<AclBinding> aclsToAdd, List<AclBinding> aclsToDelete) { }
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorStateSender.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorStateSender.java
@@ -30,10 +30,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * Queue-based sender for asynchronous inter-broker requests used by {@link MirrorMetadataManager}
  * to forward mirror state updates to other coordinator brokers in the destination cluster.
  */
-class ClusterMirrorStateSender extends InterBrokerSendThread {
+class MirrorStateSender extends InterBrokerSendThread {
     private final ConcurrentLinkedQueue<RequestAndCompletionHandler> queue = new ConcurrentLinkedQueue<>();
 
-    ClusterMirrorStateSender(String name, KafkaClient networkClient, int requestTimeoutMs, Time time) {
+    MirrorStateSender(String name, KafkaClient networkClient, int requestTimeoutMs, Time time) {
         super(name, networkClient, requestTimeoutMs, time);
     }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -341,15 +341,15 @@ class BrokerServer(
        */
       val defaultActionQueue = new DelayedActionQueue
 
-      val mirrorScheduler = new KafkaScheduler(1, true, "cluster-mirror-")
+      val mirrorScheduler = new KafkaScheduler(1, true, "ClusterMirror-")
       mirrorMetadataManager = new MirrorMetadataManager(
         config,
-        metrics,
-        time,
-        metadataCache,
         clientToControllerChannelManager,
         () => replicaManager,
-        mirrorScheduler
+        metadataCache,
+        mirrorScheduler,
+        metrics,
+        time
       )
 
       this._replicaManager = new ReplicaManager(
@@ -403,7 +403,7 @@ class BrokerServer(
         producerIdManagerSupplier, metrics, metadataCache, Time.SYSTEM)
 
       clusterMirrorCoordinator = new ClusterMirrorCoordinator(config, replicaManager,
-        mirrorScheduler, metrics, metadataCache, Time.SYSTEM, mirrorMetadataManager)
+        mirrorMetadataManager, metadataCache, mirrorScheduler, metrics, Time.SYSTEM)
 
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
         config, clientToControllerChannelManager, groupCoordinator,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -308,7 +308,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         })
         partitionMetadata.put(topic.name(), partMetadata)
       })
-      clusterMirrorCoordinator.writePartitionStateInfo(mirrorName, partitionMetadata, res => requestHelper.sendMaybeThrottle(request, res))
+      clusterMirrorCoordinator.updateTopicMetadata(mirrorName, partitionMetadata, res => requestHelper.sendMaybeThrottle(request, res))
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring write mirror states request")
       requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
@@ -331,7 +331,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         })
         partitionMetadata.put(topic.name(), parts)
       })
-      clusterMirrorCoordinator.getCachedPartitionMetadata(mirrorName, partitionMetadata,
+      clusterMirrorCoordinator.getTopicMetadata(mirrorName, partitionMetadata,
         res => requestHelper.sendMaybeThrottle(request, res))
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring read mirror states request")

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -32,8 +32,8 @@ import scala.collection.{Map, mutable}
 import scala.collection.concurrent.TrieMap
 
 /**
- * Manages replica fetcher threads for cluster mirroring, assigning partitions from different
- * mirrors to separate threads for authentication, configuration, and load balancing isolation.
+ * Manages {@link MirrorFetcherThread}s, assigning partitions from different mirrors
+ * to separate threads for authentication, configuration, and load balancing isolation.
  */
 class MirrorFetcherManager(brokerConfig: KafkaConfig,
                            protected val replicaManager: ReplicaManager,
@@ -53,14 +53,14 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
   override def deadThreadCount: Int = lock synchronized { mirrorFetcherThreadMap.values.count(_.isThreadFailed) }
 
   override def minFetchRate: Double = {
-    // current min fetch rate across all fetchers/topics/partitions
+    // Current min fetch rate across all fetchers/topics/partitions
     val headRate = mirrorFetcherThreadMap.values.headOption.map(_.fetcherStats.requestRate.oneMinuteRate).getOrElse(0.0)
     mirrorFetcherThreadMap.values.foldLeft(headRate)((curMinAll, fetcherThread) =>
       math.min(curMinAll, fetcherThread.fetcherStats.requestRate.oneMinuteRate))
   }
 
   override def maxLag: Long = {
-    // current max lag across all fetchers/topics/partitions
+    // Current max lag across all fetchers/topics/partitions
     mirrorFetcherThreadMap.values.foldLeft(0L) { (curMaxLagAll, fetcherThread) =>
       val maxLagThread = fetcherThread.fetcherLagStats.stats.values.stream().mapToLong(v => v.lag).max().orElse(0L)
       math.max(curMaxLagAll, maxLagThread)
@@ -102,7 +102,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
       for ((remoteFetcherKey, initialFetchOffsets) <- partitionsPerFetcher) {
         val fetcherThread = mirrorFetcherThreadMap.get(remoteFetcherKey) match {
           case Some(currentFetcherThread) if currentFetcherThread.leader.brokerEndPoint() == remoteFetcherKey.sourceBroker =>
-            // reuse the fetcher thread
+            // Reuse the fetcher thread
             logger.debug("Reusing mirror fetcher for {}", remoteFetcherKey)
             currentFetcherThread
           case Some(f) =>
@@ -113,7 +113,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
             logger.debug("Creating new mirror fetcher for {}", remoteFetcherKey)
             addAndStartFetcherThread(remoteFetcherKey)
         }
-        // failed partitions are removed when added partitions to thread
+        // Failed partitions are removed when added partitions to thread
         addPartitionsToFetcherThread(fetcherThread, initialFetchOffsets)
 
         // Initialize lag information for newly added partitions
@@ -173,7 +173,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
     fetchStates
   }
 
-  // collect idle fetchers under lock, shut down outside to avoid deadlock
+  // Collect idle fetchers under lock, shut down outside to avoid deadlock
   override def shutdownIdleFetcherThreads(): Unit = {
     val idleFetchers = this.synchronized {
       val keysToBeRemoved = new mutable.HashSet[FetcherKey]

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -32,9 +32,7 @@ import java.util.Optional
 import scala.collection.{Map, Set}
 
 /**
- * Fetcher thread for cross-cluster mirroring. Unlike ReplicaFetcherThread, this rewrites
- * leader epochs to the destination's local epoch and producer IDs to negative space,
- * and routes fetcher operations to MirrorFetcherManager.
+ * Fetcher thread for cross-cluster mirroring.
  */
 class MirrorFetcherThread(name: String,
                           leader: LeaderEndPoint,
@@ -60,7 +58,7 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.removeFetcherForPartitions(partitions)
   }
 
-  // uses leader info from fetch response to update cache and create new fetchers directly
+  // Uses leader info from fetch response to update cache and create new fetchers directly
   override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
     replicaMgr.mirrorMetadataManager.foreach { mmm =>
       partitionAndOffsets.foreach { case (tp, state) =>
@@ -71,16 +69,16 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
-  // Transition to FAILED so the coordinator can schedule exponential backoff retries.
+  // Transition to FAILED so the coordinator can schedule exponential backoff retries
   override protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition]): Unit = {
-    replicaMgr.mirrorMetadataManager.foreach(_.scheduleRediscoverSource(mirrorName))
+    replicaMgr.mirrorMetadataManager.foreach(_.scheduleSourceClusterMetadataUpdate(mirrorName))
     mirrorPartitions.foreach { tp =>
       replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, tp, MirrorPartitionState.FAILED))
     }
   }
 
   // Bridges fetcher failures (e.g. KafkaStorageException) to the mirror state machine,
-  // so the coordinator can schedule exponential backoff retries.
+  // so the coordinator can schedule exponential backoff retries
   override protected def handlePartitionFailed(topicPartition: TopicPartition): Unit = {
     replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, topicPartition, MirrorPartitionState.FAILED))
   }
@@ -92,7 +90,7 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, topicPartition, MirrorPartitionState.EPOCH_FENCING))
   }
 
-  // Validates batch epoch against local epoch (destination) and partition epoch (source metadata).
+  // Validates batch epoch against local epoch (destination) and partition epoch (source metadata)
   private def validateLeaderEpoch(topicPartition: TopicPartition, partition: Partition, records: Records, partitionLeaderEpoch: Int): Unit = {
     val localLeaderEpoch = partition.getLeaderEpoch
     val highestBatchLeaderEpoch = if (records.lastBatch().isPresent)
@@ -131,7 +129,7 @@ class MirrorFetcherThread(name: String,
     }
   }
 
-  // process fetched data
+  // Processes fetched data
   override def processPartitionData(
     topicPartition: TopicPartition,
     fetchOffset: Long,
@@ -190,7 +188,7 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorMetadataManager.map(mmm => mmm.resolveSourceLeader(mirrorName, tp).leaderEpoch())
   }
 
-  // return the mirror partition lag
+  // Returns the mirror partition lag
   // TODO: Since we already record the lag in stats, maybe we don't cache the logInfo in mirrorFetcherManager anymore.
   override def getPartitionLag(topicPartition: TopicPartition, leaderHW: Long, nextOffset: Long, mirrorName: String): Long = {
     replicaMgr.mirrorFetcherManager.getMirrorLagInfo(mirrorName).get(topicPartition).map(_.lag).getOrElse(0L)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -31,7 +31,7 @@ from kafkatest.version import (
 )
 
 
-class ClusterMirroringCompPlainTest(MirrorUtils, Test):
+class ClusterMirroringCompTest(MirrorUtils, Test):
     """Tests for KIP-1279 Cluster Mirroring across different Kafka versions."""
 
     DEST_SERVER_PROPS = [
@@ -55,7 +55,7 @@ class ClusterMirroringCompPlainTest(MirrorUtils, Test):
     ]
 
     def __init__(self, test_context):
-        super(ClusterMirroringCompPlainTest, self).__init__(test_context)
+        super(ClusterMirroringCompTest, self).__init__(test_context)
 
     def teardown(self):
         if hasattr(self, "_original_metadata_quorum"):


### PR DESCRIPTION
Add leaderEpoch to TopicPartitionInfo so the DescribeTopicPartitions response (which already carries it on the wire) surfaces it through the Admin API. This requires KIP update.

Replace all three MetadataRequest call sites in MirrorMetadataManager with Admin API equivalents:

- discoverSourceBrokers: Admin.describeCluster()
- syncSourceTopicState: Admin.describeTopics()
- discoverTopicsByPattern: Admin.listTopics() + Admin.describeTopics()

Introduce SourceTopicInfo/SourcePartitionInfo records to decouple processTopicMetadata, maybeStopDeletedTopics, and the epoch bump chain from MetadataResponse types.

Remove trySendSourceClusterRequest which no longer has callers.

Initialize all admin clients lazily.

Bug fixes:

- Race: partitions stuck in UNKNOWN after onMetadataUpdate: onMetadataUpdate only reacts to destination metadata changes. If the source leader wasn't known when it first fired, the partition stayed in UNKNOWN forever. Added maybeStartMissedPartitions to transition those partitions on each source metadata sync.
- Newly discovered topics missing source leaders: discoverTopicsByPattern discovered topics and sent StartMirrorTopicsRequest but did not populate sourceLeaders. The fetcher started with a bootstrap broker, got a redirect it couldn't resolve, and cycled through FAILED/retry. Added cacheSourceLeaders to pre-populate leaders from the describeTopics results before the topic is created.
