### PR TITLE
shutdown mirror fetcher threads when connection change or deleted

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -488,21 +488,26 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         boolean mirrorDeleted = newImage.configs()
                                 .configProperties(e.getKey()).isEmpty();
                         if (mirrorDeleted) {
-                            log.info("Mirror '{}' has been deleted. Writing tombstone records.", mirrorName);
+                            log.info("Mirror '{}' has been deleted. Writing tombstone records and recreating connections.", mirrorName);
                             tombstoneWriter.ifPresent(h -> h.accept(mirrorName));
                         }
 
                         boolean connectionConfigChanged = e.getValue().changes().keySet().stream()
                                 .anyMatch(key -> !NON_CONNECTION_CONFIGS.contains(key));
 
+                        if (connectionConfigChanged) {
+                            log.info("Mirror '{}' has connection config changed. Recreating connections.", mirrorName);
+                        }
                         if (connectionConfigChanged || mirrorDeleted) {
                             sourceLeaders.remove(mirrorName);
                             sourceClusterIds.remove(mirrorName);
                             Admin admin = srcAdmins.remove(mirrorName);
                             if (admin != null) {
-                                admin.close();
+                                admin.close(Duration.ZERO);
                             }
-                            replicaManagerSupplier.get().mirrorFetcherManager().removeFetchersForMirror(mirrorName);
+                            var mirrorFetcherManager = replicaManagerSupplier.get().mirrorFetcherManager();
+                            mirrorFetcherManager.removeFetchersForMirror(mirrorName);
+                            mirrorFetcherManager.shutdownIdleFetcherThreads();
                             if (!mirrorDeleted) {
                                 reconnectedMirrors.add(mirrorName);
                             }


### PR DESCRIPTION
When mirror `bootstrap.server` changed, the flow will be like this:
1. MMM onMetadataUpdate detects the change
2. MMM shutdown caches, srcAdmin, removeFetcherFromMirror
3. MMM tries to create a new fetcher thread for `MIRRORING` state but fails due to no source leader metadata (cleaned in step 2)
```
ERROR [Broker id=4] Error setting up mirror fetcher for partition quickstart-events-0, refresh source cluster metadata and try again: No source cluster metadata available for mirror my-link partition:quickstart-events-0
```
4. Moving the state to `FAILED`, and do the source metadata refresh async 
5. `FAILED` backoff done, reentering the `MIRRORING` state, and try to recreate the mirror fetcher thread again

In this step, although we detect the new bootstrap server and try to recreate the fetcher thread, but in step (2) we forgot to shutdown the old mirror fetcher thread, which causes the step (5) fails to create a new thread (MirrorSourceSender) due to the duplicated metric registration error:
```
ERROR [Broker id=4] Error adding mirror fetcher for partitions Set(quickstart-events-0) (state.change.logger)
java.lang.IllegalArgumentException: A metric named 'MetricName [name=connection-count, group=mirror-fetcherId-0-mirrorName-my-link-metrics, description=The current number of active connections., tags={broker-id=1, fetcher-id=1}]' already exists, can't register another one.
at kafka.server.mirror.MirrorFetcherManager.createFetcherThread(MirrorFetcherManager.scala:147) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
```

Fix it by shutting down the idle fetcher threads when connectionConfigChanged or mirror deleted. 

Side fix: We do the `srcAdmin.close()` without providing timeout, which will block until all closed. Using 0 and do the close in async way.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
