### PR TITLE
MirrorMetadataManager: use String to represent cluster id

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.ClusterMirrorDescription;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.internals.Topic;
@@ -819,7 +818,7 @@ public class ClusterMirrorCoordinator {
     private CompletableFuture<Map<TopicPartition, ProduceResponse.PartitionResponse>> writeMirrorPidReset(
             String mirrorName, Set<TopicPartition> topicPartitions) {
         CompletableFuture<Map<TopicPartition, ProduceResponse.PartitionResponse>> writePidResetFuture = new CompletableFuture<>();
-        Uuid sourceClusterId = metadataManager.getSourceClusterId(mirrorName);
+        String sourceClusterId = metadataManager.getSourceClusterId(mirrorName);
         if (sourceClusterId == null) {
             log.warn("Source cluster ID not available for mirror {}. Skipping PID reset barrier.", mirrorName);
             writePidResetFuture.complete(Map.of());
@@ -827,7 +826,7 @@ public class ClusterMirrorCoordinator {
         }
         MirrorPidResetRecord record = new MirrorPidResetRecord()
             .setVersion(ControlRecordUtils.MIRROR_PID_RESET_CURRENT_VERSION)
-            .setSourceClusterId(sourceClusterId.toString());
+            .setSourceClusterId(sourceClusterId);
         long timestamp = time.milliseconds();
         for (TopicPartition tp : topicPartitions) {
             try {
@@ -1009,7 +1008,7 @@ public class ClusterMirrorCoordinator {
     }
 
     /** Returns the source cluster ID for the given mirror. */
-    public Uuid getSourceClusterId(String mirrorName) {
+    public String getSourceClusterId(String mirrorName) {
         return metadataManager.getSourceClusterId(mirrorName);
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -170,7 +170,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>(); // source cluster metadata discovery (one per mirror)
     private volatile Admin dstAdmin; // group offset and ACLs sync
 
-    private final Map<String, Uuid> sourceClusterIds = new ConcurrentHashMap<>();
+    // Map from mirror name to cluster id. The cluster id is represented as a String because KIP-78
+    // does not mandate the use of UUIDs for it and assuming so may break compatibility with existing clusters
+    private final Map<String, String> sourceClusterIds = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, ClusterMirrorUtils.LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
     private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates = new ConcurrentHashMap<>();
@@ -569,10 +571,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
         try {
             var clusterResult = srcAdmin.describeCluster();
-            String clusterId = clusterResult.clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-            if (clusterId != null && !clusterId.isEmpty()) {
-                Uuid newClusterId = Uuid.fromString(clusterId);
-                Uuid previousClusterId = sourceClusterIds.put(mirrorName, newClusterId);
+            String newClusterId = clusterResult.clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            if (newClusterId != null && !newClusterId.isEmpty()) {
+                String previousClusterId = sourceClusterIds.put(mirrorName, newClusterId);
                 if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
                     throw new IllegalStateException("Source cluster ID changed for mirror " + mirrorName
                             + ": expected " + previousClusterId + ", got " + newClusterId
@@ -1898,17 +1899,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return result;
     }
 
-    Uuid getSourceClusterId(String mirrorName) {
-        Uuid cached = sourceClusterIds.get(mirrorName);
+    String getSourceClusterId(String mirrorName) {
+        String cached = sourceClusterIds.get(mirrorName);
         if (cached != null) {
             return cached;
         }
         Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
         try {
-            String clusterId = srcAdmin.describeCluster()
+            cached = srcAdmin.describeCluster()
                 .clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-            if (clusterId != null && !clusterId.isEmpty()) {
-                cached = Uuid.fromString(clusterId);
+            if (cached != null && !cached.isEmpty()) {
                 sourceClusterIds.put(mirrorName, cached);
                 return cached;
             }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -398,7 +398,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           .setMirrorName(mirrorName)
           .setSourceBootstrap(if (clusterMirrorCoordinator.getSourceBootstrap(mirrorName) != null)
             clusterMirrorCoordinator.getSourceBootstrap(mirrorName) else "")
-          .setSourceClusterId(if (sourceClusterId != null) sourceClusterId.toString else "")
+          .setSourceClusterId(if (sourceClusterId != null) sourceClusterId else "")
           .setTopicCount(clusterMirrorCoordinator.getActiveTopicCount(mirrorName)))
       })
       responseData.setMirrors(mirrors)


### PR DESCRIPTION
As discussed in
https://github.com/apache/kafka/pull/22384#discussion_r3380173308, KIP-78 introduced cluster ids with default generation being a base64 url encoded uuid. At the same time, users were free to pre-populate a cluster id as the broker did not perform any validation on it upfront. This carried over with kafka-storage.sh in KRaft mode where the formatter does not enforce the use of UUIDs. As a result, we should not try to parse the cluster id as a UUID and instead represent it as a String.