### PR TITLE
RPC improvements

### DIFF
--- a/clients/src/main/resources/common/message/BumpLeaderEpochsResponse.json
+++ b/clients/src/main/resources/common/message/BumpLeaderEpochsResponse.json
@@ -25,6 +25,8 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+      "about": "The top-level error message, or null if there was no error." },
     { "name": "Topics", "type": "[]TopicPartitions", "versions": "0+",
       "about": "Each topic in the mirror.", "fields": [
       { "name": "TopicName", "type": "string", "versions": "0+",
@@ -34,7 +36,9 @@
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
         { "name": "ErrorCode", "type": "int16", "versions": "0",
-          "about": "The error code, or 0 if there was no error." }
+          "about": "The error code, or 0 if there was no error." },
+        { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+          "about": "The error message, or null if there was no error." }
       ]}
     ]}
   ]

--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -41,12 +41,12 @@
           "about": "The mirror partition state." },
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
           "about": "The error code, or 0 if there was no error." },
-        { "name": "PreviousState", "type": "int8", "taggedVersions": "0+", "tag": 0, "default": 16,
+        { "name": "PreviousState", "type": "int8", "versions": "0+", "default": 16,
           "about": "The mirror partition state before the last transition; UNKNOWN if not recorded." },
-        { "name": "RetryAttempt", "type": "int16", "taggedVersions": "0+", "tag": 1, "default": 0,
+        { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": 0,
           "about": "The number of automatic retry attempts while in FAILED state." },
-        { "name": "ErrorMessage", "type": "string", "taggedVersions": "0+", "tag": 2, "nullableVersions": "0+", "default": "null",
-          "about": "The error message when in FAILED state, or null if not applicable." }
+        { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+          "about": "The error message, or null if there was no error." }
       ]}
     ]}
   ]

--- a/clients/src/main/resources/common/message/WriteMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/WriteMirrorStatesResponse.json
@@ -36,7 +36,9 @@
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
-          "about": "The error code, or 0 if there was no error." }
+          "about": "The error code, or 0 if there was no error." },
+        { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+          "about": "The error message, or null if there was no error." }
       ]}
     ]}
   ]

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1581,6 +1581,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 ReadMirrorStatesResponseData.PartitionResult partitionResult = new ReadMirrorStatesResponseData.PartitionResult();
                 if (!isLocalCoordinator(mirrorName, tp, part)) {
                     partitionResult.setErrorCode(Errors.NOT_COORDINATOR.code());
+                    partitionResult.setErrorMessage(Errors.NOT_COORDINATOR.message());
                 } else {
                     partitionResult.setPartitionIndex(part);
                     partitionResult.setLastMirrorEpoch(lastMirrorEpochs.getOrDefault(pk, -1));

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -284,7 +284,8 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleWriteMirrorStates(request: RequestChannel.Request): Unit = {
     if (ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
-        requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData().setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)))
+        requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData()
+          .setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code).setErrorMessage(Errors.CLUSTER_AUTHORIZATION_FAILED.message)))
         return
       }
       val writeMirrorStatesRequest = request.body[WriteMirrorStatesRequest]
@@ -300,14 +301,16 @@ class KafkaApis(val requestChannel: RequestChannel,
       clusterMirrorCoordinator.updateTopicMetadata(mirrorName, partitionMetadata, res => requestHelper.sendMaybeThrottle(request, res))
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring write mirror states request")
-      requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
+      requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData()
+        .setErrorCode(Errors.UNSUPPORTED_VERSION.code).setErrorMessage(Errors.UNSUPPORTED_VERSION.message)))
     }
   }
 
   def handleReadMirrorStates(request: RequestChannel.Request): Unit = {
     if (ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
-        requestHelper.sendMaybeThrottle(request, new ReadMirrorStatesResponse(new ReadMirrorStatesResponseData().setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)))
+        requestHelper.sendMaybeThrottle(request, new ReadMirrorStatesResponse(new ReadMirrorStatesResponseData()
+          .setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code).setErrorMessage(Errors.CLUSTER_AUTHORIZATION_FAILED.message)))
         return
       }
       val readMirrorStatesRequest = request.body[ReadMirrorStatesRequest]
@@ -324,7 +327,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         res => requestHelper.sendMaybeThrottle(request, res))
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring read mirror states request")
-      requestHelper.sendMaybeThrottle(request, new ReadMirrorStatesResponse(new ReadMirrorStatesResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
+      requestHelper.sendMaybeThrottle(request, new ReadMirrorStatesResponse(new ReadMirrorStatesResponseData()
+        .setErrorCode(Errors.UNSUPPORTED_VERSION.code).setErrorMessage(Errors.UNSUPPORTED_VERSION.message)))
     }
   }
 


### PR DESCRIPTION
Convert tagged fields to normal fields in ReadMirrorStatesResponse and add ErrorMessage alongside ErrorCode for consistency across internal RPCs (ReadMirrorStates, WriteMirrorStates, BumpLeaderEpochs).