### PR TITLE
Fix consumer group offset sync skipping EMPTY groups

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1111,8 +1111,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     GroupState.PREPARING_REBALANCE,
                     GroupState.COMPLETING_REBALANCE,
                     GroupState.ASSIGNING,
-                    GroupState.RECONCILING,
-                    GroupState.EMPTY));
+                    GroupState.RECONCILING));
             return Optional.of(getOrCreateDestAdmin().listGroups(options).all()
                     .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
                     .map(GroupListing::groupId)


### PR DESCRIPTION
The getNonSyncableDestinationGroupIds method included GroupState.EMPTY in its filter, causing groups with no active members to be treated as non-syncable. After the first offset commit created the group on the destination in EMPTY state, all subsequent sync cycles skipped it, leaving offsets permanently stale.