### PR TITLE
Adding and persist source cluster id in mirror config

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -247,6 +247,10 @@ public class CommonClientConfigs {
             "metadata for this interval, client repeats the bootstrap process using <code>bootstrap.servers</code> configuration.";
     public static final long DEFAULT_METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS = 300 * 1000;
 
+    // the mirror configs for kafka admin client and server use
+    public static final String MIRROR_SOURCE_CLUSTER_ID_CONFIG = "mirror.source.cluster.id";
+    public static final String MIRROR_SOURCE_CLUSTER_ID_DOC = "The mirrored source cluster ID. This is a required configuration when creating a cluster mirror.";
+
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4868,6 +4868,16 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             CreateClusterMirrorRequest.Builder createRequest(int timeoutMs) {
+                if (!configs.containsKey(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG)) {
+                    Map<String, Object> adminConfig = new HashMap<>(configs);
+                    try (Admin sourceAdmin = Admin.create(adminConfig)) {
+                        var sourceClusterId = sourceAdmin.describeCluster().clusterId().get();
+                        configs.put(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG, sourceClusterId);
+                    } catch (Exception e) {
+                        log.error("Failed to get cluster id from source cluster", e);
+                        throw new RuntimeException(e);
+                    }
+                }
                 return new CreateClusterMirrorRequest.Builder(mirrorName, configs);
             }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4866,13 +4866,15 @@ public class KafkaAdminClient extends AdminClient {
         final Call call = new Call("createClusterMirror", calcDeadlineMs(now, options.timeoutMs()),
                 new LeastLoadedBrokerOrActiveKController()) {
 
+            @SuppressWarnings("unchecked")
             @Override
             CreateClusterMirrorRequest.Builder createRequest(int timeoutMs) {
                 if (!configs.containsKey(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG)) {
-                    Map<String, Object> adminConfig = new HashMap<>(configs);
-                    try (Admin sourceAdmin = Admin.create(adminConfig)) {
+                    Map<String, String> mutableConfigs = new HashMap<>(configs);
+                    try (Admin sourceAdmin = Admin.create((Map) mutableConfigs)) {
                         var sourceClusterId = sourceAdmin.describeCluster().clusterId().get();
-                        configs.put(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG, sourceClusterId);
+                        mutableConfigs.put(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG, sourceClusterId);
+                        return new CreateClusterMirrorRequest.Builder(mirrorName, mutableConfigs);
                     } catch (Exception e) {
                         log.error("Failed to get cluster id from source cluster", e);
                         throw new RuntimeException(e);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -24,6 +24,7 @@ import kafka.server.mirror.ClusterMirrorUtils.FailedPartitionInfo;
 import kafka.server.mirror.ClusterMirrorUtils.PartitionKey;
 
 import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -175,10 +176,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private volatile MirrorStateSender mirrorStateSender; // raw WriteMirrorStates/ReadMirrorStates RPCs to coord brokers
     private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>(); // source cluster metadata discovery (one per mirror)
     private volatile Admin dstAdmin; // group offset and ACLs sync
-
-    // Map from mirror name to cluster id. The cluster id is represented as a String because KIP-78
-    // does not mandate the use of UUIDs for it and assuming so may break compatibility with existing clusters.
-    private final Map<String, String> sourceClusterIds = new ConcurrentHashMap<>();
 
     private final Map<String, Map<TopicPartition, ClusterMirrorUtils.LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
@@ -369,7 +366,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         }
                         if (connectionConfigChanged || mirrorDeleted) {
                             sourceLeaders.remove(mirrorName);
-                            sourceClusterIds.remove(mirrorName);
                             Admin admin = srcAdmins.remove(mirrorName);
                             if (admin != null) {
                                 admin.close(Duration.ZERO);
@@ -538,7 +534,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         partitionStates.clear();
         partitionStateCounts.clear();
         lastMirrorEpochs.clear();
-        sourceClusterIds.clear();
         sourceLeaders.clear();
         pendingLeaderEpochBumps.clear();
         pendingPartitionStates.clear();
@@ -656,7 +651,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             var clusterResult = srcAdmin.describeCluster();
             String newClusterId = clusterResult.clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
             if (newClusterId != null && !newClusterId.isEmpty()) {
-                String previousClusterId = sourceClusterIds.put(mirrorName, newClusterId);
+                String previousClusterId = getSourceClusterId(mirrorName);
                 if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
                     throw new IllegalStateException("Source cluster ID changed for mirror " + mirrorName
                             + ": expected " + previousClusterId + ", got " + newClusterId
@@ -2019,17 +2014,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     String getSourceClusterId(String mirrorName) {
-        String cached = sourceClusterIds.get(mirrorName);
-        if (cached != null) {
-            return cached;
-        }
-
-        try {
-            validateSourceClusterId(mirrorName);
-        } catch (Exception e) {
-            log.warn("Failed to resolve source cluster ID for mirror {}", mirrorName, e);
-        }
-        return sourceClusterIds.get(mirrorName);
+        Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName));
+        return (String) props.get(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG);
     }
 
     /** Groups loaded partition states by mirror and state, then invokes the callback for each group. */

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -213,10 +213,12 @@ class ControllerApis(
       altersByName.put(config.name, new util.AbstractMap.SimpleEntry[AlterConfigOp.OpType, String](
         AlterConfigOp.OpType.forId(0), config.value))
     }
-    if (!altersByName.containsKey(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG) ||
-      !altersByName.containsKey(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG)) {
-      throw new InvalidRequestException(s"Missing required config ${CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG} or" +
-        s" ${CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG} in CreateClusterMirrorRequest")
+    if (!altersByName.containsKey(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG)) {
+      throw new InvalidRequestException(s"Missing required config ${CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG} in CreateClusterMirrorRequest")
+    }
+
+    if (!altersByName.containsKey(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG)) {
+      throw new InvalidRequestException(s"Missing required config ${CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG} in CreateClusterMirrorRequest")
     }
 
     controller.createClusterMirror(context, createMirrorRequest.data().mirrorName(), altersByName)

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -29,6 +29,7 @@ import kafka.server.logger.RuntimeLoggerManager
 import kafka.server.metadata.KRaftMetadataCache
 import kafka.server.mirror.ClusterMirrorUtils
 import kafka.utils.Logging
+import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.{AlterConfigOp, EndpointType}
 import org.apache.kafka.common.Uuid.ZERO_UUID
 import org.apache.kafka.common.acl.AclOperation.{ALTER, ALTER_CONFIGS, CLUSTER_ACTION, CREATE, CREATE_TOKENS, DELETE, DESCRIBE, DESCRIBE_CONFIGS}
@@ -211,6 +212,11 @@ class ControllerApis(
     createMirrorRequest.data().config.forEach { config =>
       altersByName.put(config.name, new util.AbstractMap.SimpleEntry[AlterConfigOp.OpType, String](
         AlterConfigOp.OpType.forId(0), config.value))
+    }
+    if (!altersByName.containsKey(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG) ||
+      !altersByName.containsKey(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG)) {
+      throw new InvalidRequestException(s"Missing required config ${CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG} or" +
+        s" ${CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG} in CreateClusterMirrorRequest")
     }
 
     controller.createClusterMirror(context, createMirrorRequest.data().mirrorName(), altersByName)

--- a/server/src/main/java/org/apache/kafka/server/config/ClusterMirrorConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/ClusterMirrorConfig.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import static org.apache.kafka.clients.CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG;
+import static org.apache.kafka.clients.CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_DOC;
 import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
 import static org.apache.kafka.common.config.ConfigDef.Importance.LOW;
 import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
@@ -285,6 +287,7 @@ public final class ClusterMirrorConfig {
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             // Connection
             .define(BOOTSTRAP_SERVERS_CONFIG, LIST, null, HIGH, BOOTSTRAP_SERVERS_DOC)
+            .define(MIRROR_SOURCE_CLUSTER_ID_CONFIG, STRING, null, HIGH, MIRROR_SOURCE_CLUSTER_ID_DOC)
             .define(REQUEST_TIMEOUT_MS_CONFIG, INT, REQUEST_TIMEOUT_MS_DEFAULT, atLeast(0), MEDIUM, REQUEST_TIMEOUT_MS_DOC)
             .define(CONNECTION_SETUP_TIMEOUT_MS_CONFIG, LONG, CONNECTION_SETUP_TIMEOUT_MS_DEFAULT, atLeast(0L), MEDIUM, CONNECTION_SETUP_TIMEOUT_MS_DOC)
             .define(CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG, LONG, CONNECTION_SETUP_TIMEOUT_MAX_MS_DEFAULT, atLeast(0L), MEDIUM, CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC)


### PR DESCRIPTION
Adding and persisting the "mirror.source.cluster.id" into metadata log in cluster-mirrors resource.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
