### PR TITLE
Add dynamic config

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -75,6 +75,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -103,6 +104,7 @@ public class ClusterMirrorCoordinator {
     private final MirrorMetadataManager metadataManager;
     private final MetadataCache metadataCache;
     private final ClusterMirrorRecordSerde serde = new ClusterMirrorRecordSerde();
+    private volatile ScheduledFuture<?> metadataRefreshFuture;
     private final Scheduler scheduler;
     private final Metrics metrics;
     private final Time time;
@@ -152,10 +154,20 @@ public class ClusterMirrorCoordinator {
         scheduler.startup();
 
         // periodically query source cluster to get the metadata
-        scheduler.schedule("MirrorMetadataRefresh", metadataManager::periodicSync, 0,
-                brokerConfig.mirrorConfig().metadataRefreshIntervalMs());
+        metadataRefreshFuture = scheduler.schedule("MirrorMetadataRefresh",
+                metadataManager::runMetadataRefresh, 0, brokerConfig.mirrorConfig().metadataRefreshIntervalMs());
 
         log.info("Startup complete.");
+    }
+
+    public void rescheduleMetadataRefresh(long newIntervalMs) {
+        ScheduledFuture<?> oldFuture = metadataRefreshFuture;
+        if (oldFuture != null) {
+            oldFuture.cancel(false);
+        }
+        metadataRefreshFuture = scheduler.schedule("MirrorMetadataRefresh",
+                metadataManager::runMetadataRefresh, newIntervalMs, newIntervalMs);
+        log.info("Rescheduled metadata refresh with interval {} ms", newIntervalMs);
     }
 
     /** Shuts down the coordinator scheduler and mirror state sender. */

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -537,14 +537,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
 
-    /** Periodic metadata sync entry point. */
-    void periodicSync() {
+    /** Periodic metadata refresh entry point. */
+    void runMetadataRefresh() {
         Set<String> mirrors = getConfiguredMirrors();
         if (mirrors.isEmpty()) {
             return;
         }
 
-        log.info("Syncing metadata for mirrors: {}", mirrors);
+        log.info("Running metadata refresh for mirrors: {}", mirrors);
 
         for (String mirrorName : mirrors) {
             try {
@@ -552,7 +552,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 var topicsState = syncSourceTopicsState(mirrorName);
                 syncCoordinatorMetadata(mirrorName, topicsState);
             } catch (Exception e) {
-                log.error("Failed to sync metadata for mirror {}", mirrorName, e);
+                log.error("Failed to refresh metadata for mirror {}", mirrorName, e);
             }
         }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -100,6 +100,12 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
     }
   }
 
+  private[server] def updateNumFetchers(newSize: Int): Int = lock synchronized {
+    val oldSize = numFetchersPerBroker
+    numFetchersPerBroker = newSize
+    oldSize
+  }
+
   // Visible for testing
   private[server] def getFetcher(topicPartition: TopicPartition): Option[T] = {
     lock synchronized {

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -553,6 +553,8 @@ class BrokerServer(
       // Register parts of the broker that can be reconfigured via dynamic configs.  This needs to
       // be done before we publish the dynamic configs, so that we don't miss anything.
       config.dynamicConfig.addReconfigurables(this)
+      config.dynamicConfig.addBrokerReconfigurable(
+        new DynamicClusterMirrorConfig(replicaManager, clusterMirrorCoordinator))
 
       // Install all the metadata publishers.
       FutureUtils.waitWithLogging(logger.underlying, logIdent,

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -553,8 +553,6 @@ class BrokerServer(
       // Register parts of the broker that can be reconfigured via dynamic configs.  This needs to
       // be done before we publish the dynamic configs, so that we don't miss anything.
       config.dynamicConfig.addReconfigurables(this)
-      config.dynamicConfig.addBrokerReconfigurable(
-        new DynamicClusterMirrorConfig(replicaManager, clusterMirrorCoordinator))
 
       // Install all the metadata publishers.
       FutureUtils.waitWithLogging(logger.underlying, logIdent,

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -309,6 +309,7 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
     addBrokerReconfigurable(kafkaServer.socketServer)
     addBrokerReconfigurable(new DynamicProducerStateManagerConfig(kafkaServer.logManager.producerStateManagerConfig))
     addBrokerReconfigurable(new DynamicRemoteLogConfig(kafkaServer))
+    addBrokerReconfigurable(new DynamicClusterMirrorConfig(kafkaServer.replicaManager, kafkaServer.clusterMirrorCoordinator))
   }
 
   /**
@@ -1140,7 +1141,7 @@ class DynamicClusterMirrorConfig(replicaManager: ReplicaManager,
     val newFetchers = newConfig.mirrorConfig.numReplicaFetchers
     val oldFetchers = replicaManager.config.mirrorConfig.numReplicaFetchers
     if (newFetchers != oldFetchers) {
-      val errorMsg = s"Dynamic thread count update validation failed for ${ClusterMirrorConfig.NUM_REPLICA_FETCHERS_CONFIG}=$newFetchers"
+      val errorMsg = s"Dynamic thread count update validation failed for ${ClusterMirrorConfig.MIRROR_NUM_REPLICA_FETCHERS_CONFIG}=$newFetchers"
       if (newFetchers <= 0)
         throw new ConfigException(s"$errorMsg, value should be at least 1")
       if (newFetchers < oldFetchers / 2)
@@ -1151,7 +1152,7 @@ class DynamicClusterMirrorConfig(replicaManager: ReplicaManager,
 
     val newInterval = newConfig.mirrorConfig.metadataRefreshIntervalMs
     if (newInterval < 0)
-      throw new ConfigException(s"${ClusterMirrorConfig.METADATA_REFRESH_INTERVAL_MS_CONFIG} must be >= 0")
+      throw new ConfigException(s"${ClusterMirrorConfig.MIRROR_METADATA_REFRESH_INTERVAL_MS_CONFIG} must be >= 0")
   }
 
   override def reconfigure(oldConfig: KafkaConfig, newConfig: KafkaConfig): Unit = {
@@ -1160,13 +1161,13 @@ class DynamicClusterMirrorConfig(replicaManager: ReplicaManager,
 
     if (newMirrorConfig.numReplicaFetchers != oldMirrorConfig.numReplicaFetchers) {
       replicaManager.mirrorFetcherManager.resizeThreadPool(newMirrorConfig.numReplicaFetchers)
-      info(s"Updated ${ClusterMirrorConfig.NUM_REPLICA_FETCHERS_CONFIG} " +
+      info(s"Updated ${ClusterMirrorConfig.MIRROR_NUM_REPLICA_FETCHERS_CONFIG} " +
         s"from ${oldMirrorConfig.numReplicaFetchers} to ${newMirrorConfig.numReplicaFetchers}")
     }
 
     if (newMirrorConfig.metadataRefreshIntervalMs != oldMirrorConfig.metadataRefreshIntervalMs) {
       coordinator.rescheduleMetadataRefresh(newMirrorConfig.metadataRefreshIntervalMs)
-      info(s"Updated ${ClusterMirrorConfig.METADATA_REFRESH_INTERVAL_MS_CONFIG} " +
+      info(s"Updated ${ClusterMirrorConfig.MIRROR_METADATA_REFRESH_INTERVAL_MS_CONFIG} " +
         s"from ${oldMirrorConfig.metadataRefreshIntervalMs} to ${newMirrorConfig.metadataRefreshIntervalMs}")
     }
   }
@@ -1174,7 +1175,7 @@ class DynamicClusterMirrorConfig(replicaManager: ReplicaManager,
 
 object DynamicClusterMirrorConfig {
   val ReconfigurableConfigs: Set[String] = Set(
-    ClusterMirrorConfig.NUM_REPLICA_FETCHERS_CONFIG,
-    ClusterMirrorConfig.METADATA_REFRESH_INTERVAL_MS_CONFIG
+    ClusterMirrorConfig.MIRROR_NUM_REPLICA_FETCHERS_CONFIG,
+    ClusterMirrorConfig.MIRROR_METADATA_REFRESH_INTERVAL_MS_CONFIG
   )
 }

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kafka.log.LogManager
 import kafka.network.{DataPlaneAcceptor, SocketServer}
+import kafka.server.mirror.ClusterMirrorCoordinator
 import kafka.raft.KafkaRaftManager
 import kafka.server.DynamicBrokerConfig._
 import kafka.utils.{CoreUtils, Logging}
@@ -42,7 +43,7 @@ import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.raft.KafkaRaftClient
 import org.apache.kafka.server.{DynamicThreadPool, ProcessRole}
 import org.apache.kafka.server.common.ApiMessageAndVersion
-import org.apache.kafka.server.config.{DynamicProducerStateManagerConfig, ServerConfigs, ServerLogConfigs, ServerTopicConfigSynonyms}
+import org.apache.kafka.server.config.{ClusterMirrorConfig, DynamicProducerStateManagerConfig, ServerConfigs, ServerLogConfigs, ServerTopicConfigSynonyms}
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.{ClientMetricsReceiverPlugin, MetricConfigs}
 import org.apache.kafka.server.telemetry.ClientTelemetry
@@ -99,6 +100,7 @@ object DynamicBrokerConfig {
     SocketServer.ReconfigurableConfigs ++
     DynamicProducerStateManagerConfig ++
     DynamicRemoteLogConfig.ReconfigurableConfigs ++
+    DynamicClusterMirrorConfig.ReconfigurableConfigs ++
     Set(AbstractConfig.CONFIG_PROVIDERS_CONFIG)
 
   private val ClusterLevelListenerConfigs = Set(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, SocketServerConfigs.MAX_CONNECTION_CREATION_RATE_CONFIG, SocketServerConfigs.NUM_NETWORK_THREADS_CONFIG)
@@ -1124,5 +1126,55 @@ object DynamicRemoteLogConfig {
     RemoteLogManagerConfig.REMOTE_LOG_MANAGER_EXPIRATION_THREAD_POOL_SIZE_PROP,
     RemoteLogManagerConfig.REMOTE_LOG_MANAGER_FOLLOWER_THREAD_POOL_SIZE_PROP,
     RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP
+  )
+}
+
+class DynamicClusterMirrorConfig(replicaManager: ReplicaManager,
+                                 coordinator: ClusterMirrorCoordinator) extends BrokerReconfigurable with Logging {
+
+  override def reconfigurableConfigs: Set[String] = {
+    DynamicClusterMirrorConfig.ReconfigurableConfigs
+  }
+
+  override def validateReconfiguration(newConfig: KafkaConfig): Unit = {
+    val newFetchers = newConfig.mirrorConfig.numReplicaFetchers
+    val oldFetchers = replicaManager.config.mirrorConfig.numReplicaFetchers
+    if (newFetchers != oldFetchers) {
+      val errorMsg = s"Dynamic thread count update validation failed for ${ClusterMirrorConfig.NUM_REPLICA_FETCHERS_CONFIG}=$newFetchers"
+      if (newFetchers <= 0)
+        throw new ConfigException(s"$errorMsg, value should be at least 1")
+      if (newFetchers < oldFetchers / 2)
+        throw new ConfigException(s"$errorMsg, value should be at least half the current value $oldFetchers")
+      if (newFetchers > oldFetchers * 2)
+        throw new ConfigException(s"$errorMsg, value should not be greater than double the current value $oldFetchers")
+    }
+
+    val newInterval = newConfig.mirrorConfig.metadataRefreshIntervalMs
+    if (newInterval < 0)
+      throw new ConfigException(s"${ClusterMirrorConfig.METADATA_REFRESH_INTERVAL_MS_CONFIG} must be >= 0")
+  }
+
+  override def reconfigure(oldConfig: KafkaConfig, newConfig: KafkaConfig): Unit = {
+    val oldMirrorConfig = oldConfig.mirrorConfig
+    val newMirrorConfig = newConfig.mirrorConfig
+
+    if (newMirrorConfig.numReplicaFetchers != oldMirrorConfig.numReplicaFetchers) {
+      replicaManager.mirrorFetcherManager.resizeThreadPool(newMirrorConfig.numReplicaFetchers)
+      info(s"Updated ${ClusterMirrorConfig.NUM_REPLICA_FETCHERS_CONFIG} " +
+        s"from ${oldMirrorConfig.numReplicaFetchers} to ${newMirrorConfig.numReplicaFetchers}")
+    }
+
+    if (newMirrorConfig.metadataRefreshIntervalMs != oldMirrorConfig.metadataRefreshIntervalMs) {
+      coordinator.rescheduleMetadataRefresh(newMirrorConfig.metadataRefreshIntervalMs)
+      info(s"Updated ${ClusterMirrorConfig.METADATA_REFRESH_INTERVAL_MS_CONFIG} " +
+        s"from ${oldMirrorConfig.metadataRefreshIntervalMs} to ${newMirrorConfig.metadataRefreshIntervalMs}")
+    }
+  }
+}
+
+object DynamicClusterMirrorConfig {
+  val ReconfigurableConfigs: Set[String] = Set(
+    ClusterMirrorConfig.NUM_REPLICA_FETCHERS_CONFIG,
+    ClusterMirrorConfig.METADATA_REFRESH_INTERVAL_MS_CONFIG
   )
 }

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import kafka.log.LogManager
 import kafka.network.SocketServer
+import kafka.server.mirror.ClusterMirrorCoordinator
 import kafka.utils.Logging
 import org.apache.kafka.common.ClusterResource
 import org.apache.kafka.common.internals.{ClusterResourceListeners, Plugin}
@@ -92,6 +93,7 @@ trait KafkaBroker extends Logging {
   def metrics: Metrics
   def quotaManagers: QuotaFactory.QuotaManagers
   def replicaManager: ReplicaManager
+  def clusterMirrorCoordinator: ClusterMirrorCoordinator
   def socketServer: SocketServer
   def metadataCache: MetadataCache
   def groupCoordinator: GroupCoordinator

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.server.network.BrokerEndPoint
 
 import scala.collection.{Map, mutable}
 import scala.collection.concurrent.TrieMap
+import scala.jdk.OptionConverters._
 
 /**
  * Manages {@link MirrorFetcherThread}s, assigning partitions from different mirrors
@@ -188,6 +189,36 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
       fetchersToShutdown
     }
     idleFetchers.foreach(_.shutdown())
+  }
+
+  override def resizeThreadPool(newSize: Int): Unit = {
+    val excessThreads = new mutable.ArrayBuffer[MirrorFetcherThread]()
+    this.synchronized {
+      if (isClosed) return
+      val currentSize = updateNumFetchers(newSize)
+      if (newSize == currentSize) return
+      info(s"Resizing mirror fetcher thread pool from $currentSize to $newSize")
+      val allPartitions = mutable.Map[TopicPartition, InitialFetchState]()
+      for ((key, thread) <- mirrorFetcherThreadMap) {
+        val partitionStates = thread.removeAllPartitions()
+        if (key.fetcherId >= newSize) {
+          thread.initiateShutdown()
+          excessThreads += thread
+        }
+        partitionStates.foreachEntry { (topicPartition, state) =>
+          allPartitions += topicPartition -> InitialFetchState(state.topicId.toScala,
+            thread.leader.brokerEndPoint(),
+            currentLeaderEpoch = state.currentLeaderEpoch,
+            initOffset = state.fetchOffset,
+            mirrorName = state.mirrorName(),
+            mirrorLeaderEpoch = state.mirrorLeaderEpoch())
+        }
+      }
+      mirrorFetcherThreadMap.filterInPlace((key, _) => key.fetcherId < newSize)
+      addFetcherForPartitions(allPartitions)
+      shutdownIdleFetcherThreads()
+    }
+    excessThreads.foreach(_.shutdown())
   }
 
   override def closeAllFetchers(): Unit = {

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -216,8 +216,8 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
       }
       mirrorFetcherThreadMap.filterInPlace((key, _) => key.fetcherId < newSize)
       addFetcherForPartitions(allPartitions)
-      shutdownIdleFetcherThreads()
     }
+    shutdownIdleFetcherThreads()
     excessThreads.foreach(_.shutdown())
   }
 

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -69,7 +69,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Timeout(value = 180, unit = TimeUnit.SECONDS)
 public class AsyncClusterMirrorIntegrationTest {
-    private static final String TOPIC = "my-topic-async";
+    private static final String TOPIC_NAME = "my-topic-async";
     private static final long METADATA_REFRESH_INTERVAL_MS = 5_000L;
     private static final String MIRROR_NAME = "my-mirror";
 
@@ -140,25 +140,25 @@ public class AsyncClusterMirrorIntegrationTest {
     void testAsyncMirrorReplication() throws Exception {
         // Create topic and produce data
         srcAdmin.createTopics(List.of(
-                new NewTopic(TOPIC, 1, (short) 1)
+                new NewTopic(TOPIC_NAME, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
-        produceRecords(srcCluster, TOPIC, 0, 50);
+        produceRecords(srcCluster, TOPIC_NAME, 0, 50);
 
         // Create mirror and add topic
         dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC), new StartMirrorTopicsOptions())
+        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC_NAME), new StartMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(TOPIC);
+        waitForMirrorLagZero(TOPIC_NAME);
 
         // Produce more data while in ASYNC mode
-        produceRecords(srcCluster, TOPIC, 50, 50);
+        produceRecords(srcCluster, TOPIC_NAME, 50, 50);
 
         // Verify all 100 records arrive at destination
         List<ConsumerRecord<String, String>> records = consumeRecords(
-                dstCluster, TOPIC, 100, null);
+                dstCluster, TOPIC_NAME, 100, null);
         assertEquals(100, records.size(),
                 "Destination should have all 100 records");
     }
@@ -207,31 +207,31 @@ public class AsyncClusterMirrorIntegrationTest {
     void testMirrorWithPreCreatedTopic() throws Exception {
         // Create topic on source
         srcAdmin.createTopics(List.of(
-                new NewTopic(TOPIC, 1, (short) 1)
+                new NewTopic(TOPIC_NAME, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
         // Get source topic description (TopicId)
-        var topicDesc = describeTopics(srcAdmin, List.of(TOPIC));
-        String sourceTopicId = topicDesc.get(TOPIC).topicId().toString();
+        var topicDesc = describeTopics(srcAdmin, List.of(TOPIC_NAME));
+        String sourceTopicId = topicDesc.get(TOPIC_NAME).topicId().toString();
 
         // Produce data to source
-        produceRecords(srcCluster, TOPIC, 0, 50);
+        produceRecords(srcCluster, TOPIC_NAME, 0, 50);
 
         // Pre-create topic on destination with source's TopicId (like ClusterMirrorCommand does)
         dstAdmin.createTopics(List.of(
-                new NewTopic(TOPIC, Optional.of(1), Optional.empty(), Optional.of(sourceTopicId))
+                new NewTopic(TOPIC_NAME, Optional.of(1), Optional.empty(), Optional.of(sourceTopicId))
         )).all().get(30, TimeUnit.SECONDS);
 
         // Create mirror
         dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC), new StartMirrorTopicsOptions())
+        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC_NAME), new StartMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(TOPIC);
+        waitForMirrorLagZero(TOPIC_NAME);
 
         // Wait for async replication
-        consumeRecords(dstCluster, TOPIC, 50);
+        consumeRecords(dstCluster, TOPIC_NAME, 50);
     }
 
     /**

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -61,7 +61,6 @@ class MirrorConfig:
     ):
         self.properties = {
             "bootstrap.servers": bootstrap_servers,
-            "mirror.metadata.refresh.interval.ms": "10000",
         }
         if mirror_topic_properties_exclude is not None:
             self.properties["mirror.topic.properties.exclude"] = (
@@ -102,9 +101,9 @@ class MirrorUtils:
         return "%s:9092" % node.account.hostname
 
     @staticmethod
-    def produce_records(logger, kafka, topic, num_records, client_node,
-                        bootstrap_servers=None):
-        """Produce records on a client node using kafka-producer-perf-test."""
+    def produce_messages(logger, kafka, client_node, topic, num_messages,
+                         bootstrap_servers=None):
+        """Produce messages on a client node using kafka-producer-perf-test."""
         if bootstrap_servers is None:
             bootstrap_servers = kafka.bootstrap_servers(kafka.security_protocol)
         env_prefix, cmd_suffix = kafka._cmd_security_opts(client_node)
@@ -112,7 +111,7 @@ class MirrorUtils:
               " --producer-props bootstrap.servers=%s%s" % (
                   env_prefix,
                   kafka.path.script("kafka-producer-perf-test.sh", client_node),
-                  topic, num_records, bootstrap_servers,
+                  topic, num_messages, bootstrap_servers,
                   cmd_suffix.replace("--command-config", "--producer.config")
                   if cmd_suffix else "")
         output = ""
@@ -121,10 +120,11 @@ class MirrorUtils:
         logger.debug("Producer output for %s:\n%s", topic, output.strip())
 
     @staticmethod
-    def consume_records(logger, kafka, topic, client_node, max_messages=None,
-                        timeout_ms=30000, isolation_level=None, group=None,
-                        from_beginning=True, expected_count=None,
-                        wait_timeout_sec=240):
+    def consume_messages(logger, kafka, client_node, topic, group=None,
+                         max_messages=None, expected_count=None,
+                         timeout_ms=30000, wait_timeout_sec=240,
+                         isolation_level=None,
+                         from_beginning=True):
         env_prefix, cmd_suffix = kafka._cmd_security_opts(client_node)
         cmd = "%s%s --bootstrap-server %s --topic %s --timeout-ms %d" % (
             env_prefix,
@@ -139,7 +139,6 @@ class MirrorUtils:
             cmd += " --isolation-level %s" % isolation_level
         if group is not None:
             cmd += " --group %s" % group
-        cmd += " --consumer-property group.protocol=consumer"
         if cmd_suffix:
             cmd += cmd_suffix.replace("--command-config", "--consumer.config")
         cmd += " 2>/dev/null"
@@ -149,7 +148,7 @@ class MirrorUtils:
             for line in client_node.account.ssh_capture(cmd, allow_fail=True):
                 if line.strip():
                     count[0] += 1
-            logger.info("Consumed %d records from %s so far (expected %s)",
+            logger.info("Consumed %d messages from %s so far (expected %s)",
                         count[0], topic, expected_count)
             return expected_count is None or count[0] >= expected_count
 
@@ -201,20 +200,19 @@ class MirrorUtils:
                 lambda p: p["state"] == state, topics)
         if err_msg is None:
             err_msg = "Mirror did not reach %s state" % state
-        wait_until(check, timeout_sec=300, backoff_sec=2, err_msg=err_msg)
+        wait_until(check, timeout_sec=120, backoff_sec=2, err_msg=err_msg)
 
     @staticmethod
-    def wait_for_metadata_refresh(logger, kafka, client_node, mirror_name, num_cycles=1):
+    def wait_for_metadata_refresh(logger, kafka, client_node, mirror_name):
         """Wait for metadata sync by sleeping based on the configured refresh interval."""
         output = kafka.describe_mirror_config(client_node, mirror_name)
         interval_ms = 30000
-        for line in output.splitlines():
-            if "mirror.metadata.refresh.interval.ms=" in line:
-                interval_ms = int(line.strip().split()[0].split("=")[1])
+        for prop in kafka.server_prop_overrides:
+            if prop[0] == "mirror.metadata.refresh.interval.ms":
+                interval_ms = int(prop[1])
                 break
-        sleep_s = (interval_ms // 1000) * num_cycles
-        logger.info("Waiting %ds for %d metadata sync cycle(s) (interval=%dms)",
-                    sleep_s, num_cycles, interval_ms)
+        sleep_s = interval_ms // 1000
+        logger.info("Waiting %ds for metadata sync (interval=%dms)", sleep_s, interval_ms)
         time.sleep(sleep_s)
 
     @staticmethod
@@ -225,7 +223,7 @@ class MirrorUtils:
             return MirrorUtils.all_satisfy_in_mirror(logger,
                 kafka, client_node, mirror_name,
                 lambda p: p["lag"] == 0 and p["state"] == "MIRRORING", topics)
-        wait_until(check, timeout_sec=300, backoff_sec=5, err_msg=err_msg)
+        wait_until(check, timeout_sec=120, backoff_sec=2, err_msg=err_msg)
 
     @staticmethod
     def describe_consumer_group(kafka, group, client_node):
@@ -272,7 +270,7 @@ class MirrorUtils:
 
         wait_until(
             check,
-            timeout_sec=300,
+            timeout_sec=120,
             backoff_sec=5,
             err_msg="Log segments did not converge between source and destination",
         )

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_sasl_ssl_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_sasl_ssl_test.py
@@ -37,7 +37,7 @@ ZK_ACL_AUTHORIZER_OLD = "kafka.security.auth.SimpleAclAuthorizer"
 ZK_ACL_AUTHORIZER_NEW = "kafka.security.authorizer.AclAuthorizer"
 
 
-class ClusterMirroringCompAclsTest(MirrorUtils, Test):
+class ClusterMirroringCompSaslSslTest(MirrorUtils, Test):
     """Tests for KIP-1279 Cluster Mirroring ACLs sync across different Kafka versions."""
 
     DEST_SERVER_PROPS = [
@@ -50,6 +50,8 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
         ["share.coordinator.state.topic.replication.factor", "2"],
         ["share.coordinator.state.topic.min.isr", "1"],
         ["mirror.state.topic.replication.factor", "2"],
+        ["mirror.metadata.refresh.interval.ms", "10000"],
+        ["mirror.num.replica.fetchers", "2"],
         ["super.users", "User:kafka"],
     ]
 
@@ -63,7 +65,7 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
     ]
 
     def __init__(self, test_context):
-        super(ClusterMirroringCompAclsTest, self).__init__(test_context)
+        super(ClusterMirroringCompSaslSslTest, self).__init__(test_context)
 
     def teardown(self):
         if hasattr(self, "_original_metadata_quorum"):
@@ -170,7 +172,7 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
         return kafka.run_cli_tool(client_node, cmd)
 
     @staticmethod
-    def produce_as_client(logger, kafka, topic, num_records, client_node):
+    def produce_as_client(logger, kafka, client_node, topic, num_messages):
         client_env = "KAFKA_OPTS='-D%s -D%s' " % (
             KafkaService.JAAS_CONF_PROPERTY, KafkaService.KRB5_CONF)
         client_props = str(kafka.security_config.client_config(
@@ -180,7 +182,7 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
               " --producer.config <(echo '%s')" % (
                   client_env,
                   kafka.path.script("kafka-producer-perf-test.sh", client_node),
-                  topic, num_records,
+                  topic, num_messages,
                   kafka.bootstrap_servers(kafka.security_protocol),
                   client_props)
         output = ""
@@ -189,9 +191,9 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
         logger.debug("Producer output for %s:\n%s", topic, output.strip())
 
     @staticmethod
-    def consume_as_client(logger, kafka, topic, client_node, max_messages,
-                          group=None, timeout_ms=30000, expected_count=None,
-                          wait_timeout_sec=240):
+    def consume_as_client(logger, kafka, client_node, topic, group=None,
+                          max_messages=None, expected_count=None,
+                          timeout_ms=30000, wait_timeout_sec=240):
         client_env = "KAFKA_OPTS='-D%s -D%s' " % (
             KafkaService.JAAS_CONF_PROPERTY, KafkaService.KRB5_CONF)
         client_props = str(kafka.security_config.client_config(
@@ -211,7 +213,7 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             for line in client_node.account.ssh_capture(cmd, allow_fail=True):
                 if line.strip():
                     count[0] += 1
-            logger.debug("Consumed %d records from %s so far (expected %s)",
+            logger.debug("Consumed %d messages from %s so far (expected %s)",
                          count[0], topic, expected_count)
             return expected_count is None or count[0] >= expected_count
 
@@ -229,15 +231,15 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
 
     @staticmethod
     def list_acls(kafka, client_node):
-        return ClusterMirroringCompAclsTest.run_acl_cmd(kafka, "--list", client_node)
+        return ClusterMirroringCompSaslSslTest.run_acl_cmd(kafka, "--list", client_node)
 
     def wait_for_acl_condition(self, kafka, mirror_name, condition, err_msg, client_node):
         MirrorUtils.wait_for_metadata_refresh(self.logger, kafka, client_node, mirror_name)
         def check():
-            dest_acls = ClusterMirroringCompAclsTest.list_acls(kafka, client_node)
+            dest_acls = ClusterMirroringCompSaslSslTest.list_acls(kafka, client_node)
             self.logger.debug("Destination ACLs:\n%s" % dest_acls)
             return condition(dest_acls)
-        wait_until(check, timeout_sec=300, backoff_sec=5, err_msg=err_msg)
+        wait_until(check, timeout_sec=120, backoff_sec=2, err_msg=err_msg)
 
 
     @cluster(num_nodes=8)
@@ -260,76 +262,74 @@ class ClusterMirroringCompAclsTest(MirrorUtils, Test):
             self.source_kafka.create_topic({"topic": t, **cfg})
 
         self.logger.info("Granting ACLs on source cluster")
-        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompSaslSslTest.run_acl_cmd(self.source_kafka,
                          "--add --allow-principal User:client --operation READ --topic my-topic-a",
                          self.source_client_node)
-        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompSaslSslTest.run_acl_cmd(self.source_kafka,
                          "--add --allow-principal User:client --operation WRITE --topic my-topic-a",
                          self.source_client_node)
-        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompSaslSslTest.run_acl_cmd(self.source_kafka,
                          "--add --allow-principal User:client --operation READ --group my-group",
                          self.source_client_node)
-        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompSaslSslTest.run_acl_cmd(self.source_kafka,
                          "--add --allow-principal User:other-client --operation READ --topic new-topic",
                          self.source_client_node)
 
-        self.logger.info("Producing 10 records to my-topic-a as client user")
-        ClusterMirroringCompAclsTest.produce_as_client(self.logger, self.source_kafka, "my-topic-a",
-                                                       10, self.source_client_node)
+        self.logger.info("Producing 10 messages to my-topic-a as client user")
+        ClusterMirroringCompSaslSslTest.produce_as_client(self.logger, self.source_kafka,
+                                                       self.source_client_node, "my-topic-a", 10)
 
         self.logger.info("Creating and starting cluster mirror with ACL include filter")
-        mirror_name = "my-mirror"
-        mirror_cfg = ClusterMirroringCompAclsTest.create_mirror_config(self.source_kafka)
+        mirror_cfg = ClusterMirroringCompSaslSslTest.create_mirror_config(self.source_kafka)
         mirror_cfg.properties["mirror.acl.include"] = "TOPIC;my-topic-.*,GROUP;my-group"
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.dest_client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.dest_client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         for regex in ["my-topic.*", "new-topic"]:
             wait_until(
                 lambda r=regex: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                    self.dest_client_node, mirror_name, r),
-                timeout_sec=300, backoff_sec=2,
+                    self.dest_client_node, "my-mirror", r),
+                timeout_sec=120, backoff_sec=2,
                 err_msg="Failed to start mirror topics for %s" % regex,
             )
         self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag")
         MirrorUtils.wait_mirror_lag_zero(self.logger,
-            self.dest_kafka, self.dest_client_node, mirror_name, topics=list(topics.keys()))
+            self.dest_kafka, self.dest_client_node, "my-mirror", topics=list(topics.keys()))
 
-        # Retry consuming because the HW may lag behind mirror lag reaching zero.
-        self.logger.info("Consuming 10 records from my-topic-a on destination as client user")
-        count = ClusterMirroringCompAclsTest.consume_as_client(self.logger, self.dest_kafka, "my-topic-a",
-                                                               self.dest_client_node, max_messages=10,
-                                                               group="my-group", expected_count=10)
-        assert count >= 10, "Expected 10 records on my-topic-a, got %d" % count
+        self.logger.info("Consuming 10 messages from my-topic-a on destination as client user")
+        count = ClusterMirroringCompSaslSslTest.consume_as_client(self.logger, self.dest_kafka,
+                                                               self.dest_client_node, "my-topic-a", "my-group",
+                                                               max_messages=10, expected_count=10)
+        assert count >= 10, "Expected 10 messages on my-topic-a, got %d" % count
 
         self.logger.info("Verifying ACL filtering: my-topic-a ACL synced, new-topic ACL filtered out")
         self.wait_for_acl_condition(
-            self.dest_kafka, mirror_name,
+            self.dest_kafka, "my-mirror",
             lambda acls: "User:client" in acls and "my-topic-a" in acls,
             "Client READ ACL on my-topic-a should be synced (matches include rule)",
             self.dest_client_node)
 
-        dest_acls = ClusterMirroringCompAclsTest.list_acls(self.dest_kafka, self.dest_client_node)
+        dest_acls = ClusterMirroringCompSaslSslTest.list_acls(self.dest_kafka, self.dest_client_node)
         assert "User:other-client" not in dest_acls and "new-topic" not in dest_acls, \
             "Other-client READ ACL on new-topic should not be synced (filtered out)"
 
         self.logger.info("Removing my-topic-a ACLs from source cluster")
-        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompSaslSslTest.run_acl_cmd(self.source_kafka,
                          "--remove --allow-principal User:client --operation READ "
                          "--topic my-topic-a --force",
                          self.source_client_node)
-        ClusterMirroringCompAclsTest.run_acl_cmd(self.source_kafka,
+        ClusterMirroringCompSaslSslTest.run_acl_cmd(self.source_kafka,
                          "--remove --allow-principal User:client --operation WRITE "
                          "--topic my-topic-a --force",
                          self.source_client_node)
 
         self.logger.info("Verifying ACL removal propagated to destination")
         self.wait_for_acl_condition(
-            self.dest_kafka, mirror_name,
+            self.dest_kafka, "my-mirror",
             lambda acls: "my-topic-a" not in acls,
             "Client READ ACL on my-topic-a should have been removed from destination",
             self.dest_client_node)

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -44,6 +44,8 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
         ["share.coordinator.state.topic.replication.factor", "2"],
         ["share.coordinator.state.topic.min.isr", "1"],
         ["mirror.state.topic.replication.factor", "2"],
+        ["mirror.metadata.refresh.interval.ms", "10000"],
+        ["mirror.num.replica.fetchers", "2"],
     ]
 
     SOURCE_SERVER_PROPS = [
@@ -133,7 +135,6 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
         self.setup_source(KafkaVersion(source_version), metadata_quorum)
         self.setup_dest()
 
-        num_records = 100
         topics = {
             "my-topic-a": {"partitions": 3, "replication-factor": 2},
             "my-topic-b": {"partitions": 1, "replication-factor": 2},
@@ -147,55 +148,43 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
         self.logger.info("Restart source cluster to bump the partitions leader epoch")
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
-        self.logger.info("Producing %d records to each source topic", num_records)
+        self.logger.info("Producing %d messages to each source topic", 100)
         for t in topics:
-            MirrorUtils.produce_records(self.logger, self.source_kafka, t, num_records, self.source_client_node)
+            MirrorUtils.produce_messages(self.logger, self.source_kafka, self.source_client_node, t, 100)
 
         self.logger.info("Creating consumer group on source by consuming my-topic-a")
-        MirrorUtils.consume_records(self.logger, self.source_kafka, "my-topic-a", self.source_client_node,
-                             max_messages=num_records, group="my-group")
+        MirrorUtils.consume_messages(self.logger, self.source_kafka, self.source_client_node,
+                             "my-topic-a", "my-group", max_messages=100)
 
         self.logger.info("Setting dynamic topic config on source")
         self.source_kafka.alter_topic_config("my-topic-a", "retention.ms=100002", node=self.source_client_node)
 
         self.logger.info("Creating and starting cluster mirror")
-        mirror_name = "my-mirror"
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.dest_client_node, mirror_name, mirror_cfg),
+                self.dest_client_node, "my-mirror", mirror_cfg),
             timeout_sec=20, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         for regex in ["my-topic.*", "new-topic"]:
             wait_until(
                 lambda r=regex: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                    self.dest_client_node, mirror_name, r),
+                    self.dest_client_node, "my-mirror", r),
                 timeout_sec=20, backoff_sec=2,
                 err_msg="Failed to start mirror topics for %s" % regex,
             )
         self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag")
         MirrorUtils.wait_mirror_lag_zero(self.logger,
-            self.dest_kafka, self.dest_client_node, mirror_name, topics=list(topics.keys()))
-
-        self.logger.info("Shutting down the leader of one topic, and send more records to make sure the mirror can still work.")
-        leader_node = self.source_kafka.leader("my-topic-b", 0)
-        self.source_kafka.stop_node(leader_node, clean_shutdown=False)
-
-        self.logger.info("Producing %d more records to each source topic", num_records)
-        for t in topics:
-            MirrorUtils.produce_records(self.logger, self.source_kafka, t, num_records, self.source_client_node)
-
-        self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag after one source node down")
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.dest_client_node, mirror_name, topics=list(topics.keys()))
+            self.dest_kafka, self.dest_client_node, "my-mirror", topics=list(topics.keys()))
 
         self.logger.info("Verifying consumer group offset sync")
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.dest_client_node, mirror_name, num_cycles=2)
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.dest_client_node, "my-mirror")
         wait_until(
             lambda: "my-topic-a" in MirrorUtils.describe_consumer_group(
                 self.dest_kafka, "my-group", self.dest_client_node),
-            timeout_sec=60, backoff_sec=5,
+            timeout_sec=120, backoff_sec=2,
             err_msg="Expected my-topic-a offset to be synced on destination",
         )
 
@@ -204,19 +193,30 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
         assert "retention.ms=100002" in dest_topic_desc, \
             "Expected retention.ms=100002 synced to destination, got: %s" % dest_topic_desc
 
+        self.logger.info("Shutting down the leader of one topic, and send more messages to make sure the mirror can still work.")
+        leader_node = self.source_kafka.leader("my-topic-b", 0)
+        self.source_kafka.stop_node(leader_node, clean_shutdown=False)
+
+        self.logger.info("Producing %d more messages to each source topic", 100)
+        for t in topics:
+            MirrorUtils.produce_messages(self.logger, self.source_kafka, self.source_client_node, t, 100)
+
+        self.logger.info("Waiting for all partitions to reach MIRRORING with zero lag after one source node down")
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.dest_client_node, "my-mirror", topics=list(topics.keys()))
+
         self.logger.info("Stopping mirroring (failover)")
         for regex in ["my-topic.*", "new-topic"]:
             self.dest_kafka.stop_cluster_mirror_topics(
-                self.dest_client_node, mirror_name, regex)
+                self.dest_client_node, "my-mirror", regex)
         MirrorUtils.wait_mirror_state(self.logger,
-            self.dest_kafka, self.dest_client_node, mirror_name, "STOPPED",
+            self.dest_kafka, self.dest_client_node, "my-mirror", "STOPPED",
             topics=list(topics.keys()))
 
-        self.logger.info("Verifying destination records after failover")
+        self.logger.info("Verifying destination messages after failover")
         for topic in topics:
-            count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.dest_client_node,
-                                         max_messages=num_records, expected_count=num_records)
-            assert count >= num_records, "Expected %d records on %s, got %d" % (num_records, topic, count)
+            count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.dest_client_node, topic,
+                                         max_messages=100, expected_count=100)
+            assert count >= 100, "Expected %d messages on %s, got %d" % (100, topic, count)
 
     @cluster(num_nodes=8)
     @parametrize(source_version=str(LATEST_2_1), metadata_quorum=quorum.zk)
@@ -225,15 +225,13 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
     def test_ule_mirroring(self, source_version, metadata_quorum):
         """Verify migration with unclean leader elections."""
         self.logger.info("Create source topic with ULE support enabled")
-        topic = "my-topic"
-        mirror_name = "new-mirror"
-        topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        topics = {"my-topic": {"partitions": 1, "replication-factor": 2}}
 
         self.setup_source(KafkaVersion(source_version), metadata_quorum)
         self.setup_dest()
 
         self.source_kafka.create_topic({
-            "topic": topic, **topics[topic],
+            "topic": "my-topic", **topics["my-topic"],
             # this is needed because we started to support manual ULE only in 2.4
             "configs": {"unclean.leader.election.enable": "true"},
         })
@@ -245,7 +243,7 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
         self.logger.info("Send 1 message via source broker 0")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.source_client_node,
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.source_client_node, "my-topic", 1,
                              bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker0))
 
         self.logger.info("Start cluster mirror on destination")
@@ -253,18 +251,18 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.dest_client_node, mirror_name, mirror_cfg),
+                self.dest_client_node, "my-mirror", mirror_cfg),
             timeout_sec=60, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.dest_client_node, mirror_name, topic),
+                self.dest_client_node, "my-mirror", "my-topic"),
             timeout_sec=60, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
         MirrorUtils.wait_mirror_state(
-            self.logger, self.dest_kafka, self.dest_client_node, mirror_name, "MIRRORING", [topic],
+            self.logger, self.dest_kafka, self.dest_client_node, "my-mirror", "MIRRORING", ["my-topic"],
             err_msg="Mirror did not reach MIRRORING state",
         )
 
@@ -272,7 +270,7 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
         self.source_kafka.stop_node(src_broker0)
 
         self.logger.info("Send 1 message via source broker 1")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.source_client_node,
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.source_client_node, "my-topic", 1,
                              bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker1))
         MirrorUtils.wait_for_log_convergence(self.logger, self.source_kafka, self.dest_kafka, topics)
 
@@ -281,10 +279,10 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
         self.source_kafka.start_node(src_broker0)
 
         self.logger.info("Send 2 messages via source broker 0")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 2, self.source_client_node,
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.source_client_node, "my-topic", 2,
                              bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker0))
         MirrorUtils.wait_for_log_convergence(self.logger, self.source_kafka, self.dest_kafka, topics)
 
         self.logger.info("Failover: stop mirror so destination topic becomes writable")
-        self.dest_kafka.stop_cluster_mirror_topics(self.dest_client_node, mirror_name, topic)
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.dest_client_node, mirror_name, "STOPPED", [topic])
+        self.dest_kafka.stop_cluster_mirror_topics(self.dest_client_node, "my-mirror", "my-topic")
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.dest_client_node, "my-mirror", "STOPPED", ["my-topic"])

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -46,6 +46,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
             ["share.coordinator.state.topic.replication.factor", "2"],
             ["share.coordinator.state.topic.min.isr", "1"],
             ["mirror.state.topic.replication.factor", "2"],
+            ["mirror.metadata.refresh.interval.ms", "5000"],
+            ["mirror.num.replica.fetchers", "2"],
         ]
         self.source_kafka = KafkaService(
             test_context, num_nodes=2, zk=None,
@@ -89,44 +91,26 @@ class ClusterMirroringTest(MirrorUtils, Test):
                     kafka.stop_node(node, clean_shutdown=False)
 
     @staticmethod
-    def run_background_producer(kafka, client_node, topic, num_records,
+    def run_background_producer(kafka, client_node, topic, num_messages,
                                 throughput=10):
         """Start a background producer."""
         cmd = "%s --topic %s --num-records %d --record-size 1 --throughput %d" \
               " --producer-props bootstrap.servers=%s" % (
                   kafka.path.script("kafka-producer-perf-test.sh", client_node),
-                  topic, num_records, throughput,
+                  topic, num_messages, throughput,
                   kafka.bootstrap_servers(kafka.security_protocol))
         client_node.account.ssh("nohup %s >/dev/null 2>&1 &" % cmd, allow_fail=True)
 
     @staticmethod
-    def run_background_consumer(kafka, client_node, topic, group):
-        """Start a background console consumer."""
-        cmd = "%s --bootstrap-server %s --topic %s --group %s" % (
-            kafka.path.script("kafka-console-consumer.sh", client_node),
-            kafka.bootstrap_servers(kafka.security_protocol),
-            topic, group)
-        client_node.account.ssh("nohup %s >/dev/null 2>&1 &" % cmd, allow_fail=True)
-
-    @staticmethod
-    def run_background_share_consumer(kafka, client_node, topic, group):
-        """Start a background console share consumer."""
-        cmd = "%s --bootstrap-server %s --topic %s --group %s" % (
-            kafka.path.script("kafka-console-share-consumer.sh", client_node),
-            kafka.bootstrap_servers(kafka.security_protocol),
-            topic, group)
-        client_node.account.ssh("nohup %s >/dev/null 2>&1 &" % cmd, allow_fail=True)
-
-    @staticmethod
-    def kill_background_process(client_node, pattern):
-        """Kill background processes matching the given pattern."""
+    def stop_background_process(client_node, pattern, signal="SIGTERM"):
+        """Stop background processes matching the given pattern."""
         client_node.account.ssh(
-            "pkill -SIGKILL -f '%s' || true" % pattern, allow_fail=True)
+            "pkill -%s -f '%s' || true" % (signal, pattern), allow_fail=True)
 
     @staticmethod
-    def consume_share_records(logger, kafka, client_node, topic, group,
-                              max_messages=None, timeout_ms=30000,
-                              expected_count=None, wait_timeout_sec=240):
+    def consume_share_messages(logger, kafka, client_node, topic, group,
+                               max_messages=None, expected_count=None,
+                               timeout_ms=20000, wait_timeout_sec=120):
         cmd = "%s --bootstrap-server %s --topic %s --group %s --timeout-ms %d" % (
             kafka.path.script("kafka-console-share-consumer.sh", client_node),
             kafka.bootstrap_servers(kafka.security_protocol),
@@ -140,7 +124,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
             for line in client_node.account.ssh_capture(cmd, allow_fail=True):
                 if line.strip():
                     count[0] += 1
-            logger.debug("Share-consumed %d records from %s so far (expected %s)",
+            logger.debug("Share-consumed %d messages from %s so far (expected %s)",
                          count[0], topic, expected_count)
             return expected_count is None or count[0] >= expected_count
 
@@ -150,7 +134,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
             while count[0] < expected_count:
                 if time.time() >= deadline:
                     raise AssertionError(
-                        "Expected %d records on %s, got %d" % (expected_count, topic, count[0]))
+                        "Expected %d messages on %s, got %d" % (expected_count, topic, count[0]))
                 time.sleep(5)
                 try_consume()
         else:
@@ -215,7 +199,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
     @staticmethod
     def run_txn_producer(client_node, kafka, topic, transactional_id=None, mode="commit",
-                         num_records=1, waiting_ms=0, background=False):
+                         num_messages=1, waiting_ms=0, background=False):
         """Run TransactionalTestProducer."""
         cmd = kafka.path.script("kafka-run-class.sh", client_node)
         cmd += " org.apache.kafka.tools.TransactionalTestProducer"
@@ -226,7 +210,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
             cmd += " --mode %s" % mode
             if waiting_ms > 0:
                 cmd += " --waiting-ms %s" % str(waiting_ms)
-        cmd += " --num-records %s" % str(num_records)
+        cmd += " --num-records %s" % str(num_messages)
         if background:
             cmd += " &"
         client_node.account.ssh(cmd, allow_fail=False)
@@ -259,302 +243,290 @@ class ClusterMirroringTest(MirrorUtils, Test):
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_start_stop(self, metadata_quorum):
         """Verify failover makes destination writable and failback truncates non-mirrored data."""
-        topic = "my-topic"
-        mirror_name = "my-mirror"
-        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
 
-        self.logger.info("Send 3 records to source")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
+        self.logger.info("Send 3 messages to source")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
 
-        self.logger.info("Consume from destination (expect 3 records)")
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=3,
-                                     expected_count=3)
-        assert count >= 3, "Expected 3 records on %s, got %d" % (topic, count)
+        self.logger.info("Consume from destination (expect 3 messages)")
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic",
+                                     max_messages=3, expected_count=3)
+        assert count >= 3, "Expected 3 messages on my-topic, got %d" % count
 
         self.logger.info("Produce to destination while mirroring (should fail)")
-        MirrorUtils.produce_records(self.logger, self.dest_kafka, topic, 1, self.client_node)
+        MirrorUtils.produce_messages(self.logger, self.dest_kafka, self.client_node, "my-topic", 1)
 
         self.logger.info("Failover: stop mirror so destination topic becomes writable")
-        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
+        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, "my-mirror", "my-topic")
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "STOPPED", ["my-topic"])
 
         self.logger.info("Send 1 record to destination (should work now)")
-        MirrorUtils.produce_records(self.logger, self.dest_kafka, topic, 1, self.client_node)
+        MirrorUtils.produce_messages(self.logger, self.dest_kafka, self.client_node, "my-topic", 1)
 
-        self.logger.info("Send 2 more records to source (not mirrored)")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 2, self.client_node)
+        self.logger.info("Send 2 more messages to source (not mirrored)")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 2)
 
-        self.logger.info("Consume from source (expect 5 records)")
-        count = MirrorUtils.consume_records(self.logger, self.source_kafka, topic, self.client_node, max_messages=5,
-                                     expected_count=5)
-        assert count >= 5, "Expected 5 records on %s, got %d" % (topic, count)
+        self.logger.info("Consume from source (expect 5 messages)")
+        count = MirrorUtils.consume_messages(self.logger, self.source_kafka, self.client_node, "my-topic",
+                                     max_messages=5, expected_count=5)
+        assert count >= 5, "Expected 5 messages on my-topic, got %d" % count
 
-        self.logger.info("Failback: source mirrors from destination (same mirror name to retrieve LMO)")
+        # Use the same mirror name to retrieve the LME
+        self.logger.info("Failback: source mirrors from destination")
         mirror_cfg = MirrorConfig(self.dest_kafka.bootstrap_servers())
 
         wait_until(
             lambda: self.source_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create reverse cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.source_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start reverse mirror topics",
         )
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.source_kafka, self.client_node, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.source_kafka, self.client_node, "my-mirror", ["my-topic"])
 
         self.logger.info("Consume from source (non-mirrored data should be truncated)")
-        count = MirrorUtils.consume_records(self.logger, self.source_kafka, topic, self.client_node,
+        count = MirrorUtils.consume_messages(self.logger, self.source_kafka, self.client_node, "my-topic",
                                      max_messages=5, timeout_ms=5000, expected_count=4)
-        assert count >= 4, "Expected 4 records on %s, got %d" % (topic, count)
+        assert count >= 4, "Expected 4 messages on my-topic, got %d" % count
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_pause_resume(self, metadata_quorum):
         """Verify that pausing stops replication and resuming catches up."""
-        topic = "my-topic"
-        mirror_name = "my-mirror"
-        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
 
-        self.logger.info("Send 3 records to source")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
+        self.logger.info("Send 3 messages to source")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
 
         self.logger.info("Pause mirroring and send 1 more record to source")
-        self.dest_kafka.pause_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.client_node)
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "PAUSED", [topic])
+        self.dest_kafka.pause_cluster_mirror_topics(self.client_node, "my-mirror", "my-topic")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 1)
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "PAUSED", ["my-topic"])
 
         self.logger.info("Consume from destination while paused (expect 3, the 4th is not mirrored yet)")
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node,
-                                     max_messages=4, timeout_ms=5000)
-        assert count == 3, "Expected 3 records on destination while paused, got %d" % count
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic",
+                                     max_messages=4, timeout_ms=5000, expected_count=3)
+        assert count == 3, "Expected 3 messages on destination while paused, got %d" % count
 
         self.logger.info("Produce to destination while paused (should fail)")
-        MirrorUtils.produce_records(self.logger, self.dest_kafka, topic, 1, self.client_node)
+        MirrorUtils.produce_messages(self.logger, self.dest_kafka, self.client_node, "my-topic", 1)
 
         self.logger.info("Resume mirroring and wait for it to catch up")
-        self.dest_kafka.resume_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
+        self.dest_kafka.resume_cluster_mirror_topics(self.client_node, "my-mirror", "my-topic")
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["my-topic"])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
 
-        self.logger.info("Consume from destination (expect 4 records after resume)")
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=4,
-                                     expected_count=4)
-        assert count >= 4, "Expected 4 records on %s, got %d" % (topic, count)
+        self.logger.info("Consume from destination (expect 4 messages after resume)")
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic",
+                                     max_messages=4, expected_count=4)
+        assert count == 4, "Expected 4 messages on my-topic, got %d" % count
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_config_update(self, metadata_quorum):
         """Verify that updating mirror config triggers reconnection and mirroring continues."""
-        topic = "my-topic"
-        mirror_name = "my-mirror"
-        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 1})
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["my-topic"])
 
         self.logger.info("describe_mirror_config: %s",
-                         self.dest_kafka.describe_mirror_config(self.client_node, mirror_name))
+                         self.dest_kafka.describe_mirror_config(self.client_node, "my-mirror"))
         self.logger.info("list_cluster_mirror: %s",
                          self.dest_kafka.list_cluster_mirror(self.client_node))
         self.logger.info("describe_cluster_mirror: %s",
                          self.dest_kafka.describe_cluster_mirror(self.client_node))
 
         self.logger.info("Alter config with invalid config (should fail)")
-        self.dest_kafka.alter_mirror_config(self.client_node, mirror_name, "invalid.config=foo")
+        self.dest_kafka.alter_mirror_config(self.client_node, "my-mirror", "invalid.config=foo")
 
         self.logger.info("Alter config with valid bootstrap.servers pointing to source broker 1 (triggers reconnection)")
         new_bootstrap = "%s:9092" % self.source_kafka.nodes[1].account.hostname
-        self.dest_kafka.alter_mirror_config(self.client_node, mirror_name,
-                                            "bootstrap.servers=%s" % new_bootstrap)
+        self.dest_kafka.alter_mirror_config(self.client_node, "my-mirror", "bootstrap.servers=%s" % new_bootstrap)
 
         self.logger.info("describe_mirror_config: %s",
-                         self.dest_kafka.describe_mirror_config(self.client_node, mirror_name))
+                         self.dest_kafka.describe_mirror_config(self.client_node, "my-mirror"))
         self.logger.info("list_cluster_mirror: %s",
                          self.dest_kafka.list_cluster_mirror(self.client_node))
         self.logger.info("describe_cluster_mirror: %s",
                          self.dest_kafka.describe_cluster_mirror(self.client_node))
 
         self.logger.info("Verify mirroring still works after config change")
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["my-topic"])
 
-        self.logger.info("Send records to source and verify they arrive at destination")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
+        self.logger.info("Send messages to source and verify they arrive at destination")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
 
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=3,
-                                     expected_count=3)
-        assert count >= 3, "Expected 3 records on %s, got %d" % (topic, count)
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic",
+                                     max_messages=3, expected_count=3)
+        assert count >= 3, "Expected 3 messages on my-topic, got %d" % count
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_mirror_deletion(self, metadata_quorum):
         """Verify that a mirror cannot be deleted while not empty, but can after stopping all topics."""
-        topic = "my-topic"
-        mirror_name = "my-mirror"
-        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 1})
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["my-topic"])
 
         self.logger.info("Delete mirror while not empty (should fail)")
-        self.dest_kafka.delete_cluster_mirror(self.client_node, mirror_name)
+        self.dest_kafka.delete_cluster_mirror(self.client_node, "my-mirror")
         output = self.dest_kafka.list_cluster_mirror(self.client_node)
-        assert mirror_name in output, "Mirror should still exist after failed deletion"
+        assert "my-mirror" in output, "Mirror should still exist after failed deletion"
 
         self.logger.info("Stop mirror topics and wait for STOPPED state")
-        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
+        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, "my-mirror", "my-topic")
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "STOPPED", ["my-topic"])
 
         self.logger.info("Delete mirror (should work now)")
-        self.dest_kafka.delete_cluster_mirror(self.client_node, mirror_name)
+        self.dest_kafka.delete_cluster_mirror(self.client_node, "my-mirror")
         output = self.dest_kafka.list_cluster_mirror(self.client_node)
-        assert mirror_name not in output, "Mirror should be gone after deletion"
+        assert "my-mirror" not in output, "Mirror should be gone after deletion"
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_topic_deletion(self, metadata_quorum):
         """Verify that deleting a source topic transitions mirror partitions to STOPPED."""
-        topic = "my-topic"
-        mirror_name = "my-mirror"
-        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
 
         self.logger.info("Start cluster mirror on destination")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["my-topic"])
 
         self.logger.info("Delete topic on source and wait for metadata sync")
-        self.source_kafka.delete_topic(topic)
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name)
+        self.source_kafka.delete_topic("my-topic")
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
         self.logger.info("Verify mirror partitions transitioned to STOPPED")
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "STOPPED", ["my-topic"])
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_topics_filtering(self, metadata_quorum):
         """Verify topic include/exclude filtering, stopped topics not re-discovered, and auto-discovery."""
-        mirror_name = "my-mirror"
-
         self.logger.info("Create 4 topics on source")
-        topics_cfg = {
+        topics = {
             "orders-us": {"partitions": 1, "replication-factor": 2},
             "orders-eu": {"partitions": 1, "replication-factor": 2},
             "orders-internal": {"partitions": 1, "replication-factor": 2},
             "payments": {"partitions": 1, "replication-factor": 2},
         }
-        for t, cfg in topics_cfg.items():
+        for t, cfg in topics.items():
             self.source_kafka.create_topic({"topic": t, **cfg})
 
-        self.logger.info("Send records to source topics")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-us", 3, self.client_node)
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-eu", 3, self.client_node)
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-internal", 2, self.client_node)
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "payments", 2, self.client_node)
+        self.logger.info("Send messages to source topics")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "orders-us", 3)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "orders-eu", 3)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "orders-internal", 2)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "payments", 2)
 
         self.logger.info("Start mirror with regex include and exclude")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, "orders-.*", exclude="orders-internal"),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "orders-.*", exclude="orders-internal"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
 
         self.logger.info("Only orders-us and orders-eu should be mirrored")
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name,
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror",
                                   ["orders-us", "orders-eu"])
 
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-us", self.client_node, max_messages=3,
-                                     expected_count=3)
-        assert count >= 3, "Expected 3 records on orders-us, got %d" % count
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-eu", self.client_node, max_messages=3,
-                                     expected_count=3)
-        assert count >= 3, "Expected 3 records on orders-eu, got %d" % count
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "orders-us",
+                                     max_messages=3, expected_count=3)
+        assert count >= 3, "Expected 3 messages on orders-us, got %d" % count
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "orders-eu",
+                                     max_messages=3, expected_count=3)
+        assert count >= 3, "Expected 3 messages on orders-eu, got %d" % count
 
         self.logger.info("Verify excluded and non-matching topics don't exist on destination")
         dest_topics = list(self.dest_kafka.list_topics(self.client_node))
@@ -564,47 +536,47 @@ class ClusterMirroringTest(MirrorUtils, Test):
             "Expected payments to not exist on destination (not included)"
 
         self.logger.info("Stop orders-eu")
-        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, mirror_name, "orders-eu")
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", ["orders-eu"])
+        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, "my-mirror", "orders-eu")
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "STOPPED", ["orders-eu"])
 
-        self.logger.info("Send 3 more records to orders-eu on source (should not be mirrored)")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-eu", 3, self.client_node)
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
+        self.logger.info("Send 3 more messages to orders-eu on source (should not be mirrored)")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "orders-eu", 3)
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
-        count_eu = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-eu", self.client_node, timeout_ms=5000)
+        count_eu = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "orders-eu", timeout_ms=5000)
         assert count_eu == 3, \
-            "Expected 3 records for orders-eu after stop (not 6), got %d" % count_eu
+            "Expected 3 messages for orders-eu after stop (not 6), got %d" % count_eu
 
         self.logger.info("Verify orders-eu is not re-discovered after two more metadata refresh cycles")
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
         self.logger.info("describe_cluster_mirror: %s",
                          self.dest_kafka.describe_cluster_mirror(self.client_node))
-        count_eu = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-eu", self.client_node, timeout_ms=5000)
+        count_eu = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "orders-eu", timeout_ms=5000)
         assert count_eu == 3, \
-            "Expected orders-eu to remain at 3 records (not re-discovered), got %d" % count_eu
+            "Expected orders-eu to remain at 3 messages (not re-discovered), got %d" % count_eu
 
         self.logger.info("Create new topic on source that matches the include pattern")
         self.source_kafka.create_topic({"topic": "orders-jp", "partitions": 1, "replication-factor": 2})
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "orders-jp", 3, self.client_node)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "orders-jp", 3)
 
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", ["orders-jp"])
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["orders-jp"])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["orders-jp"])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["orders-jp"])
 
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, "orders-jp", self.client_node, max_messages=3,
-                                     expected_count=3)
-        assert count >= 3, "Expected 3 records on orders-jp, got %d" % count
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "orders-jp",
+                                     max_messages=3, expected_count=3)
+        assert count >= 3, "Expected 3 messages on orders-jp, got %d" % count
 
         self.logger.info("Add payments to include pattern via alter config")
         self.dest_kafka.alter_mirror_config(
-            self.client_node, mirror_name, "mirror.topics.include=[orders-.*,payments]")
+            self.client_node, "my-mirror", "mirror.topics.include=[orders-.*,payments]")
 
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", ["payments"])
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["payments"])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["payments"])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["payments"])
 
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, "payments", self.client_node,
-                                            max_messages=2, expected_count=2)
-        assert count >= 2, "Expected 2 records on payments, got %d" % count
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "payments",
+                                     max_messages=2, expected_count=2)
+        assert count >= 2, "Expected 2 messages on payments, got %d" % count
 
         self.logger.info("Verify orders-internal still doesn't exist on destination after all operations")
         dest_topics = list(self.dest_kafka.list_topics(self.client_node))
@@ -615,9 +587,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_props_exclude(self, metadata_quorum):
         """Verify that excluded topic properties are not synced to destination."""
-        topic = "my-topic"
-        mirror_name = "my-mirror"
-        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 1})
 
         self.logger.info("Starting cluster mirror with properties exclude")
         mirror_cfg = MirrorConfig(
@@ -625,27 +595,27 @@ class ClusterMirroringTest(MirrorUtils, Test):
             mirror_topic_properties_exclude="retention.bytes,min.insync.replicas")
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["my-topic"])
 
         self.logger.info("Altering topic config on source")
         self.source_kafka.alter_topic_config(
-            topic, "retention.ms=100002,retention.bytes=10000000002,min.insync.replicas=2",
+            "my-topic", "retention.ms=100002,retention.bytes=10000000002,min.insync.replicas=2",
             node=self.client_node)
 
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
         self.logger.info("Verifying excluded properties were not synced to destination")
-        dest_configs = ClusterMirroringTest.parse_topic_configs(self.dest_kafka.describe_topic(topic, node=self.client_node))
+        dest_configs = ClusterMirroringTest.parse_topic_configs(self.dest_kafka.describe_topic("my-topic", node=self.client_node))
         self.logger.info("Dest topic configs: %s", dest_configs)
 
         assert dest_configs.get("retention.ms") == "100002", \
@@ -659,16 +629,14 @@ class ClusterMirroringTest(MirrorUtils, Test):
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_groups_filtering(self, metadata_quorum):
         """Verify consumer group offset mirroring with include/exclude filtering."""
-        topic = "my-topic"
-        mirror_name = "my-mirror"
-        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
 
-        self.logger.info("Produce records to source")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
+        self.logger.info("Produce messages to source")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
 
-        self.logger.info("Create consumer groups on source by consuming all records")
+        self.logger.info("Create consumer groups on source by consuming all messages")
         for group in ["app-group1", "app-group2", "internal-group1"]:
-            MirrorUtils.consume_records(self.logger, self.source_kafka, topic, self.client_node, max_messages=3, group=group)
+            MirrorUtils.consume_messages(self.logger, self.source_kafka, self.client_node, "my-topic", group, max_messages=3)
 
         self.logger.info("Start mirror with groups include (app-.*) and exclude (app-group2)")
         mirror_cfg = MirrorConfig(
@@ -678,18 +646,18 @@ class ClusterMirroringTest(MirrorUtils, Test):
         )
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
         self.logger.info("Verify only app-group1 is synced on destination")
         groups_output = self.dest_kafka.list_consumer_groups(self.client_node)
@@ -713,8 +681,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
         for t, cfg in topics.items():
             self.source_kafka.create_topic({"topic": t, **cfg})
 
-        for t in topics:
-            MirrorUtils.produce_records(self.logger, self.source_kafka, t, 100, self.client_node)
+        for topic in topics:
+            MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, topic, 100)
 
         self.logger.info("Bounce source cluster to trigger leader elections before mirroring")
         self.source_kafka.restart_cluster(clean_shutdown=True)
@@ -734,7 +702,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
                 lambda mn=mirror_name: self.dest_kafka.create_cluster_mirror(
                     self.client_node, mn, mirror_cfg
                 ),
-                timeout_sec=300,
+                timeout_sec=120,
                 backoff_sec=2,
                 err_msg="Failed to create cluster mirror %s" % mirror_name,
             )
@@ -744,7 +712,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
                     "Started"
                     in self.dest_kafka.start_cluster_mirror_topics(self.client_node, mn, tr)
                 ),
-                timeout_sec=300,
+                timeout_sec=120,
                 backoff_sec=2,
                 err_msg="Failed to start mirror topics for %s" % mirror_name,
             )
@@ -769,8 +737,8 @@ class ClusterMirroringTest(MirrorUtils, Test):
             kafka.restart_node(node)
 
         self.logger.info("Kill background producers")
-        ClusterMirroringTest.kill_background_process(
-            self.client_node, "ProducerPerformance")
+        ClusterMirroringTest.stop_background_process(
+            self.client_node, "ProducerPerformance", signal="SIGKILL")
 
         for mirror_name, (_, topic_list) in mirrors.items():
             MirrorUtils.wait_mirror_lag_zero(self.logger,
@@ -785,12 +753,10 @@ class ClusterMirroringTest(MirrorUtils, Test):
     def test_log_convergence_ule(self, metadata_quorum):
         """Verify log convergence after unclean leader elections and failover/failback."""
         self.logger.info("Create source topic with ULE support enabled")
-        topic = "my-topic"
-        mirror_name = "new-mirror"
-        topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        topics = {"my-topic": {"partitions": 1, "replication-factor": 2}}
 
         self.source_kafka.create_topic({
-            "topic": topic, **topics[topic],
+            "topic": "my-topic", **topics["my-topic"],
             "configs": {"mirror.support.unclean.leader.election": "true"},
         })
 
@@ -801,7 +767,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
         self.logger.info("Send 1 message via source broker 0")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.client_node,
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 1,
                              bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker0))
 
         self.logger.info("Start cluster mirror on destination")
@@ -809,18 +775,18 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "new-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "new-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
         MirrorUtils.wait_mirror_state(self.logger,
-            self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic],
+            self.dest_kafka, self.client_node, "new-mirror", "MIRRORING", ["my-topic"],
             err_msg="Mirror did not reach MIRRORING state",
         )
 
@@ -828,12 +794,12 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.stop_node(src_broker0)
 
         self.logger.info("Send 1 message via source broker 1")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 1, self.client_node,
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 1,
                              bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker1))
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic],
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "new-mirror", ["my-topic"],
                                   err_msg="Mirror did not catch up after broker 0 stopped")
         ClusterMirroringTest.log_hashes(
-            self.logger, self.source_kafka, self.dest_kafka, topic,
+            self.logger, self.source_kafka, self.dest_kafka, "my-topic",
             "After source broker 0 stopped (broker 0 should be out of sync)")
 
         self.logger.info("ULE 1: stop broker 1, start broker 0 (stale), elect it as leader")
@@ -841,42 +807,42 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.source_kafka.start_node(src_broker0)
         wait_until(
             lambda: ClusterMirroringTest.trigger_ule(
-                self.source_kafka, self.client_node, src_broker0, topic),
+                self.source_kafka, self.client_node, src_broker0, "my-topic"),
             timeout_sec=30, backoff_sec=2,
             err_msg="Failed to trigger unclean leader election on %s" % src_broker0.name)
 
         self.logger.info("Send 2 messages via source broker 0")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 2, self.client_node,
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 2,
                              bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker0))
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic],
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "new-mirror", ["my-topic"],
                                   err_msg="Mirror did not catch up after ULE 1")
         ClusterMirroringTest.log_hashes(
-            self.logger, self.source_kafka, self.dest_kafka, topic,
+            self.logger, self.source_kafka, self.dest_kafka, "my-topic",
             "After ULE 1 (broker 1 should be out of sync)")
 
         self.logger.info("Failover: stop mirror so destination topic becomes writable")
-        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, mirror_name, topic)
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
+        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, "new-mirror", "my-topic")
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "new-mirror", "STOPPED", ["my-topic"])
         self.logger.info("describe_cluster_mirror: %s",
                          self.dest_kafka.describe_cluster_mirror(self.client_node))
 
         self.logger.info("Send 2 messages via destination broker 0")
-        MirrorUtils.produce_records(self.logger, self.dest_kafka, topic, 2, self.client_node)
+        MirrorUtils.produce_messages(self.logger, self.dest_kafka, self.client_node, "my-topic", 2)
 
         self.logger.info("ULE 2: stop broker 0, start broker 1 (stale), elect it as leader")
         self.source_kafka.stop_node(src_broker0)
         self.source_kafka.start_node(src_broker1)
         wait_until(
             lambda: ClusterMirroringTest.trigger_ule(
-                self.source_kafka, self.client_node, src_broker1, topic),
+                self.source_kafka, self.client_node, src_broker1, "my-topic"),
             timeout_sec=30, backoff_sec=2,
             err_msg="Failed to trigger unclean leader election on %s" % src_broker1.name)
 
         self.logger.info("Send 6 messages via source broker 1")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 6, self.client_node,
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 6,
                              bootstrap_servers=MirrorUtils.broker_bootstrap(src_broker1))
         ClusterMirroringTest.log_hashes(
-            self.logger, self.source_kafka, self.dest_kafka, topic,
+            self.logger, self.source_kafka, self.dest_kafka, "my-topic",
             "After ULE 2 (broker 1 should have the most up to date data)")
 
         self.logger.info("Failback: source now mirrors from destination")
@@ -885,27 +851,27 @@ class ClusterMirroringTest(MirrorUtils, Test):
 
         wait_until(
             lambda: self.source_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "new-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create reverse cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.source_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "new-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start reverse mirror topics",
         )
-        MirrorUtils.wait_mirror_state(self.logger, self.source_kafka, self.client_node, mirror_name, "LOG_TRUNCATION", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.source_kafka, self.client_node, "new-mirror", "LOG_TRUNCATION", ["my-topic"])
 
         self.logger.info("Start the stopped source broker so all replicas rejoin ISR for LME truncation")
         self.source_kafka.start_node(src_broker0)
-        MirrorUtils.wait_mirror_state(self.logger, self.source_kafka, self.client_node, mirror_name, "MIRRORING", [topic],
+        MirrorUtils.wait_mirror_state(self.logger, self.source_kafka, self.client_node, "new-mirror", "MIRRORING", ["my-topic"],
                                err_msg="Reverse mirror did not reach MIRRORING state")
         self.logger.info("describe_cluster_mirror: %s",
                          self.source_kafka.describe_cluster_mirror(self.client_node))
 
         self.logger.info("Wait for reverse mirror to catch up")
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.source_kafka, self.client_node, mirror_name, [topic],
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.source_kafka, self.client_node, "new-mirror", ["my-topic"],
                                          err_msg="Reverse mirror did not catch up")
 
         self.logger.info("Poll until log segment hashes converge (dest is source of truth after failback)")
@@ -916,40 +882,34 @@ class ClusterMirroringTest(MirrorUtils, Test):
     def test_stop_with_txns(self, metadata_quorum):
         """Verify that stop operation aborts pending transactions and allows committed reads."""
         self.logger.info("Create source topic")
-        topic = "my-topic"
-        topics = {topic: {"partitions": 1, "replication-factor": 2}}
+        topics = {"my-topic": {"partitions": 1, "replication-factor": 2}}
         for t, cfg in topics.items():
             self.source_kafka.create_topic({"topic": t, **cfg})
 
         self.logger.info("Run initial committed transaction and bounce source to bump leader epoch")
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-a", "commit")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, "my-topic", "my-topic-a", "commit")
         self.source_kafka.restart_cluster(clean_shutdown=True)
 
-        self.logger.info("Send interleaved transactional and non-transactional records, leaving 2 txns pending")
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-a", "commit", waiting_ms=5000, background=True)
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic)
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-b", "pending")
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-d", "pending")
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-c", "abort", waiting_ms=5000, background=True)
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic, topic + "-d", "pending")
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, topic)
+        self.logger.info("Send interleaved transactional and non-transactional messages, leaving 2 txns pending")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, "my-topic", "my-topic-a", "commit", waiting_ms=5000, background=True)
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, "my-topic")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, "my-topic", "my-topic-b", "pending")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, "my-topic", "my-topic-d", "pending")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, "my-topic", "my-topic-c", "abort", waiting_ms=5000, background=True)
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, "my-topic", "my-topic-d", "pending")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.source_kafka, "my-topic")
 
-        ongoing = ClusterMirroringTest.count_ongoing_txns(self.client_node, self.source_kafka, topic, topics)
+        ongoing = ClusterMirroringTest.count_ongoing_txns(self.client_node, self.source_kafka, "my-topic", topics)
         assert ongoing == 2, "Expected 2 ongoing transactions, got %d" % ongoing
 
         self.logger.info("Create and start cluster mirror, wait for it to catch up")
-        mirror_name = "my-mirror"
-
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
-        self.logger.info(
-            "Creating mirror %s with settings %s", mirror_name, mirror_cfg
-        )
 
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg
+                self.client_node, "my-mirror", mirror_cfg
             ),
-            timeout_sec=300,
+            timeout_sec=120,
             backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
@@ -957,84 +917,81 @@ class ClusterMirroringTest(MirrorUtils, Test):
             lambda: (
                 "Started"
                 in self.dest_kafka.start_cluster_mirror_topics(
-                    self.client_node, mirror_name, topic
+                    self.client_node, "my-mirror", "my-topic"
                 )
             ),
-            timeout_sec=300,
+            timeout_sec=120,
             backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
 
         self.logger.info("Stop cluster mirror (aborts pending transactions and writes PID reset barriers)")
         self.dest_kafka.stop_cluster_mirror_topics(
-            self.client_node, mirror_name, topic
+            self.client_node, "my-mirror", "my-topic"
         )
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "STOPPED", ["my-topic"])
 
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "STOPPED", [topic])
-
-        self.logger.info("Verify extra records on destination from abort markers and PID reset barriers")
-        source_offsets = ClusterMirroringTest.get_end_offsets(self.source_kafka, self.client_node, topic)
-        dest_offsets = ClusterMirroringTest.get_end_offsets(self.dest_kafka, self.client_node, topic)
+        self.logger.info("Verify extra messages on destination from abort markers and PID reset barriers")
+        source_offsets = ClusterMirroringTest.get_end_offsets(self.source_kafka, self.client_node, "my-topic")
+        dest_offsets = ClusterMirroringTest.get_end_offsets(self.dest_kafka, self.client_node, "my-topic")
         extra = sum(dest_offsets.values()) - sum(source_offsets.values())
         # 2 abort markers (one per pending txn) + 1 PID reset barrier per partition
-        num_partitions = topics[topic]["partitions"]
+        num_partitions = topics["my-topic"]["partitions"]
         expected_extra = 2 + num_partitions
         assert extra == expected_extra, \
-            "Expected %d extra records (2 abort + %d PID reset) on destination, got %d. " \
+            "Expected %d extra messages (2 abort + %d PID reset) on destination, got %d. " \
             "source=%s, dest=%s" % (expected_extra, num_partitions, extra, source_offsets, dest_offsets)
 
         self.logger.info("Commit pending transactions on destination and verify consumer counts")
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.dest_kafka, topic, topic + "-b", "commit")
-        ClusterMirroringTest.run_txn_producer(self.client_node, self.dest_kafka, topic, topic + "-d", "commit")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.dest_kafka, "my-topic", "my-topic-b", "commit")
+        ClusterMirroringTest.run_txn_producer(self.client_node, self.dest_kafka, "my-topic", "my-topic-d", "commit")
 
-        self.logger.info("Checking raw number of records")
-        source_count = MirrorUtils.consume_records(self.logger, self.source_kafka, topic, self.client_node)
-        dest_count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node,
+        self.logger.info("Checking raw number of messages")
+        source_count = MirrorUtils.consume_messages(self.logger, self.source_kafka, self.client_node, "my-topic")
+        dest_count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic",
                                           expected_count=source_count + 2)
         assert dest_count >= source_count + 2, \
-            "Expected %d records on %s, got %d" % (source_count + 2, topic, dest_count)
+            "Expected %d messages on my-topic, got %d" % (source_count + 2, dest_count)
 
         self.logger.info("Checking read_committed consumer can make progress")
-        # 4 aborted data records are filtered out: txn-b, txn-c, txn-d fenced, txn-d pending
-        committed_count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node,
+        # 4 aborted messages are filtered out: txn-b, txn-c, txn-d fenced, txn-d pending
+        committed_count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic",
                                                isolation_level="read_committed",
                                                expected_count=dest_count - 4)
         assert committed_count >= dest_count - 4, \
-            "Expected %d read_committed records on %s, got %d" % (dest_count - 4, topic, committed_count)
+            "Expected %d read_committed messages on my-topic, got %d" % (dest_count - 4, committed_count)
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_consumer_groups_commit(self, metadata_quorum):
-        """Verify consumer group offset sync for mirror topics and active consumer protection."""
-        mirror_name = "my-mirror"
-
-        self.logger.info("Create two topics on source")
+        """Verify consumer group offset sync for mirror topics."""
+        self.logger.info("Create two topics on source and send 3 messages each")
         self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
         self.source_kafka.create_topic({"topic": "other-topic", "partitions": 1, "replication-factor": 2})
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 3, self.client_node)
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "other-topic", 3, self.client_node)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "other-topic", 3)
 
-        self.logger.info("Create consumer group my-group on source by consuming both topics")
-        MirrorUtils.consume_records(self.logger, self.source_kafka, "my-topic", self.client_node, max_messages=3, group="my-group")
-        MirrorUtils.consume_records(self.logger, self.source_kafka, "other-topic", self.client_node, max_messages=3, group="my-group")
+        self.logger.info("Consume from both topics using a named consumer group")
+        MirrorUtils.consume_messages(self.logger, self.source_kafka, self.client_node, "my-topic", "my-group", max_messages=3)
+        MirrorUtils.consume_messages(self.logger, self.source_kafka, self.client_node, "other-topic", "my-group", max_messages=3)
 
         self.logger.info("Start mirror with only my-topic (not other-topic)")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, "my-topic"),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["my-topic"])
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
         self.logger.info("Verify my-group on dest has my-topic offset but not other-topic")
         group_desc = MirrorUtils.describe_consumer_group(self.dest_kafka, "my-group", self.client_node)
@@ -1043,221 +1000,185 @@ class ClusterMirroringTest(MirrorUtils, Test):
         assert "other-topic" not in group_desc, \
             "Expected other-topic offset to not appear on destination"
 
-        self.logger.info("Produce 2 more records to my-topic and verify synced offset is exactly 3")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 2, self.client_node)
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["my-topic"])
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
+        self.logger.info("Produce 2 more messages and consume on source to advance offset")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 2)
+        MirrorUtils.consume_messages(self.logger, self.source_kafka, self.client_node, "my-topic", "my-group",
+                                    max_messages=2, from_beginning=False)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
-        dest_desc = MirrorUtils.describe_consumer_group(self.dest_kafka, "my-group", self.client_node)
-        dest_offset = ClusterMirroringTest.parse_group_offset(dest_desc, "my-topic")
-        assert dest_offset == 3, "Expected dest offset 3 (synced from source), got %s" % dest_offset
-
-        self.logger.info("Start active consumer on destination (background)")
-        ClusterMirroringTest.run_background_consumer(self.dest_kafka, self.client_node, "my-topic", "my-group")
+        self.logger.info("Stop mirror and verify offset synced to destination")
+        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, "my-mirror", "my-topic")
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "STOPPED", ["my-topic"])
         wait_until(
             lambda: ClusterMirroringTest.parse_group_offset(
                 MirrorUtils.describe_consumer_group(self.dest_kafka, "my-group", self.client_node),
                 "my-topic") == 5,
-            timeout_sec=60, backoff_sec=2,
-            err_msg="Background consumer did not commit offset 5 for my-group")
-
-        self.logger.info("Reset source offset to 2 to prove sync skips active consumer")
-        self.source_kafka.reset_consumer_group_offsets(self.client_node, "my-group", "my-topic", 2)
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
-
-        self.logger.info("Verify source offset is 2 but dest offset is still 5 (sync skipped)")
-        src_desc = MirrorUtils.describe_consumer_group(self.source_kafka, "my-group", self.client_node)
-        dest_desc = MirrorUtils.describe_consumer_group(self.dest_kafka, "my-group", self.client_node)
-        self.logger.info("Source group describe: %s", src_desc)
-        self.logger.info("Dest group describe: %s", dest_desc)
-
-        src_offset = ClusterMirroringTest.parse_group_offset(src_desc, "my-topic")
-        dest_offset = ClusterMirroringTest.parse_group_offset(dest_desc, "my-topic")
-        assert src_offset == 2, "Expected source offset 2, got %s" % src_offset
-        assert dest_offset == 5, "Expected dest offset 5 (sync skipped), got %s" % dest_offset
+            timeout_sec=30, backoff_sec=2,
+            err_msg="Consumer group offset did not reach 5 on destination")
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_share_groups_commit(self, metadata_quorum):
-        """Verify share group offset sync for mirror topics and active consumer protection."""
-        mirror_name = "my-mirror"
-        share_group = "my-share-group"
-
-        self.logger.info("Create two topics on source")
+        """Verify share group offset sync for mirror topics."""
+        self.logger.info("Create two topics on source and send 3 messages each")
         self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 2})
         self.source_kafka.create_topic({"topic": "other-topic", "partitions": 1, "replication-factor": 2})
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 3, self.client_node)
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "other-topic", 3, self.client_node)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "other-topic", 3)
 
-        self.logger.info("Set share.auto.offset.reset=earliest and consume both topics")
-        self.source_kafka.set_share_group_offset_reset_strategy(share_group, "earliest", node=self.client_node)
-        ClusterMirroringTest.consume_share_records(
-            self.logger, self.source_kafka, self.client_node, "my-topic", share_group, max_messages=3)
-        ClusterMirroringTest.consume_share_records(
-            self.logger, self.source_kafka, self.client_node, "other-topic", share_group, max_messages=3)
+        # Set config before first consume (group doesn't exist yet, so reset_share_group_offsets won't work)
+        self.source_kafka.set_share_group_offset_reset_strategy("my-share-group", "earliest", node=self.client_node)
 
-        self.logger.info("Run background share consumer + produce more data to commit SPSO")
-        ClusterMirroringTest.run_background_share_consumer(self.source_kafka, self.client_node, "my-topic", share_group)
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 3, self.client_node)
-        wait_until(
-            lambda: len(self.source_kafka.describe_share_group_members(
-                share_group, self.client_node)) > 0,
-            timeout_sec=60, backoff_sec=2,
-            err_msg="Share consumer did not join group %s" % share_group)
+        self.logger.info("Consume from both topics using a named share group")
+        ClusterMirroringTest.consume_share_messages(
+            self.logger, self.source_kafka, self.client_node, "my-topic", "my-share-group", max_messages=3)
+        ClusterMirroringTest.consume_share_messages(
+            self.logger, self.source_kafka, self.client_node, "other-topic", "my-share-group", max_messages=3)
 
+        self.logger.info("Produce 3 messages and consume to commit SPSO")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
+        ClusterMirroringTest.consume_share_messages(
+            self.logger, self.source_kafka, self.client_node, "my-topic", "my-share-group", max_messages=3)
         self.logger.info("Source share group describe: %s",
-                         self.source_kafka.describe_share_group(share_group, self.client_node))
-
-        # Kill the source share consumer so the group is inactive before mirroring starts,
-        # otherwise reset_share_group_offsets will fail on an active group.
-        self.logger.info("Kill background share consumer")
-        ClusterMirroringTest.kill_background_process(
-            self.client_node, "ConsoleShareConsumer")
+                         self.source_kafka.describe_share_group("my-share-group", self.client_node))
 
         self.logger.info("Start mirror with only my-topic")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, "my-topic"),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["my-topic"])
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
         self.logger.info("Verify my-share-group on dest has my-topic but not other-topic")
-        src_desc = self.source_kafka.describe_share_group(share_group, self.client_node)
-        dest_desc = self.dest_kafka.describe_share_group(share_group, self.client_node)
+        src_desc = self.source_kafka.describe_share_group("my-share-group", self.client_node)
+        dest_desc = self.dest_kafka.describe_share_group("my-share-group", self.client_node)
         self.logger.info("Source share group describe: %s", src_desc)
         self.logger.info("Dest share group describe: %s", dest_desc)
         assert "my-topic" in dest_desc, "Expected my-topic offset to be synced on destination"
         assert "other-topic" not in dest_desc, "Expected other-topic offset to not appear on destination"
 
-        self.logger.info("Produce 2 more and consume delta using synced offsets")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, "my-topic", 2, self.client_node)
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, ["my-topic"])
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
-
-        ClusterMirroringTest.consume_share_records(
-            self.logger, self.dest_kafka, self.client_node, "my-topic", share_group,
+        self.logger.info("Produce and consume more messages on source to advance SPSO")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 2)
+        ClusterMirroringTest.consume_share_messages(
+            self.logger, self.source_kafka, self.client_node, "my-topic", "my-share-group",
             max_messages=2, expected_count=2)
-
-        self.logger.info("Start active share consumer on destination (background)")
-        ClusterMirroringTest.run_background_share_consumer(self.dest_kafka, self.client_node, "my-topic", share_group)
+        # SPSO archival lags behind consumption, so an extra produce+consume
+        # is needed to trigger archival of the previous batch.
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 1)
+        ClusterMirroringTest.consume_share_messages(
+            self.logger, self.source_kafka, self.client_node, "my-topic", "my-share-group",
+            max_messages=1, expected_count=1)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
         wait_until(
-            lambda: len(self.dest_kafka.describe_share_group_members(
-                share_group, self.client_node)) > 0,
-            timeout_sec=60, backoff_sec=2,
-            err_msg="Share consumer did not join group %s on destination" % share_group)
+            lambda: ClusterMirroringTest.parse_group_offset(
+                self.source_kafka.describe_share_group("my-share-group", self.client_node),
+                "my-topic") == 8,
+            timeout_sec=120, backoff_sec=2,
+            err_msg="Source share group offset did not reach 8")
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
-        self.logger.info("Reset source offset to earliest to prove sync skips active consumer")
-        self.source_kafka.reset_share_group_offsets(self.client_node, share_group, "my-topic")
-        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, mirror_name, num_cycles=2)
-
-        self.logger.info("Verify source offset reset but dest offset unchanged (sync skipped)")
-        src_desc = self.source_kafka.describe_share_group(share_group, self.client_node)
-        dest_desc = self.dest_kafka.describe_share_group(share_group, self.client_node)
-        self.logger.info("Source share group describe after reset: %s", src_desc)
-        self.logger.info("Dest share group describe after reset: %s", dest_desc)
-
-        src_offset = ClusterMirroringTest.parse_group_offset(src_desc, "my-topic")
-        dest_offset = ClusterMirroringTest.parse_group_offset(dest_desc, "my-topic")
-        assert src_offset == 0, "Expected source offset 0 (reset to earliest), got %s" % src_offset
-        assert dest_offset == 5, "Expected dest offset 5 (sync skipped), got %s" % dest_offset
+        self.logger.info("Stop mirror and verify SPSO synced to destination")
+        self.dest_kafka.stop_cluster_mirror_topics(self.client_node, "my-mirror", "my-topic")
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "STOPPED", ["my-topic"])
+        wait_until(
+            lambda: ClusterMirroringTest.parse_group_offset(
+                self.dest_kafka.describe_share_group("my-share-group", self.client_node),
+                "my-topic") == 8,
+            timeout_sec=30, backoff_sec=2,
+            err_msg="Share group offset did not reach 8 on destination")
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_epoch_bump(self, metadata_quorum):
         """Verify that consumers on mirror topics with source leader epochs don't hang on restart."""
-        topic = "my-topic"
-        mirror_name = "my-mirror"
-        group = "my-group"
-        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 1})
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 1, "replication-factor": 1})
 
-        self.logger.info("Produce 3 records and bounce source brokers to bump leader epoch")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
+        self.logger.info("Produce 3 messages and bounce source brokers to bump leader epoch")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
         for node in self.source_kafka.nodes:
             self.source_kafka.restart_node(node)
 
-        self.logger.info("Produce 2 more records after leader elections")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 2, self.client_node)
+        self.logger.info("Produce 2 more messages after leader elections")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 2)
 
         self.logger.info("Start cluster mirror")
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
 
-        self.logger.info("Consume 2 records from destination with a consumer group (commits offsets with source LE)")
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node,
-                                     max_messages=2, group=group, expected_count=2)
-        assert count >= 2, "Expected 2 records on %s, got %d" % (topic, count)
+        self.logger.info("Consume 2 messages from destination with a consumer group (commits offsets with source LE)")
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic", "my-group",
+                                     max_messages=2, expected_count=2)
+        assert count >= 2, "Expected 2 messages on my-topic, got %d" % count
 
         self.logger.info("Restart consumer (triggers OffsetFetch and refreshCommittedOffsets)")
         # Without the epoch bump fix, this would hang because source LE > local LE
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=2,
-                                     timeout_ms=20000, group=group, from_beginning=False,
-                                     expected_count=2)
-        assert count >= 2, "Expected 2 records on %s after restart, got %d" % (topic, count)
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic", "my-group",
+                                     max_messages=2, expected_count=2, timeout_ms=20000, from_beginning=False)
+        assert count >= 2, "Expected 2 messages on my-topic after restart, got %d" % count
 
     @cluster(num_nodes=7)
     @defaults(metadata_quorum=[quorum.isolated_kraft])
     def test_failed_retry(self, metadata_quorum):
         """Verify that mirror recovers from FAILED state after source cluster comes back."""
-        topic = "my-topic"
-        mirror_name = "my-mirror"
-        self.source_kafka.create_topic({"topic": topic, "partitions": 3, "replication-factor": 1})
+        self.source_kafka.create_topic({"topic": "my-topic", "partitions": 3, "replication-factor": 1})
 
-        self.logger.info("Produce initial records and start cluster mirror")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
+        self.logger.info("Produce initial messages and start cluster mirror")
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
 
         mirror_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
         wait_until(
             lambda: self.dest_kafka.create_cluster_mirror(
-                self.client_node, mirror_name, mirror_cfg),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", mirror_cfg),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to create cluster mirror",
         )
         wait_until(
             lambda: "Started" in self.dest_kafka.start_cluster_mirror_topics(
-                self.client_node, mirror_name, topic),
-            timeout_sec=300, backoff_sec=2,
+                self.client_node, "my-mirror", "my-topic"),
+            timeout_sec=120, backoff_sec=2,
             err_msg="Failed to start mirror topics",
         )
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic])
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["my-topic"])
 
         self.logger.info("Stop all source brokers to trigger FAILED state")
         for node in self.source_kafka.nodes:
             self.source_kafka.stop_node(node)
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "FAILED", [topic],
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "FAILED", ["my-topic"],
                                err_msg="Mirror did not reach FAILED state after source shutdown")
 
         self.logger.info("Restart source brokers so scheduled retry can recover")
         for node in self.source_kafka.nodes:
             self.source_kafka.start_node(node)
-        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, mirror_name, "MIRRORING", [topic],
+        MirrorUtils.wait_mirror_state(self.logger, self.dest_kafka, self.client_node, "my-mirror", "MIRRORING", ["my-topic"],
                                err_msg="Mirror did not recover to MIRRORING after source restart")
 
         self.logger.info("Verify data still flows after recovery")
-        MirrorUtils.produce_records(self.logger, self.source_kafka, topic, 3, self.client_node)
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, mirror_name, [topic])
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
 
-        count = MirrorUtils.consume_records(self.logger, self.dest_kafka, topic, self.client_node, max_messages=6,
-                                     expected_count=6)
-        assert count >= 6, "Expected 6 records on %s, got %d" % (topic, count)
+        count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic",
+                                     max_messages=6, expected_count=6)
+        assert count >= 6, "Expected 6 messages on my-topic, got %d" % count


### PR DESCRIPTION
Add mirror.num.replica.fetchers and mirror.metadata.refresh.interval.ms to AllDynamicConfigs and introduce a DynamicClusterMirrorConfig handler that validates and applies changes at runtime without broker restart.

For mirror.num.replica.fetchers, MirrorFetcherManager overrides resizeThreadPool to redistribute existing partitions across the new thread count.

For mirror.metadata.refresh.interval.ms, ClusterMirrorCoordinator stores the ScheduledFuture returned by the scheduler and exposes rescheduleMetadataRefresh which cancels the old periodic task and schedules a new one with the updated interval.
