### PR TITLE
Allow mirror start to recover failed partitions

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -78,6 +78,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -98,6 +99,7 @@ import static org.apache.kafka.common.utils.Utils.require;
  * partitions it leads in that topic. Writes targeting a remote coordinator
  * are forwarded via {@link MirrorMetadataManager}.
  */
+@SuppressWarnings("ClassDataAbstractionCoupling")
 public class ClusterMirrorCoordinator {
     private final Logger log;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
@@ -108,6 +110,7 @@ public class ClusterMirrorCoordinator {
     private final MetadataCache metadataCache;
     private final ClusterMirrorRecordSerde serde = new ClusterMirrorRecordSerde();
     private volatile ScheduledFuture<?> metadataRefreshFuture;
+    private final Map<TopicPartition, ScheduledFuture<?>> pendingRetryFutures = new ConcurrentHashMap<>();
     private final Scheduler scheduler;
     private final Metrics metrics;
     private final Time time;
@@ -388,6 +391,10 @@ public class ClusterMirrorCoordinator {
                 || newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
             metadataManager.failedPartitionInfo().remove(tp);
+            ScheduledFuture<?> pending = pendingRetryFutures.remove(tp);
+            if (pending != null) {
+                pending.cancel(false);
+            }
         }
     }
 
@@ -411,7 +418,9 @@ public class ClusterMirrorCoordinator {
             long delay = failedRetryBackoff.backoff(attempt);
             MirrorPartitionState targetState = fpi != null ? fpi.previousState() : MirrorPartitionState.MIRRORING;
             log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
-            scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState, null), delay);
+            ScheduledFuture<?> future = scheduler.scheduleOnce("MirrorFailedRetry-" + tp,
+                    () -> transitionTo(mirrorName, Set.of(tp), targetState, null), delay);
+            pendingRetryFutures.put(tp, future);
         });
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -163,18 +163,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final int nodeId;
 
     private final KafkaConfig brokerConfig;
-    private final NodeToControllerChannelManager channelManager;
+    private final NodeToControllerChannelManager controllerChannel;
+    private volatile MirrorStateSender mirrorStateSender;
+    private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>();
+    private volatile Admin dstAdmin;
     private final Supplier<ReplicaManager> replicaManagerSupplier;
+    private volatile MetadataImage metadataImage = MetadataImage.EMPTY;
     private final MetadataCache metadataCache;
     private final KafkaScheduler scheduler;
     private final Metrics metrics;
     private final Time time;
-
-    private volatile MetadataImage metadataImage = MetadataImage.EMPTY;
-
-    private volatile MirrorStateSender mirrorStateSender; // raw WriteMirrorStates/ReadMirrorStates RPCs to coord brokers
-    private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>(); // source cluster metadata discovery (one per mirror)
-    private volatile Admin dstAdmin; // group offset and ACLs sync
 
     // Map from mirror name to cluster id. The cluster id is represented as a String because KIP-78
     // does not mandate the use of UUIDs for it and assuming so may break compatibility with existing clusters.
@@ -205,7 +203,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public MirrorMetadataManager(
         KafkaConfig brokerConfig,
-        NodeToControllerChannelManager channelManager,
+        NodeToControllerChannelManager controllerChannel,
         Supplier<ReplicaManager> replicaManagerSupplier,
         MetadataCache metadataCache,
         KafkaScheduler scheduler,
@@ -217,7 +215,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         this.log = new LogContext(name).logger(MirrorMetadataManager.class);
         this.nodeId = brokerConfig.nodeId();
 
-        this.channelManager = channelManager;
+        this.controllerChannel = controllerChannel;
         this.replicaManagerSupplier = replicaManagerSupplier;
         this.metadataCache = metadataCache;
 
@@ -804,7 +802,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 }
             }
         };
-        channelManager.sendRequest(
+        controllerChannel.sendRequest(
                 new CreateTopicsRequest.Builder(createTopicsData),
                 requestCompletionHandler);
     }
@@ -812,7 +810,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private void maybeScalePartitions(CreatePartitionsRequestData.CreatePartitionsTopicCollection topics) {
         if (!topics.isEmpty()) {
             log.debug("Detected partition count change, sending CreatePartitionsRequest: {}", topics);
-            channelManager.sendRequest(new CreatePartitionsRequest.Builder(
+            controllerChannel.sendRequest(new CreatePartitionsRequest.Builder(
                     new CreatePartitionsRequestData()
                             .setTopics(topics)
                             .setValidateOnly(false)
@@ -999,7 +997,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         .setResourceName(resource.name()).setConfigs(alterableConfigSet);
                 data.resources().add(alterConfigsResource);
             }
-            channelManager.sendRequest(new IncrementalAlterConfigsRequest.Builder(data), new TimeoutHandler(log));
+            controllerChannel.sendRequest(new IncrementalAlterConfigsRequest.Builder(data), new TimeoutHandler(log));
         }
     }
 
@@ -1277,7 +1275,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                     .setOperation(aclBinding.entry().operation().code())
                                     .setPermissionType(aclBinding.entry().permissionType().code()))
                     .toList();
-            channelManager.sendRequest(
+            controllerChannel.sendRequest(
                     new CreateAclsRequest.Builder(new CreateAclsRequestData().setCreations(requestData)),
                     new TimeoutHandler(log)
             );
@@ -1296,7 +1294,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                     .setOperation(aclBinding.entry().operation().code())
                                     .setPermissionType(aclBinding.entry().permissionType().code()))
                     .toList();
-            channelManager.sendRequest(
+            controllerChannel.sendRequest(
                     new DeleteAclsRequest.Builder(new DeleteAclsRequestData().setFilters(requestData)),
                     new TimeoutHandler(log)
             );
@@ -1358,7 +1356,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         // TODO: creation failures from auto-discovery are silently lost here (fire-and-forget).
         //  Add per-topic status tracking so describeMirror can surface failed topics to users.
-        channelManager.sendRequest(
+        controllerChannel.sendRequest(
                 new StartMirrorTopicsRequest.Builder(data),
                 new TimeoutHandler(log)
         );
@@ -1383,7 +1381,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         log.info("Stopping {} topic(s) matching mirror.topics.exclude for mirror {}: {}",
                 excludedTopics.size(), mirrorName, excludedTopics);
 
-        channelManager.sendRequest(
+        controllerChannel.sendRequest(
                 new StopMirrorTopicsRequest.Builder(mirrorName, excludedTopics),
                 new TimeoutHandler(log)
         );
@@ -1770,7 +1768,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         pendingLeaderEpochBumps.add(new ClusterMirrorUtils.LeaderEpochBump(future, new ConcurrentHashMap<>(partitionMinEpochs)));
         maybeCompletePendingEpochBumps(); // already-met condition is detected immediately (e.g. epoch 11 vs target 0)
 
-        channelManager.sendRequest(new BumpLeaderEpochsRequest.Builder(
+        controllerChannel.sendRequest(new BumpLeaderEpochsRequest.Builder(
                 new BumpLeaderEpochsRequestData().setTopics(topicStates)
         ), new ControllerRequestCompletionHandler() {
             @Override
@@ -1819,6 +1817,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
             collectEpochBumpTargets(ts, topicPartitions, leaderEpochFromMetadata);
         }
+        leaderEpochFromMetadata.keySet().removeIf(tp ->
+                partitionStates.getOrDefault(new PartitionKey(mirrorName, tp.topic(), tp.partition()),
+                        MirrorPartitionState.UNKNOWN) == MirrorPartitionState.FAILED);
         if (!leaderEpochFromMetadata.isEmpty()) {
             log.info("Bumping leader epoch for partitions {}", leaderEpochFromMetadata);
         }
@@ -1993,7 +1994,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     private void sendDeleteClusterMirror(String mirrorName, long brokerMetadataOffset, Consumer<Optional<Errors>> callback) {
-        channelManager.sendRequest(
+        controllerChannel.sendRequest(
                 new DeleteClusterMirrorRequest.Builder(mirrorName, brokerMetadataOffset),
                 new ControllerRequestCompletionHandler() {
                     @Override

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -101,8 +101,6 @@ class MirrorFetcherThread(name: String,
         s"epoch $highestBatchLeaderEpoch is higher than local leader epoch $localLeaderEpoch")
     } else {
       replicaMgr.mirrorMetadataManager.foreach { mmm =>
-        mmm.failedPartitionInfo.remove(topicPartition)
-
         if (highestBatchLeaderEpoch > localLeaderEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
           // When source batch is close to the local epoch (within LEADER_EPOCH_BUMP_THRESHOLD),
           // schedule a proactive local epoch bump while still allowing the current batch to append.

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -320,7 +320,9 @@ public class ConfigurationControlManager {
             if (topicInfo != null) {
                 String currMirrorNameValue = topicInfo.mirrorName();
                 int currMirrorStateChange = topicInfo.mirrorState();
-                if (currMirrorNameValue != null && !currMirrorNameValue.isBlank() && currMirrorStateChange != MirrorPartitionState.STOPPED.value()) {
+                if (currMirrorNameValue != null && !currMirrorNameValue.isBlank()
+                        && currMirrorStateChange != MirrorPartitionState.STOPPED.value()
+                        && currMirrorStateChange != MirrorPartitionState.MIRRORING.value()) {
                     topicRes.setErrorCode(Errors.TOPIC_ALREADY_IN_CLUSTER_MIRROR.code()).setName(topicName)
                             .setErrorMessage("Topic '" + topicName + "' is already in mirror '" + currMirrorNameValue
                                     + "' in " + MirrorPartitionState.fromValue((byte) currMirrorStateChange) + " state");

--- a/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
@@ -204,8 +204,7 @@ public final class TopicDelta {
         boolean mirrorNameChanged = mirrorName != null && !mirrorName.isBlank()
                 && !mirrorName.equals(image.mirrorName());
         boolean mirrorStateChanged = desiredMirrorState != null
-                && desiredMirrorState != MirrorPartitionState.UNKNOWN.value()
-                && desiredMirrorState != image.desiredMirrorState();
+                && desiredMirrorState != MirrorPartitionState.UNKNOWN.value();
         if (mirrorNameChanged || mirrorStateChanged) {
             mirrorTopicChanges.put(image.id(), new LocalReplicaChanges.MirrorTopicState(mirrorName, desiredMirrorState));
         }


### PR DESCRIPTION
Previously, recovering FAILED mirror partitions required a stop followed by a start, because two gates blocked an idempotent start:

1. ConfigurationControlManager.startMirrorTopics rejected the request with TOPIC_ALREADY_IN_CLUSTER_MIRROR when the desired state was already MIRRORING.

2. TopicDelta.localChanges suppressed the delta when the desired state had not changed, preventing onMetadataUpdate from firing.

Relax both checks so that a start command re-emits the MirrorTopicStateChangeRecord and propagates the delta even when the desired state is unchanged. The existing applyStateTransition logic already transitions FAILED partitions to LOG_TRUNCATION, and healthy MIRRORING partitions receive a harmless no-op transition.