### PR TITLE
Fix describe json output and add offset overwrite IT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,6 @@ jobs:
 
       - name: Unit Tests
         run: ./gradlew unitTest
+
+      - name: Cluster Mirroring Integration Tests
+        run: ./gradlew core:test --tests AsyncClusterMirrorIntegrationTest

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -19,9 +19,10 @@ package kafka.server;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.ClusterMirrorListing;
+import org.apache.kafka.clients.admin.ClusterMirrorDescription;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateClusterMirrorOptions;
+import org.apache.kafka.clients.admin.DescribeClusterMirrorsOptions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.StartMirrorTopicsOptions;
 import org.apache.kafka.clients.admin.StopMirrorTopicsOptions;
@@ -30,14 +31,17 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
 import org.apache.kafka.common.test.TestKitNodes;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.server.config.ClusterMirrorConfig;
 import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.server.config.ServerLogConfigs;
@@ -55,36 +59,31 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Integration test for async cluster mirroring between two independent KRaft clusters.
- * Tests the full lifecycle:
- * 1. Create source and destination KRaft clusters
- * 2. Create a topic on the source cluster and produce data
- * 3. Create a mirror link on the destination cluster pointing to the source
- * 4. Add topics to the mirror (ASYNC replication)
- * 5. Wait for the destination to catch up
- * 6. Verify all data is present on the destination
+ * Integration test for async Cluster Mirroring between two independent KRaft clusters.
  */
 @Timeout(value = 180, unit = TimeUnit.SECONDS)
 public class AsyncClusterMirrorIntegrationTest {
-    private static final String TOPIC = "test-async-topic";
-    private static final String MIRROR_NAME = "test-mirror";
+    private static final String TOPIC = "my-topic-async";
+    private static final long METADATA_REFRESH_INTERVAL_MS = 5_000L;
+    private static final String MIRROR_NAME = "my-mirror";
 
-    private KafkaClusterTestKit sourceCluster;
-    private KafkaClusterTestKit destCluster;
-    private Admin sourceAdmin;
-    private Admin destAdmin;
+    private KafkaClusterTestKit srcCluster;
+    private KafkaClusterTestKit dstCluster;
+    private Admin srcAdmin;
+    private Admin dstAdmin;
 
     private String singleSourceBootstrapServer;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void beforeEach() throws Exception {
         // Source cluster: 2 brokers, 1 controller
-        sourceCluster = new KafkaClusterTestKit.Builder(
+        srcCluster = new KafkaClusterTestKit.Builder(
                 new TestKitNodes.Builder()
                         .setNumBrokerNodes(2)
                         .setNumControllerNodes(1)
@@ -92,227 +91,153 @@ public class AsyncClusterMirrorIntegrationTest {
                 .setConfigProp(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true")
                 .setConfigProp(ServerConfigs.UNSTABLE_FEATURE_VERSIONS_ENABLE_CONFIG, "true")
                 .build();
-        sourceCluster.format();
-        sourceCluster.startup();
-        sourceCluster.waitForReadyBrokers();
-        singleSourceBootstrapServer = sourceCluster.bootstrapServers().split(",")[0];
+        srcCluster.format();
+        srcCluster.startup();
+        srcCluster.waitForReadyBrokers();
+        singleSourceBootstrapServer = srcCluster.bootstrapServers().split(",")[0];
 
         // Destination cluster: 2 brokers, 1 controller
         // Use a short metadata refresh interval so mirror topics are created quickly
-        destCluster = new KafkaClusterTestKit.Builder(
+        dstCluster = new KafkaClusterTestKit.Builder(
                 new TestKitNodes.Builder()
                         .setNumBrokerNodes(2)
                         .setNumControllerNodes(1)
                         .build())
-                .setConfigProp(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true")
-                .setConfigProp(ServerConfigs.UNSTABLE_FEATURE_VERSIONS_ENABLE_CONFIG, "true")
-                .setConfigProp(ClusterMirrorConfig.MIRROR_METADATA_REFRESH_INTERVAL_MS_CONFIG, "5000")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_NUM_REPLICA_FETCHERS_CONFIG, "2")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_METADATA_REFRESH_INTERVAL_MS_CONFIG,
+                        String.valueOf(METADATA_REFRESH_INTERVAL_MS))
                 .setConfigProp(ServerLogConfigs.AUTO_CREATE_TOPICS_ENABLE_CONFIG, "false")
                 .setConfigProp(ClusterMirrorConfig.MIRROR_STATE_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
+                .setConfigProp(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
+                .setConfigProp(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true")
+                .setConfigProp(ServerConfigs.UNSTABLE_FEATURE_VERSIONS_ENABLE_CONFIG, "true")
                 .build();
-        destCluster.format();
-        destCluster.startup();
-        destCluster.waitForReadyBrokers();
+        dstCluster.format();
+        dstCluster.startup();
+        dstCluster.waitForReadyBrokers();
 
-        sourceAdmin = Admin.create(Map.of(
-                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, sourceCluster.bootstrapServers()
+        srcAdmin = Admin.create(Map.of(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, srcCluster.bootstrapServers()
         ));
-        destAdmin = Admin.create(Map.of(
-                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, destCluster.bootstrapServers()
+        dstAdmin = Admin.create(Map.of(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, dstCluster.bootstrapServers()
         ));
     }
 
     @AfterEach
-    void tearDown() {
-        closeQuietly(sourceAdmin);
-        closeQuietly(destAdmin);
-        closeQuietly(sourceCluster);
-        closeQuietly(destCluster);
-    }
-
-    private void produceRecords(KafkaClusterTestKit cluster, String topic,
-                                int startIndex, int count) throws Exception {
-        Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
-        props.put(ProducerConfig.ACKS_CONFIG, "all");
-        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-
-        try (KafkaProducer<String, String> producer = new KafkaProducer<>(props)) {
-            for (int i = startIndex; i < startIndex + count; i++) {
-                producer.send(new ProducerRecord<>(topic, "key-" + i, "value-" + i))
-                        .get(10, TimeUnit.SECONDS);
-            }
-        }
-    }
-
-    private List<ConsumerRecord<String, String>> consumeFromCluster(
-            KafkaClusterTestKit cluster, String topic, int expectedRecords) throws Exception {
-
-        Properties props = new Properties();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-" + System.currentTimeMillis());
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-
-        List<ConsumerRecord<String, String>> allRecords = new ArrayList<>();
-        long deadline = System.currentTimeMillis() + 90_000;
-        while (allRecords.size() < expectedRecords && System.currentTimeMillis() < deadline) {
-            try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props)) {
-                var partitions = consumer.partitionsFor(topic).stream()
-                        .map(info -> new org.apache.kafka.common.TopicPartition(topic, info.partition()))
-                        .toList();
-                consumer.assign(partitions);
-                consumer.seekToBeginning(partitions);
-                allRecords.clear();
-                long pollDeadline = System.currentTimeMillis() + 5_000;
-                while (allRecords.size() < expectedRecords && System.currentTimeMillis() < pollDeadline) {
-                    ConsumerRecords<String, String> batch = consumer.poll(Duration.ofMillis(500));
-                    batch.forEach(allRecords::add);
-                }
-            } catch (Exception e) {
-                // topic may not exist yet, retry
-            }
-            if (allRecords.size() < expectedRecords) {
-                Thread.sleep(1000);
-            }
-        }
-        assertEquals(expectedRecords, allRecords.size(),
-                "Destination topic " + topic + " did not catch up within timeout. Expected " +
-                        expectedRecords + " records but got " + allRecords.size());
-        return allRecords;
-    }
-
-    private void waitForMirror(int numberOfTopics) throws Exception {
-        long deadline = System.currentTimeMillis() + 90_000;
-        boolean mirrorFound = false;
-        List<ClusterMirrorListing> mirrorListings = new ArrayList<>();
-        String sourceClusterId = sourceAdmin.describeCluster().clusterId().get();
-        ClusterMirrorListing expectedMirror = new ClusterMirrorListing(
-                MIRROR_NAME, singleSourceBootstrapServer, sourceClusterId, numberOfTopics
-        );
-        while (System.currentTimeMillis() < deadline) {
-            try {
-                mirrorListings = destAdmin.listClusterMirrors().all().get(5, TimeUnit.SECONDS).stream().toList();
-                if (mirrorListings.contains(expectedMirror)) {
-                    mirrorFound = true;
-                    break;
-                }
-                Thread.sleep(2000);
-            } catch (Exception e) {
-                Thread.sleep(2000);
-            }
-        }
-        assertTrue(mirrorFound, "Mirror " + MIRROR_NAME + " was not created on destination cluster within timeout. "
-                + "Expected mirror =" + expectedMirror + " not found in " + mirrorListings);
-    }
-
-    private static void closeQuietly(AutoCloseable closeable) {
-        if (closeable != null) {
-            try {
-                closeable.close();
-            } catch (Exception e) {
-                // ignore
-            }
-        }
-    }
-
-    private Map<String, TopicDescription> describeTopicsWithRetry(
-            Admin admin, List<String> topics) throws Exception {
-        long deadline = System.currentTimeMillis() + 30_000;
-        while (true) {
-            try {
-                return admin.describeTopics(topics).allTopicNames().get(5, TimeUnit.SECONDS);
-            } catch (Exception e) {
-                if (System.currentTimeMillis() >= deadline) {
-                    throw e;
-                }
-                Thread.sleep(500);
-            }
-        }
+    void afterEach() {
+        closeQuietly(srcAdmin);
+        closeQuietly(dstAdmin);
+        closeQuietly(srcCluster);
+        closeQuietly(dstCluster);
     }
 
     /**
-     * Test that mirrors the ClusterMirrorCommand flow: pre-create topics on the destination
-     * with the source's TopicId before adding them to the mirror.
-     * This isolates whether the fetcher works when topics are pre-created.
-     */
-    @Test
-    void testAsyncMirrorWithPreCreatedTopic() throws Exception {
-        // Create topic on source
-        sourceAdmin.createTopics(List.of(
-                new NewTopic(TOPIC, 1, (short) 2)
-        )).all().get(30, TimeUnit.SECONDS);
-
-        // Get source topic description (TopicId)
-        var topicDesc = describeTopicsWithRetry(sourceAdmin, List.of(TOPIC));
-        String sourceTopicId = topicDesc.get(TOPIC).topicId().toString();
-
-        // Produce data to source
-        produceRecords(sourceCluster, TOPIC, 0, 50);
-
-        // Pre-create topic on destination with source's TopicId (like ClusterMirrorCommand does)
-        destAdmin.createTopics(List.of(
-                new NewTopic(TOPIC, Optional.of(1), Optional.empty(), Optional.of(sourceTopicId))
-        )).all().get(30, TimeUnit.SECONDS);
-
-        // Create mirror link
-        destAdmin.createClusterMirror(MIRROR_NAME, Map.of(
-                "bootstrap.servers", singleSourceBootstrapServer
-        ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-
-        waitForMirror(0);
-
-        // Add topic to mirror
-        destAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC), new StartMirrorTopicsOptions())
-                .all().get(30, TimeUnit.SECONDS);
-        waitForMirror(1);
-
-        // Wait for async replication
-        consumeFromCluster(destCluster, TOPIC, 50);
-    }
-
-    /**
-     * Test that ASYNC replication works.
-     * This is a simpler smoke test for the mirror link setup.
+     * Tests that ASYNC replication works.
+     * This is a simpler smoke test for the mirror setup.
      */
     @Test
     void testAsyncMirrorReplication() throws Exception {
         // Create topic and produce data
-        sourceAdmin.createTopics(List.of(
-                new NewTopic(TOPIC, 1, (short) 2)
+        srcAdmin.createTopics(List.of(
+                new NewTopic(TOPIC, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
-        produceRecords(sourceCluster, TOPIC, 0, 50);
+        produceRecords(srcCluster, TOPIC, 0, 50);
 
         // Create mirror and add topic
-        destAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-
-        waitForMirror(0);
-
-        destAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC), new StartMirrorTopicsOptions())
+        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC), new StartMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-
-        // Now verify the mirror listing shows the topic
-        waitForMirror(1);
+        waitForMirrorLagZero(TOPIC);
 
         // Produce more data while in ASYNC mode
-        produceRecords(sourceCluster, TOPIC, 50, 50);
+        produceRecords(srcCluster, TOPIC, 50, 50);
 
         // Verify all 100 records arrive at destination
-        List<ConsumerRecord<String, String>> records = consumeFromCluster(
-                destCluster, TOPIC, 100);
+        List<ConsumerRecord<String, String>> records = consumeRecords(
+                dstCluster, TOPIC, 100, null);
         assertEquals(100, records.size(),
-                "Destination should have all 100 records via async replication");
+                "Destination should have all 100 records");
     }
 
     /**
-     * Test that mirror.topics.include regex patterns trigger auto-discovery and replication,
+     * Test that stopping a mirror topic and then draining the destination partition
+     * does not cause consumer group offsets to be overwritten by stale source offsets.
+     */
+    @Test
+    void testStoppedMirrorDoesNotOverwriteOffsets() throws Exception {
+        String topic = "drain-test";
+        String groupId = "drain-group";
+        int recordCount = 50;
+
+        srcAdmin.createTopics(List.of(
+                new NewTopic(topic, 1, (short) 1)
+        )).all().get(30, TimeUnit.SECONDS);
+
+        produceRecords(srcCluster, topic, 0, recordCount);
+
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+                "bootstrap.servers", singleSourceBootstrapServer
+        ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(topic), new StartMirrorTopicsOptions())
+                .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(topic);
+
+        // Stop the mirror topic
+        dstAdmin.stopMirrorTopics(MIRROR_NAME, Set.of(topic), new StopMirrorTopicsOptions())
+                .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorState(topic, "STOPPED");
+
+        // Consume all records from the destination with a stable consumer group
+        consumeRecords(dstCluster, topic, recordCount, groupId);
+
+        // Poll across several metadata refresh cycles to verify the offset stays stable
+        // Log end is recordCount + 1 due to PID-reset control record written on mirror stop
+        TopicPartition tp = new TopicPartition(topic, 0);
+        assertStableOffset(dstAdmin, groupId, tp, recordCount + 1);
+    }
+
+    /**
+     * Tests whether the fetcher works when topics are pre-created.
+     */
+    @Test
+    void testMirrorWithPreCreatedTopic() throws Exception {
+        // Create topic on source
+        srcAdmin.createTopics(List.of(
+                new NewTopic(TOPIC, 1, (short) 1)
+        )).all().get(30, TimeUnit.SECONDS);
+
+        // Get source topic description (TopicId)
+        var topicDesc = describeTopics(srcAdmin, List.of(TOPIC));
+        String sourceTopicId = topicDesc.get(TOPIC).topicId().toString();
+
+        // Produce data to source
+        produceRecords(srcCluster, TOPIC, 0, 50);
+
+        // Pre-create topic on destination with source's TopicId (like ClusterMirrorCommand does)
+        dstAdmin.createTopics(List.of(
+                new NewTopic(TOPIC, Optional.of(1), Optional.empty(), Optional.of(sourceTopicId))
+        )).all().get(30, TimeUnit.SECONDS);
+
+        // Create mirror
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+                "bootstrap.servers", singleSourceBootstrapServer
+        ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC), new StartMirrorTopicsOptions())
+                .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(TOPIC);
+
+        // Wait for async replication
+        consumeRecords(dstCluster, TOPIC, 50);
+    }
+
+    /**
+     * Tests that mirror.topics.include regex patterns trigger auto-discovery and replication,
      * and that appending a new pattern discovers additional topics.
-     * No explicit startMirrorTopics calls — discoverTopicsByPattern handles it.
+     * No explicit startMirrorTopics calls, discoverTopicsByPattern handles it.
      */
     @Test
     void testMirrorTopicsIncludeRegexMerge() throws Exception {
@@ -320,69 +245,34 @@ public class AsyncClusterMirrorIntegrationTest {
         String eventsTopic = "events-click";
 
         // Create source topics and produce data
-        sourceAdmin.createTopics(List.of(
-                new NewTopic(ordersTopic, 1, (short) 2),
-                new NewTopic(eventsTopic, 1, (short) 2)
+        srcAdmin.createTopics(List.of(
+                new NewTopic(ordersTopic, 1, (short) 1),
+                new NewTopic(eventsTopic, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
-        produceRecords(sourceCluster, ordersTopic, 0, 30);
-        produceRecords(sourceCluster, eventsTopic, 0, 20);
-
-        // Get source topic descriptions for pre-creation on destination
-        var sourceDescs = describeTopicsWithRetry(sourceAdmin, List.of(ordersTopic, eventsTopic));
-
-        // Pre-create topics on destination with source TopicIds
-        destAdmin.createTopics(List.of(
-                new NewTopic(ordersTopic,
-                        Optional.of(sourceDescs.get(ordersTopic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(ordersTopic).topicId().toString())),
-                new NewTopic(eventsTopic,
-                        Optional.of(sourceDescs.get(eventsTopic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(eventsTopic).topicId().toString()))
-        )).all().get(30, TimeUnit.SECONDS);
+        produceRecords(srcCluster, ordersTopic, 0, 30);
+        produceRecords(srcCluster, eventsTopic, 0, 20);
 
         // Create mirror with mirror.topics.include=orders-.* — auto-discovery picks up orders-us
-        destAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "orders-.*"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(".*");
 
         // Auto-discovery should find orders-us and start replication
-        waitForMirror(1);
-        consumeFromCluster(destCluster, ordersTopic, 30);
+        consumeRecords(dstCluster, ordersTopic, 30);
 
         // Append second pattern to mirror.topics.include
         appendToTopicsInclude(MIRROR_NAME, "events-.*");
 
         // Auto-discovery should now find events-click and start replication
-        waitForMirror(2);
-        consumeFromCluster(destCluster, eventsTopic, 20);
-    }
-
-    private void appendToTopicsInclude(String mirrorName, String pattern) throws Exception {
-        ConfigResource mirrorResource = new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName);
-        var configResult = destAdmin.describeConfigs(List.of(mirrorResource)).all().get(30, TimeUnit.SECONDS);
-        var mirrorConfigEntries = configResult.get(mirrorResource);
-
-        String existingValue = "";
-        ConfigEntry existingEntry = mirrorConfigEntries.get(ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG);
-        if (existingEntry != null && existingEntry.value() != null && !existingEntry.value().isEmpty()) {
-            existingValue = existingEntry.value();
-        }
-        String newValue = existingValue.isEmpty() ? pattern : existingValue + "," + pattern;
-
-        destAdmin.incrementalAlterConfigs(Map.of(mirrorResource, List.of(
-                new AlterConfigOp(
-                        new ConfigEntry(ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, newValue),
-                        AlterConfigOp.OpType.SET)
-        ))).all().get(30, TimeUnit.SECONDS);
+        consumeRecords(dstCluster, eventsTopic, 20);
     }
 
     /**
-     * Test that mirror.topics.exclude prevents specific topics from being mirrored
-     * even when they match mirror.topics.include.
+     * Tests that mirror.topics.exclude prevents specific topics from
+     * being mirrored even when they match mirror.topics.include.
      */
     @Test
     void testMirrorTopicsExclude() throws Exception {
@@ -390,69 +280,28 @@ public class AsyncClusterMirrorIntegrationTest {
         String excludedTopic = "orders-internal";
 
         // Create source topics and produce data
-        sourceAdmin.createTopics(List.of(
-                new NewTopic(includedTopic, 1, (short) 2),
-                new NewTopic(excludedTopic, 1, (short) 2)
+        srcAdmin.createTopics(List.of(
+                new NewTopic(includedTopic, 1, (short) 1),
+                new NewTopic(excludedTopic, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
-        produceRecords(sourceCluster, includedTopic, 0, 30);
-        produceRecords(sourceCluster, excludedTopic, 0, 20);
-
-        // Pre-create both topics on destination
-        var sourceDescs = describeTopicsWithRetry(sourceAdmin, List.of(includedTopic, excludedTopic));
-        destAdmin.createTopics(List.of(
-                new NewTopic(includedTopic,
-                        Optional.of(sourceDescs.get(includedTopic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(includedTopic).topicId().toString())),
-                new NewTopic(excludedTopic,
-                        Optional.of(sourceDescs.get(excludedTopic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(excludedTopic).topicId().toString()))
-        )).all().get(30, TimeUnit.SECONDS);
+        produceRecords(srcCluster, includedTopic, 0, 30);
+        produceRecords(srcCluster, excludedTopic, 0, 20);
 
         // Create mirror: include orders-.* but exclude orders-internal
-        destAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "orders-.*",
                 ClusterMirrorConfig.MIRROR_TOPICS_EXCLUDE_CONFIG, "orders-internal"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(includedTopic);
 
-        // Only orders-us should be discovered — orders-internal is excluded
-        waitForMirror(1);
-        consumeFromCluster(destCluster, includedTopic, 30);
+        // Only orders-us should be discovered, orders-internal is excluded
+        consumeRecords(dstCluster, includedTopic, 30);
 
-        // Verify orders-internal was NOT mirrored by waiting and checking it has no records
-        Thread.sleep(15_000);
-        List<ConsumerRecord<String, String>> excludedRecords = tryConsumeFromCluster(
-                destCluster, excludedTopic, Duration.ofSeconds(5));
-        assertEquals(0, excludedRecords.size(),
+        // Verify orders-internal was NOT mirrored
+        assertStableRecordCount(dstCluster, excludedTopic, 0,
                 "Excluded topic should have no mirrored records");
-    }
-
-    private List<ConsumerRecord<String, String>> tryConsumeFromCluster(
-            KafkaClusterTestKit cluster, String topic, Duration timeout) {
-        Properties props = new Properties();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-" + System.currentTimeMillis());
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-
-        List<ConsumerRecord<String, String>> allRecords = new ArrayList<>();
-        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props)) {
-            var partitions = consumer.partitionsFor(topic).stream()
-                    .map(info -> new org.apache.kafka.common.TopicPartition(topic, info.partition()))
-                    .toList();
-            consumer.assign(partitions);
-            consumer.seekToBeginning(partitions);
-            long deadline = System.currentTimeMillis() + timeout.toMillis();
-            while (System.currentTimeMillis() < deadline) {
-                ConsumerRecords<String, String> batch = consumer.poll(Duration.ofMillis(500));
-                batch.forEach(allRecords::add);
-            }
-        }
-        return allRecords;
     }
 
     /**
@@ -465,77 +314,53 @@ public class AsyncClusterMirrorIntegrationTest {
         String internalTopic = "__test-internal";
 
         // Create source topics and produce data
-        sourceAdmin.createTopics(List.of(
-                new NewTopic(userTopic, 1, (short) 2),
-                new NewTopic(internalTopic, 1, (short) 2)
+        srcAdmin.createTopics(List.of(
+                new NewTopic(userTopic, 1, (short) 1),
+                new NewTopic(internalTopic, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
-        produceRecords(sourceCluster, userTopic, 0, 25);
-        produceRecords(sourceCluster, internalTopic, 0, 10);
-
-        // Pre-create both on destination
-        var sourceDescs = describeTopicsWithRetry(sourceAdmin, List.of(userTopic, internalTopic));
-        destAdmin.createTopics(List.of(
-                new NewTopic(userTopic,
-                        Optional.of(sourceDescs.get(userTopic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(userTopic).topicId().toString())),
-                new NewTopic(internalTopic,
-                        Optional.of(sourceDescs.get(internalTopic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(internalTopic).topicId().toString()))
-        )).all().get(30, TimeUnit.SECONDS);
+        produceRecords(srcCluster, userTopic, 0, 25);
+        produceRecords(srcCluster, internalTopic, 0, 10);
 
         // Create mirror with include=.* and no explicit exclude — default __.*  applies
-        destAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, ".*"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(userTopic);
 
         // user-events should be discovered and replicated
-        waitForMirror(1);
-        consumeFromCluster(destCluster, userTopic, 25);
+        consumeRecords(dstCluster, userTopic, 25);
 
         // __test-internal should NOT be mirrored due to default exclude
-        Thread.sleep(15_000);
-        List<ConsumerRecord<String, String>> internalRecords = tryConsumeFromCluster(
-                destCluster, internalTopic, Duration.ofSeconds(5));
-        assertEquals(0, internalRecords.size(),
+        assertStableRecordCount(dstCluster, internalTopic, 0,
                 "Internal topic starting with __ should not be mirrored by default");
     }
 
     /**
-     * Test that a literal topic name in mirror.topics.include works for auto-discovery.
+     * Tests that a literal topic name in mirror.topics.include works for auto-discovery.
      */
     @Test
     void testMirrorTopicsIncludeLiteral() throws Exception {
         String topic = "payments";
 
-        sourceAdmin.createTopics(List.of(
-                new NewTopic(topic, 1, (short) 2)
+        srcAdmin.createTopics(List.of(
+                new NewTopic(topic, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
-        produceRecords(sourceCluster, topic, 0, 40);
+        produceRecords(srcCluster, topic, 0, 40);
 
-        var sourceDescs = describeTopicsWithRetry(sourceAdmin, List.of(topic));
-        destAdmin.createTopics(List.of(
-                new NewTopic(topic,
-                        Optional.of(sourceDescs.get(topic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(topic).topicId().toString()))
-        )).all().get(30, TimeUnit.SECONDS);
-
-        destAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "payments"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(topic);
 
-        waitForMirror(1);
-        consumeFromCluster(destCluster, topic, 40);
+        consumeRecords(dstCluster, topic, 40);
     }
 
     /**
-     * Test that a mix of literal and regex patterns in mirror.topics.include works.
+     * Tests that a mix of literal and regex patterns in mirror.topics.include works.
      */
     @Test
     void testMirrorTopicsIncludeMixedLiteralAndRegex() throws Exception {
@@ -543,53 +368,33 @@ public class AsyncClusterMirrorIntegrationTest {
         String regexMatchedTopic = "orders-eu";
         String unmatchedTopic = "logs-app";
 
-        sourceAdmin.createTopics(List.of(
-                new NewTopic(literalTopic, 1, (short) 2),
-                new NewTopic(regexMatchedTopic, 1, (short) 2),
-                new NewTopic(unmatchedTopic, 1, (short) 2)
+        srcAdmin.createTopics(List.of(
+                new NewTopic(literalTopic, 1, (short) 1),
+                new NewTopic(regexMatchedTopic, 1, (short) 1),
+                new NewTopic(unmatchedTopic, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
-        produceRecords(sourceCluster, literalTopic, 0, 20);
-        produceRecords(sourceCluster, regexMatchedTopic, 0, 15);
-        produceRecords(sourceCluster, unmatchedTopic, 0, 10);
-
-        var sourceDescs = describeTopicsWithRetry(sourceAdmin, List.of(literalTopic, regexMatchedTopic, unmatchedTopic));
-        destAdmin.createTopics(List.of(
-                new NewTopic(literalTopic,
-                        Optional.of(sourceDescs.get(literalTopic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(literalTopic).topicId().toString())),
-                new NewTopic(regexMatchedTopic,
-                        Optional.of(sourceDescs.get(regexMatchedTopic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(regexMatchedTopic).topicId().toString())),
-                new NewTopic(unmatchedTopic,
-                        Optional.of(sourceDescs.get(unmatchedTopic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(unmatchedTopic).topicId().toString()))
-        )).all().get(30, TimeUnit.SECONDS);
+        produceRecords(srcCluster, literalTopic, 0, 20);
+        produceRecords(srcCluster, regexMatchedTopic, 0, 15);
+        produceRecords(srcCluster, unmatchedTopic, 0, 10);
 
         // Include literal "payments" and regex "orders-.*"
-        destAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "payments,orders-.*"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(literalTopic, regexMatchedTopic);
 
-        waitForMirror(2);
-
-        consumeFromCluster(destCluster, literalTopic, 20);
-        consumeFromCluster(destCluster, regexMatchedTopic, 15);
+        consumeRecords(dstCluster, literalTopic, 20);
+        consumeRecords(dstCluster, regexMatchedTopic, 15);
 
         // logs-app should NOT be mirrored
-        Thread.sleep(15_000);
-        List<ConsumerRecord<String, String>> unmatchedRecords = tryConsumeFromCluster(
-                destCluster, unmatchedTopic, Duration.ofSeconds(5));
-        assertEquals(0, unmatchedRecords.size(),
+        assertStableRecordCount(dstCluster, unmatchedTopic, 0,
                 "Unmatched topic should not be mirrored");
     }
 
     /**
-     * Test that a stopped topic is not re-discovered by discoverTopicsByPattern,
+     * Tests that a stopped topic is not re-discovered by discoverTopicsByPattern,
      * because mirror.name with STOPPED_TOPIC_SUFFIX keeps it in getConfiguredTopics.
      */
     @Test
@@ -597,99 +402,255 @@ public class AsyncClusterMirrorIntegrationTest {
         String topicA = "orders-us";
         String topicB = "orders-eu";
 
-        sourceAdmin.createTopics(List.of(
-                new NewTopic(topicA, 1, (short) 2),
-                new NewTopic(topicB, 1, (short) 2)
+        srcAdmin.createTopics(List.of(
+                new NewTopic(topicA, 1, (short) 1),
+                new NewTopic(topicB, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
-        produceRecords(sourceCluster, topicA, 0, 20);
-        produceRecords(sourceCluster, topicB, 0, 20);
+        produceRecords(srcCluster, topicA, 0, 20);
+        produceRecords(srcCluster, topicB, 0, 20);
 
-        var sourceDescs = describeTopicsWithRetry(sourceAdmin, List.of(topicA, topicB));
-        destAdmin.createTopics(List.of(
-                new NewTopic(topicA,
-                        Optional.of(sourceDescs.get(topicA).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(topicA).topicId().toString())),
-                new NewTopic(topicB,
-                        Optional.of(sourceDescs.get(topicB).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(topicB).topicId().toString()))
-        )).all().get(30, TimeUnit.SECONDS);
-
-        destAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "orders-.*"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(topicA, topicB);
 
-        waitForMirror(2);
+        consumeRecords(dstCluster, topicA, 20);
+        consumeRecords(dstCluster, topicB, 20);
 
-        consumeFromCluster(destCluster, topicA, 20);
-        consumeFromCluster(destCluster, topicB, 20);
-
-        // Stop orders-eu — sets mirror.name to test-mirror.stopped
-        destAdmin.stopMirrorTopics(MIRROR_NAME, Set.of(topicB), new StopMirrorTopicsOptions())
+        // Stop orders-eu (sets mirror.name to test-mirror.stopped)
+        dstAdmin.stopMirrorTopics(MIRROR_NAME, Set.of(topicB), new StopMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorState(topicB, "STOPPED");
 
-        waitForMirror(1);
+        // Produce more data to both topics (only orders-us should receive new records)
+        produceRecords(srcCluster, topicA, 20, 20);
+        produceRecords(srcCluster, topicB, 20, 20);
 
-        // Produce more data to both topics — only orders-us should receive new records
-        produceRecords(sourceCluster, topicA, 20, 20);
-        produceRecords(sourceCluster, topicB, 20, 20);
-
-        consumeFromCluster(destCluster, topicA, 40);
+        consumeRecords(dstCluster, topicA, 40);
 
         // Verify orders-eu did NOT receive new data (still at 20, not 40)
-        Thread.sleep(15_000);
-        List<ConsumerRecord<String, String>> stoppedRecords = tryConsumeFromCluster(
-                destCluster, topicB, Duration.ofSeconds(5));
-        assertEquals(20, stoppedRecords.size(),
+        assertStableRecordCount(dstCluster, topicB, 20,
                 "Stopped topic should not have received new mirrored records");
     }
 
     /**
-     * Test that startMirrorTopics with includePatterns in options
+     * Tests that startMirrorTopics with includePatterns in options
      * persists patterns to mirror.topics.include via KafkaAdminClient.
      */
     @Test
     void testStartMirrorTopicsWithIncludePatterns() throws Exception {
         String topic = "orders-us";
 
-        sourceAdmin.createTopics(List.of(
-                new NewTopic(topic, 1, (short) 2)
+        srcAdmin.createTopics(List.of(
+                new NewTopic(topic, 1, (short) 1)
         )).all().get(30, TimeUnit.SECONDS);
 
-        produceRecords(sourceCluster, topic, 0, 30);
-
-        var sourceDescs = describeTopicsWithRetry(sourceAdmin, List.of(topic));
-        destAdmin.createTopics(List.of(
-                new NewTopic(topic,
-                        Optional.of(sourceDescs.get(topic).partitions().size()),
-                        Optional.empty(),
-                        Optional.of(sourceDescs.get(topic).topicId().toString()))
-        )).all().get(30, TimeUnit.SECONDS);
+        produceRecords(srcCluster, topic, 0, 30);
 
         // Create mirror with NO initial mirror.topics.include
-        destAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
                 "bootstrap.servers", singleSourceBootstrapServer
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
 
-        waitForMirror(0);
-
         // Start mirroring with includePatterns — should persist "orders-.*" to config
-        destAdmin.startMirrorTopics(MIRROR_NAME, Set.of(topic),
-                new StartMirrorTopicsOptions().includePatterns(List.of("orders-.*")))
+        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(topic),
+                        new StartMirrorTopicsOptions().includePatterns(List.of("orders-.*")))
                 .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(topic);
 
-        waitForMirror(1);
-        consumeFromCluster(destCluster, topic, 30);
+        consumeRecords(dstCluster, topic, 30);
 
         // Verify the pattern was persisted to mirror.topics.include
         ConfigResource mirrorResource = new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, MIRROR_NAME);
-        var configResult = destAdmin.describeConfigs(List.of(mirrorResource)).all().get(30, TimeUnit.SECONDS);
+        var configResult = dstAdmin.describeConfigs(List.of(mirrorResource)).all().get(30, TimeUnit.SECONDS);
         var mirrorConfigEntries = configResult.get(mirrorResource);
         ConfigEntry includeEntry = mirrorConfigEntries.get(ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG);
         assertTrue(includeEntry != null && includeEntry.value().contains("orders-.*"),
                 "mirror.topics.include should contain 'orders-.*' after startMirrorTopics with includePatterns");
+    }
+
+    private void produceRecords(KafkaClusterTestKit cluster, String topic,
+                                int startIndex, int count) {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(props)) {
+            for (int i = startIndex; i < startIndex + count; i++) {
+                producer.send(new ProducerRecord<>(topic, "key-" + i, "value-" + i));
+            }
+            producer.flush();
+        }
+    }
+
+    private List<ConsumerRecord<String, String>> consumeRecords(
+            KafkaClusterTestKit cluster, String topic, int expectedRecords) throws Exception {
+        return consumeRecords(cluster, topic, expectedRecords, null);
+    }
+
+    private List<ConsumerRecord<String, String>> consumeRecords(
+            KafkaClusterTestKit cluster, String topic, int expectedRecords,
+            String groupId) throws Exception {
+        boolean commitOffsets = groupId != null;
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, commitOffsets ? groupId : "test-" + System.currentTimeMillis());
+        props.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, "consumer");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+
+        List<ConsumerRecord<String, String>> allRecords = new ArrayList<>();
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (allRecords.size() < expectedRecords && System.currentTimeMillis() < deadline) {
+            try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props)) {
+                consumer.subscribe(List.of(topic));
+                allRecords.clear();
+                long pollDeadline = System.currentTimeMillis() + 5_000;
+                while (allRecords.size() < expectedRecords && System.currentTimeMillis() < pollDeadline) {
+                    ConsumerRecords<String, String> batch = consumer.poll(Duration.ofMillis(500));
+                    batch.forEach(allRecords::add);
+                }
+                if (commitOffsets && allRecords.size() >= expectedRecords) {
+                    consumer.commitSync();
+                }
+            } catch (Exception e) {
+                if (commitOffsets && allRecords.size() >= expectedRecords) {
+                    throw e;
+                }
+            }
+            if (allRecords.size() < expectedRecords) {
+                TimeUnit.MILLISECONDS.sleep(1_000);
+            }
+        }
+        assertEquals(expectedRecords, allRecords.size(),
+                "Expected to consume " + expectedRecords + " records from " + topic);
+        return allRecords;
+    }
+
+    private Map<String, TopicDescription> describeTopics(
+            Admin admin, List<String> topics) throws Exception {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (true) {
+            try {
+                return admin.describeTopics(topics).allTopicNames().get(5, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                if (System.currentTimeMillis() >= deadline) {
+                    throw e;
+                }
+                TimeUnit.MILLISECONDS.sleep(500);
+            }
+        }
+    }
+
+    private boolean allPartitionsSatisfy(
+            String topicPattern, Predicate<ClusterMirrorDescription.LeaderState> condition) throws Exception {
+        var result = dstAdmin.describeClusterMirrors(
+                List.of(MIRROR_NAME), new DescribeClusterMirrorsOptions());
+        var descriptions = result.allDescriptions().get(5, TimeUnit.SECONDS);
+        ClusterMirrorDescription desc = descriptions.get(MIRROR_NAME);
+        if (desc == null) return false;
+        var pattern = java.util.regex.Pattern.compile(topicPattern);
+        var matched = desc.topics().entrySet().stream()
+                .filter(e -> pattern.matcher(e.getKey()).matches())
+                .toList();
+        return !matched.isEmpty()
+                && matched.stream().allMatch(e -> e.getValue().stream().allMatch(condition));
+    }
+
+    private void waitForMirrorState(String topicPattern, String state) throws Exception {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (allPartitionsSatisfy(topicPattern, s -> state.equals(s.state()))) return;
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+        throw new AssertionError("Mirror partitions for " + topicPattern + " did not reach state " + state + " within timeout");
+    }
+
+    private void waitForMirrorLagZero(String... topicPatterns) throws Exception {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline) {
+            boolean allReady = true;
+            for (String pattern : topicPatterns) {
+                if (!allPartitionsSatisfy(pattern, s -> s.lag() == 0 && "MIRRORING".equals(s.state()))) {
+                    allReady = false;
+                    break;
+                }
+            }
+            if (allReady) return;
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+        throw new AssertionError("Mirror lag did not reach zero for " + List.of(topicPatterns) + " within timeout");
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    private void appendToTopicsInclude(String mirrorName, String pattern) throws Exception {
+        ConfigResource mirrorResource = new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName);
+        var configResult = dstAdmin.describeConfigs(List.of(mirrorResource)).all().get(30, TimeUnit.SECONDS);
+        var mirrorConfigEntries = configResult.get(mirrorResource);
+
+        String existingValue = "";
+        ConfigEntry existingEntry = mirrorConfigEntries.get(ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG);
+        if (existingEntry != null && existingEntry.value() != null && !existingEntry.value().isEmpty()) {
+            existingValue = existingEntry.value();
+        }
+        String newValue = existingValue.isEmpty() ? pattern : existingValue + "," + pattern;
+
+        dstAdmin.incrementalAlterConfigs(Map.of(mirrorResource, List.of(
+                new AlterConfigOp(
+                        new ConfigEntry(ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, newValue),
+                        AlterConfigOp.OpType.SET)
+        ))).all().get(30, TimeUnit.SECONDS);
+    }
+
+    private void assertStableOffset(Admin admin, String groupId,
+                                    TopicPartition tp, long expectedOffset) throws Exception {
+        long deadline = System.currentTimeMillis() + 3 * METADATA_REFRESH_INTERVAL_MS;
+        while (System.currentTimeMillis() < deadline) {
+            long current = getCommittedOffset(admin, groupId, tp);
+            assertEquals(expectedOffset, current,
+                    "Consumer group offset must not be overwritten after mirror stop");
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+    }
+
+    private long getCommittedOffset(Admin admin, String groupId, TopicPartition tp) throws Exception {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                var offsets = admin.listConsumerGroupOffsets(groupId)
+                        .partitionsToOffsetAndMetadata().get(10, TimeUnit.SECONDS);
+                OffsetAndMetadata oam = offsets.get(tp);
+                if (oam != null) return oam.offset();
+            } catch (Exception e) {
+                // group may not be visible yet, retry
+            }
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+        throw new AssertionError("No committed offset for " + tp + " in group " + groupId + " within timeout");
+    }
+
+    private void assertStableRecordCount(KafkaClusterTestKit cluster, String topic,
+                                         int expectedCount, String message) throws Exception {
+        long deadline = System.currentTimeMillis() + 3 * METADATA_REFRESH_INTERVAL_MS;
+        while (System.currentTimeMillis() < deadline) {
+            var records = consumeRecords(cluster, topic, expectedCount);
+            assertEquals(expectedCount, records.size(), message);
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
     }
 }

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -139,6 +139,7 @@ class MirrorUtils:
             cmd += " --isolation-level %s" % isolation_level
         if group is not None:
             cmd += " --group %s" % group
+        cmd += " --consumer-property group.protocol=consumer"
         if cmd_suffix:
             cmd += cmd_suffix.replace("--command-config", "--consumer.config")
         cmd += " 2>/dev/null"

--- a/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
@@ -285,7 +285,11 @@ public abstract class ClusterMirrorCommand {
             Map<String, ClusterMirrorDescription> descriptions = result.allDescriptions().get();
 
             if (descriptions.isEmpty()) {
-                System.out.println("No mirror partitions found");
+                if (opts.hasJsonOption()) {
+                    System.out.print("[]");
+                } else {
+                    System.out.println("No mirror partitions found");
+                }
                 return;
             }
 


### PR DESCRIPTION
Fix ClusterMirrorCommand to return [] instead of a text message when --describe --json is used and no mirrors exist. Add integration test to verify that stopping a mirror topic does not cause syncGroupOffsets to overwrite consumer group offsets with stale source values.

Refactor AsyncClusterMirrorIntegrationTest to make it faster. We are down from 12 min (cl3) to 2.45 min with one additional test.