### PR TITLE
Fix offset sync overwriting CG offsets after mirror stop

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -930,7 +930,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private void syncGroupOffsets(String mirrorName, ClusterMirrorConfig mirrorConfig) {
         Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
 
-        Set<String> mirrorTopics = getConfiguredTopics(mirrorName, false);
+        Set<String> mirrorTopics = getConfiguredTopics(mirrorName, false, false);
         if (mirrorTopics.isEmpty()) {
             return;
         }


### PR DESCRIPTION
syncGroupOffsets() was calling getConfiguredTopics(mirrorName, false) which defaults to includeStopped=true, causing the periodic metadata sync to keep overwriting destination consumer group offsets with source values even after mirror topics were stopped.
