### PR TITLE
Surface failed partition error messages and allow manual restart

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
@@ -27,16 +27,16 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * A detailed description of a single mirror.
+ * A detailed description of a single cluster mirror.
  */
 @InterfaceStability.Evolving
-public class ClusterMirrorDescription {
+public class ClusterMirrorDesc {
     private final String mirrorName;
-    private final Map<String, Set<LeaderState>> topics;
+    private final Map<String, Set<LeaderStateDesc>> topics;
     private final Set<AclOperation> authorizedOperations;
 
-    public ClusterMirrorDescription(String mirrorName,
-                             Map<String, Set<LeaderState>> topics,
+    public ClusterMirrorDesc(String mirrorName,
+                             Map<String, Set<LeaderStateDesc>> topics,
                              Set<AclOperation> authorizedOperations) {
         this.mirrorName = mirrorName;
         this.topics = Collections.unmodifiableMap(topics);
@@ -47,13 +47,10 @@ public class ClusterMirrorDescription {
         return mirrorName;
     }
 
-    public Map<String, Set<LeaderState>> topics() {
+    public Map<String, Set<LeaderStateDesc>> topics() {
         return topics;
     }
 
-    /**
-     * Returns the authorized operations for this mirror, or null if not requested.
-     */
     public Set<AclOperation> authorizedOperations() {
         return authorizedOperations;
     }
@@ -62,7 +59,7 @@ public class ClusterMirrorDescription {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        ClusterMirrorDescription that = (ClusterMirrorDescription) o;
+        ClusterMirrorDesc that = (ClusterMirrorDesc) o;
         return Objects.equals(mirrorName, that.mirrorName) &&
                Objects.equals(topics, that.topics) &&
                Objects.equals(authorizedOperations, that.authorizedOperations);
@@ -75,35 +72,33 @@ public class ClusterMirrorDescription {
 
     @Override
     public String toString() {
-        return "ClusterMirrorDescription{" +
+        return "ClusterMirrorDesc{" +
                "mirrorName='" + mirrorName + '\'' +
                ", topics=" + topics +
                ", authorizedOperations=" + authorizedOperations +
                '}';
     }
 
-    /**
-     * Represents the mirroring state of the leader partition.
-     */
-    public static class LeaderState {
+    /** Represents the mirroring state of a leader partition. */
+    public static class LeaderStateDesc {
         private final TopicPartition topicPartition;
         private final long sourceOffset;
         private final long destinationOffset;
         private final long lag;
         private final String state;
+        private final short retryAttempt;
+        private final String errorMessage;
         private final int lastMirrorEpoch;
 
-        public LeaderState(TopicPartition topicPartition,
-                           long sourceOffset,
-                           long destinationOffset,
-                           long lag,
-                           String state,
-                           int lastMirrorEpoch) {
+        public LeaderStateDesc(TopicPartition topicPartition, long sourceOffset, long destinationOffset,
+                               long lag, String state, short retryAttempt, String errorMessage, int lastMirrorEpoch) {
             this.topicPartition = topicPartition;
             this.sourceOffset = sourceOffset;
             this.destinationOffset = destinationOffset;
             this.lag = lag;
             this.state = state;
+            this.retryAttempt = retryAttempt;
+            this.errorMessage = errorMessage;
             this.lastMirrorEpoch = lastMirrorEpoch;
         }
 
@@ -127,6 +122,14 @@ public class ClusterMirrorDescription {
             return state;
         }
 
+        public short retryAttempt() {
+            return retryAttempt;
+        }
+
+        public String errorMessage() {
+            return errorMessage;
+        }
+
         public int lastMirrorEpoch() {
             return lastMirrorEpoch;
         }
@@ -135,28 +138,32 @@ public class ClusterMirrorDescription {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            LeaderState that = (LeaderState) o;
+            LeaderStateDesc that = (LeaderStateDesc) o;
             return sourceOffset == that.sourceOffset &&
                    destinationOffset == that.destinationOffset &&
                    lag == that.lag &&
+                   retryAttempt == that.retryAttempt &&
                    lastMirrorEpoch == that.lastMirrorEpoch &&
                    Objects.equals(topicPartition, that.topicPartition) &&
-                   Objects.equals(state, that.state);
+                   Objects.equals(state, that.state) &&
+                   Objects.equals(errorMessage, that.errorMessage);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(topicPartition, sourceOffset, destinationOffset, lag, state, lastMirrorEpoch);
+            return Objects.hash(topicPartition, sourceOffset, destinationOffset, lag, state, retryAttempt, errorMessage, lastMirrorEpoch);
         }
 
         @Override
         public String toString() {
-            return "PartitionMirrorState{" +
+            return "LeaderStateDesc{" +
                    "topicPartition=" + topicPartition +
                    ", sourceOffset=" + sourceOffset +
                    ", destinationOffset=" + destinationOffset +
                    ", lag=" + lag +
                    ", state='" + state + '\'' +
+                   ", retryAttempt=" + retryAttempt +
+                   ", errorMessage='" + errorMessage + '\'' +
                    ", lastMirrorEpoch=" + lastMirrorEpoch +
                    '}';
         }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterMirrorsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterMirrorsResult.java
@@ -29,16 +29,16 @@ import java.util.Map;
  */
 @InterfaceStability.Evolving
 public class DescribeClusterMirrorsResult {
-    private final KafkaFuture<Map<String, ClusterMirrorDescription>> future;
+    private final KafkaFuture<Map<String, ClusterMirrorDesc>> future;
 
-    DescribeClusterMirrorsResult(KafkaFuture<Map<String, ClusterMirrorDescription>> future) {
+    DescribeClusterMirrorsResult(KafkaFuture<Map<String, ClusterMirrorDesc>> future) {
         this.future = future;
     }
 
     /**
      * Return a future which succeeds only if all the mirror descriptions succeed.
      */
-    public KafkaFuture<Map<String, ClusterMirrorDescription>> allDescriptions() {
+    public KafkaFuture<Map<String, ClusterMirrorDesc>> allDescriptions() {
         return future;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5208,7 +5208,7 @@ public class KafkaAdminClient extends AdminClient {
 
     @Override
     public DescribeClusterMirrorsResult describeClusterMirrors(Collection<String> mirrorNames, DescribeClusterMirrorsOptions options) {
-        final KafkaFutureImpl<Map<String, ClusterMirrorDescription>> all = new KafkaFutureImpl<>();
+        final KafkaFutureImpl<Map<String, ClusterMirrorDesc>> all = new KafkaFutureImpl<>();
         final long nowMetadata = time.milliseconds();
         final long deadline = calcDeadlineMs(nowMetadata, options.timeoutMs());
         // We query all brokers to get up-to-date lag AND state
@@ -5279,11 +5279,11 @@ public class KafkaAdminClient extends AdminClient {
         private final Set<String> requestedMirrors;
         private final boolean describeAll;
         private final HashSet<Node> remaining;
-        private final KafkaFutureImpl<Map<String, ClusterMirrorDescription>> allFuture;
+        private final KafkaFutureImpl<Map<String, ClusterMirrorDesc>> allFuture;
 
         DescribeClusterMirrorsResults(Collection<Node> brokers,
                                Collection<String> mirrorNames,
-                               KafkaFutureImpl<Map<String, ClusterMirrorDescription>> allFuture) {
+                               KafkaFutureImpl<Map<String, ClusterMirrorDesc>> allFuture) {
             this.partialDescriptions = new HashMap<>();
             this.requestedMirrors = new HashSet<>(mirrorNames);
             this.describeAll = mirrorNames.isEmpty();
@@ -5323,7 +5323,7 @@ public class KafkaAdminClient extends AdminClient {
 
         private synchronized void tryComplete() {
             if (remaining.isEmpty()) {
-                Map<String, ClusterMirrorDescription> descriptions = new HashMap<>(partialDescriptions.size());
+                Map<String, ClusterMirrorDesc> descriptions = new HashMap<>(partialDescriptions.size());
                 Throwable firstError = null;
                 for (Map.Entry<String, PartialMirrorDescription> entry : partialDescriptions.entrySet()) {
                     PartialMirrorDescription partial = entry.getValue();
@@ -5349,10 +5349,10 @@ public class KafkaAdminClient extends AdminClient {
             }
         }
 
-        // Accumulated ClusterMirrorDescription data from all brokers
+        // Accumulated ClusterMirrorDesc data from all brokers
         private static class PartialMirrorDescription {
             final String mirrorName;
-            final Map<String, Set<ClusterMirrorDescription.LeaderState>> topicPartitions;
+            final Map<String, Set<ClusterMirrorDesc.LeaderStateDesc>> topicPartitions;
             int authorizedOperations;
             boolean hasSuccess;
             Throwable error;
@@ -5386,18 +5386,20 @@ public class KafkaAdminClient extends AdminClient {
 
                 // Merge topic partitions
                 for (DescribeClusterMirrorsResponseData.TopicPartitions topic : mirror.topics()) {
-                    Set<ClusterMirrorDescription.LeaderState> partitions =
+                    Set<ClusterMirrorDesc.LeaderStateDesc> partitions =
                             topicPartitions.computeIfAbsent(topic.topicName(), k -> new HashSet<>());
 
                     for (DescribeClusterMirrorsResponseData.PartitionDetail partition : topic.partitions()) {
                         TopicPartition tp = new TopicPartition(topic.topicName(), partition.partitionIndex());
-                        ClusterMirrorDescription.LeaderState leaderState =
-                                new ClusterMirrorDescription.LeaderState(
+                        ClusterMirrorDesc.LeaderStateDesc leaderState =
+                                new ClusterMirrorDesc.LeaderStateDesc(
                                         tp,
                                         partition.sourceOffset(),
                                         partition.destinationOffset(),
                                         partition.lag(),
                                         partition.stateValue(),
+                                        partition.retryAttempt(),
+                                        partition.errorMessage(),
                                         partition.lastMirrorEpoch()
                                 );
                         partitions.add(leaderState);
@@ -5406,8 +5408,8 @@ public class KafkaAdminClient extends AdminClient {
 
             }
 
-            ClusterMirrorDescription toMirrorDescription() {
-                return new ClusterMirrorDescription(
+            ClusterMirrorDesc toMirrorDescription() {
+                return new ClusterMirrorDesc(
                         mirrorName,
                         topicPartitions,
                         validAclOperations(authorizedOperations)

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
@@ -51,6 +51,10 @@
             "about": "The lag (source offset - destination offset), or -1 if not yet available." },
           { "name": "StateValue", "type": "string", "versions": "0+",
             "about": "The partition state as a string value." },
+          { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",
+            "about": "The number of automatic retry attempts while in FAILED state." },
+          { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+            "about": "The error message when in FAILED state, or null if not applicable." },
           { "name": "LastMirrorEpoch", "type": "int32", "versions": "0+", "default": "-1",
             "about": "The last mirror leader epoch, or -1 if not available."
           }

--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -44,7 +44,9 @@
         { "name": "PreviousState", "type": "int8", "taggedVersions": "0+", "tag": 0, "default": 16,
           "about": "The mirror partition state before the last transition; UNKNOWN if not recorded." },
         { "name": "RetryAttempt", "type": "int16", "taggedVersions": "0+", "tag": 1, "default": 0,
-          "about": "The number of automatic retry attempts while in FAILED state." }
+          "about": "The number of automatic retry attempts while in FAILED state." },
+        { "name": "ErrorMessage", "type": "string", "taggedVersions": "0+", "tag": 2, "nullableVersions": "0+", "default": "null",
+          "about": "The error message when in FAILED state, or null if not applicable." }
       ]}
     ]}
   ]

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1409,17 +1409,17 @@ public class MockAdminClient extends AdminClient {
 
     @Override
     public synchronized DescribeClusterMirrorsResult describeClusterMirrors(Collection<String> mirrorNames, DescribeClusterMirrorsOptions options) {
-        Map<String, ClusterMirrorDescription> descriptions = new HashMap<>();
+        Map<String, ClusterMirrorDesc> descriptions = new HashMap<>();
         for (String mirrorName : mirrorNames) {
             // Return empty description for mock
-            ClusterMirrorDescription description = new ClusterMirrorDescription(
+            ClusterMirrorDesc description = new ClusterMirrorDesc(
                 mirrorName,
                 Collections.emptyMap(),
                 null
             );
             descriptions.put(mirrorName, description);
         }
-        KafkaFutureImpl<Map<String, ClusterMirrorDescription>> future = new KafkaFutureImpl<>();
+        KafkaFutureImpl<Map<String, ClusterMirrorDesc>> future = new KafkaFutureImpl<>();
         future.complete(descriptions);
         return new DescribeClusterMirrorsResult(future);
     }

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -18,9 +18,11 @@ package kafka.server.mirror;
 
 import kafka.server.KafkaConfig;
 import kafka.server.ReplicaManager;
+import kafka.server.mirror.ClusterMirrorUtils.FailedPartitionInfo;
+import kafka.server.mirror.ClusterMirrorUtils.PartitionKey;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.admin.ClusterMirrorDescription;
+import org.apache.kafka.clients.admin.ClusterMirrorDesc;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.compress.Compression;
@@ -147,7 +149,7 @@ public class ClusterMirrorCoordinator {
         log.info("Starting up.");
 
         metadataManager.initialize(
-                (mirrorName, tp, state) -> transitionTo(mirrorName, tp, state),
+                (mirrorName, tp, state, errorMessage) -> transitionTo(mirrorName, tp, state, errorMessage),
                 this::tombstoneMirrorRecords,
                 this::getCoordinatorPartitionByKey,
                 this::getCoordinatorPartitionByName);
@@ -273,17 +275,10 @@ public class ClusterMirrorCoordinator {
                                 String clusterName = readMirrorNameFromKey(record.key());
                                 if (record.hasValue()) {
                                     ClusterMirrorUtils.PartitionStateLogEntry value = readMirrorPartitionStateValue(record.value());
-                                    ClusterMirrorUtils.PartitionKey pk = new ClusterMirrorUtils.PartitionKey(
-                                            clusterName, value.topic(), value.partition());
+                                    PartitionKey pk = new PartitionKey(clusterName, value.topic(), value.partition());
                                     metadataManager.updatePartitionState(pk, value.state());
                                     TopicPartition tp = new TopicPartition(value.topic(), value.partition());
-                                    if (value.state() == MirrorPartitionState.FAILED && value.retryAttempt() > 0) {
-                                        metadataManager.failedRetryAttempts().put(tp, value.retryAttempt());
-                                        metadataManager.partitionPreviousStates().put(pk, value.previousState());
-                                    } else {
-                                        metadataManager.failedRetryAttempts().remove(tp);
-                                        metadataManager.partitionPreviousStates().remove(pk);
-                                    }
+                                    restoreFailedState(tp, value.state(), value.retryAttempt(), value.errorMessage(), value.previousState());
                                 } else {
                                     metadataManager.removeMirrorStates(clusterName);
                                 }
@@ -319,9 +314,9 @@ public class ClusterMirrorCoordinator {
                     .whenComplete((v, ex) -> {
                         if (ex != null) {
                             log.error("Failed to bump leader epoch for {}", topicPartitions, ex);
-                            transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED);
+                            transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED, ex.getMessage());
                         } else {
-                            transitionTo(mirrorName, topicPartitions, MirrorPartitionState.MIRRORING);
+                            transitionTo(mirrorName, topicPartitions, MirrorPartitionState.MIRRORING, null);
                         }
                     });
                 break;
@@ -332,7 +327,7 @@ public class ClusterMirrorCoordinator {
             case PAUSING:
                 log.info("PAUSING mirroring for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                topicPartitions.forEach(tp -> transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED));
+                topicPartitions.forEach(tp -> transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED, null));
                 break;
             case PAUSED:
                 log.info("PAUSED mirroring for topics {}.", topicPartitions);
@@ -372,16 +367,27 @@ public class ClusterMirrorCoordinator {
         }
     }
 
-    /** Tracks retry attempts and previous state for FAILED transitions; clears them on STOPPED/PAUSED. */
-    private void updateRetryAttemptsAndPrevState(String mirrorName, TopicPartition tp, MirrorPartitionState currentState, MirrorPartitionState newState) {
-        ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
+    private void restoreFailedState(TopicPartition tp, MirrorPartitionState state, short retryAttempt,
+                                    String errorMessage, MirrorPartitionState previousState) {
+        if (state == MirrorPartitionState.FAILED) {
+            metadataManager.failedPartitionInfo().put(tp,
+                    new FailedPartitionInfo(retryAttempt, errorMessage, previousState));
+        } else {
+            metadataManager.failedPartitionInfo().remove(tp);
+        }
+    }
+
+    private void updateFailedState(TopicPartition tp, MirrorPartitionState currentState,
+                                   MirrorPartitionState newState, String errorMessage) {
         if (newState == MirrorPartitionState.FAILED) {
-            metadataManager.failedRetryAttempts().merge(tp, 1, Integer::sum);
-            metadataManager.partitionPreviousStates().putIfAbsent(key, currentState);
-        } else if (newState == MirrorPartitionState.STOPPED
+            metadataManager.failedPartitionInfo().merge(tp,
+                    new FailedPartitionInfo((short) 1, errorMessage, currentState),
+                    (old, next) -> new FailedPartitionInfo(
+                            (short) (old.retryAttempt() + 1), next.errorMessage(), old.previousState()));
+        } else if (newState == MirrorPartitionState.LOG_TRUNCATION
+                || newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
-            metadataManager.failedRetryAttempts().remove(tp);
-            metadataManager.partitionPreviousStates().remove(key);
+            metadataManager.failedPartitionInfo().remove(tp);
         }
     }
 
@@ -389,8 +395,9 @@ public class ClusterMirrorCoordinator {
     private void scheduleFailedRetries(String mirrorName, Set<TopicPartition> topicPartitions) {
         int maxAttempts = brokerConfig.mirrorConfig().failedRetryMaxAttempts();
         topicPartitions.forEach(tp -> {
-            int attempt = metadataManager.failedRetryAttempts().getOrDefault(tp, 0);
-            if (maxAttempts > 0 && attempt >= maxAttempts) {
+            FailedPartitionInfo fpi = metadataManager.failedPartitionInfo().get(tp);
+            int attempt = fpi != null ? fpi.retryAttempt() : 1;
+            if (attempt >= maxAttempts) {
                 log.error("Partition {} exceeded max retry attempts ({}), requires manual intervention.", tp, maxAttempts);
                 return;
             }
@@ -402,20 +409,19 @@ public class ClusterMirrorCoordinator {
                     brokerConfig.mirrorConfig().failedRetryMaxBackoffMs(),
                     CommonClientConfigs.RETRY_BACKOFF_JITTER);
             long delay = failedRetryBackoff.backoff(attempt);
-            MirrorPartitionState targetState = metadataManager.partitionPreviousStates()
-                    .getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition()), MirrorPartitionState.MIRRORING);
+            MirrorPartitionState targetState = fpi != null ? fpi.previousState() : MirrorPartitionState.MIRRORING;
             log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
-            scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
+            scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState, null), delay);
         });
     }
 
-    /** Validates and persists partition state, then executes transition actions. */
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState newState) {
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
+                             MirrorPartitionState newState, String errorMessage) {
         topicPartitions.forEach(tp -> {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
-                updateRetryAttemptsAndPrevState(mirrorName, tp, currentState, newState);
+                updateFailedState(tp, currentState, newState, errorMessage);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
@@ -712,7 +718,7 @@ public class ClusterMirrorCoordinator {
                                 log.error("Failed to write partition state to coordinator: {}", pr.error.message());
                                 future.completeExceptionally(pr.error.exception());
                             } else {
-                                metadataManager.updatePartitionState(new ClusterMirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
+                                metadataManager.updatePartitionState(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
                                 future.complete(Optional.of(topicPartition));
                             }
                             return null;
@@ -730,7 +736,7 @@ public class ClusterMirrorCoordinator {
             metadataManager.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
                     res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
                         if (par.errorCode() == Errors.NONE.code()) {
-                            metadataManager.updatePartitionState(new ClusterMirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
+                            metadataManager.updatePartitionState(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
                             future.complete(Optional.of(topicPartition));
                         } else {
                             // propagate remote coordinator errors to trigger retry
@@ -746,7 +752,7 @@ public class ClusterMirrorCoordinator {
     /** Schedules truncation to align replicas with last mirrored epoch. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
         final Consumer<TopicPartition> truncateCallback =
-            partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING);
+            partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING, null);
         scheduler.scheduleOnce("LastMirrorEpochsTruncation",
             () -> {
                 try {
@@ -761,12 +767,12 @@ public class ClusterMirrorCoordinator {
                                     replicaManager.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
                                 } else {
                                     log.warn("Failed to truncate to last mirrored epoch for mirror {}", mirrorName, error);
-                                    transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED);
+                                    transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED, error.getMessage());
                                 }
                                 return;
                             }
 
-                            ClusterMirrorDescription description = descriptions.get(mirrorName);
+                            ClusterMirrorDesc description = descriptions.get(mirrorName);
                             if (description == null) {
                                 log.warn("Mirror {} not found in source cluster. Replication will be one-way without failback",
                                     mirrorName);
@@ -793,11 +799,11 @@ public class ClusterMirrorCoordinator {
                             }
 
                             replicaManager.maybeTruncateForLeaderEpoch(epochs,
-                                    partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING));
+                                    partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING, null));
                         });
                 } catch (Exception e) {
                     log.warn("Failed to truncate to last mirror epochs for mirror {}", mirrorName, e);
-                    transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED);
+                    transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED, e.getMessage());
                 }
             }, 0);
     }
@@ -827,7 +833,7 @@ public class ClusterMirrorCoordinator {
                 }
             }
             if (!succeeded.isEmpty()) {
-                transitionTo(mirrorName, succeeded, MirrorPartitionState.STOPPED);
+                transitionTo(mirrorName, succeeded, MirrorPartitionState.STOPPED, null);
             }
             if (!failed.isEmpty()) {
                 scheduler.scheduleOnce("MirrorPidResetRetry", () -> writeMirrorPidResetAndStop(mirrorName, failed), 5000);
@@ -895,22 +901,20 @@ public class ClusterMirrorCoordinator {
     }
 
     private CoordinatorRecord buildPartitionStateRecord(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
-        short retryAttempt = (state == MirrorPartitionState.FAILED)
-                ? metadataManager.failedRetryAttempts().getOrDefault(topicPartition, 0).shortValue()
-                : 0;
+        FailedPartitionInfo fpi = metadataManager.failedPartitionInfo().get(topicPartition);
         var key = new MirrorPartitionStateKey().setMirrorName(mirrorName);
         var val = new MirrorPartitionStateValue()
                 .setTopicName(topicPartition.topic())
                 .setPartition(topicPartition.partition())
                 .setState(state.value())
-                .setPreviousState(metadataManager.partitionPreviousStates().getOrDefault(
-                        new ClusterMirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), MirrorPartitionState.UNKNOWN).value())
-                .setRetryAttempt(retryAttempt);
+                .setPreviousState(fpi != null ? fpi.previousState().value() : MirrorPartitionState.UNKNOWN.value())
+                .setRetryAttempt(fpi != null ? fpi.retryAttempt() : 0)
+                .setErrorMessage(fpi != null ? fpi.errorMessage() : null);
         var apiVersion = new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);
     }
 
-    private static CoordinatorRecord buildLastMirrorEpochsRecord(String mirrorName, Map<ClusterMirrorUtils.PartitionKey, Integer> offsets) {
+    private static CoordinatorRecord buildLastMirrorEpochsRecord(String mirrorName, Map<PartitionKey, Integer> offsets) {
         Map<String, Map<Integer, Integer>> grouped = new HashMap<>();
         offsets.forEach((pk, value) -> grouped.computeIfAbsent(pk.topic(), k -> new HashMap<>()).put(pk.partition(), value));
 
@@ -951,7 +955,7 @@ public class ClusterMirrorCoordinator {
             // No local coordinator partitions — clear cached entries
             states.keySet().forEach(tp ->
                 metadataManager.removePartitionState(
-                    new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition())));
+                    new PartitionKey(mirrorName, tp.topic(), tp.partition())));
             return;
         }
 
@@ -983,7 +987,7 @@ public class ClusterMirrorCoordinator {
                                 mirrorTopicPartition, partitionRes.error.message());
                         } else {
                             tps.forEach(tp -> metadataManager.removePartitionState(
-                                new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition())));
+                                new PartitionKey(mirrorName, tp.topic(), tp.partition())));
                         }
                         return null;
                     });
@@ -1029,7 +1033,8 @@ public class ClusterMirrorCoordinator {
             MirrorPartitionStateValue value = new MirrorPartitionStateValue(new ByteBufferAccessor(buffer), version);
             return new ClusterMirrorUtils.PartitionStateLogEntry(value.topicName(), value.partition(),
                     MirrorPartitionState.fromValue(value.state()),
-                    MirrorPartitionState.fromValue(value.previousState()), value.retryAttempt());
+                    MirrorPartitionState.fromValue(value.previousState()), value.retryAttempt(),
+                    value.errorMessage());
         } else {
             throw new IllegalStateException("Unsupported partition state value version: " + version);
         }
@@ -1058,6 +1063,10 @@ public class ClusterMirrorCoordinator {
     /** Returns the current partition states for all partitions in the given mirror. */
     public Map<TopicPartition, MirrorPartitionState> getMirrorStates(String mirrorName) {
         return metadataManager.getMirrorStates(mirrorName);
+    }
+
+    public Map<TopicPartition, FailedPartitionInfo> getFailedPartitionInfo() {
+        return metadataManager.failedPartitionInfo();
     }
 
     public void deleteClusterMirror(String mirrorName, Consumer<Optional<Errors>> callback) {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
@@ -75,7 +75,8 @@ public final class ClusterMirrorUtils {
     public record PartitionStateInfo(int partition, MirrorPartitionState state, Integer leaderEpoch) { }
 
     public record PartitionStateLogEntry(String topic, int partition, MirrorPartitionState state,
-                                         MirrorPartitionState previousState, int retryAttempt) { }
+                                         MirrorPartitionState previousState, short retryAttempt,
+                                         String errorMessage) { }
 
     public record PartitionKey(String mirrorName, String topic, int partition) { }
 
@@ -83,8 +84,10 @@ public final class ClusterMirrorUtils {
 
     public record LeaderInfo(Node node, int leaderEpoch) { }
 
+    public record FailedPartitionInfo(short retryAttempt, String errorMessage, MirrorPartitionState previousState) { }
+
     interface StateTransitioner {
-        void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state);
+        void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage);
     }
 
     interface StateTransitionCallback {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -20,12 +20,14 @@ import kafka.log.LogManager;
 import kafka.server.KafkaConfig;
 import kafka.server.NetworkUtils;
 import kafka.server.ReplicaManager;
+import kafka.server.mirror.ClusterMirrorUtils.FailedPartitionInfo;
+import kafka.server.mirror.ClusterMirrorUtils.PartitionKey;
 
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.ClusterMirrorDescription;
+import org.apache.kafka.clients.admin.ClusterMirrorDesc;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.DescribeClusterMirrorsResult;
@@ -175,27 +177,25 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private volatile Admin dstAdmin; // group offset and ACLs sync
 
     // Map from mirror name to cluster id. The cluster id is represented as a String because KIP-78
-    // does not mandate the use of UUIDs for it and assuming so may break compatibility with existing clusters
+    // does not mandate the use of UUIDs for it and assuming so may break compatibility with existing clusters.
     private final Map<String, String> sourceClusterIds = new ConcurrentHashMap<>();
+
     private final Map<String, Map<TopicPartition, ClusterMirrorUtils.LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
-    private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
-    private final Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates = new ConcurrentHashMap<>();
-    private final Map<ClusterMirrorUtils.PartitionKey, Integer> lastMirrorEpochs = new ConcurrentHashMap<>();
+    private final Map<PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
+    private final Map<PartitionKey, Integer> lastMirrorEpochs = new ConcurrentHashMap<>();
     private final Map<MirrorPartitionState, AtomicLong> partitionStateCounts = new ConcurrentHashMap<>();
+    private final Map<TopicPartition, FailedPartitionInfo> failedPartitionInfo = new ConcurrentHashMap<>();
+    private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
+    private final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
+
+    // Leader epoch bumps require a request to the controller followed by a metadata log fetch.
+    // The bump must be confirmed on the broker side before we can write the PID reset control record.
+    private final Set<ClusterMirrorUtils.LeaderEpochBump> pendingLeaderEpochBumps = ConcurrentHashMap.newKeySet();
 
     private Optional<ClusterMirrorUtils.StateTransitioner> stateTransitioner = Optional.empty();
     private Optional<Consumer<String>> tombstoneWriter = Optional.empty();
     private Optional<Function<ClusterMirrorRecordKey, Integer>> coordPartitionFinderByKey = Optional.empty();
     private Optional<Function<String, Integer>> coordPartitionFinderByName = Optional.empty();
-
-    // lets the transition handler skip partitions that are already being processed
-    private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
-    private final Map<TopicPartition, Integer> failedRetryAttempts = new ConcurrentHashMap<>();
-    private final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
-
-    // Leader epoch bumps require a request to the controller followed by a metadata log fetch.
-    // The bump must be confirmed on the broker side before we can write the PID reset record.
-    private final Set<ClusterMirrorUtils.LeaderEpochBump> pendingLeaderEpochBumps = ConcurrentHashMap.newKeySet();
 
     private final AtomicLong metadataRefreshError;
     private final AtomicLong topicConfigSyncError;
@@ -293,6 +293,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private Admin getOrCreateSourceAdmin(String mirrorName) {
         return srcAdmins.computeIfAbsent(mirrorName, k -> {
             Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
+            props.put(AdminClientConfig.CLIENT_ID_CONFIG, "mirror-src-admin-" + k + "-" + nodeId);
             return Admin.create(props);
         });
     }
@@ -311,12 +312,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
-     * Called when cluster metadata is updated.
+     * Called when cluster metadata is updated and it is executed in the KRaft metadata publisher thread.
      * Detects mirror partition leadership changes and triggers state transitions via batched coordinator reads.
+     * On connection config changes, source connections are recreated, source metadata is fetched eagerly,
+     * and fetchers are re-created for affected MIRRORING partitions.
      *
-     * This is executed in the KRaft metadata publisher thread.
-     * Must be called after ReplicaManager#applyDelta.
-     * The metadata cache can't be used here because it is updated concurrently.
+     * This method must be called after ReplicaManager#applyDelta.
+     * The metadataCache can't be used here because it is updated concurrently.
      */
     @Override
     public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage, LoaderManifest manifest) {
@@ -324,50 +326,156 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
 
-        // Caching the metadata image for query purpose
         this.metadataImage = newImage;
 
         Set<String> reconnectedMirrors = maybeRecreateSourceConnection(delta, newImage);
-
-        // Get all mirror partition leaders on this node based on the delta
-        Set<TopicPartition> mirrorLeaders = getMirrorLeadersAndClearFollowerStates(delta, newImage);
-
-        // After a connection config change (e.g. bootstrap.servers), fetchers were removed
-        // and must be recreated by re-evaluating MIRRORING partitions for the affected mirrors
-        if (!reconnectedMirrors.isEmpty()) {
-            partitionStates.forEach((key, state) -> {
-                if (reconnectedMirrors.contains(key.mirrorName()) && state == MirrorPartitionState.MIRRORING) {
-                    mirrorLeaders.add(new TopicPartition(key.topic(), key.partition()));
-                }
-            });
-        }
+        Set<TopicPartition> mirrorLeaders = collectMirrorLeaderChanges(delta, newImage, reconnectedMirrors);
 
         if (mirrorLeaders.isEmpty()) {
             return;
         }
 
-        log.info("onMetadataUpdate: {}", mirrorLeaders);
+        log.info("Processing metadata update for {} mirror leader partition(s): {}", mirrorLeaders.size(), mirrorLeaders);
 
-        // Collect remote coordinator partitions grouped by mirrorName for batched reads
+        processStateTransitions(mirrorLeaders, newImage);
+        maybeCompletePendingEpochBumps();
+    }
+
+    /**
+     * Handles mirror config changes from the metadata delta. When a connection config changes
+     * (e.g. bootstrap.servers), closes the old source AdminClient, removes fetchers, and eagerly
+     * fetches source metadata so fetchers can be recreated immediately. When a mirror is deleted,
+     * writes tombstone records and cleans up all cached state.
+     *
+     * @return names of mirrors whose source connections were recreated (excludes deleted mirrors)
+     */
+    private Set<String> maybeRecreateSourceConnection(MetadataDelta delta, MetadataImage newImage) {
+        Set<String> reconnectedMirrors = new HashSet<>();
+        if (delta.configsDelta() != null) {
+            delta.configsDelta().changes().entrySet().stream()
+                    .filter(e -> e.getKey().type() == ConfigResource.Type.CLUSTER_MIRROR)
+                    .forEach(e -> {
+                        String mirrorName = e.getKey().name();
+                        boolean mirrorDeleted = newImage.configs().configProperties(e.getKey()).isEmpty();
+                        if (mirrorDeleted) {
+                            log.info("Mirror '{}' has been deleted. Writing tombstone records.", mirrorName);
+                            tombstoneWriter.ifPresent(h -> h.accept(mirrorName));
+                        }
+
+                        boolean connectionConfigChanged = e.getValue().changes().keySet().stream()
+                                .anyMatch(key -> !NON_CONNECTION_CONFIGS.contains(key));
+                        if (connectionConfigChanged) {
+                            log.info("Mirror '{}' has connection config changed. Recreating connections.", mirrorName);
+                        }
+                        if (connectionConfigChanged || mirrorDeleted) {
+                            sourceLeaders.remove(mirrorName);
+                            sourceClusterIds.remove(mirrorName);
+                            Admin admin = srcAdmins.remove(mirrorName);
+                            if (admin != null) {
+                                admin.close(Duration.ZERO);
+                            }
+                            var mirrorFetcherManager = replicaManagerSupplier.get().mirrorFetcherManager();
+                            mirrorFetcherManager.removeFetchersForMirror(mirrorName);
+                            mirrorFetcherManager.shutdownIdleFetcherThreads();
+                            if (!mirrorDeleted) {
+                                reconnectedMirrors.add(mirrorName);
+                            }
+                        }
+                    });
+        }
+        return reconnectedMirrors;
+    }
+
+    /**
+     * Collects mirror partitions that need state transitions and cleans up state for lost leadership.
+     * Three phases:
+     * 1. Collect new mirror leaders from the topics delta (leadership gains and mirror state changes)
+     * 2. Clean up cached state for partitions where this broker lost leadership
+     * 3. Re-add MIRRORING partitions for reconnected mirrors so their fetchers get recreated
+     */
+    private Set<TopicPartition> collectMirrorLeaderChanges(MetadataDelta delta, MetadataImage image,
+                                                           Set<String> reconnectedMirrors) {
+        Set<TopicPartition> mirrorLeaderPartitions = new HashSet<>();
+
+        if (delta.topicsDelta() != null) {
+            LocalReplicaChanges localReplicaChanges = delta.topicsDelta().localChanges(nodeId);
+
+            // Phase 1: collect partitions where this broker gained mirror leadership
+            localReplicaChanges.leaders().keySet().forEach(tp -> {
+                String mirrorName = image.topics().getTopic(tp.topic()).mirrorName();
+                if (mirrorName != null && !mirrorName.isBlank()) {
+                    mirrorLeaderPartitions.add(tp);
+                }
+            });
+            localReplicaChanges.mirrorTopicStates().keySet().forEach(topicId -> {
+                TopicImage topicImage = image.topics().getTopic(topicId);
+                if (topicImage != null) {
+                    topicImage.partitions().forEach((partitionId, partition) -> {
+                        if (partition.leader == nodeId) {
+                            mirrorLeaderPartitions.add(new TopicPartition(topicImage.name(), partitionId));
+                        }
+                    });
+                }
+            });
+
+            // Phase 2: clean up state for partitions where this broker lost leadership
+            localReplicaChanges.followers().keySet().forEach(tp -> {
+                String mirrorName = image.topics().getTopic(tp.topic()).mirrorName();
+                if (mirrorName == null || mirrorName.isBlank()) {
+                    return;
+                }
+                pendingPartitionStates.remove(tp);
+                pendingLeaderEpochBumps.removeIf(bump -> {
+                    if (bump.partitionToEpoch().containsKey(tp)) {
+                        bump.future().completeExceptionally(new IllegalStateException("Not leader anymore for " + tp));
+                        return true;
+                    }
+                    return false;
+                });
+                if (!isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
+                    PartitionKey key = new PartitionKey(mirrorName, tp.topic(), tp.partition());
+                    removePartitionState(key);
+                    lastMirrorEpochs.remove(key);
+                }
+            });
+        }
+
+        // Phase 3: re-add MIRRORING partitions for mirrors whose source connection was recreated
+        if (!reconnectedMirrors.isEmpty()) {
+            log.info("Re-evaluating MIRRORING partitions for reconnected mirrors: {}", reconnectedMirrors);
+            partitionStates.forEach((key, state) -> {
+                if (reconnectedMirrors.contains(key.mirrorName()) && state == MirrorPartitionState.MIRRORING) {
+                    mirrorLeaderPartitions.add(new TopicPartition(key.topic(), key.partition()));
+                }
+            });
+        }
+
+        return mirrorLeaderPartitions;
+    }
+
+    /**
+     * Applies state transitions for mirror leader partitions. Local coordinator partitions are handled
+     * inline. Remote coordinator partitions are grouped by mirror for batched reads, then transitions
+     * are applied from the responses.
+     */
+    private void processStateTransitions(Set<TopicPartition> mirrorLeaders, MetadataImage newImage) {
         Map<String, Map<String, Set<Integer>>> remotePartitionsByMirror = new HashMap<>();
         Map<String, Map<TopicPartition, Boolean>> remoteStopFlags = new HashMap<>();
         Map<String, Map<TopicPartition, Boolean>> remotePauseFlags = new HashMap<>();
 
         mirrorLeaders.forEach(tp -> {
             TopicImage topicImage = newImage.topics().getTopic(tp.topic());
-            String rawMirrorName = topicImage.mirrorName();
+            String mirrorName = topicImage.mirrorName();
             int desiredMirrorState = topicImage.desiredMirrorState();
             boolean stopRequested = desiredMirrorState == MirrorPartitionState.STOPPED.value();
             boolean pauseRequested = desiredMirrorState == MirrorPartitionState.PAUSED.value();
-            String mirrorName = rawMirrorName;
 
-            ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
+            PartitionKey key = new PartitionKey(mirrorName, tp.topic(), tp.partition());
             if (isLocalCoordinator(key.mirrorName(), key.topic(), key.partition())) {
-                // Handle local coordinator partitions inline (no network call needed)
                 MirrorPartitionState curState = partitionStates.getOrDefault(key, MirrorPartitionState.UNKNOWN);
-                applyMirrorStateTransition(key.mirrorName(), tp, curState, null, stopRequested, pauseRequested);
+                log.debug("Local transition for {} (current: {})", tp, curState);
+                applyStateTransition(key.mirrorName(), tp, curState, null, stopRequested, pauseRequested);
             } else {
-                // Collect for batched remote read
                 remotePartitionsByMirror
                         .computeIfAbsent(mirrorName, k -> new HashMap<>())
                         .computeIfAbsent(tp.topic(), k -> new HashSet<>())
@@ -381,10 +489,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
         });
 
-        // Send one batched read per mirrorName (readStatesFromRemoteCoordinator handles per-node batching internally)
         remotePartitionsByMirror.forEach((mirrorName, partitions) -> {
             Map<TopicPartition, Boolean> stopFlags = remoteStopFlags.get(mirrorName);
             Map<TopicPartition, Boolean> pauseFlags = remotePauseFlags.get(mirrorName);
+            log.debug("Reading remote coordinator state for mirror '{}': {}", mirrorName, partitions);
             readStatesFromRemoteCoordinator(mirrorName, partitions, res ->
                     res.data().topics().forEach(topic ->
                             topic.partitions().forEach(partition -> {
@@ -397,16 +505,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 MirrorPartitionState state = MirrorPartitionState.fromValue(partition.state());
                                 boolean stopRequested = stopFlags.getOrDefault(resTp, false);
                                 boolean pauseRequested = pauseFlags.getOrDefault(resTp, false);
-                                ClusterMirrorUtils.PartitionKey mpk = new ClusterMirrorUtils.PartitionKey(mirrorName, resTp.topic(), resTp.partition());
+                                PartitionKey mpk = new PartitionKey(mirrorName, resTp.topic(), resTp.partition());
                                 MirrorPartitionState curState = partitionStates.getOrDefault(mpk, MirrorPartitionState.UNKNOWN);
-                                applyMirrorStateTransition(mirrorName, resTp, curState, state, stopRequested, pauseRequested);
+                                applyStateTransition(mirrorName, resTp, curState, state, stopRequested, pauseRequested);
                             })));
         });
-
-        if (delta.topicsDelta() != null) {
-            clearFollowersState(delta.topicsDelta().localChanges(nodeId).followers().keySet(), newImage);
-        }
-        maybeCompletePendingEpochBumps();
     }
 
     @Override
@@ -431,9 +534,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     void clearCache() {
-        failedRetryAttempts.clear();
+        failedPartitionInfo.clear();
         partitionStates.clear();
-        partitionPreviousStates.clear();
         partitionStateCounts.clear();
         lastMirrorEpochs.clear();
         sourceClusterIds.clear();
@@ -447,74 +549,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return pendingPartitionStates;
     }
 
-    /** Returns the per-partition count of consecutive failed retry attempts. */
-    public Map<TopicPartition, Integer> failedRetryAttempts() {
-        return failedRetryAttempts;
+    public Map<TopicPartition, FailedPartitionInfo> failedPartitionInfo() {
+        return failedPartitionInfo;
     }
 
-    /** Returns the previous state of each partition before its last transition. */
-    public Map<ClusterMirrorUtils.PartitionKey, MirrorPartitionState> partitionPreviousStates() {
-        return partitionPreviousStates;
-    }
-
-    /** Transitions a mirror partition to the given state via the configured state transitioner. */
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state) {
-        stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state));
-    }
-
-    private void retryPendingTombstoneWrites() {
-        if (tombstoneWriter.isEmpty()) {
-            log.warn("Mirror deletion handler not configured. Tombstone record writes will be skipped.");
-            return;
-        }
-        Set<String> configuredMirrors = getConfiguredMirrors();
-        Set<String> staleMirrors = partitionStates.keySet().stream()
-            .map(ClusterMirrorUtils.PartitionKey::mirrorName)
-            .filter(name -> !configuredMirrors.contains(name))
-            .collect(Collectors.toSet());
-        for (String mirrorName : staleMirrors) {
-            log.info("Found stale partition states for deleted mirror '{}'. Writing tombstones.", mirrorName);
-            tombstoneWriter.ifPresent(h -> h.accept(mirrorName));
-        }
-    }
-
-    private Set<String> maybeRecreateSourceConnection(MetadataDelta delta, MetadataImage newImage) {
-        Set<String> reconnectedMirrors = new HashSet<>();
-        if (delta.configsDelta() != null) {
-            delta.configsDelta().changes().entrySet().stream()
-                    .filter(e -> e.getKey().type() == ConfigResource.Type.CLUSTER_MIRROR)
-                    .forEach(e -> {
-                        String mirrorName = e.getKey().name();
-                        boolean mirrorDeleted = newImage.configs()
-                                .configProperties(e.getKey()).isEmpty();
-                        if (mirrorDeleted) {
-                            log.info("Mirror '{}' has been deleted. Writing tombstone records and recreating connections.", mirrorName);
-                            tombstoneWriter.ifPresent(h -> h.accept(mirrorName));
-                        }
-
-                        boolean connectionConfigChanged = e.getValue().changes().keySet().stream()
-                                .anyMatch(key -> !NON_CONNECTION_CONFIGS.contains(key));
-
-                        if (connectionConfigChanged) {
-                            log.info("Mirror '{}' has connection config changed. Recreating connections.", mirrorName);
-                        }
-                        if (connectionConfigChanged || mirrorDeleted) {
-                            sourceLeaders.remove(mirrorName);
-                            sourceClusterIds.remove(mirrorName);
-                            Admin admin = srcAdmins.remove(mirrorName);
-                            if (admin != null) {
-                                admin.close(Duration.ZERO);
-                            }
-                            var mirrorFetcherManager = replicaManagerSupplier.get().mirrorFetcherManager();
-                            mirrorFetcherManager.removeFetchersForMirror(mirrorName);
-                            mirrorFetcherManager.shutdownIdleFetcherThreads();
-                            if (!mirrorDeleted) {
-                                reconnectedMirrors.add(mirrorName);
-                            }
-                        }
-                    });
-        }
-        return reconnectedMirrors;
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage) {
+        stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state, errorMessage));
     }
 
     /**
@@ -530,51 +570,61 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      *
      * When stopRequested=false and pauseRequested=false:
      *   1. if it's in PAUSED state, we should move it to MIRRORING state. It will happen when users resume mirroring
-     *   2. if it's in UNKNOWN or STOPPED state, we should move it to LOG_TRUNCATION state. It will happen when users startMirrorTopics
+     *   2. if it's in UNKNOWN, STOPPED, or FAILED state, we should move it to LOG_TRUNCATION state.
+     *      UNKNOWN/STOPPED happens on startMirrorTopics. FAILED happens on manual restart after retries are exhausted.
      *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should continue to complete the process in previous leader
      */
-    private void applyMirrorStateTransition(String mirrorName, TopicPartition tp,
-                                            MirrorPartitionState curState, MirrorPartitionState fetchedState,
-                                            boolean stopRequested, boolean pauseRequested) {
+    private void applyStateTransition(String mirrorName, TopicPartition tp,
+                                      MirrorPartitionState curState, MirrorPartitionState fetchedState,
+                                      boolean stopRequested, boolean pauseRequested) {
         stateTransitioner.ifPresent(t -> {
             if (stopRequested) {
                 if (curState != MirrorPartitionState.STOPPED) {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPING);
+                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPING, null);
                 } else {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED);
+                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED, null);
                 }
             } else if (pauseRequested) {
                 if (curState != MirrorPartitionState.PAUSED) {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSING);
+                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSING, null);
                 } else {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED);
+                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED, null);
                 }
             } else if (curState == MirrorPartitionState.PAUSED) {
-                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.MIRRORING);
+                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.MIRRORING, null);
             } else if (curState == MirrorPartitionState.UNKNOWN
-                    || curState == MirrorPartitionState.STOPPED) {
-                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
+                    || curState == MirrorPartitionState.STOPPED
+                    || curState == MirrorPartitionState.FAILED) {
+                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION, null);
             } else {
-                t.transitionTo(mirrorName, Set.of(tp), fetchedState != null ? fetchedState : curState);
+                t.transitionTo(mirrorName, Set.of(tp), fetchedState != null ? fetchedState : curState, null);
             }
         });
     }
 
+    public void scheduleSourceMetadataSync(String mirrorName) {
+        scheduler.scheduleOnce("SourceMetadataSync", () -> {
+            syncTopicMetadata(mirrorName);
+        });
+    }
 
     /** Periodic metadata refresh entry point. */
     void runMetadataRefresh() {
+        // retry the pending tombstone writes first to make sure they are all clean up even if no mirror existed
+        retryPendingTombstoneWrites();
+
         Set<String> mirrors = getConfiguredMirrors();
         if (mirrors.isEmpty()) {
             return;
         }
 
-        log.info("Running metadata refresh for mirrors: {}", mirrors);
+        log.info("Refreshing metadata for mirrors: {}", mirrors);
 
         for (String mirrorName : mirrors) {
             try {
                 validateSourceClusterId(mirrorName);
-                var topicsState = syncSourceTopicsState(mirrorName);
-                syncCoordinatorMetadata(mirrorName, topicsState);
+                var topicMetadata = syncTopicMetadata(mirrorName);
+                syncCoordinatorMetadata(mirrorName, topicMetadata);
             } catch (Exception e) {
                 log.error("Failed to refresh metadata for mirror {}", mirrorName, e);
             }
@@ -584,11 +634,20 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         metadataRefreshError.incrementAndGet();
     }
 
-    /** Schedules a source cluster metadata update. */
-    public void scheduleSourceClusterMetadataUpdate(String mirrorName) {
-        scheduler.scheduleOnce("SourceClusterMetadataUpdate", () -> {
-            syncSourceTopicsState(mirrorName);
-        });
+    private void retryPendingTombstoneWrites() {
+        if (tombstoneWriter.isEmpty()) {
+            log.warn("Mirror deletion handler not configured. Tombstone record writes will be skipped.");
+            return;
+        }
+        Set<String> configuredMirrors = getConfiguredMirrors();
+        Set<String> staleMirrors = partitionStates.keySet().stream()
+                .map(ClusterMirrorUtils.PartitionKey::mirrorName)
+                .filter(name -> !configuredMirrors.contains(name))
+                .collect(Collectors.toSet());
+        for (String mirrorName : staleMirrors) {
+            log.info("Found stale partition states for deleted mirror '{}'. Writing tombstones.", mirrorName);
+            tombstoneWriter.ifPresent(h -> h.accept(mirrorName));
+        }
     }
 
     private void validateSourceClusterId(String mirrorName) {
@@ -615,7 +674,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Fetches topics metadata from the source cluster via Admin.describeTopics.
      * Runs on every broker to keep partition leaders, topic creation, topic deletion, and partition counts in sync.
      */
-    private Optional<List<SourceTopicState>> syncSourceTopicsState(String mirrorName) {
+    private Optional<List<SourceTopicState>> syncTopicMetadata(String mirrorName) {
         log.info("Syncing source topic state for mirror {}", mirrorName);
         Set<String> topics = getConfiguredTopics(mirrorName, false);
         if (topics.isEmpty()) {
@@ -789,7 +848,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 Set.copyOf(partitionStates.keySet()).stream()
                         .filter(key -> key.mirrorName().equals(mirrorName) && key.topic().equals(name))
                         .forEach(key -> stateTransitioner.ifPresent(t ->
-                                t.transitionTo(mirrorName, Set.of(new TopicPartition(key.topic(), key.partition())), MirrorPartitionState.STOPPING)));
+                                t.transitionTo(mirrorName, Set.of(new TopicPartition(key.topic(), key.partition())), MirrorPartitionState.STOPPING, null)));
             }
         });
     }
@@ -817,7 +876,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
         partitionLeaders.keySet().forEach(tp -> {
-            ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, tp.topic(), tp.partition());
+            PartitionKey key = new PartitionKey(mirrorName, tp.topic(), tp.partition());
             if (partitionStates.getOrDefault(key, MirrorPartitionState.UNKNOWN) != MirrorPartitionState.UNKNOWN) {
                 return;
             }
@@ -828,7 +887,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             var partition = topicImage.partitions().get(tp.partition());
             if (partition != null && partition.leader == nodeId) {
                 log.info("Source leader for {} discovered after initial onMetadataUpdate, transitioning to LOG_TRUNCATION", tp);
-                stateTransitioner.ifPresent(t -> t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION));
+                stateTransitioner.ifPresent(t -> t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION, null));
             }
         });
     }
@@ -1330,64 +1389,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         );
     }
 
-    /** Returns mirror partitions led by this broker, detecting both leadership and config changes */
-    private Set<TopicPartition> getMirrorLeadersAndClearFollowerStates(MetadataDelta delta, MetadataImage image) {
-        Set<TopicPartition> mirrorLeaderPartitions = new HashSet<>();
-
-        if (delta.topicsDelta() != null) {
-            LocalReplicaChanges localReplicaChanges = delta.topicsDelta().localChanges(nodeId);
-            // new partition leader in topicsDelta that has mirror.name not empty
-            localReplicaChanges.leaders().keySet().forEach(tp -> {
-                String mirrorName = image.topics().getTopic(tp.topic()).mirrorName();
-                if (mirrorName != null && !mirrorName.isBlank()) {
-                    mirrorLeaderPartitions.add(tp);
-                }
-            });
-
-            localReplicaChanges.mirrorTopicStates().keySet().forEach(topicId -> {
-                // get the partition leader is the local node
-                TopicImage topicImage = image.topics().getTopic(topicId);
-                if (topicImage != null) {
-                    topicImage.partitions().forEach((partitionId, partition) -> {
-                        if (partition.leader == nodeId) {
-                            mirrorLeaderPartitions.add(new TopicPartition(topicImage.name(), partitionId));
-                        }
-                    });
-                }
-            });
-
-            // remove the pending state from this node because it is not the leader anymore
-            localReplicaChanges.followers().keySet().forEach(tp -> {
-                String mirrorName = image.topics().getTopic(tp.topic()).mirrorName();
-                if (mirrorName != null && !mirrorName.isBlank()) {
-                    pendingPartitionStates.remove(tp);
-                    pendingLeaderEpochBumps.removeIf(bumpLeaderEpoch -> {
-                        if (bumpLeaderEpoch.partitionToEpoch().containsKey(tp)) {
-                            bumpLeaderEpoch.future().completeExceptionally(
-                                    new IllegalStateException("Not leader anymore for " + tp));
-                            return true;
-                        }
-                        return false;
-                    });
-                }
-            });
-        }
-
-        return mirrorLeaderPartitions;
-    }
-
-    /** Clears state for partitions where this broker lost leadership, unless it is the coordinator */
-    private void clearFollowersState(Set<TopicPartition> followerDelta, MetadataImage newImage) {
-        followerDelta.forEach(followerTp -> {
-            String mirrorName = newImage.topics().getTopic(followerTp.topic()).mirrorName();
-            if (mirrorName != null && !mirrorName.isEmpty() && !isLocalCoordinator(mirrorName, followerTp.topic(), followerTp.partition())) {
-                ClusterMirrorUtils.PartitionKey key = new ClusterMirrorUtils.PartitionKey(mirrorName, followerTp.topic(), followerTp.partition());
-                removePartitionState(key);
-                lastMirrorEpochs.remove(key);
-            }
-        });
-    }
-
     /** Finds the coordinator node (leader of the __mirror_state partition) for a mirror record key */
     private Node findCoordinatorNode(ClusterMirrorRecordKey key) {
         try {
@@ -1542,7 +1543,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         // Update cache
                         readMirrorStatesResponse.data().topics().forEach(topic -> {
                             topic.partitions().forEach(partition -> {
-                                ClusterMirrorUtils.PartitionKey mpk = new ClusterMirrorUtils.PartitionKey(
+                                PartitionKey mpk = new PartitionKey(
                                         mirrorName, topic.name(), partition.partitionIndex());
                                 TopicPartition tp = new TopicPartition(topic.name(), partition.partitionIndex());
                                 if (partition.lastMirrorEpoch() != -1) {
@@ -1552,8 +1553,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                     partitionStates.put(mpk, MirrorPartitionState.fromValue(partition.state()));
                                 }
                                 if (partition.state() == MirrorPartitionState.FAILED.value()) {
-                                    partitionPreviousStates.put(mpk, MirrorPartitionState.fromValue(partition.previousState()));
-                                    failedRetryAttempts.put(tp, (int) partition.retryAttempt());
+                                    failedPartitionInfo.put(tp, new FailedPartitionInfo(
+                                            partition.retryAttempt(), partition.errorMessage(),
+                                            MirrorPartitionState.fromValue(partition.previousState())));
                                 }
                             });
                         });
@@ -1575,7 +1577,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             ReadMirrorStatesResponseData.TopicResult topicResult = new ReadMirrorStatesResponseData.TopicResult().setName(tp);
             List<ReadMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();
             parts.forEach(part -> {
-                ClusterMirrorUtils.PartitionKey pk = new ClusterMirrorUtils.PartitionKey(mirrorName, tp, part);
+                PartitionKey pk = new PartitionKey(mirrorName, tp, part);
                 ReadMirrorStatesResponseData.PartitionResult partitionResult = new ReadMirrorStatesResponseData.PartitionResult();
                 if (!isLocalCoordinator(mirrorName, tp, part)) {
                     partitionResult.setErrorCode(Errors.NOT_COORDINATOR.code());
@@ -1583,10 +1585,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     partitionResult.setPartitionIndex(part);
                     partitionResult.setLastMirrorEpoch(lastMirrorEpochs.getOrDefault(pk, -1));
                     partitionResult.setState(partitionStates.getOrDefault(pk, MirrorPartitionState.UNKNOWN).value());
+                    FailedPartitionInfo fpi = failedPartitionInfo.get(new TopicPartition(tp, part));
                     partitionResult.setPreviousState(
-                            partitionPreviousStates.getOrDefault(pk, MirrorPartitionState.UNKNOWN).value());
-                    partitionResult.setRetryAttempt(
-                            failedRetryAttempts.getOrDefault(new TopicPartition(tp, part), 0).shortValue());
+                            fpi != null ? fpi.previousState().value() : MirrorPartitionState.UNKNOWN.value());
+                    partitionResult.setRetryAttempt(fpi != null ? fpi.retryAttempt() : 0);
+                    partitionResult.setErrorMessage(fpi != null ? fpi.errorMessage() : null);
                 }
                 partitionResults.add(partitionResult);
             });
@@ -1606,6 +1609,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         Properties props = new Properties();
         props.put(BOOTSTRAP_SERVERS_CONFIG, endpoint.host() + ":" + endpoint.port());
+        props.put(AdminClientConfig.CLIENT_ID_CONFIG, "mirror-dst-admin-" + brokerConfig.nodeId());
 
         SecurityProtocol securityProtocol = endpoint.securityProtocol();
         props.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, securityProtocol.name);
@@ -1645,7 +1649,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>()).put(tp, leader);
     }
 
-    /** Resolves source partition leader from cache, falling back to bootstrap server if not cached. */
     public ClusterMirrorUtils.LeaderInfo resolveSourceLeader(String mirrorName, TopicPartition tp) {
         var partitionLeaders = sourceLeaders.get(mirrorName);
         if (partitionLeaders != null) {
@@ -1654,12 +1657,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 return leader;
             }
         }
-        // No cached metadata. We throw exception and enter FAILED state and do the source cluster metadata refresh
         throw new IllegalStateException("No source cluster metadata available for mirror " + mirrorName + " partition:" + tp);
     }
 
     // Atomic per-key update to keep partition state counts consistent
-    void updatePartitionState(ClusterMirrorUtils.PartitionKey key, MirrorPartitionState newState) {
+    void updatePartitionState(PartitionKey key, MirrorPartitionState newState) {
         partitionStates.compute(key, (k, oldState) -> {
             if (oldState != null && oldState != newState) {
                 partitionStateCounts.computeIfAbsent(oldState, s -> new AtomicLong()).decrementAndGet();
@@ -1672,12 +1674,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     // Atomic remove + counter decrement to keep partition state counts consistent
-    void removePartitionState(ClusterMirrorUtils.PartitionKey key) {
+    void removePartitionState(PartitionKey key) {
         partitionStates.computeIfPresent(key, (k, oldState) -> {
             partitionStateCounts.computeIfAbsent(oldState, s -> new AtomicLong()).decrementAndGet();
             return null;
         });
-        partitionPreviousStates.remove(key);
     }
 
     void removeMirrorStates(String mirrorName) {
@@ -1694,7 +1695,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     void removeStateForPartitions(Set<TopicPartition> partitions) {
         partitions.forEach(tp -> {
             pendingPartitionStates.remove(tp);
-            failedRetryAttempts.remove(tp);
+            failedPartitionInfo.remove(tp);
         });
         pendingLeaderEpochBumps.removeIf(bump -> {
             bump.partitionToEpoch().keySet().removeAll(partitions);
@@ -1711,14 +1712,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     public MirrorPartitionState getPartitionState(String mirrorName, TopicPartition topicPartition) {
-        return partitionStates.get(new ClusterMirrorUtils.PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()));
+        return partitionStates.get(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()));
     }
 
     /** Schedules a source metadata sync followed by a leader epoch bump request. */
     public CompletableFuture<Void> scheduleBumpLeaderEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         scheduler.scheduleOnce("bump-leader-epoch", () -> {
-            Optional<List<SourceTopicState>> topics = syncSourceTopicsState(mirrorName);
+            Optional<List<SourceTopicState>> topics = syncTopicMetadata(mirrorName);
             maybeBumpLeaderEpochs(mirrorName, topics, topicPartitions)
                     .whenComplete((v, ex) -> {
                         if (ex != null) {
@@ -1785,6 +1786,27 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return future;
     }
 
+    private void maybeCompletePendingEpochBumps() {
+        pendingLeaderEpochBumps.removeIf(bumpLeaderEpoch -> {
+            Set<TopicPartition> pendingPartitions = bumpLeaderEpoch.partitionToEpoch().entrySet().stream().filter(entry -> {
+                TopicPartition tp = entry.getKey();
+                int epoch = entry.getValue();
+                var topicImage = metadataImage.topics().getTopic(tp.topic());
+                if (topicImage == null) return false;
+                var partitionReg = topicImage.partitions().get(tp.partition());
+                if (partitionReg == null) return false;
+                return partitionReg.leaderEpoch <= epoch;
+            }).map(Map.Entry::getKey).collect(Collectors.toSet());
+            if (pendingPartitions.isEmpty()) {
+                bumpLeaderEpoch.future().complete(null);
+                return true;
+            } else {
+                log.info("bumpLeaderEpoch future is pending for partitions: {}, all: {}", pendingPartitions, bumpLeaderEpoch.partitionToEpoch().keySet());
+                return false;
+            }
+        });
+    }
+
     private Map<TopicPartition, Integer> buildSourceEpochBumpTargets(String mirrorName, List<SourceTopicState> topicInfos, Set<TopicPartition> topicPartitions) {
         Set<String> mirrorTopics = topicPartitions.isEmpty() ? getConfiguredTopics(mirrorName, false) : Set.of();
         Map<TopicPartition, Integer> leaderEpochFromMetadata = new HashMap<>();
@@ -1835,27 +1857,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             partitionMinEpochs.put(tp, epoch);
         });
         return partitionMinEpochs;
-    }
-
-    private void maybeCompletePendingEpochBumps() {
-        pendingLeaderEpochBumps.removeIf(bumpLeaderEpoch -> {
-            Set<TopicPartition> pendingPartitions = bumpLeaderEpoch.partitionToEpoch().entrySet().stream().filter(entry -> {
-                TopicPartition tp = entry.getKey();
-                int epoch = entry.getValue();
-                var topicImage = metadataImage.topics().getTopic(tp.topic());
-                if (topicImage == null) return false;
-                var partitionReg = topicImage.partitions().get(tp.partition());
-                if (partitionReg == null) return false;
-                return partitionReg.leaderEpoch <= epoch;
-            }).map(Map.Entry::getKey).collect(Collectors.toSet());
-            if (pendingPartitions.isEmpty()) {
-                bumpLeaderEpoch.future().complete(null);
-                return true;
-            } else {
-                log.info("bumpLeaderEpoch future is pending for partitions: {}, all: {}", pendingPartitions, bumpLeaderEpoch.partitionToEpoch().keySet());
-                return false;
-            }
-        });
     }
 
     /**
@@ -1946,7 +1947,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
             for (int i = 0; i < partitionSize; i++) {
                 if (isLocalCoordinator(mirrorName, topic, i)) {
-                    MirrorPartitionState state = partitionStates.getOrDefault(new ClusterMirrorUtils.PartitionKey(mirrorName, topic, i), MirrorPartitionState.UNKNOWN);
+                    MirrorPartitionState state = partitionStates.getOrDefault(new PartitionKey(mirrorName, topic, i), MirrorPartitionState.UNKNOWN);
                     if (state != MirrorPartitionState.STOPPED) {
                         log.error("Partition {}-{} is not in STOPPED state. Current state: {}.", topic, i, state);
                         callback.accept(Optional.of(Errors.INVALID_CLUSTER_MIRROR_STATES));
@@ -2079,28 +2080,27 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /** Truncates local replicas using last mirrored leader epochs from this broker's coordinator cache. */
-    CompletionStage<Map<String, ClusterMirrorDescription>> truncateToLastMirrorEpochs(
+    CompletionStage<Map<String, ClusterMirrorDesc>> truncateToLastMirrorEpochs(
             String mirrorName, Set<TopicPartition> topicPartitionSet) {
         log.info("Truncating to last mirrored epochs from local state for mirror {}: {}", mirrorName, topicPartitionSet);
-        Admin admin = srcAdmins.computeIfAbsent(mirrorName, k -> {
-            Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
-            return Admin.create(props);
-        });
+        Admin admin = getOrCreateSourceAdmin(mirrorName);
         DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName));
-        return result.allDescriptions().toCompletionStage();
+        return result.allDescriptions().toCompletionStage()
+                .toCompletableFuture()
+                .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
     }
 
     /** Removes stopped partition epochs and upserts added ones, returning the full epoch map for record serialization. */
-    Map<ClusterMirrorUtils.PartitionKey, Integer> updateLastMirrorEpochs(
+    Map<PartitionKey, Integer> updateLastMirrorEpochs(
             String clusterName, Map<String, Map<Integer, Integer>> addedEpochs, Map<String, Map<Integer, Integer>> stoppedEpochs) {
         stoppedEpochs.forEach((topic, partitionOffsets) -> {
             partitionOffsets.forEach((partition, offset) -> {
-                lastMirrorEpochs.remove(new ClusterMirrorUtils.PartitionKey(clusterName, topic, partition));
+                lastMirrorEpochs.remove(new PartitionKey(clusterName, topic, partition));
             });
         });
         addedEpochs.forEach((topic, partitionOffsets) -> {
             partitionOffsets.forEach((partition, offset) -> {
-                lastMirrorEpochs.put(new ClusterMirrorUtils.PartitionKey(clusterName, topic, partition), offset);
+                lastMirrorEpochs.put(new PartitionKey(clusterName, topic, partition), offset);
             });
         });
         return lastMirrorEpochs;

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -953,9 +953,11 @@ class Partition(val topicPartition: TopicPartition,
     // Check if this in-sync replica needs to be added to the ISR.
     maybeExpandIsr(replica)
 
-    // check if the HW of the partition can now be incremented
-    // since the replica may already be in the ISR and its LEO has just incremented
-    val leaderHWIncremented = if (prevFollowerEndOffset != replica.stateSnapshot.logEndOffset) {
+    // Check if HW can be incremented since the replica's LEO may have changed,
+    // or if a pending truncation callback needs to complete (followers may already
+    // be at the leader's LEO after mirror truncation reset both to the same offset).
+    val leaderHWIncremented = if (prevFollowerEndOffset != replica.stateSnapshot.logEndOffset
+        || onCompleteCallback.isPresent) {
       // the leader log may be updated by ReplicaAlterLogDirsThread so the following method must be in lock of
       // leaderIsrUpdateLock to prevent adding new hw to invalid log.
       inReadLock(leaderIsrUpdateLock) {
@@ -1262,7 +1264,7 @@ class Partition(val topicPartition: TopicPartition,
     if (onCompleteCallback.isPresent) {
       this.onCompleteCallback = onCompleteCallback
     }
-    if (onCompleteCallback.isEmpty) {
+    if (this.onCompleteCallback.isEmpty) {
       return false
     }
     if (onCaughtupCallback.isPresent) {

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -113,7 +113,7 @@ abstract class AbstractFetcherThread(name: String,
 
   protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {}
 
-  protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition]): Unit = {}
+  protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition], reason: String): Unit = {}
 
   protected def shouldUpdateMirrorLeaderEpoch(topicPartition: TopicPartition): Boolean = {
     false
@@ -170,7 +170,7 @@ abstract class AbstractFetcherThread(name: String,
       if (fetchException.exists(_.isInstanceOf[IOException]) && mirrorName.nonEmpty && isRunning) {
         try {
           partitions.foreach(markPartitionRemoved)
-          refreshSourceClusterMetadata(partitions.toSet)
+          refreshSourceClusterMetadata(partitions.toSet, s"Fetch IO error: ${fetchException.get.getMessage}")
         } catch {
           case t: Throwable =>
             warn(s"Failed to re-resolve source leader for mirror $mirrorName", t)
@@ -229,12 +229,12 @@ abstract class AbstractFetcherThread(name: String,
     catch {
       case e: KafkaStorageException =>
         error(s"Failed to truncate $topicPartition at offset ${truncationState.offset}", e)
-        markPartitionFailed(topicPartition)
+        markPartitionFailed(topicPartition, s"Truncation failed: ${e.getMessage}")
         false
       case t: Throwable =>
         error(s"Unexpected error occurred during truncation for $topicPartition "
           + s"at offset ${truncationState.offset}", t)
-        markPartitionFailed(topicPartition)
+        markPartitionFailed(topicPartition, s"Truncation failed: ${t.getMessage}")
         false
     }
   }
@@ -276,7 +276,7 @@ abstract class AbstractFetcherThread(name: String,
     if (!partitionsNeedsRefreshMetadata.isEmpty) {
       info(s"Refreshing source metadata for mirror name $mirrorName with partitions: $partitionsNeedsRefreshMetadata")
       removeFetcherForPartitions(partitionsNeedsRefreshMetadata.asScala)
-      refreshSourceClusterMetadata(partitionsNeedsRefreshMetadata.asScala)
+      refreshSourceClusterMetadata(partitionsNeedsRefreshMetadata.asScala, "Truncation requires source metadata refresh")
     }
   }
 
@@ -320,7 +320,7 @@ abstract class AbstractFetcherThread(name: String,
     partitionStates.set(newStates)
     if (!partitionsToBeRemoved.isEmpty) {
       removeFetcherForPartitions(partitionsToBeRemoved.asScala)
-      refreshSourceClusterMetadata(partitionsToBeRemoved.asScala)
+      refreshSourceClusterMetadata(partitionsToBeRemoved.asScala, "Source leader changed")
     }
   }
 
@@ -357,7 +357,7 @@ abstract class AbstractFetcherThread(name: String,
       warn(s"No endpoint info to redirect mirror partitions $stalePartitions, refreshing source metadata")
       stalePartitions.foreach(markPartitionRemoved)
       removeFetcherForPartitions(stalePartitions)
-      refreshSourceClusterMetadata(stalePartitions)
+      refreshSourceClusterMetadata(stalePartitions, "No endpoint info in fetch response")
     }
   }
 
@@ -437,7 +437,7 @@ abstract class AbstractFetcherThread(name: String,
       if (requestEpoch.isPresent && requestEpoch.get == currentLeaderEpoch) {
         info(s"Partition $tp has an older epoch ($currentLeaderEpoch) than the current leader. Will await " +
           s"the new LeaderAndIsr state before resuming fetching.")
-        markPartitionFailed(tp)
+        markPartitionFailed(tp, s"Leader epoch $currentLeaderEpoch is older than current leader")
         false
       } else {
         info(s"Partition $tp has a newer epoch ($currentLeaderEpoch) than the current leader. Retry the partition later.")
@@ -578,7 +578,7 @@ abstract class AbstractFetcherThread(name: String,
                     case e: KafkaStorageException =>
                       error(s"Error while processing data for partition $topicPartition " +
                         s"at offset ${currentFetchState.fetchOffset}", e)
-                      markPartitionFailed(topicPartition)
+                      markPartitionFailed(topicPartition, s"Storage error: ${e.getMessage}")
                     case e: MirrorLeaderEpochExceededException =>
                       error(s"Error while processing data for mirror partition $topicPartition " +
                         s"at offset ${currentFetchState.fetchOffset}, triggering leader epoch bump.", e)
@@ -588,12 +588,11 @@ abstract class AbstractFetcherThread(name: String,
                       error(s"Error while processing data for mirror partition $topicPartition " +
                         s"at offset ${currentFetchState.fetchOffset}, triggering metadata update.", e)
                       markPartitionRemoved(topicPartition)
-                      refreshSourceClusterMetadata(Set(topicPartition))
+                      refreshSourceClusterMetadata(Set(topicPartition), e.getMessage)
                     case t: Throwable =>
-                      // stop monitoring this partition and add it to the set of failed partitions
                       error(s"Unexpected error occurred while processing data for partition $topicPartition " +
                         s"at offset ${currentFetchState.fetchOffset}", t)
-                      markPartitionFailed(topicPartition)
+                      markPartitionFailed(topicPartition, s"Unexpected error: ${t.getMessage}")
                   }
                 case Errors.OFFSET_OUT_OF_RANGE =>
                   if (!handleOutOfRangeError(topicPartition, currentFetchState, fetchPartitionData.currentLeaderEpoch))
@@ -695,12 +694,12 @@ abstract class AbstractFetcherThread(name: String,
     warn(s"Partition $topicPartition marked as failed")
   }
 
-  private def markPartitionFailed(topicPartition: TopicPartition): Unit = {
+  private def markPartitionFailed(topicPartition: TopicPartition, reason: String): Unit = {
     markPartitionRemoved(topicPartition)
-    handlePartitionFailed(topicPartition)
+    handlePartitionFailed(topicPartition, reason)
   }
 
-  protected def handlePartitionFailed(topicPartition: TopicPartition): Unit = {}
+  protected def handlePartitionFailed(topicPartition: TopicPartition, reason: String): Unit = {}
 
   /**
    * Returns initial partition fetch state based on current state and the provided `initialFetchState`.

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -440,6 +440,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           val lagInfoMap = replicaManager.getMirrorLagInfo(mirrorName)
           val partitionStates = clusterMirrorCoordinator.getMirrorStates(mirrorName).asScala
           val lastMirrorEpoch = clusterMirrorCoordinator.getLastMirrorEpochs(mirrorName)
+          val failedInfo = clusterMirrorCoordinator.getFailedPartitionInfo()
 
           // Report partition if: (1) we have lag info, OR (2) we're the partition leader and have no lag info
           val partitionsToReport = (lagInfoMap.keySet ++ partitionStates.keySet.filter { tp =>
@@ -458,12 +459,16 @@ class KafkaApis(val requestChannel: RequestChannel,
                 tp
               })
 
+              val state = partitionStates.getOrElse(topicPartition, MirrorPartitionState.UNKNOWN)
+              val isMirroring = state == MirrorPartitionState.MIRRORING
               val partitionDetail = new DescribeClusterMirrorsResponseData.PartitionDetail()
                 .setPartitionIndex(topicPartition.partition())
-                .setSourceOffset(lagInfoMap.get(topicPartition).map(_.sourceOffset).getOrElse(-1L))
-                .setDestinationOffset(lagInfoMap.get(topicPartition).map(_.destinationOffset).getOrElse(-1L))
-                .setLag(lagInfoMap.get(topicPartition).map(_.lag).getOrElse(-1L))
-                .setStateValue(partitionStates.getOrElse(topicPartition, MirrorPartitionState.UNKNOWN).name())
+                .setSourceOffset(if (isMirroring) lagInfoMap.get(topicPartition).map(_.sourceOffset).getOrElse(-1L) else -1L)
+                .setDestinationOffset(if (isMirroring) lagInfoMap.get(topicPartition).map(_.destinationOffset).getOrElse(-1L) else -1L)
+                .setLag(if (isMirroring) lagInfoMap.get(topicPartition).map(_.lag).getOrElse(-1L) else -1L)
+                .setStateValue(state.name())
+                .setRetryAttempt(Option(failedInfo.get(topicPartition)).map(_.retryAttempt()).getOrElse(0.toShort))
+                .setErrorMessage(Option(failedInfo.get(topicPartition)).map(_.errorMessage()).orNull)
                 .setLastMirrorEpoch(lastMirrorEpoch.getOrDefault(topicPartition, -1))
 
               topicPartitions.partitions().add(partitionDetail)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2641,6 +2641,7 @@ class ReplicaManager(val config: KafkaConfig,
 
     stateChangeLogger.info(s"Starting mirror fetchers for ${mirrorLeaders.size} read-only leader partition(s).")
     val partitionAndOffsets = new mutable.HashMap[TopicPartition, InitialFetchState]
+    val pendingMetadataPartitions = new mutable.HashSet[TopicPartition]
     val errorPartitionAndOffsets = new mutable.HashSet[TopicPartition]
 
     mirrorLeaders.stream().forEach { tp =>
@@ -2677,10 +2678,12 @@ class ReplicaManager(val config: KafkaConfig,
               maybeAddListener(tp, mirrorLagListener)
             }
           } catch {
+            case _: IllegalStateException =>
+              pendingMetadataPartitions.add(tp)
+              stateChangeLogger.info(s"Source metadata not yet available for partition $tp, will retry after refresh")
             case e: Exception =>
               errorPartitionAndOffsets.add(tp)
-              stateChangeLogger.error(s"Error setting up mirror fetcher for partition $tp, " +
-                s"refresh source cluster metadata and try again: ${e.getMessage}")
+              stateChangeLogger.error(s"Error setting up mirror fetcher for partition $tp: ${e.getMessage}")
           }
         case _ =>
           stateChangeLogger.warn(s"Skipping mirror fetcher setup for offline partition $tp")
@@ -2697,9 +2700,16 @@ class ReplicaManager(val config: KafkaConfig,
       }
     }
 
+    if (pendingMetadataPartitions.nonEmpty) {
+      mirrorMetadataManager.foreach(_.scheduleSourceMetadataSync(mirrorName))
+      mirrorMetadataManager.foreach(_.transitionTo(mirrorName, pendingMetadataPartitions.asJava,
+        MirrorPartitionState.FAILED, "Failed to get source metadata"))
+    }
+
     if (errorPartitionAndOffsets.nonEmpty) {
-      mirrorMetadataManager.foreach(_.scheduleSourceClusterMetadataUpdate(mirrorName))
-      mirrorMetadataManager.foreach(_.transitionTo(mirrorName, errorPartitionAndOffsets.asJava, MirrorPartitionState.FAILED))
+      mirrorMetadataManager.foreach(_.scheduleSourceMetadataSync(mirrorName))
+      mirrorMetadataManager.foreach(_.transitionTo(mirrorName, errorPartitionAndOffsets.asJava,
+        MirrorPartitionState.FAILED, "Failed to add mirror fetcher"))
     }
   }
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -18,7 +18,7 @@ package kafka.server.mirror
 
 import kafka.cluster.Partition
 import kafka.server._
-import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, LeaderInfo, PartitionKey}
+import kafka.server.mirror.ClusterMirrorUtils.{LEADER_EPOCH_BUMP_THRESHOLD, LeaderInfo}
 import org.apache.kafka.common.errors.{MirrorLeaderEpochExceededException, MirrorPartitionStaleMetadataException}
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
@@ -70,23 +70,22 @@ class MirrorFetcherThread(name: String,
     replicaMgr.mirrorFetcherManager.addFetcherForPartitions(partitionAndOffsets)
   }
 
-  // Transition to FAILED so the coordinator can schedule exponential backoff retries
-  override protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition]): Unit = {
-    replicaMgr.mirrorMetadataManager.foreach(_.scheduleSourceClusterMetadataUpdate(mirrorName))
-    replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, mirrorPartitions.asJava, MirrorPartitionState.FAILED))
+  override protected def refreshSourceClusterMetadata(mirrorPartitions: Set[TopicPartition], reason: String): Unit = {
+    replicaMgr.mirrorMetadataManager.foreach(_.scheduleSourceMetadataSync(mirrorName))
+    replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, mirrorPartitions.asJava,
+      MirrorPartitionState.FAILED, reason))
   }
 
-  // Bridges fetcher failures (e.g. KafkaStorageException) to the mirror state machine,
-  // so the coordinator can schedule exponential backoff retries
-  override protected def handlePartitionFailed(topicPartition: TopicPartition): Unit = {
-    replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, java.util.Set.of(topicPartition), MirrorPartitionState.FAILED))
+  override protected def handlePartitionFailed(topicPartition: TopicPartition, reason: String): Unit = {
+    replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, java.util.Set.of(topicPartition),
+      MirrorPartitionState.FAILED, reason))
   }
 
   // Source leader epoch exceeds local epoch: transition to EPOCH_FENCING to bump the
   // local epoch before allowing further appends. If the bump fails, the coordinator
   // transitions to FAILED and the exponential backoff retry takes over.
   override protected def handleMirrorLeaderEpochExceeded(mirrorName: String, topicPartition: TopicPartition): Unit = {
-    replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, java.util.Set.of(topicPartition), MirrorPartitionState.EPOCH_FENCING))
+    replicaMgr.mirrorMetadataManager.foreach(_.transitionTo(mirrorName, java.util.Set.of(topicPartition), MirrorPartitionState.EPOCH_FENCING, null))
   }
 
   // Validates batch epoch against local epoch (destination) and partition epoch (source metadata)
@@ -102,9 +101,7 @@ class MirrorFetcherThread(name: String,
         s"epoch $highestBatchLeaderEpoch is higher than local leader epoch $localLeaderEpoch")
     } else {
       replicaMgr.mirrorMetadataManager.foreach { mmm =>
-        // successful fetch, remove the failed metadata
-        mmm.failedRetryAttempts.remove(topicPartition)
-        mmm.partitionPreviousStates().remove(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()))
+        mmm.failedPartitionInfo.remove(topicPartition)
 
         if (highestBatchLeaderEpoch > localLeaderEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
           // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -125,7 +125,7 @@ public class AsyncClusterMirrorIntegrationTest {
                 // Fast mirror timeouts and retry backoff for testing
                 .setConfigProp(ServerConfigs.REQUEST_TIMEOUT_MS_CONFIG, "5000")
                 .setConfigProp(ClusterMirrorConfig.MIRROR_SOCKET_TIMEOUT_MS_CONFIG, "5000")
-                .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_MAX_ATTEMPTS_CONFIG, "2")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_MAX_ATTEMPTS_CONFIG, "3")
                 .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_INITIAL_BACKOFF_MS_CONFIG, "1000")
                 .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_MAX_BACKOFF_MS_CONFIG, "5000")
 

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -21,7 +21,7 @@ import kafka.utils.TestUtils;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.ClusterMirrorDescription;
+import org.apache.kafka.clients.admin.ClusterMirrorDesc;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateClusterMirrorOptions;
 import org.apache.kafka.clients.admin.DeleteClusterMirrorOptions;
@@ -121,6 +121,15 @@ public class AsyncClusterMirrorIntegrationTest {
                 .setConfigProp(ServerLogConfigs.AUTO_CREATE_TOPICS_ENABLE_CONFIG, "false")
                 .setConfigProp(ClusterMirrorConfig.MIRROR_STATE_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
                 .setConfigProp(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
+
+                // Fast mirror timeouts and retry backoff for testing
+                .setConfigProp(ServerConfigs.REQUEST_TIMEOUT_MS_CONFIG, "5000")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_SOCKET_TIMEOUT_MS_CONFIG, "5000")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_MAX_ATTEMPTS_CONFIG, "2")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_INITIAL_BACKOFF_MS_CONFIG, "1000")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_MAX_BACKOFF_MS_CONFIG, "5000")
+
+                // Enable cluster mirroring in early access stage
                 .setConfigProp(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true")
                 .setConfigProp(ServerConfigs.UNSTABLE_FEATURE_VERSIONS_ENABLE_CONFIG, "true")
                 .build();
@@ -548,6 +557,42 @@ public class AsyncClusterMirrorIntegrationTest {
         assertTrue(records.get(1).key().apiKey() == new LastMirrorEpochsKey().apiKey() && records.get(1).value() == null);
     }
 
+    @Test
+    void testFailedRetryExhaustion() throws Exception {
+        String topic = "failed-retry-topic";
+
+        srcAdmin.createTopics(List.of(
+                new NewTopic(topic, 2, (short) 1)
+        )).all().get(30, TimeUnit.SECONDS);
+
+        produceRecords(srcCluster, topic, 0, 50);
+
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+                "bootstrap.servers", singleSourceBootstrapServer
+        ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(topic), new StartMirrorTopicsOptions())
+                .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(topic);
+
+        // Stop all source brokers to trigger FAILED state
+        srcCluster.brokers().values().forEach(b -> b.shutdown());
+
+        waitForFailedWithRetriesExhausted(topic, 2);
+    }
+
+    private void waitForFailedWithRetriesExhausted(String topicPattern, int maxAttempts) throws Exception {
+        long deadline = System.currentTimeMillis() + 120_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (allPartitionsSatisfy(topicPattern,
+                    s -> "FAILED".equals(s.state()) && s.retryAttempt() >= maxAttempts)) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+        throw new AssertionError("Mirror partitions for " + topicPattern
+                + " did not exhaust retries within timeout");
+    }
+
     private void produceRecords(KafkaClusterTestKit cluster, String topic,
                                 int startIndex, int count) {
         Properties props = new Properties();
@@ -626,11 +671,11 @@ public class AsyncClusterMirrorIntegrationTest {
     }
 
     private boolean allPartitionsSatisfy(
-            String topicPattern, Predicate<ClusterMirrorDescription.LeaderState> condition) throws Exception {
+            String topicPattern, Predicate<ClusterMirrorDesc.LeaderStateDesc> condition) throws Exception {
         var result = dstAdmin.describeClusterMirrors(
                 List.of(MIRROR_NAME), new DescribeClusterMirrorsOptions());
         var descriptions = result.allDescriptions().get(5, TimeUnit.SECONDS);
-        ClusterMirrorDescription desc = descriptions.get(MIRROR_NAME);
+        ClusterMirrorDesc desc = descriptions.get(MIRROR_NAME);
         if (desc == null) return false;
         var pattern = java.util.regex.Pattern.compile(topicPattern);
         var matched = desc.topics().entrySet().stream()

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
@@ -33,6 +33,8 @@
     { "name": "PreviousState", "type": "int8",  "versions": "0+", "default": 16,
       "about": "The mirror partition state before this transition; UNKNOWN if not recorded." },
     { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",
-      "about": "The number of automatic retry attempts while in FAILED state." }
+      "about": "The number of automatic retry attempts while in FAILED state." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The error message when in FAILED state, or null if not applicable." }
   ]
 }

--- a/server-common/src/main/java/org/apache/kafka/server/common/MirrorPartitionState.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MirrorPartitionState.java
@@ -133,7 +133,8 @@ public enum MirrorPartitionState {
                 return source == MirrorPartitionState.LOG_TRUNCATION
                         || source == MirrorPartitionState.EPOCH_FENCING
                         || source == MirrorPartitionState.PAUSED
-                        || source == MirrorPartitionState.FAILED;
+                        || source == MirrorPartitionState.FAILED
+                        || source == MirrorPartitionState.MIRRORING;
             case PAUSING:
                 return source == MirrorPartitionState.MIRRORING;
             case PAUSED:

--- a/server/src/main/java/org/apache/kafka/server/config/ClusterMirrorConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/ClusterMirrorConfig.java
@@ -84,7 +84,7 @@ public final class ClusterMirrorConfig {
     public static final int MIRROR_FAILED_RETRY_MAX_ATTEMPTS_DEFAULT = 10;
     public static final String MIRROR_FAILED_RETRY_MAX_ATTEMPTS_DOC = "The maximum number of automatic retry attempts for a mirror partition in FAILED state. " +
             "After this limit is reached, manual intervention is required via the start-mirror-topics command. " +
-            "Set to 0 for unlimited retries.";
+            "Set to 0 to disable automatic retries.";
 
     // ---------------------------------------------------------------
     // Mirror level configs: Set when creating/altering a specific mirror. Stored in cluster metadata.

--- a/tests/kafkatest/tests/core/cluster_mirroring_common.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_common.py
@@ -203,6 +203,16 @@ class MirrorUtils:
         wait_until(check, timeout_sec=120, backoff_sec=2, err_msg=err_msg)
 
     @staticmethod
+    def wait_mirror_lag_zero(logger, kafka, client_node, mirror_name,
+                             topics, err_msg="Mirror did not catch up"):
+        """Wait until all mirror partitions reach MIRRORING state with zero lag."""
+        def check():
+            return MirrorUtils.all_satisfy_in_mirror(logger,
+                kafka, client_node, mirror_name,
+                lambda p: p["lag"] == 0 and p["state"] == "MIRRORING", topics)
+        wait_until(check, timeout_sec=120, backoff_sec=2, err_msg=err_msg)
+
+    @staticmethod
     def wait_for_metadata_refresh(logger, kafka, client_node, mirror_name):
         """Wait for metadata sync by sleeping based on the configured refresh interval."""
         kafka.describe_mirror_config(client_node, mirror_name)
@@ -214,16 +224,6 @@ class MirrorUtils:
         sleep_s = interval_ms // 1000
         logger.info("Waiting %ds for metadata sync (interval=%dms)", sleep_s, interval_ms)
         time.sleep(sleep_s)
-
-    @staticmethod
-    def wait_mirror_lag_zero(logger, kafka, client_node, mirror_name,
-                             topics, err_msg="Mirror did not catch up"):
-        """Wait until all mirror partitions reach MIRRORING state with zero lag."""
-        def check():
-            return MirrorUtils.all_satisfy_in_mirror(logger,
-                kafka, client_node, mirror_name,
-                lambda p: p["lag"] == 0 and p["state"] == "MIRRORING", topics)
-        wait_until(check, timeout_sec=120, backoff_sec=2, err_msg=err_msg)
 
     @staticmethod
     def describe_consumer_group(kafka, group, client_node):

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_sasl_ssl_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_sasl_ssl_test.py
@@ -48,9 +48,10 @@ class ClusterMirroringCompSaslSslTest(MirrorUtils, Test):
         ["share.coordinator.state.topic.replication.factor", "2"],
         ["share.coordinator.state.topic.min.isr", "1"],
         ["mirror.state.topic.replication.factor", "2"],
-        ["mirror.metadata.refresh.interval.ms", "10000"],
-        ["mirror.num.replica.fetchers", "2"],
         ["super.users", "User:kafka"],
+        ["mirror.metadata.refresh.interval.ms", "5000"],
+        ["mirror.num.replica.fetchers", "2"],
+        ["mirror.socket.timeout.ms", "5000"],
     ]
 
     SOURCE_SERVER_PROPS = [

--- a/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_comp_test.py
@@ -42,8 +42,9 @@ class ClusterMirroringCompTest(MirrorUtils, Test):
         ["share.coordinator.state.topic.replication.factor", "2"],
         ["share.coordinator.state.topic.min.isr", "1"],
         ["mirror.state.topic.replication.factor", "2"],
-        ["mirror.metadata.refresh.interval.ms", "10000"],
+        ["mirror.metadata.refresh.interval.ms", "5000"],
         ["mirror.num.replica.fetchers", "2"],
+        ["mirror.socket.timeout.ms", "5000"],
     ]
 
     SOURCE_SERVER_PROPS = [

--- a/tests/kafkatest/tests/core/cluster_mirroring_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_test.py
@@ -48,6 +48,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
             ["mirror.state.topic.replication.factor", "2"],
             ["mirror.metadata.refresh.interval.ms", "5000"],
             ["mirror.num.replica.fetchers", "2"],
+            ["mirror.socket.timeout.ms", "5000"],
         ]
         self.source_kafka = KafkaService(
             test_context, num_nodes=2, zk=None,
@@ -396,6 +397,7 @@ class ClusterMirroringTest(MirrorUtils, Test):
         self.logger.info("Send messages to source and verify they arrive at destination")
         MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, "my-topic", 3)
         MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest_kafka, self.client_node, "my-mirror", ["my-topic"])
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest_kafka, self.client_node, "my-mirror")
 
         count = MirrorUtils.consume_messages(self.logger, self.dest_kafka, self.client_node, "my-topic",
                                      max_messages=3, expected_count=3)

--- a/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
@@ -18,14 +18,13 @@ package org.apache.kafka.tools;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.ClusterMirrorDescription;
+import org.apache.kafka.clients.admin.ClusterMirrorDesc;
 import org.apache.kafka.clients.admin.ClusterMirrorListing;
 import org.apache.kafka.clients.admin.CreateClusterMirrorOptions;
 import org.apache.kafka.clients.admin.CreateClusterMirrorResult;
 import org.apache.kafka.clients.admin.DeleteClusterMirrorOptions;
 import org.apache.kafka.clients.admin.DeleteClusterMirrorResult;
 import org.apache.kafka.clients.admin.DescribeClusterMirrorsOptions;
-import org.apache.kafka.clients.admin.DescribeClusterMirrorsResult;
 import org.apache.kafka.clients.admin.ListClusterMirrorsResult;
 import org.apache.kafka.clients.admin.PauseMirrorTopicsOptions;
 import org.apache.kafka.clients.admin.PauseMirrorTopicsResult;
@@ -255,18 +254,12 @@ public abstract class ClusterMirrorCommand {
         }
 
         private void describeClusterMirrors(MirrorCommandOptions opts) throws ExecutionException, InterruptedException {
-            // If --mirror is specified, describe only that mirror; otherwise describe all mirrors
             List<String> mirrorNames = opts.mirror().isPresent()
                 ? List.of(opts.mirror().get())
                 : List.of();
 
-            // Describe the mirror(s) using the admin client
-            DescribeClusterMirrorsResult result = adminClient.describeClusterMirrors(
-                mirrorNames,
-                new DescribeClusterMirrorsOptions()
-            );
-
-            Map<String, ClusterMirrorDescription> descriptions = result.allDescriptions().get();
+            Map<String, ClusterMirrorDesc> descriptions = adminClient.describeClusterMirrors(
+                mirrorNames, new DescribeClusterMirrorsOptions()).allDescriptions().get();
 
             if (descriptions.isEmpty()) {
                 if (opts.hasJsonOption()) {
@@ -277,30 +270,12 @@ public abstract class ClusterMirrorCommand {
                 return;
             }
 
-            // Collect partition states from all mirrors (one entry per mirror+topic+partition)
-            List<PartitionInfo> partitionInfos = new ArrayList<>();
-            for (Map.Entry<String, ClusterMirrorDescription> mirrorEntry : descriptions.entrySet()) {
-                String mirrorName = mirrorEntry.getKey();
-                ClusterMirrorDescription description = mirrorEntry.getValue();
+            List<PartitionInfo> partitionInfos = collectPartitionInfos(descriptions);
 
-                for (Map.Entry<String, Set<ClusterMirrorDescription.LeaderState>> topicEntry : description.topics().entrySet()) {
-                    String topic = topicEntry.getKey();
-                    for (ClusterMirrorDescription.LeaderState state : topicEntry.getValue()) {
-                        partitionInfos.add(new PartitionInfo(
-                            mirrorName,
-                            topic,
-                            state.topicPartition().partition(),
-                            state.sourceOffset(),
-                            state.destinationOffset(),
-                            state.lag(),
-                            state.state(),
-                            state.lastMirrorEpoch()
-                        ));
-                    }
-                }
+            if (opts.hasFailedOption()) {
+                partitionInfos.removeIf(info -> !"FAILED".equals(info.state()));
             }
 
-            // Sort by mirror, then topic, then partition
             partitionInfos.sort(Comparator.comparing(PartitionInfo::mirror)
                 .thenComparing(PartitionInfo::topic)
                 .thenComparing(PartitionInfo::partition));
@@ -314,20 +289,88 @@ public abstract class ClusterMirrorCommand {
                 }
             }
 
-            // Only print header and results if there are partitions to display
-            if (!partitionInfos.isEmpty()) {
-                System.out.printf("%-30s %-40s %-10s %-15s %-18s %-10s %-12s%n",
-                    "MIRROR", "TOPIC", "PARTITION", "SOURCE-OFFSET", "DESTINATION-OFFSET", "LAG", "STATE");
-                for (PartitionInfo info : partitionInfos) {
-                    System.out.printf("%-30s %-40s %-10d %-15s %-18s %-10s %-12s%n",
-                        truncateLeft(info.mirror(), 30),
-                        truncateLeft(info.topic(), 40),
-                        info.partition(),
-                        formatOffset(info.sourceOffset()),
-                        formatOffset(info.destinationOffset()),
-                        formatOffset(info.lag()),
-                        info.state());
+            if (partitionInfos.isEmpty()) {
+                if (opts.hasFailedOption()) {
+                    System.out.println("No failed partitions found");
                 }
+                return;
+            }
+
+            if (opts.hasFailedOption()) {
+                printFailedPartitions(partitionInfos, getMaxRetryAttempts());
+            } else {
+                printPartitions(partitionInfos);
+            }
+        }
+
+        private List<PartitionInfo> collectPartitionInfos(Map<String, ClusterMirrorDesc> descriptions) {
+            List<PartitionInfo> partitionInfos = new ArrayList<>();
+            for (Map.Entry<String, ClusterMirrorDesc> mirrorEntry : descriptions.entrySet()) {
+                String mirrorName = mirrorEntry.getKey();
+                for (Map.Entry<String, Set<ClusterMirrorDesc.LeaderStateDesc>> topicEntry : mirrorEntry.getValue().topics().entrySet()) {
+                    String topic = topicEntry.getKey();
+                    for (ClusterMirrorDesc.LeaderStateDesc state : topicEntry.getValue()) {
+                        partitionInfos.add(new PartitionInfo(
+                            mirrorName, topic,
+                            state.topicPartition().partition(),
+                            state.sourceOffset(), state.destinationOffset(), state.lag(),
+                            state.state(), state.retryAttempt(), state.errorMessage(),
+                            state.lastMirrorEpoch()));
+                    }
+                }
+            }
+            return partitionInfos;
+        }
+
+        private int getMaxRetryAttempts() {
+            try {
+                String brokerId = adminClient.describeCluster().nodes().get().iterator().next().idString();
+                ConfigResource brokerResource = new ConfigResource(ConfigResource.Type.BROKER, brokerId);
+                var configs = adminClient.describeConfigs(List.of(brokerResource)).all().get();
+                var brokerConfig = configs.get(brokerResource);
+                if (brokerConfig != null) {
+                    var entry = brokerConfig.get("mirror.failed.retry.max.attempts");
+                    if (entry != null) {
+                        return Integer.parseInt(entry.value());
+                    }
+                }
+            } catch (RuntimeException | InterruptedException | ExecutionException e) {
+                // fall through to default
+            }
+            return 10;
+        }
+
+        private void printFailedPartitions(List<PartitionInfo> partitionInfos, int maxRetryAttempts) {
+            int maxError = 80;
+            System.out.printf("%-30s %-40s %-10s %-7s %s%n",
+                "MIRROR", "TOPIC", "PARTITION", "RETRY", "ERROR");
+            for (PartitionInfo info : partitionInfos) {
+                String error = info.errorMessage() != null ? info.errorMessage() : "";
+                if (error.length() > maxError) {
+                    error = error.substring(0, maxError - 3) + "...";
+                }
+                String retry = info.retryAttempt() + "/" + maxRetryAttempts;
+                System.out.printf("%-30s %-40s %-10d %-7s %s%n",
+                    truncateLeft(info.mirror(), 30),
+                    truncateLeft(info.topic(), 40),
+                    info.partition(),
+                    retry,
+                    error);
+            }
+        }
+
+        private void printPartitions(List<PartitionInfo> partitionInfos) {
+            System.out.printf("%-30s %-40s %-10s %-15s %-18s %-10s %-12s%n",
+                "MIRROR", "TOPIC", "PARTITION", "SOURCE-OFFSET", "DESTINATION-OFFSET", "LAG", "STATE");
+            for (PartitionInfo info : partitionInfos) {
+                System.out.printf("%-30s %-40s %-10d %-15s %-18s %-10s %-12s%n",
+                    truncateLeft(info.mirror(), 30),
+                    truncateLeft(info.topic(), 40),
+                    info.partition(),
+                    formatOffset(info.sourceOffset()),
+                    formatOffset(info.destinationOffset()),
+                    formatOffset(info.lag()),
+                    info.state());
             }
         }
 
@@ -359,7 +402,9 @@ public abstract class ClusterMirrorCommand {
         }
 
         private record PartitionInfo(String mirror, String topic, int partition,
-                                     long sourceOffset, long destinationOffset, long lag, String state, int lastMirrorEpoch) { }
+                                     long sourceOffset, long destinationOffset, long lag,
+                                     String state, short retryAttempt, String errorMessage,
+                                     int lastMirrorEpoch) { }
     }
 
     private static final class MirrorCommandOptions extends CommandDefaultOptions {
@@ -378,6 +423,7 @@ public abstract class ClusterMirrorCommand {
         private final ArgumentAcceptingOptionSpec<String> topicsOpt;
         private final ArgumentAcceptingOptionSpec<String> excludeOpt;
         private final OptionSpecBuilder jsonOpt;
+        private final OptionSpecBuilder failedOpt;
 
         MirrorCommandOptions(String[] args) {
             super(args);
@@ -423,6 +469,7 @@ public abstract class ClusterMirrorCommand {
                 .ofType(String.class);
 
             jsonOpt = parser.accepts("json", "Output description in JSON format");
+            failedOpt = parser.accepts("failed", "Show only failed partitions with error details.");
 
             options = parser.parse(args);
             checkArgs();
@@ -466,6 +513,10 @@ public abstract class ClusterMirrorCommand {
 
         private boolean hasJsonOption() {
             return has(jsonOpt);
+        }
+
+        private boolean hasFailedOption() {
+            return has(failedOpt);
         }
 
         private boolean hasDescribeOption() {
@@ -554,6 +605,9 @@ public abstract class ClusterMirrorCommand {
 
             if (has(jsonOpt) && !has(describeOpt))
                 throw new IllegalArgumentException("--json is only supported for describing mirrors");
+
+            if (has(failedOpt) && !has(describeOpt))
+                throw new IllegalArgumentException("--failed is only supported for describing mirrors");
         }
     }
 }


### PR DESCRIPTION
When a mirror partition enters FAILED state, the error is only visible
in broker logs. This makes it hard for operators to diagnose failures
without access to the broker log files.

This change persists the error message in MirrorPartitionStateValue and
exposes it through the DescribeClusterMirrors and ReadMirrorStates APIs.
A new --failed flag on kafka-cluster-mirrors.sh --describe filters to
failed partitions and shows a compact table with retry count and error.

Once retries are exhausted, the operator can easily recover permanently
failed partitions by issuing a stop followed by a start. We can also
automate this with an additional flag or command.
