### PR TITLE
Add TopicLineage-based LME lookup to DescribeClusterMirrors

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -247,9 +247,9 @@ public class CommonClientConfigs {
             "metadata for this interval, client repeats the bootstrap process using <code>bootstrap.servers</code> configuration.";
     public static final long DEFAULT_METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS = 300 * 1000;
 
-    // the mirror configs for kafka admin client and server use
+    // Cluster Mirroring
     public static final String MIRROR_SOURCE_CLUSTER_ID_CONFIG = "mirror.source.cluster.id";
-    public static final String MIRROR_SOURCE_CLUSTER_ID_DOC = "The mirrored source cluster ID. This is a required configuration when creating a cluster mirror.";
+    public static final String MIRROR_SOURCE_CLUSTER_ID_DOC = "The mirror source cluster ID. Automatically recovered from the source cluster if not present.";
 
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * A detailed description of a single cluster mirror.
+ * A detailed description of a cluster mirror.
  */
 @InterfaceStability.Evolving
 public class ClusterMirrorDesc {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterMirrorsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterMirrorsOptions.java
@@ -18,6 +18,10 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.message.DescribeClusterMirrorsRequestData;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Options for {@link Admin#describeClusterMirrors(java.util.Collection, DescribeClusterMirrorsOptions)}.
@@ -28,6 +32,7 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 public class DescribeClusterMirrorsOptions extends AbstractOptions<DescribeClusterMirrorsOptions> {
 
     private boolean includeAuthorizedOperations = false;
+    private List<DescribeClusterMirrorsRequestData.TopicLineage> topicLineages = Collections.emptyList();
 
     /**
      * Set whether authorized operations should be included in the response.
@@ -45,5 +50,14 @@ public class DescribeClusterMirrorsOptions extends AbstractOptions<DescribeClust
      */
     public boolean includeAuthorizedOperations() {
         return includeAuthorizedOperations;
+    }
+
+    public DescribeClusterMirrorsOptions topicLineages(List<DescribeClusterMirrorsRequestData.TopicLineage> topicLineages) {
+        this.topicLineages = topicLineages;
+        return this;
+    }
+
+    public List<DescribeClusterMirrorsRequestData.TopicLineage> topicLineages() {
+        return topicLineages;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterMirrorsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterMirrorsResult.java
@@ -18,8 +18,10 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -30,9 +32,16 @@ import java.util.Map;
 @InterfaceStability.Evolving
 public class DescribeClusterMirrorsResult {
     private final KafkaFuture<Map<String, ClusterMirrorDesc>> future;
+    private final KafkaFuture<Map<Uuid, Map<Integer, Integer>>> lineageEpochsFuture;
 
     DescribeClusterMirrorsResult(KafkaFuture<Map<String, ClusterMirrorDesc>> future) {
+        this(future, KafkaFuture.completedFuture(Collections.emptyMap()));
+    }
+
+    DescribeClusterMirrorsResult(KafkaFuture<Map<String, ClusterMirrorDesc>> future,
+                                 KafkaFuture<Map<Uuid, Map<Integer, Integer>>> lineageEpochsFuture) {
         this.future = future;
+        this.lineageEpochsFuture = lineageEpochsFuture;
     }
 
     /**
@@ -40,5 +49,13 @@ public class DescribeClusterMirrorsResult {
      */
     public KafkaFuture<Map<String, ClusterMirrorDesc>> allDescriptions() {
         return future;
+    }
+
+    /**
+     * Return a future containing lineage-based LME results.
+     * Keyed by topicId, then partitionIndex to lastMirrorEpoch.
+     */
+    public KafkaFuture<Map<Uuid, Map<Integer, Integer>>> lineageEpochs() {
+        return lineageEpochsFuture;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5221,10 +5221,9 @@ public class KafkaAdminClient extends AdminClient {
     @Override
     public DescribeClusterMirrorsResult describeClusterMirrors(Collection<String> mirrorNames, DescribeClusterMirrorsOptions options) {
         final KafkaFutureImpl<Map<String, ClusterMirrorDesc>> all = new KafkaFutureImpl<>();
+        final KafkaFutureImpl<Map<Uuid, Map<Integer, Integer>>> lineageAll = new KafkaFutureImpl<>();
         final long nowMetadata = time.milliseconds();
         final long deadline = calcDeadlineMs(nowMetadata, options.timeoutMs());
-        // We query all brokers to get up-to-date lag AND state
-        // Each broker that's actively fetching partitions already has state in its local cache
         runnable.call(new Call("findAllBrokers", deadline, new LeastLoadedNodeProvider()) {
             @Override
             MetadataRequest.Builder createRequest(int timeoutMs) {
@@ -5241,7 +5240,7 @@ public class KafkaAdminClient extends AdminClient {
                     throw new StaleMetadataException("Metadata fetch failed due to missing broker list");
 
                 HashSet<Node> allNodes = new HashSet<>(nodes);
-                final DescribeClusterMirrorsResults results = new DescribeClusterMirrorsResults(allNodes, mirrorNames, all);
+                final DescribeClusterMirrorsResults results = new DescribeClusterMirrorsResults(allNodes, mirrorNames, all, lineageAll);
 
                 for (final Node node : allNodes) {
                     final long nowDescribe = time.milliseconds();
@@ -5251,6 +5250,9 @@ public class KafkaAdminClient extends AdminClient {
                             DescribeClusterMirrorsRequestData data = new DescribeClusterMirrorsRequestData()
                                 .setMirrorNames(new ArrayList<>(mirrorNames))
                                 .setIncludeAuthorizedOperations(options.includeAuthorizedOperations());
+                            if (!options.topicLineages().isEmpty()) {
+                                data.setTopicLineages(new ArrayList<>(options.topicLineages()));
+                            }
                             return new DescribeClusterMirrorsRequest.Builder(data);
                         }
 
@@ -5261,6 +5263,7 @@ public class KafkaAdminClient extends AdminClient {
                                 for (DescribeClusterMirrorsResponseData.DescribedMirror mirror : response.data().mirrors()) {
                                     results.handleMirror(mirror);
                                 }
+                                results.handleLineageResults(response.data().lineageResults());
                                 results.tryComplete(node);
                             }
                         }
@@ -5280,10 +5283,11 @@ public class KafkaAdminClient extends AdminClient {
             void handleFailure(Throwable throwable) {
                 KafkaException exception = new KafkaException("Failed to find brokers to send DescribeMirrors", throwable);
                 all.completeExceptionally(exception);
+                lineageAll.completeExceptionally(exception);
             }
         }, nowMetadata);
 
-        return new DescribeClusterMirrorsResult(all);
+        return new DescribeClusterMirrorsResult(all, lineageAll);
     }
 
     private static final class DescribeClusterMirrorsResults {
@@ -5292,15 +5296,20 @@ public class KafkaAdminClient extends AdminClient {
         private final boolean describeAll;
         private final HashSet<Node> remaining;
         private final KafkaFutureImpl<Map<String, ClusterMirrorDesc>> allFuture;
+        private final KafkaFutureImpl<Map<Uuid, Map<Integer, Integer>>> lineageFuture;
+        private final Map<Uuid, Map<Integer, Integer>> lineageEpochs;
 
         DescribeClusterMirrorsResults(Collection<Node> brokers,
                                Collection<String> mirrorNames,
-                               KafkaFutureImpl<Map<String, ClusterMirrorDesc>> allFuture) {
+                               KafkaFutureImpl<Map<String, ClusterMirrorDesc>> allFuture,
+                               KafkaFutureImpl<Map<Uuid, Map<Integer, Integer>>> lineageFuture) {
             this.partialDescriptions = new HashMap<>();
             this.requestedMirrors = new HashSet<>(mirrorNames);
             this.describeAll = mirrorNames.isEmpty();
             this.remaining = new HashSet<>(brokers);
             this.allFuture = allFuture;
+            this.lineageFuture = lineageFuture;
+            this.lineageEpochs = new HashMap<>();
 
             // Pre-populate partial descriptions only if specific mirrors are requested
             if (!describeAll) {
@@ -5328,6 +5337,15 @@ public class KafkaAdminClient extends AdminClient {
             partial.merge(mirror);
         }
 
+        synchronized void handleLineageResults(List<DescribeClusterMirrorsResponseData.LineageTopicResult> results) {
+            for (DescribeClusterMirrorsResponseData.LineageTopicResult topic : results) {
+                Map<Integer, Integer> partitionEpochs = lineageEpochs.computeIfAbsent(topic.topicId(), k -> new HashMap<>());
+                for (DescribeClusterMirrorsResponseData.LineagePartitionResult partition : topic.partitions()) {
+                    partitionEpochs.merge(partition.partitionIndex(), partition.lastMirrorEpoch(), Math::max);
+                }
+            }
+        }
+
         synchronized void tryComplete(Node broker) {
             remaining.remove(broker);
             tryComplete();
@@ -5349,8 +5367,10 @@ public class KafkaAdminClient extends AdminClient {
                 }
                 if (descriptions.isEmpty() && firstError != null) {
                     allFuture.completeExceptionally(firstError);
+                    lineageFuture.completeExceptionally(firstError);
                 } else {
                     allFuture.complete(descriptions);
+                    lineageFuture.complete(lineageEpochs);
                 }
             }
         }
@@ -5358,6 +5378,9 @@ public class KafkaAdminClient extends AdminClient {
         synchronized void completeAllExceptionally(Throwable throwable) {
             if (!allFuture.isDone()) {
                 allFuture.completeExceptionally(throwable);
+            }
+            if (!lineageFuture.isDone()) {
+                lineageFuture.completeExceptionally(throwable);
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5333,14 +5333,15 @@ public class KafkaAdminClient extends AdminClient {
                 partialDescriptions.put(mirror.mirrorName(), partial);
             }
 
-            // Merge this broker's data
+            // Merge across all brokers
             partial.merge(mirror);
         }
 
-        synchronized void handleLineageResults(List<DescribeClusterMirrorsResponseData.LineageTopicResult> results) {
-            for (DescribeClusterMirrorsResponseData.LineageTopicResult topic : results) {
-                Map<Integer, Integer> partitionEpochs = lineageEpochs.computeIfAbsent(topic.topicId(), k -> new HashMap<>());
-                for (DescribeClusterMirrorsResponseData.LineagePartitionResult partition : topic.partitions()) {
+        synchronized void handleLineageResults(List<DescribeClusterMirrorsResponseData.LineageResult> results) {
+            for (DescribeClusterMirrorsResponseData.LineageResult result : results) {
+                Map<Integer, Integer> partitionEpochs = lineageEpochs.computeIfAbsent(result.topicId(), k -> new HashMap<>());
+                // Merge across all brokers
+                for (DescribeClusterMirrorsResponseData.PartitionResult partition : result.partitions()) {
                     partitionEpochs.merge(partition.partitionIndex(), partition.lastMirrorEpoch(), Math::max);
                 }
             }
@@ -5419,7 +5420,6 @@ public class KafkaAdminClient extends AdminClient {
                     this.authorizedOperations = mirror.authorizedOperations();
                 }
 
-                // Merge topic partitions
                 for (DescribeClusterMirrorsResponseData.TopicPartitions topic : mirror.topics()) {
                     Set<ClusterMirrorDesc.LeaderStateDesc> partitions =
                             topicPartitions.computeIfAbsent(topic.topicName(), k -> new HashSet<>());

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsRequest.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsRequest.json
@@ -25,6 +25,17 @@
     { "name": "MirrorNames", "type": "[]string", "versions": "0+", "entityType": "mirrorName",
       "about": "The names of the mirrors to describe. Null or empty array means all mirrors." },
     { "name": "IncludeAuthorizedOperations", "type": "bool", "versions": "0+", "default": "false",
-      "about": "Whether to include authorized operations." }
+      "about": "Whether to include authorized operations." },
+    { "name": "TopicLineages", "type": "[]TopicLineage", "versions": "0+",
+      "about": "Topic lineages for cross-mirror LME lookup during topology changes.", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic ID." },
+      { "name": "Partitions", "type": "[]int32", "versions": "0+",
+        "about": "The partition indexes." },
+      { "name": "SrcClusterId", "type": "string", "versions": "0+",
+        "about": "The source cluster ID from the requesting cluster's mirror config." },
+      { "name": "DstClusterId", "type": "string", "versions": "0+",
+        "about": "The requesting cluster's own cluster ID." }
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsRequest.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsRequest.json
@@ -27,6 +27,7 @@
     { "name": "IncludeAuthorizedOperations", "type": "bool", "versions": "0+", "default": "false",
       "about": "Whether to include authorized operations." },
     { "name": "TopicLineages", "type": "[]TopicLineage", "versions": "0+",
+      "taggedVersions": "0+", "tag": 0, "ignorable": true,
       "about": "Topic lineages for cross-mirror LME lookup during topology changes.", "fields": [
       { "name": "TopicId", "type": "uuid", "versions": "0+",
         "about": "The topic ID." },

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsRequest.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsRequest.json
@@ -34,9 +34,7 @@
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
         "about": "The partition indexes." },
       { "name": "SrcClusterIds", "type": "[]string", "versions": "0+",
-        "about": "The source cluster IDs from the requesting cluster's mirror configs." },
-      { "name": "DstClusterId", "type": "string", "versions": "0+",
-        "about": "The requesting cluster's own cluster ID." }
+        "about": "Cluster IDs to match against stored mirror configs on the receiving broker. Includes the requesting cluster's own ID and source IDs from its mirror configs." }
     ]}
   ]
 }

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsRequest.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsRequest.json
@@ -33,8 +33,8 @@
         "about": "The topic ID." },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
         "about": "The partition indexes." },
-      { "name": "SrcClusterId", "type": "string", "versions": "0+",
-        "about": "The source cluster ID from the requesting cluster's mirror config." },
+      { "name": "SrcClusterIds", "type": "[]string", "versions": "0+",
+        "about": "The source cluster IDs from the requesting cluster's mirror configs." },
       { "name": "DstClusterId", "type": "string", "versions": "0+",
         "about": "The requesting cluster's own cluster ID." }
     ]}

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
@@ -62,6 +62,7 @@
       ]}
     ]},
     { "name": "LineageResults", "type": "[]LineageTopicResult", "versions": "0+",
+      "taggedVersions": "0+", "tag": 0, "ignorable": true,
       "about": "LME results from cross-mirror topic lineage matching.", "fields": [
       { "name": "TopicId", "type": "uuid", "versions": "0+",
         "about": "The topic ID." },

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
@@ -61,12 +61,12 @@
         ]}
       ]}
     ]},
-    { "name": "LineageResults", "type": "[]LineageTopicResult", "versions": "0+",
+    { "name": "LineageResults", "type": "[]LineageResult", "versions": "0+",
       "taggedVersions": "0+", "tag": 0, "ignorable": true,
       "about": "LME results from cross-mirror topic lineage matching.", "fields": [
       { "name": "TopicId", "type": "uuid", "versions": "0+",
         "about": "The topic ID." },
-      { "name": "Partitions", "type": "[]LineagePartitionResult", "versions": "0+",
+      { "name": "Partitions", "type": "[]PartitionResult", "versions": "0+",
         "about": "Per-partition LME from lineage matching.", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
@@ -60,6 +60,18 @@
           }
         ]}
       ]}
+    ]},
+    { "name": "LineageResults", "type": "[]LineageTopicResult", "versions": "0+",
+      "about": "LME results from cross-mirror topic lineage matching.", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic ID." },
+      { "name": "Partitions", "type": "[]LineagePartitionResult", "versions": "0+",
+        "about": "Per-partition LME from lineage matching.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "LastMirrorEpoch", "type": "int32", "versions": "0+", "default": "-1",
+          "about": "The max last mirror epoch across all matching mirrors, or -1 if not found." }
+      ]}
     ]}
   ]
 }

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -22,7 +22,6 @@ import kafka.server.mirror.ClusterMirrorUtils.FailedPartitionInfo;
 import kafka.server.mirror.ClusterMirrorUtils.PartitionKey;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.admin.ClusterMirrorDesc;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.compress.Compression;
@@ -749,22 +748,22 @@ public class ClusterMirrorCoordinator {
         return future;
     }
 
-    /** Schedules truncation to align replicas with last mirrored epoch. */
+    /** Schedules truncation to align replicas with last mirror epoch. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
         final Consumer<TopicPartition> truncateCallback =
             partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING, null);
-        scheduler.scheduleOnce("LastMirrorEpochsTruncation",
+        scheduler.scheduleOnce("LastMirrorEpochTruncation",
             () -> {
                 try {
                     metadataManager.truncateToLastMirrorEpochs(mirrorName, topicPartitions)
-                        .whenComplete((descriptions, error) -> {
+                        .whenComplete((epochs, error) -> {
                             if (error != null) {
                                 if (error instanceof UnsupportedVersionException) {
                                     log.warn("Source cluster doesn't support DescribeClusterMirror API. " +
                                         "Replication will be one-way without failback");
-                                    Map<TopicPartition, Integer> epochs = topicPartitions.stream()
+                                    Map<TopicPartition, Integer> fallback = topicPartitions.stream()
                                         .collect(Collectors.toMap(tp -> tp, tp -> -1));
-                                    replicaManager.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
+                                    replicaManager.maybeTruncateForLeaderEpoch(fallback, truncateCallback);
                                 } else {
                                     log.warn("Failed to truncate to last mirrored epoch for mirror {}", mirrorName, error);
                                     transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED, error.getMessage());
@@ -772,24 +771,6 @@ public class ClusterMirrorCoordinator {
                                 return;
                             }
 
-                            ClusterMirrorDesc description = descriptions.get(mirrorName);
-                            if (description == null) {
-                                log.warn("Mirror {} not found in source cluster. Replication will be one-way without failback",
-                                    mirrorName);
-                                Map<TopicPartition, Integer> epochs = topicPartitions.stream()
-                                    .collect(Collectors.toMap(tp -> tp, tp -> -1));
-                                replicaManager.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
-                                return;
-                            }
-
-                            Map<TopicPartition, Integer> epochs = new HashMap<>();
-                            description.topics().forEach((topicName, leaderState) -> {
-                                leaderState.forEach(leaderStateEntry -> {
-                                    epochs.put(leaderStateEntry.topicPartition(), leaderStateEntry.lastMirrorEpoch());
-                                });
-                            });
-
-                            // if the source cluster doesn't have mirror info, no result will be returned.
                             if (epochs.size() != topicPartitions.size()) {
                                 topicPartitions.forEach(partition -> {
                                     if (!epochs.containsKey(partition)) {
@@ -798,8 +779,7 @@ public class ClusterMirrorCoordinator {
                                 });
                             }
 
-                            replicaManager.maybeTruncateForLeaderEpoch(epochs,
-                                    partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING, null));
+                            replicaManager.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
                         });
                 } catch (Exception e) {
                     log.warn("Failed to truncate to last mirror epochs for mirror {}", mirrorName, e);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -424,9 +424,7 @@ public class ClusterMirrorCoordinator {
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
-                                // TODO: a new component will handle state transitions from a shared queue, so retry means put back in the queue
-                                log.error("Failed to update partition state for {}: {}, retrying", tp, ex.getMessage());
-                                scheduler.scheduleOnce("MirrorStateUpdateRetry", () -> updateMirrorPartitionState(mirrorName, tp, newState), 100);
+                                log.error("Failed to update partition state for {}: {}", tp, ex.getMessage());
                             } else {
                                 // successfully writes data into internal log
                                 try {
@@ -648,9 +646,10 @@ public class ClusterMirrorCoordinator {
                         response.foreach(res -> {
                             ProduceResponse.PartitionResponse partitionRes = res._2;
                             if (partitionRes.error.code() != Errors.NONE.code()) {
-                                // TODO: retry logic
-                                log.error("Failed to write last mirrored epochs to coordinator: {}", partitionRes.error.message());
-                                future.completeExceptionally(partitionRes.error.exception());
+                                // TODO: handle failure, we can't retry forever
+                                log.error("Failed to write LMEs to coordinator: {}, retrying", partitionRes.error.message());
+                                scheduler.scheduleOnce("LmeWriteRetry-" + mirrorName,
+                                        () -> updateLastMirrorEpochs(mirrorName, partitionOffsets), 100);
                             } else {
                                 future.complete(null);
                             }
@@ -670,8 +669,10 @@ public class ClusterMirrorCoordinator {
                 res.data().topics().forEach(topicResult -> {
                     topicResult.partitions().forEach(partitionResult -> {
                         if (partitionResult.errorCode() != Errors.NONE.code()) {
-                            log.error("Failed to write last mirrored epochs to remote coordinator: {}", partitionResult.errorCode());
-                            future.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
+                            // TODO: handle failure, we can't retry forever
+                            log.error("Failed to write LMEs to remote coordinator: {}, retrying", partitionResult.errorCode());
+                            scheduler.scheduleOnce("LmeWriteRetry-" + mirrorName,
+                                    () -> updateLastMirrorEpochs(mirrorName, partitionOffsets), 100);
                         } else {
                             future.complete(null);
                         }
@@ -714,7 +715,10 @@ public class ClusterMirrorCoordinator {
                         partitionResponses.foreach(partitionRes -> {
                             ProduceResponse.PartitionResponse pr = partitionRes._2;
                             if (pr.error.code() != Errors.NONE.code()) {
-                                log.error("Failed to write partition state to coordinator: {}", pr.error.message());
+                                // TODO: handle failure, we can't retry forever
+                                log.error("Failed to write partition state to coordinator: {}, retrying", pr.error.message());
+                                scheduler.scheduleOnce("PartitionStateWriteRetry-" + topicPartition,
+                                        () -> updateMirrorPartitionState(mirrorName, topicPartition, newState), 100);
                                 future.completeExceptionally(pr.error.exception());
                             } else {
                                 metadataManager.updatePartitionState(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
@@ -738,8 +742,10 @@ public class ClusterMirrorCoordinator {
                             metadataManager.updatePartitionState(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
                             future.complete(Optional.of(topicPartition));
                         } else {
-                            // propagate remote coordinator errors to trigger retry
-                            log.error("Failed to write partition state to remote coordinator: {}", par.errorCode());
+                            // TODO: handle failure, we can't retry forever
+                            log.error("Failed to write partition state to remote coordinator: {}, retrying", par.errorCode());
+                            scheduler.scheduleOnce("PartitionStateWriteRetry-" + topicPartition,
+                                    () -> updateMirrorPartitionState(mirrorName, topicPartition, newState), 100);
                             future.completeExceptionally(Errors.forCode(par.errorCode()).exception());
                         }
                     })));

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -653,6 +653,7 @@ public class ClusterMirrorCoordinator {
                                 log.error("Failed to write LMEs to coordinator: {}, retrying", partitionRes.error.message());
                                 scheduler.scheduleOnce("LmeWriteRetry-" + mirrorName,
                                         () -> updateLastMirrorEpochs(mirrorName, partitionOffsets), 100);
+                                future.completeExceptionally(partitionRes.error.exception());
                             } else {
                                 future.complete(null);
                             }
@@ -676,6 +677,7 @@ public class ClusterMirrorCoordinator {
                             log.error("Failed to write LMEs to remote coordinator: {}, retrying", partitionResult.errorCode());
                             scheduler.scheduleOnce("LmeWriteRetry-" + mirrorName,
                                     () -> updateLastMirrorEpochs(mirrorName, partitionOffsets), 100);
+                            future.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
                         } else {
                             future.complete(null);
                         }

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -424,7 +424,10 @@ public class ClusterMirrorCoordinator {
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
-                                log.error("Failed to update partition state for {}: {}", tp, ex.getMessage());
+                                // TODO: handle failure, we can't retry forever
+                                log.error("Failed to update partition state for {}: {}, retrying", tp, ex.getMessage());
+                                scheduler.scheduleOnce("MirrorStateUpdateRetry-" + tp,
+                                        () -> transitionTo(mirrorName, Set.of(tp), newState, errorMessage), 100);
                             } else {
                                 // successfully writes data into internal log
                                 try {
@@ -715,10 +718,7 @@ public class ClusterMirrorCoordinator {
                         partitionResponses.foreach(partitionRes -> {
                             ProduceResponse.PartitionResponse pr = partitionRes._2;
                             if (pr.error.code() != Errors.NONE.code()) {
-                                // TODO: handle failure, we can't retry forever
-                                log.error("Failed to write partition state to coordinator: {}, retrying", pr.error.message());
-                                scheduler.scheduleOnce("PartitionStateWriteRetry-" + topicPartition,
-                                        () -> updateMirrorPartitionState(mirrorName, topicPartition, newState), 100);
+                                log.error("Failed to write partition state to coordinator: {}", pr.error.message());
                                 future.completeExceptionally(pr.error.exception());
                             } else {
                                 metadataManager.updatePartitionState(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
@@ -742,10 +742,7 @@ public class ClusterMirrorCoordinator {
                             metadataManager.updatePartitionState(new PartitionKey(mirrorName, topicPartition.topic(), topicPartition.partition()), newState);
                             future.complete(Optional.of(topicPartition));
                         } else {
-                            // TODO: handle failure, we can't retry forever
-                            log.error("Failed to write partition state to remote coordinator: {}, retrying", par.errorCode());
-                            scheduler.scheduleOnce("PartitionStateWriteRetry-" + topicPartition,
-                                    () -> updateMirrorPartitionState(mirrorName, topicPartition, newState), 100);
+                            log.error("Failed to write partition state to remote coordinator: {}", par.errorCode());
                             future.completeExceptionally(Errors.forCode(par.errorCode()).exception());
                         }
                     })));

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -109,6 +109,7 @@ public class ClusterMirrorCoordinator {
     private final ClusterMirrorRecordSerde serde = new ClusterMirrorRecordSerde();
     private volatile ScheduledFuture<?> metadataRefreshFuture;
     private final Scheduler scheduler;
+    private final Scheduler refreshScheduler;
     private final Metrics metrics;
     private final Time time;
 
@@ -118,6 +119,7 @@ public class ClusterMirrorCoordinator {
             MirrorMetadataManager metadataManager,
             MetadataCache metadataCache,
             Scheduler scheduler,
+            Scheduler refreshScheduler,
             Metrics metrics,
             Time time
     ) {
@@ -128,6 +130,7 @@ public class ClusterMirrorCoordinator {
         this.metadataManager = metadataManager;
         this.metadataCache = metadataCache;
         this.scheduler = scheduler;
+        this.refreshScheduler = refreshScheduler;
         this.metrics = metrics;
         this.time = time;
     }
@@ -155,9 +158,11 @@ public class ClusterMirrorCoordinator {
                 this::getCoordinatorPartitionByName);
 
         scheduler.startup();
+        refreshScheduler.startup();
 
-        // periodically query source cluster to get the metadata
-        metadataRefreshFuture = scheduler.schedule("MirrorMetadataRefresh",
+        // periodically query source cluster to get the metadata (on its own thread
+        // so RPC timeouts against unreachable sources don't block state transitions)
+        metadataRefreshFuture = refreshScheduler.schedule("MirrorMetadataRefresh",
                 metadataManager::runMetadataRefresh, 0, brokerConfig.mirrorConfig().metadataRefreshIntervalMs());
 
         log.info("Startup complete.");
@@ -168,7 +173,7 @@ public class ClusterMirrorCoordinator {
         if (oldFuture != null) {
             oldFuture.cancel(false);
         }
-        metadataRefreshFuture = scheduler.schedule("MirrorMetadataRefresh",
+        metadataRefreshFuture = refreshScheduler.schedule("MirrorMetadataRefresh",
                 metadataManager::runMetadataRefresh, newIntervalMs, newIntervalMs);
         log.info("Rescheduled metadata refresh with interval {} ms", newIntervalMs);
     }
@@ -186,6 +191,12 @@ public class ClusterMirrorCoordinator {
         // in-flight periodicSync admin calls (describeCluster, describeTopics)
         // fail immediately instead of blocking for up to requestTimeoutMs each.
         metadataManager.closeSourceAdmins();
+        try {
+            refreshScheduler.shutdown();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while shutting down refresh scheduler", e);
+        }
         try {
             scheduler.shutdown();
         } catch (InterruptedException e) {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -748,14 +748,14 @@ public class ClusterMirrorCoordinator {
         return future;
     }
 
-    /** Schedules truncation to align replicas with last mirror epoch. */
+    /** Schedules log truncation to align replicas with their last mirror epoch. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
         final Consumer<TopicPartition> truncateCallback =
             partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING, null);
         scheduler.scheduleOnce("LastMirrorEpochTruncation",
             () -> {
                 try {
-                    metadataManager.truncateToLastMirrorEpochs(mirrorName, topicPartitions)
+                    metadataManager.lookupLineageEpochs(mirrorName, topicPartitions)
                         .whenComplete((epochs, rawError) -> {
                             if (rawError != null) {
                                 Throwable error = rawError instanceof CompletionException && rawError.getCause() != null

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -266,7 +266,7 @@ public class ClusterMirrorCoordinator {
                                 String clusterName = readMirrorNameFromKey(record.key());
                                 if (record.hasValue()) {
                                     Map<String, Map<Integer, Integer>> offsets = readLastMirrorEpochsValue(record.value());
-                                    metadataManager.updateLastMirrorEpochs(clusterName, offsets, Map.of());
+                                    metadataManager.updateLastMirrorEpochs(clusterName, offsets);
                                 } else {
                                     metadataManager.removeLastMirrorEpochs(clusterName);
                                 }
@@ -625,7 +625,7 @@ public class ClusterMirrorCoordinator {
         }
 
         // Update in-memory cache once with all offsets
-        var updatedOffsets = metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets, Map.of());
+        var updatedOffsets = metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets);
 
         // Write to local coordinator partitions (one append per coordinator partition)
         localByCoordPartition.forEach((coordPartition, tps) -> {
@@ -755,7 +755,7 @@ public class ClusterMirrorCoordinator {
         scheduler.scheduleOnce("LastMirrorEpochTruncation",
             () -> {
                 try {
-                    metadataManager.lookupLineageEpochs(mirrorName, topicPartitions)
+                    metadataManager.sendLmeLookup(mirrorName, topicPartitions)
                         .whenComplete((epochs, rawError) -> {
                             if (rawError != null) {
                                 Throwable error = rawError instanceof CompletionException && rawError.getCause() != null
@@ -880,6 +880,12 @@ public class ClusterMirrorCoordinator {
     /** Returns the cached last mirror epochs for the given mirror. */
     public Map<TopicPartition, Integer> getLastMirrorEpochs(String mirrorName) {
         return metadataManager.getLastMirrorEpochs(mirrorName);
+    }
+
+    /** Coordinator-aware LME lookup for lineage results. */
+    public void processLmeLookup(Map<String, Map<String, Set<Integer>>> mirrorPartitions,
+                                 Consumer<Map<String, Map<TopicPartition, Integer>>> callback) {
+        metadataManager.processLmeLookup(mirrorPartitions, callback);
     }
 
     private CoordinatorRecord buildPartitionStateRecord(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -109,7 +109,6 @@ public class ClusterMirrorCoordinator {
     private final ClusterMirrorRecordSerde serde = new ClusterMirrorRecordSerde();
     private volatile ScheduledFuture<?> metadataRefreshFuture;
     private final Scheduler scheduler;
-    private final Scheduler refreshScheduler;
     private final Metrics metrics;
     private final Time time;
 
@@ -119,7 +118,6 @@ public class ClusterMirrorCoordinator {
             MirrorMetadataManager metadataManager,
             MetadataCache metadataCache,
             Scheduler scheduler,
-            Scheduler refreshScheduler,
             Metrics metrics,
             Time time
     ) {
@@ -130,7 +128,6 @@ public class ClusterMirrorCoordinator {
         this.metadataManager = metadataManager;
         this.metadataCache = metadataCache;
         this.scheduler = scheduler;
-        this.refreshScheduler = refreshScheduler;
         this.metrics = metrics;
         this.time = time;
     }
@@ -158,11 +155,8 @@ public class ClusterMirrorCoordinator {
                 this::getCoordinatorPartitionByName);
 
         scheduler.startup();
-        refreshScheduler.startup();
 
-        // periodically query source cluster to get the metadata (on its own thread
-        // so RPC timeouts against unreachable sources don't block state transitions)
-        metadataRefreshFuture = refreshScheduler.schedule("MirrorMetadataRefresh",
+        metadataRefreshFuture = scheduler.schedule("MirrorMetadataRefresh",
                 metadataManager::runMetadataRefresh, 0, brokerConfig.mirrorConfig().metadataRefreshIntervalMs());
 
         log.info("Startup complete.");
@@ -173,7 +167,7 @@ public class ClusterMirrorCoordinator {
         if (oldFuture != null) {
             oldFuture.cancel(false);
         }
-        metadataRefreshFuture = refreshScheduler.schedule("MirrorMetadataRefresh",
+        metadataRefreshFuture = scheduler.schedule("MirrorMetadataRefresh",
                 metadataManager::runMetadataRefresh, newIntervalMs, newIntervalMs);
         log.info("Rescheduled metadata refresh with interval {} ms", newIntervalMs);
     }
@@ -191,12 +185,6 @@ public class ClusterMirrorCoordinator {
         // in-flight periodicSync admin calls (describeCluster, describeTopics)
         // fail immediately instead of blocking for up to requestTimeoutMs each.
         metadataManager.closeSourceAdmins();
-        try {
-            refreshScheduler.shutdown();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.warn("Interrupted while shutting down refresh scheduler", e);
-        }
         try {
             scheduler.shutdown();
         } catch (InterruptedException e) {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -77,6 +77,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -756,8 +757,10 @@ public class ClusterMirrorCoordinator {
             () -> {
                 try {
                     metadataManager.truncateToLastMirrorEpochs(mirrorName, topicPartitions)
-                        .whenComplete((epochs, error) -> {
-                            if (error != null) {
+                        .whenComplete((epochs, rawError) -> {
+                            if (rawError != null) {
+                                Throwable error = rawError instanceof CompletionException && rawError.getCause() != null
+                                        ? rawError.getCause() : rawError;
                                 if (error instanceof UnsupportedVersionException) {
                                     log.warn("Source cluster doesn't support DescribeClusterMirror API. " +
                                         "Replication will be one-way without failback");

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -28,9 +28,9 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.ClusterMirrorDesc;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeClusterMirrorsOptions;
 import org.apache.kafka.clients.admin.DescribeClusterMirrorsResult;
 import org.apache.kafka.clients.admin.GroupListing;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
@@ -57,6 +57,7 @@ import org.apache.kafka.common.message.CreateAclsRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.DeleteAclsRequestData;
+import org.apache.kafka.common.message.DescribeClusterMirrorsRequestData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.ReadMirrorStatesRequestData;
@@ -161,9 +162,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Logger log;
     private volatile boolean isInitialized = false;
     private final String name;
+    private final String clusterId;
+    private final KafkaConfig brokerConfig;
     private final int nodeId;
 
-    private final KafkaConfig brokerConfig;
     private final NodeToControllerChannelManager channelManager;
     private final Supplier<ReplicaManager> replicaManagerSupplier;
     private final MetadataCache metadataCache;
@@ -201,6 +203,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final AtomicLong aclSyncError;
 
     public MirrorMetadataManager(
+        String clusterId,
         KafkaConfig brokerConfig,
         NodeToControllerChannelManager channelManager,
         Supplier<ReplicaManager> replicaManagerSupplier,
@@ -209,6 +212,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         Metrics metrics,
         Time time
     ) {
+        this.clusterId = clusterId;
         this.brokerConfig = brokerConfig;
         this.name = "[" + MirrorMetadataManager.class.getSimpleName() + " id=" + brokerConfig.nodeId() + "] ";
         this.log = new LogContext(name).logger(MirrorMetadataManager.class);
@@ -2067,13 +2071,44 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /** Truncates local replicas using last mirrored leader epochs from this broker's coordinator cache. */
-    CompletionStage<Map<String, ClusterMirrorDesc>> truncateToLastMirrorEpochs(
+    CompletionStage<Map<TopicPartition, Integer>> truncateToLastMirrorEpochs(
             String mirrorName, Set<TopicPartition> topicPartitionSet) {
         log.info("Truncating to last mirrored epochs from local state for mirror {}: {}", mirrorName, topicPartitionSet);
         Admin admin = getOrCreateSourceAdmin(mirrorName);
-        DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName));
-        return result.allDescriptions().toCompletionStage()
+
+        String srcClusterId = getSourceClusterId(mirrorName);
+        Map<Uuid, List<Integer>> topicPartitionsByTopicId = new HashMap<>();
+        for (TopicPartition tp : topicPartitionSet) {
+            Uuid topicId = metadataCache.getTopicId(tp.topic());
+            topicPartitionsByTopicId.computeIfAbsent(topicId, k -> new ArrayList<>()).add(tp.partition());
+        }
+
+        List<DescribeClusterMirrorsRequestData.TopicLineage> lineages = topicPartitionsByTopicId.entrySet().stream()
+                .map(e -> new DescribeClusterMirrorsRequestData.TopicLineage()
+                        .setTopicId(e.getKey())
+                        .setPartitions(e.getValue())
+                        .setSrcClusterId(srcClusterId != null ? srcClusterId : "")
+                        .setDstClusterId(clusterId))
+                .collect(Collectors.toList());
+
+        DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
+                .topicLineages(lineages);
+        DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName), options);
+
+        return result.lineageEpochs().toCompletionStage()
                 .toCompletableFuture()
+                .thenApply(lineageEpochs -> {
+                    Map<TopicPartition, Integer> epochs = new HashMap<>();
+                    if (!lineageEpochs.isEmpty()) {
+                        lineageEpochs.forEach((topicId, partitionEpochs) -> {
+                            Optional<String> topicName = metadataCache.getTopicName(topicId);
+                            topicName.ifPresent(name ->
+                                    partitionEpochs.forEach((partIdx, lme) ->
+                                            epochs.put(new TopicPartition(name, partIdx), lme)));
+                        });
+                    }
+                    return epochs;
+                })
                 .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -923,7 +923,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             syncTopicConfigs(mirrorName, mirrorConfig);
             syncGroupOffsets(mirrorName, mirrorConfig);
             syncAcls(mirrorName, mirrorConfig);
-            maybeBumpLeaderEpochs(mirrorName, topicInfos, Set.of());
+            if (!getConfiguredTopics(mirrorName, false, false).isEmpty()) {
+                maybeBumpLeaderEpochs(mirrorName, topicInfos, Set.of());
+            }
             discoverTopicsByPattern(mirrorName, mirrorConfig);
             enforceExcludePatterns(mirrorName, mirrorConfig);
         } catch (Exception e) {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -2100,11 +2100,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
-     * Builds topic lineage entries for all configured source cluster IDs.
-     * In failback/fan-out, the source needs to match against prior mirror configs.
-     *
      * A topic lineage is a tuple of (topicId, partitions, srcClusterId, dstClusterId)
      * that describes a past or current mirroring relationship for a topic.
+     *
+     * Builds topic lineage entries for all configured source cluster IDs.
+     * The source needs to match against prior mirror configs.
      */
     private List<DescribeClusterMirrorsRequestData.TopicLineage> buildTopicLineages(
             Set<TopicPartition> topicPartitionSet) {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1553,6 +1553,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 PartitionKey mpk = new PartitionKey(
                                         mirrorName, topic.name(), partition.partitionIndex());
                                 TopicPartition tp = new TopicPartition(topic.name(), partition.partitionIndex());
+                                if (partition.lastMirrorEpoch() != -1) {
+                                    lastMirrorEpochs.put(mpk, partition.lastMirrorEpoch());
+                                }
                                 if (partition.state() != -1) {
                                     partitionStates.put(mpk, MirrorPartitionState.fromValue(partition.state()));
                                 }
@@ -2080,7 +2083,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             String mirrorName, Set<TopicPartition> topicPartitionSet) {
         Admin admin = getOrCreateSourceAdmin(mirrorName);
         List<DescribeClusterMirrorsRequestData.TopicLineage> lineages = buildTopicLineages(topicPartitionSet);
-        log.info("LME lookup request for mirror {}: {}", mirrorName, lineages);
+        log.info("Last mirror epoch lookup request for mirror {}: {}", mirrorName, lineages);
         DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
                 .topicLineages(lineages);
         DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName), options);
@@ -2096,7 +2099,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                             epochs.put(new TopicPartition(name, partIdx), lme)));
                         });
                     }
-                    log.info("LME lookup response for mirror {}: {}", mirrorName, epochs);
+                    log.info("Last mirror epoch lookup response for mirror {}: {}", mirrorName, epochs);
                     return epochs;
                 })
                 .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -124,6 +124,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -168,17 +169,23 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     private final NodeToControllerChannelManager channelManager;
     private final Supplier<ReplicaManager> replicaManagerSupplier;
+    private volatile MetadataImage metadataImage = MetadataImage.EMPTY;
     private final MetadataCache metadataCache;
     private final KafkaScheduler scheduler;
     private final Metrics metrics;
     private final Time time;
 
-    private volatile MetadataImage metadataImage = MetadataImage.EMPTY;
+    private Optional<ClusterMirrorUtils.StateTransitioner> stateTransitioner = Optional.empty();
+    private Optional<Consumer<String>> tombstoneWriter = Optional.empty();
+    private Optional<Function<ClusterMirrorRecordKey, Integer>> coordPartitionFinderByKey = Optional.empty();
+    private Optional<Function<String, Integer>> coordPartitionFinderByName = Optional.empty();
 
+    // Network communication
     private volatile MirrorStateSender mirrorStateSender; // raw WriteMirrorStates/ReadMirrorStates RPCs to coord brokers
     private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>(); // source cluster metadata discovery (one per mirror)
     private volatile Admin dstAdmin; // group offset and ACLs sync
 
+    // Broker cache
     private final Map<String, Map<TopicPartition, ClusterMirrorUtils.LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
     private final Map<PartitionKey, MirrorPartitionState> partitionStates = new ConcurrentHashMap<>();
     private final Map<PartitionKey, Integer> lastMirrorEpochs = new ConcurrentHashMap<>();
@@ -186,16 +193,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Map<TopicPartition, FailedPartitionInfo> failedPartitionInfo = new ConcurrentHashMap<>();
     private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
     private final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
-
-    // Leader epoch bumps require a request to the controller followed by a metadata log fetch.
-    // The bump must be confirmed on the broker side before we can write the PID reset control record.
     private final Set<ClusterMirrorUtils.LeaderEpochBump> pendingLeaderEpochBumps = ConcurrentHashMap.newKeySet();
 
-    private Optional<ClusterMirrorUtils.StateTransitioner> stateTransitioner = Optional.empty();
-    private Optional<Consumer<String>> tombstoneWriter = Optional.empty();
-    private Optional<Function<ClusterMirrorRecordKey, Integer>> coordPartitionFinderByKey = Optional.empty();
-    private Optional<Function<String, Integer>> coordPartitionFinderByName = Optional.empty();
-
+    // Metrics
     private final AtomicLong metadataRefreshError;
     private final AtomicLong topicConfigSyncError;
     private final AtomicLong consumerGroupOffsetSyncError;
@@ -435,7 +435,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 if (!isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
                     PartitionKey key = new PartitionKey(mirrorName, tp.topic(), tp.partition());
                     removePartitionState(key);
-                    lastMirrorEpochs.remove(key);
                 }
             });
         }
@@ -1540,15 +1539,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     if (response.responseBody() instanceof ReadMirrorStatesResponse readMirrorStatesResponse) {
                         log.debug("Read states from remote coordinator completed: {}", response.responseBody());
 
-                        // Update cache
                         readMirrorStatesResponse.data().topics().forEach(topic -> {
                             topic.partitions().forEach(partition -> {
                                 PartitionKey mpk = new PartitionKey(
                                         mirrorName, topic.name(), partition.partitionIndex());
                                 TopicPartition tp = new TopicPartition(topic.name(), partition.partitionIndex());
-                                if (partition.lastMirrorEpoch() != -1) {
-                                    lastMirrorEpochs.put(mpk, partition.lastMirrorEpoch());
-                                }
                                 if (partition.state() != -1) {
                                     partitionStates.put(mpk, MirrorPartitionState.fromValue(partition.state()));
                                 }
@@ -2072,17 +2067,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /** Looks up lineage epochs from the source cluster for failback/fan-out truncation. */
-    CompletionStage<Map<TopicPartition, Integer>> lookupLineageEpochs(
+    CompletionStage<Map<TopicPartition, Integer>> sendLmeLookup(
             String mirrorName, Set<TopicPartition> topicPartitionSet) {
-        log.info("Truncating to LME for mirror {}: {}", mirrorName, topicPartitionSet);
         Admin admin = getOrCreateSourceAdmin(mirrorName);
-
+        List<DescribeClusterMirrorsRequestData.TopicLineage> lineages = buildTopicLineages(topicPartitionSet);
+        log.info("Sending LME lookup for mirror {}, lineages {}", mirrorName, lineages);
         DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
-                .topicLineages(buildTopicLineages(topicPartitionSet));
+                .topicLineages(lineages);
         DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName), options);
 
-        return result.lineageEpochs().toCompletionStage()
-                .toCompletableFuture()
+        return result.lineageEpochs().toCompletionStage().toCompletableFuture()
                 .thenApply(lineageEpochs -> {
                     Map<TopicPartition, Integer> epochs = new HashMap<>();
                     if (!lineageEpochs.isEmpty()) {
@@ -2093,56 +2087,140 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                             epochs.put(new TopicPartition(name, partIdx), lme)));
                         });
                     }
-                    log.info("Lineage LME lookup for mirror {}: {}", mirrorName, epochs);
+                    log.info("LME lookup result for mirror {}: {}", mirrorName, epochs);
                     return epochs;
                 })
                 .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
     }
 
     /**
-     * A topic lineage is a tuple of (topicId, partitions, srcClusterId, dstClusterId)
-     * that describes a past or current mirroring relationship for a topic.
-     *
      * Builds topic lineage entries for all configured source cluster IDs.
      * The source needs to match against prior mirror configs.
      */
     private List<DescribeClusterMirrorsRequestData.TopicLineage> buildTopicLineages(
             Set<TopicPartition> topicPartitionSet) {
-        Set<String> allSourceClusterIds = new HashSet<>();
+        Map<String, String> mirrorSourceClusterIds = new HashMap<>();
         for (String mirrorName : getConfiguredMirrors()) {
             String cid = getSourceClusterId(mirrorName);
             if (cid != null && !cid.isEmpty()) {
-                allSourceClusterIds.add(cid);
+                mirrorSourceClusterIds.put(mirrorName, cid);
             }
         }
 
-        Map<Uuid, List<Integer>> topicPartitionsByTopicId = new HashMap<>();
+        Map<Uuid, List<Integer>> partitionsByTopicId = new HashMap<>();
         for (TopicPartition tp : topicPartitionSet) {
             Uuid topicId = metadataCache.getTopicId(tp.topic());
-            topicPartitionsByTopicId.computeIfAbsent(topicId, k -> new ArrayList<>()).add(tp.partition());
+            partitionsByTopicId.computeIfAbsent(topicId, k -> new ArrayList<>()).add(tp.partition());
         }
 
+        List<String> allSrcClusterIds = new ArrayList<>(mirrorSourceClusterIds.values());
         List<DescribeClusterMirrorsRequestData.TopicLineage> lineages = new ArrayList<>();
-        for (Map.Entry<Uuid, List<Integer>> entry : topicPartitionsByTopicId.entrySet()) {
-            for (String srcClusterId : allSourceClusterIds) {
-                lineages.add(new DescribeClusterMirrorsRequestData.TopicLineage()
-                        .setTopicId(entry.getKey())
-                        .setPartitions(entry.getValue())
-                        .setSrcClusterId(srcClusterId)
-                        .setDstClusterId(clusterId));
-            }
+        for (Map.Entry<Uuid, List<Integer>> entry : partitionsByTopicId.entrySet()) {
+            List<Integer> partitions = entry.getValue();
+            lineages.add(new DescribeClusterMirrorsRequestData.TopicLineage()
+                    .setTopicId(entry.getKey())
+                    .setPartitions(partitions)
+                    .setSrcClusterIds(allSrcClusterIds)
+                    .setDstClusterId(clusterId));
         }
         return lineages;
     }
 
-    /** Removes stopped partition epochs and upserts added ones, returning the full epoch map for record serialization. */
-    Map<PartitionKey, Integer> updateLastMirrorEpochs(
-            String clusterName, Map<String, Map<Integer, Integer>> addedEpochs, Map<String, Map<Integer, Integer>> stoppedEpochs) {
-        stoppedEpochs.forEach((topic, partitionOffsets) -> {
-            partitionOffsets.forEach((partition, offset) -> {
-                lastMirrorEpochs.remove(new PartitionKey(clusterName, topic, partition));
+    /**
+     * Coordinator-aware LME lookup for lineage results. For each (mirror, topic, partition),
+     * reads from local cache if this broker is the coordinator, otherwise forwards a
+     * ReadMirrorStates request to the coordinator broker.
+     *
+     * @param mirrorPartitions mirrorName -> topicName -> partition indices
+     * @param callback receives mirrorName -> (TopicPartition -> LME) when all reads complete
+     */
+    void processLmeLookup(Map<String, Map<String, Set<Integer>>> mirrorPartitions,
+                          Consumer<Map<String, Map<TopicPartition, Integer>>> callback) {
+        log.debug("Preocessing LME lookup for {}", mirrorPartitions);
+        Map<String, Map<TopicPartition, Integer>> result = new ConcurrentHashMap<>();
+
+        // Group remote partitions by (coordinator node, mirror name)
+        Map<Node, Map<String, Map<String, Set<Integer>>>> remoteByNode = new HashMap<>();
+
+        mirrorPartitions.forEach((mirrorName, topicParts) -> {
+            topicParts.forEach((topic, parts) -> {
+                parts.forEach(part -> {
+                    if (isLocalCoordinator(mirrorName, topic, part)) {
+                        PartitionKey pk = new PartitionKey(mirrorName, topic, part);
+                        int lme = lastMirrorEpochs.getOrDefault(pk, -1);
+                        result.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>())
+                                .put(new TopicPartition(topic, part), lme);
+                    } else {
+                        ClusterMirrorRecordKey key = new ClusterMirrorRecordKey(
+                                mirrorName, metadataCache.getTopicId(topic), part);
+                        Node node = findCoordinatorNode(key);
+                        if (!node.equals(Node.noNode())) {
+                            remoteByNode
+                                    .computeIfAbsent(node, k -> new HashMap<>())
+                                    .computeIfAbsent(mirrorName, k -> new HashMap<>())
+                                    .computeIfAbsent(topic, k -> new HashSet<>())
+                                    .add(part);
+                        }
+                    }
+                });
             });
         });
+
+        if (remoteByNode.isEmpty()) {
+            log.debug("LME lookup result (local): {}", result);
+            callback.accept(result);
+            return;
+        }
+
+        // Count total requests: one per (node, mirror) pair
+        int totalRequests = remoteByNode.values().stream()
+                .mapToInt(Map::size).sum();
+        AtomicInteger remaining = new AtomicInteger(totalRequests);
+
+        remoteByNode.forEach((node, mirrorMap) -> {
+            mirrorMap.forEach((mirrorName, topicParts) -> {
+                ReadMirrorStatesRequestData data = new ReadMirrorStatesRequestData()
+                        .setMirrorName(mirrorName);
+                List<ReadMirrorStatesRequestData.TopicMetadata> topicDataList = new ArrayList<>();
+                topicParts.forEach((topic, parts) -> {
+                    List<ReadMirrorStatesRequestData.PartitionData> partDataList = new ArrayList<>();
+                    parts.forEach(part -> partDataList.add(
+                            new ReadMirrorStatesRequestData.PartitionData().setPartitionIndex(part)));
+                    topicDataList.add(new ReadMirrorStatesRequestData.TopicMetadata()
+                            .setName(topic).setPartitions(partDataList));
+                });
+                data.setTopics(topicDataList);
+
+                mirrorStateSender.enqueue(new RequestAndCompletionHandler(
+                        time.milliseconds(), node,
+                        new ReadMirrorStatesRequest.Builder(data),
+                        response -> {
+                            if (response.responseBody() instanceof ReadMirrorStatesResponse resp) {
+                                resp.data().topics().forEach(topic -> {
+                                    topic.partitions().forEach(partition -> {
+                                        if (partition.lastMirrorEpoch() != -1) {
+                                            result.computeIfAbsent(mirrorName,
+                                                            k -> new ConcurrentHashMap<>())
+                                                    .put(new TopicPartition(topic.name(),
+                                                                    partition.partitionIndex()),
+                                                            partition.lastMirrorEpoch());
+                                        }
+                                    });
+                                });
+                            }
+                            if (remaining.decrementAndGet() == 0) {
+                                log.debug("LME lookup result (coordinator): {}", result);
+                                callback.accept(result);
+                            }
+                        }
+                ));
+            });
+        });
+    }
+
+    /** Upserts added paritions, returning the full epoch map for record serialization. */
+    Map<PartitionKey, Integer> updateLastMirrorEpochs(
+            String clusterName, Map<String, Map<Integer, Integer>> addedEpochs) {
         addedEpochs.forEach((topic, partitionOffsets) -> {
             partitionOffsets.forEach((partition, offset) -> {
                 lastMirrorEpochs.put(new PartitionKey(clusterName, topic, partition), offset);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -570,34 +570,42 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      *   1. if it's in PAUSED state, we should move it to MIRRORING state. It will happen when users resume mirroring
      *   2. if it's in UNKNOWN, STOPPED, or FAILED state, we should move it to LOG_TRUNCATION state.
      *      UNKNOWN/STOPPED happens on startMirrorTopics. FAILED happens on manual restart after retries are exhausted.
-     *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should
+     *   3. if it's in LOG_TRUNCATION or EPOCH_FENCING, skip. These transient states are already being processed
+     *      and re-triggering would cause redundant work (e.g. duplicate LME lookups).
+     *   4. else, keep the same state as is. This could happen like leadership change, and the new leader should
      *      continue to complete the process in previous leader
      */
     private void applyStateTransition(String mirrorName, TopicPartition tp,
                                       MirrorPartitionState curState, MirrorPartitionState fetchedState,
                                       boolean stopRequested, boolean pauseRequested) {
         stateTransitioner.ifPresent(t -> {
+            MirrorPartitionState newState;
             if (stopRequested) {
-                if (curState != MirrorPartitionState.STOPPED) {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPING, null);
-                } else {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED, null);
-                }
+                newState = curState != MirrorPartitionState.STOPPED
+                        ? MirrorPartitionState.STOPPING : MirrorPartitionState.STOPPED;
             } else if (pauseRequested) {
-                if (curState != MirrorPartitionState.PAUSED) {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSING, null);
-                } else {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED, null);
-                }
+                newState = curState != MirrorPartitionState.PAUSED
+                        ? MirrorPartitionState.PAUSING : MirrorPartitionState.PAUSED;
             } else if (curState == MirrorPartitionState.PAUSED) {
-                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.MIRRORING, null);
+                newState = MirrorPartitionState.MIRRORING;
             } else if (curState == MirrorPartitionState.UNKNOWN
                     || curState == MirrorPartitionState.STOPPED
                     || curState == MirrorPartitionState.FAILED) {
-                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION, null);
+                newState = MirrorPartitionState.LOG_TRUNCATION;
+            } else if (curState == MirrorPartitionState.LOG_TRUNCATION
+                    || curState == MirrorPartitionState.EPOCH_FENCING) {
+                // Transient state already in progress. Re-triggering would cause redundant work.
+                log.debug("Partition {} already in transient state {}, skipping re-transition.", tp, curState);
+                return;
             } else {
-                t.transitionTo(mirrorName, Set.of(tp), fetchedState != null ? fetchedState : curState, null);
+                newState = fetchedState != null ? fetchedState : curState;
             }
+            // Eagerly update the cache before the async coordinator write. This prevents a
+            // second metadata update (e.g. epoch bump) from seeing stale UNKNOWN and re-triggering
+            // the same transition. Safe because the coordinator retries writes on failure, so the
+            // state will eventually be confirmed.
+            updatePartitionState(new PartitionKey(mirrorName, tp.topic(), tp.partition()), newState);
+            t.transitionTo(mirrorName, Set.of(tp), newState, null);
         });
     }
 
@@ -881,6 +889,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
             TopicImage topicImage = metadataImage.topics().getTopic(tp.topic());
             if (topicImage == null) {
+                return;
+            }
+            // Skip stopped/paused topics: if the partition cache was cleared (e.g. coordinator
+            // leadership change), the state defaults to UNKNOWN and would be restarted here.
+            int desiredState = topicImage.desiredMirrorState();
+            if (desiredState == MirrorPartitionState.STOPPED.value()
+                    || desiredState == MirrorPartitionState.PAUSED.value()) {
                 return;
             }
             var partition = topicImage.partitions().get(tp.partition());
@@ -2071,7 +2086,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             String mirrorName, Set<TopicPartition> topicPartitionSet) {
         Admin admin = getOrCreateSourceAdmin(mirrorName);
         List<DescribeClusterMirrorsRequestData.TopicLineage> lineages = buildTopicLineages(topicPartitionSet);
-        log.info("Sending LME lookup for mirror {}, lineages {}", mirrorName, lineages);
+        log.info("LME lookup request for mirror {}: {}", mirrorName, lineages);
         DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
                 .topicLineages(lineages);
         DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName), options);
@@ -2087,7 +2102,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                             epochs.put(new TopicPartition(name, partIdx), lme)));
                         });
                     }
-                    log.info("LME lookup result for mirror {}: {}", mirrorName, epochs);
+                    log.info("LME lookup response for mirror {}: {}", mirrorName, epochs);
                     return epochs;
                 })
                 .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
@@ -2136,7 +2151,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      */
     void processLmeLookup(Map<String, Map<String, Set<Integer>>> mirrorPartitions,
                           Consumer<Map<String, Map<TopicPartition, Integer>>> callback) {
-        log.debug("Preocessing LME lookup for {}", mirrorPartitions);
+        log.debug("Processing LME lookup for {}", mirrorPartitions);
         Map<String, Map<TopicPartition, Integer>> result = new ConcurrentHashMap<>();
 
         // Group remote partitions by (coordinator node, mirror name)

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -2120,6 +2120,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                             epochs.put(new TopicPartition(name, partIdx), lme)));
                         });
                     }
+                    log.info("Lineage LME lookup for mirror {}: {}", mirrorName, epochs);
                     return epochs;
                 })
                 .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -571,7 +571,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      *   1. if it's in PAUSED state, we should move it to MIRRORING state. It will happen when users resume mirroring
      *   2. if it's in UNKNOWN, STOPPED, or FAILED state, we should move it to LOG_TRUNCATION state.
      *      UNKNOWN/STOPPED happens on startMirrorTopics. FAILED happens on manual restart after retries are exhausted.
-     *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should continue to complete the process in previous leader
+     *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should
+     *      continue to complete the process in previous leader
      */
     private void applyStateTransition(String mirrorName, TopicPartition tp,
                                       MirrorPartitionState curState, MirrorPartitionState fetchedState,
@@ -2070,18 +2071,46 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return result;
     }
 
-    /** Truncates local replicas using last mirrored leader epochs from this broker's coordinator cache. */
-    CompletionStage<Map<TopicPartition, Integer>> truncateToLastMirrorEpochs(
+    /** Looks up lineage epochs from the source cluster for failback/fan-out truncation. */
+    CompletionStage<Map<TopicPartition, Integer>> lookupLineageEpochs(
             String mirrorName, Set<TopicPartition> topicPartitionSet) {
-        log.info("Truncating to last mirror epochs from local state for mirror {}: {}", mirrorName, topicPartitionSet);
+        log.info("Truncating to LME for mirror {}: {}", mirrorName, topicPartitionSet);
         Admin admin = getOrCreateSourceAdmin(mirrorName);
 
-        // Collect sourceClusterIds from ALL mirror configs, not just the current one.
-        // In fan-out/failback, the source needs to match against prior mirror configs
-        // (e.g. D2 has old "s-to-d2" with srcCID=S, which D1 matches via its "s-to-d1").
+        DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
+                .topicLineages(buildTopicLineages(topicPartitionSet));
+        DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName), options);
+
+        return result.lineageEpochs().toCompletionStage()
+                .toCompletableFuture()
+                .thenApply(lineageEpochs -> {
+                    Map<TopicPartition, Integer> epochs = new HashMap<>();
+                    if (!lineageEpochs.isEmpty()) {
+                        lineageEpochs.forEach((topicId, partitionEpochs) -> {
+                            Optional<String> topicName = metadataCache.getTopicName(topicId);
+                            topicName.ifPresent(name ->
+                                    partitionEpochs.forEach((partIdx, lme) ->
+                                            epochs.put(new TopicPartition(name, partIdx), lme)));
+                        });
+                    }
+                    log.info("Lineage LME lookup for mirror {}: {}", mirrorName, epochs);
+                    return epochs;
+                })
+                .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Builds topic lineage entries for all configured source cluster IDs.
+     * In failback/fan-out, the source needs to match against prior mirror configs.
+     *
+     * A topic lineage is a tuple of (topicId, partitions, srcClusterId, dstClusterId)
+     * that describes a past or current mirroring relationship for a topic.
+     */
+    private List<DescribeClusterMirrorsRequestData.TopicLineage> buildTopicLineages(
+            Set<TopicPartition> topicPartitionSet) {
         Set<String> allSourceClusterIds = new HashSet<>();
-        for (String mn : getConfiguredMirrors()) {
-            String cid = getSourceClusterId(mn);
+        for (String mirrorName : getConfiguredMirrors()) {
+            String cid = getSourceClusterId(mirrorName);
             if (cid != null && !cid.isEmpty()) {
                 allSourceClusterIds.add(cid);
             }
@@ -2103,27 +2132,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         .setDstClusterId(clusterId));
             }
         }
-
-        DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
-                .topicLineages(lineages);
-        DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(mirrorName), options);
-
-        return result.lineageEpochs().toCompletionStage()
-                .toCompletableFuture()
-                .thenApply(lineageEpochs -> {
-                    Map<TopicPartition, Integer> epochs = new HashMap<>();
-                    if (!lineageEpochs.isEmpty()) {
-                        lineageEpochs.forEach((topicId, partitionEpochs) -> {
-                            Optional<String> topicName = metadataCache.getTopicName(topicId);
-                            topicName.ifPresent(name ->
-                                    partitionEpochs.forEach((partIdx, lme) ->
-                                            epochs.put(new TopicPartition(name, partIdx), lme)));
-                        });
-                    }
-                    log.info("Lineage LME lookup for mirror {}: {}", mirrorName, epochs);
-                    return epochs;
-                })
-                .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+        return lineages;
     }
 
     /** Removes stopped partition epochs and upserts added ones, returning the full epoch map for record serialization. */

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -570,42 +570,34 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      *   1. if it's in PAUSED state, we should move it to MIRRORING state. It will happen when users resume mirroring
      *   2. if it's in UNKNOWN, STOPPED, or FAILED state, we should move it to LOG_TRUNCATION state.
      *      UNKNOWN/STOPPED happens on startMirrorTopics. FAILED happens on manual restart after retries are exhausted.
-     *   3. if it's in LOG_TRUNCATION or EPOCH_FENCING, skip. These transient states are already being processed
-     *      and re-triggering would cause redundant work (e.g. duplicate LME lookups).
-     *   4. else, keep the same state as is. This could happen like leadership change, and the new leader should
+     *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should
      *      continue to complete the process in previous leader
      */
     private void applyStateTransition(String mirrorName, TopicPartition tp,
                                       MirrorPartitionState curState, MirrorPartitionState fetchedState,
                                       boolean stopRequested, boolean pauseRequested) {
         stateTransitioner.ifPresent(t -> {
-            MirrorPartitionState newState;
             if (stopRequested) {
-                newState = curState != MirrorPartitionState.STOPPED
-                        ? MirrorPartitionState.STOPPING : MirrorPartitionState.STOPPED;
+                if (curState != MirrorPartitionState.STOPPED) {
+                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPING, null);
+                } else {
+                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED, null);
+                }
             } else if (pauseRequested) {
-                newState = curState != MirrorPartitionState.PAUSED
-                        ? MirrorPartitionState.PAUSING : MirrorPartitionState.PAUSED;
+                if (curState != MirrorPartitionState.PAUSED) {
+                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSING, null);
+                } else {
+                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED, null);
+                }
             } else if (curState == MirrorPartitionState.PAUSED) {
-                newState = MirrorPartitionState.MIRRORING;
+                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.MIRRORING, null);
             } else if (curState == MirrorPartitionState.UNKNOWN
                     || curState == MirrorPartitionState.STOPPED
                     || curState == MirrorPartitionState.FAILED) {
-                newState = MirrorPartitionState.LOG_TRUNCATION;
-            } else if (curState == MirrorPartitionState.LOG_TRUNCATION
-                    || curState == MirrorPartitionState.EPOCH_FENCING) {
-                // Transient state already in progress. Re-triggering would cause redundant work.
-                log.debug("Partition {} already in transient state {}, skipping re-transition.", tp, curState);
-                return;
+                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION, null);
             } else {
-                newState = fetchedState != null ? fetchedState : curState;
+                t.transitionTo(mirrorName, Set.of(tp), fetchedState != null ? fetchedState : curState, null);
             }
-            // Eagerly update the cache before the async coordinator write. This prevents a
-            // second metadata update (e.g. epoch bump) from seeing stale UNKNOWN and re-triggering
-            // the same transition. Safe because the coordinator retries writes on failure, so the
-            // state will eventually be confirmed.
-            updatePartitionState(new PartitionKey(mirrorName, tp.topic(), tp.partition()), newState);
-            t.transitionTo(mirrorName, Set.of(tp), newState, null);
         });
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -2073,23 +2073,36 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     /** Truncates local replicas using last mirrored leader epochs from this broker's coordinator cache. */
     CompletionStage<Map<TopicPartition, Integer>> truncateToLastMirrorEpochs(
             String mirrorName, Set<TopicPartition> topicPartitionSet) {
-        log.info("Truncating to last mirrored epochs from local state for mirror {}: {}", mirrorName, topicPartitionSet);
+        log.info("Truncating to last mirror epochs from local state for mirror {}: {}", mirrorName, topicPartitionSet);
         Admin admin = getOrCreateSourceAdmin(mirrorName);
 
-        String srcClusterId = getSourceClusterId(mirrorName);
+        // Collect sourceClusterIds from ALL mirror configs, not just the current one.
+        // In fan-out/failback, the source needs to match against prior mirror configs
+        // (e.g. D2 has old "s-to-d2" with srcCID=S, which D1 matches via its "s-to-d1").
+        Set<String> allSourceClusterIds = new HashSet<>();
+        for (String mn : getConfiguredMirrors()) {
+            String cid = getSourceClusterId(mn);
+            if (cid != null && !cid.isEmpty()) {
+                allSourceClusterIds.add(cid);
+            }
+        }
+
         Map<Uuid, List<Integer>> topicPartitionsByTopicId = new HashMap<>();
         for (TopicPartition tp : topicPartitionSet) {
             Uuid topicId = metadataCache.getTopicId(tp.topic());
             topicPartitionsByTopicId.computeIfAbsent(topicId, k -> new ArrayList<>()).add(tp.partition());
         }
 
-        List<DescribeClusterMirrorsRequestData.TopicLineage> lineages = topicPartitionsByTopicId.entrySet().stream()
-                .map(e -> new DescribeClusterMirrorsRequestData.TopicLineage()
-                        .setTopicId(e.getKey())
-                        .setPartitions(e.getValue())
-                        .setSrcClusterId(srcClusterId != null ? srcClusterId : "")
-                        .setDstClusterId(clusterId))
-                .collect(Collectors.toList());
+        List<DescribeClusterMirrorsRequestData.TopicLineage> lineages = new ArrayList<>();
+        for (Map.Entry<Uuid, List<Integer>> entry : topicPartitionsByTopicId.entrySet()) {
+            for (String srcClusterId : allSourceClusterIds) {
+                lineages.add(new DescribeClusterMirrorsRequestData.TopicLineage()
+                        .setTopicId(entry.getKey())
+                        .setPartitions(entry.getValue())
+                        .setSrcClusterId(srcClusterId)
+                        .setDstClusterId(clusterId));
+            }
+        }
 
         DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
                 .topicLineages(lineages);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -124,7 +124,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -2139,95 +2138,29 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /**
-     * Coordinator-aware LME lookup for lineage results. For each (mirror, topic, partition),
-     * reads from local cache if this broker is the coordinator, otherwise forwards a
-     * ReadMirrorStates request to the coordinator broker.
+     * Local-only LME lookup for lineage results. Returns LME from the local
+     * coordinator cache for partitions this broker coordinates, and -1 for
+     * the rest. The admin client broadcasts DescribeClusterMirrors to all
+     * brokers and takes the max, so each broker only needs its local view.
      *
      * @param mirrorPartitions mirrorName -> topicName -> partition indices
-     * @param callback receives mirrorName -> (TopicPartition -> LME) when all reads complete
+     * @param callback receives mirrorName -> (TopicPartition -> LME) when done
      */
     void processLmeLookup(Map<String, Map<String, Set<Integer>>> mirrorPartitions,
                           Consumer<Map<String, Map<TopicPartition, Integer>>> callback) {
-        log.debug("Processing LME lookup for {}", mirrorPartitions);
-        Map<String, Map<TopicPartition, Integer>> result = new ConcurrentHashMap<>();
-
-        // Group remote partitions by (coordinator node, mirror name)
-        Map<Node, Map<String, Map<String, Set<Integer>>>> remoteByNode = new HashMap<>();
-
+        Map<String, Map<TopicPartition, Integer>> result = new HashMap<>();
         mirrorPartitions.forEach((mirrorName, topicParts) -> {
             topicParts.forEach((topic, parts) -> {
                 parts.forEach(part -> {
-                    if (isLocalCoordinator(mirrorName, topic, part)) {
-                        PartitionKey pk = new PartitionKey(mirrorName, topic, part);
-                        int lme = lastMirrorEpochs.getOrDefault(pk, -1);
-                        result.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>())
-                                .put(new TopicPartition(topic, part), lme);
-                    } else {
-                        ClusterMirrorRecordKey key = new ClusterMirrorRecordKey(
-                                mirrorName, metadataCache.getTopicId(topic), part);
-                        Node node = findCoordinatorNode(key);
-                        if (!node.equals(Node.noNode())) {
-                            remoteByNode
-                                    .computeIfAbsent(node, k -> new HashMap<>())
-                                    .computeIfAbsent(mirrorName, k -> new HashMap<>())
-                                    .computeIfAbsent(topic, k -> new HashSet<>())
-                                    .add(part);
-                        }
-                    }
+                    PartitionKey pk = new PartitionKey(mirrorName, topic, part);
+                    int lme = isLocalCoordinator(mirrorName, topic, part)
+                            ? lastMirrorEpochs.getOrDefault(pk, -1) : -1;
+                    result.computeIfAbsent(mirrorName, k -> new HashMap<>())
+                            .put(new TopicPartition(topic, part), lme);
                 });
             });
         });
-
-        if (remoteByNode.isEmpty()) {
-            log.debug("LME lookup result (local): {}", result);
-            callback.accept(result);
-            return;
-        }
-
-        // Count total requests: one per (node, mirror) pair
-        int totalRequests = remoteByNode.values().stream()
-                .mapToInt(Map::size).sum();
-        AtomicInteger remaining = new AtomicInteger(totalRequests);
-
-        remoteByNode.forEach((node, mirrorMap) -> {
-            mirrorMap.forEach((mirrorName, topicParts) -> {
-                ReadMirrorStatesRequestData data = new ReadMirrorStatesRequestData()
-                        .setMirrorName(mirrorName);
-                List<ReadMirrorStatesRequestData.TopicMetadata> topicDataList = new ArrayList<>();
-                topicParts.forEach((topic, parts) -> {
-                    List<ReadMirrorStatesRequestData.PartitionData> partDataList = new ArrayList<>();
-                    parts.forEach(part -> partDataList.add(
-                            new ReadMirrorStatesRequestData.PartitionData().setPartitionIndex(part)));
-                    topicDataList.add(new ReadMirrorStatesRequestData.TopicMetadata()
-                            .setName(topic).setPartitions(partDataList));
-                });
-                data.setTopics(topicDataList);
-
-                mirrorStateSender.enqueue(new RequestAndCompletionHandler(
-                        time.milliseconds(), node,
-                        new ReadMirrorStatesRequest.Builder(data),
-                        response -> {
-                            if (response.responseBody() instanceof ReadMirrorStatesResponse resp) {
-                                resp.data().topics().forEach(topic -> {
-                                    topic.partitions().forEach(partition -> {
-                                        if (partition.lastMirrorEpoch() != -1) {
-                                            result.computeIfAbsent(mirrorName,
-                                                            k -> new ConcurrentHashMap<>())
-                                                    .put(new TopicPartition(topic.name(),
-                                                                    partition.partitionIndex()),
-                                                            partition.lastMirrorEpoch());
-                                        }
-                                    });
-                                });
-                            }
-                            if (remaining.decrementAndGet() == 0) {
-                                log.debug("LME lookup result (coordinator): {}", result);
-                                callback.accept(result);
-                            }
-                        }
-                ));
-            });
-        });
+        callback.accept(result);
     }
 
     /** Upserts added paritions, returning the full epoch map for record serialization. */

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -2124,15 +2124,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             partitionsByTopicId.computeIfAbsent(topicId, k -> new ArrayList<>()).add(tp.partition());
         }
 
-        List<String> allSrcClusterIds = new ArrayList<>(mirrorSourceClusterIds.values());
+        List<String> srcClusterIds = new ArrayList<>(mirrorSourceClusterIds.values());
+        srcClusterIds.add(clusterId);
         List<DescribeClusterMirrorsRequestData.TopicLineage> lineages = new ArrayList<>();
         for (Map.Entry<Uuid, List<Integer>> entry : partitionsByTopicId.entrySet()) {
-            List<Integer> partitions = entry.getValue();
             lineages.add(new DescribeClusterMirrorsRequestData.TopicLineage()
                     .setTopicId(entry.getKey())
-                    .setPartitions(partitions)
-                    .setSrcClusterIds(allSrcClusterIds)
-                    .setDstClusterId(clusterId));
+                    .setPartitions(entry.getValue())
+                    .setSrcClusterIds(srcClusterIds));
         }
         return lineages;
     }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -343,6 +343,7 @@ class BrokerServer(
 
       val mirrorScheduler = new KafkaScheduler(1, true, "ClusterMirror-")
       mirrorMetadataManager = new MirrorMetadataManager(
+        clusterId,
         config,
         clientToControllerChannelManager,
         () => replicaManager,

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -342,6 +342,7 @@ class BrokerServer(
       val defaultActionQueue = new DelayedActionQueue
 
       val mirrorScheduler = new KafkaScheduler(1, true, "ClusterMirror-")
+      val mirrorRefreshScheduler = new KafkaScheduler(1, true, "ClusterMirrorRefresh-")
       mirrorMetadataManager = new MirrorMetadataManager(
         clusterId,
         config,
@@ -404,7 +405,7 @@ class BrokerServer(
         producerIdManagerSupplier, metrics, metadataCache, Time.SYSTEM)
 
       clusterMirrorCoordinator = new ClusterMirrorCoordinator(config, replicaManager,
-        mirrorMetadataManager, metadataCache, mirrorScheduler, metrics, Time.SYSTEM)
+        mirrorMetadataManager, metadataCache, mirrorScheduler, mirrorRefreshScheduler, metrics, Time.SYSTEM)
 
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
         config, clientToControllerChannelManager, groupCoordinator,

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -341,8 +341,10 @@ class BrokerServer(
        */
       val defaultActionQueue = new DelayedActionQueue
 
-      val mirrorScheduler = new KafkaScheduler(1, true, "ClusterMirror-")
-      val mirrorRefreshScheduler = new KafkaScheduler(1, true, "ClusterMirrorRefresh-")
+      // Two threads: one for metadata refresh (can block on RPC timeouts against
+      // unreachable sources) and one for state transitions (truncation, retries).
+      val mirrorScheduler = new KafkaScheduler(2, true, "ClusterMirror-")
+
       mirrorMetadataManager = new MirrorMetadataManager(
         clusterId,
         config,
@@ -405,7 +407,7 @@ class BrokerServer(
         producerIdManagerSupplier, metrics, metadataCache, Time.SYSTEM)
 
       clusterMirrorCoordinator = new ClusterMirrorCoordinator(config, replicaManager,
-        mirrorMetadataManager, metadataCache, mirrorScheduler, mirrorRefreshScheduler, metrics, Time.SYSTEM)
+        mirrorMetadataManager, metadataCache, mirrorScheduler, metrics, Time.SYSTEM)
 
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
         config, clientToControllerChannelManager, groupCoordinator,

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -201,15 +201,16 @@ class ControllerApis(
   }
 
   def handleCreateClusterMirror(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    val mirrorName = request.body[CreateClusterMirrorRequest].data().mirrorName()
+    val createRequest = request.body[CreateClusterMirrorRequest]
+    val mirrorName = createRequest.data().mirrorName()
     if (!authHelper.authorize(request.context, CREATE, CLUSTER_MIRROR, mirrorName))
       throw new ClusterMirrorAuthorizationException(s"Request $request needs CREATE permission on ClusterMirror:$mirrorName.")
     if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
       throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
-    val createMirrorRequest = request.body[CreateClusterMirrorRequest]
+
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal, OptionalLong.empty())
     val altersByName = new util.HashMap[String, Entry[AlterConfigOp.OpType, String]]()
-    createMirrorRequest.data().config.forEach { config =>
+    createRequest.data().config.forEach { config =>
       altersByName.put(config.name, new util.AbstractMap.SimpleEntry[AlterConfigOp.OpType, String](
         AlterConfigOp.OpType.forId(0), config.value))
     }
@@ -221,7 +222,7 @@ class ControllerApis(
       throw new InvalidRequestException(s"Missing required config ${CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG} in CreateClusterMirrorRequest")
     }
 
-    controller.createClusterMirror(context, createMirrorRequest.data().mirrorName(), altersByName)
+    controller.createClusterMirror(context, createRequest.data().mirrorName(), altersByName)
       .thenCompose[CreateClusterMirrorResponseData] { response =>
         maybeCreateMirrorStateTopic(request.context, request.session, request.header)
           .thenApply[CreateClusterMirrorResponseData](_ => response)
@@ -287,21 +288,22 @@ class ControllerApis(
   }
 
   def handleStartMirrorTopics(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    val startMirrorTopicsRequest = request.body[StartMirrorTopicsRequest]
-    val mirrorName = startMirrorTopicsRequest.data().mirrorName()
+    val startRequest = request.body[StartMirrorTopicsRequest]
+    val mirrorName = startRequest.data().mirrorName()
     if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
       throw new ClusterMirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
     if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
       throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
-    val wireTopics = startMirrorTopicsRequest.data().topics()
+
+    val wireTopics = startRequest.data().topics()
     val unauthorizedTopics = wireTopics.asScala.map(_.topicName()).filterNot(topic =>
       authHelper.authorize(request.context, ALTER_CONFIGS, TOPIC, topic, logIfDenied = false)).toSet
     if (unauthorizedTopics.nonEmpty)
       throw new TopicAuthorizationException(unauthorizedTopics.asJava)
     val topics = wireTopics.asScala.map(t =>
       new Controller.MirrorTopicMetadata(t.topicName(), t.topicId(), t.numPartitions())).toList.asJava
-    val includePatterns = startMirrorTopicsRequest.data().includePatterns()
-    val excludePatterns = startMirrorTopicsRequest.data().excludePatterns()
+    val includePatterns = startRequest.data().includePatterns()
+    val excludePatterns = startRequest.data().excludePatterns()
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
     controller.startMirrorTopics(context, mirrorName, topics,
@@ -319,21 +321,22 @@ class ControllerApis(
   }
 
   def handleStopMirrorTopics(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    val stopMirrorTopicsRequest = request.body[StopMirrorTopicsRequest]
-    val mirrorName = stopMirrorTopicsRequest.data().mirrorName()
+    val stopRequest = request.body[StopMirrorTopicsRequest]
+    val mirrorName = stopRequest.data().mirrorName()
     if (!authHelper.authorize(request.context, ALTER, CLUSTER_MIRROR, mirrorName))
       throw new ClusterMirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
     if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
       throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
+
     val topics: util.Set[String] = new util.HashSet[String]()
-    stopMirrorTopicsRequest.data().topics().forEach( topic => {
+    stopRequest.data().topics().forEach( topic => {
         topics.add(topic.topicName())
     })
     val unauthorizedTopics = topics.asScala.filterNot(topic =>
       authHelper.authorize(request.context, ALTER_CONFIGS, TOPIC, topic, logIfDenied = false))
     if (unauthorizedTopics.nonEmpty)
       throw new TopicAuthorizationException(unauthorizedTopics.asJava)
-    val patterns = stopMirrorTopicsRequest.data().patterns()
+    val patterns = stopRequest.data().patterns()
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
     controller.stopMirrorTopics(context, mirrorName, topics, patterns)
@@ -356,6 +359,7 @@ class ControllerApis(
       throw new ClusterMirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
     if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
       throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
+
     val topics: util.Set[String] = new util.HashSet[String]()
     pauseRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
     val unauthorizedTopics = topics.asScala.filterNot(topic =>
@@ -383,6 +387,7 @@ class ControllerApis(
       throw new ClusterMirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
     if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
       throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
+
     val topics: util.Set[String] = new util.HashSet[String]()
     resumeRequest.data().topics().forEach(topic => topics.add(topic.topicName()))
     val unauthorizedTopics = topics.asScala.filterNot(topic =>
@@ -410,6 +415,7 @@ class ControllerApis(
       throw new ClusterMirrorAuthorizationException(s"Request $request needs ALTER permission on ClusterMirror:$mirrorName.")
     if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures))
       throw new UnsupportedVersionException("Cluster mirroring requires mirror.version >= 1.")
+
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
     val brokerMetadataOffset = deleteMirrorRequest.data().stateValidationOffset()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -487,57 +487,67 @@ class KafkaApis(val requestChannel: RequestChannel,
         }
       }
 
-      // Process TopicLineages for cross-mirror LME lookup
-      val topicLineages = describeMirrorsRequest.data.topicLineages
-      if (topicLineages != null && !topicLineages.isEmpty) {
-        val configuredMirrors = clusterMirrorCoordinator.getConfiguredMirrors().asScala.toSeq
-        val mirrorClusterIds = configuredMirrors.flatMap { mn =>
-          Option(clusterMirrorCoordinator.getSourceClusterId(mn)).map(cid => (mn, cid))
-        }
+      maybeHandleLineageResults(describeMirrorsRequest.data.topicLineages, responseData)
 
-        // Per-lineage: find matching mirrors and aggregate max LME
-        val lineageResultsMap = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
-
-        topicLineages.forEach { lineage =>
-          val matchingMirrors = mirrorClusterIds
-            .filter { case (_, cid) => cid == lineage.srcClusterId || cid == lineage.dstClusterId }
-            .map(_._1)
-
-          val topicNameOpt = metadataCache.getTopicName(lineage.topicId)
-          if (topicNameOpt.isPresent) {
-            val topicName = topicNameOpt.get
-            val partitionEpochs = lineageResultsMap.computeIfAbsent(lineage.topicId,
-              _ => new util.HashMap[Integer, Integer]())
-
-            matchingMirrors.foreach { mn =>
-              val lmeMap = clusterMirrorCoordinator.getLastMirrorEpochs(mn)
-              lineage.partitions.forEach { partIdx =>
-                val tp = new TopicPartition(topicName, partIdx)
-                val lme = lmeMap.getOrDefault(tp, -1)
-                partitionEpochs.merge(partIdx, lme, (a: Integer, b: Integer) => Math.max(a, b))
-              }
-            }
-          }
-        }
-
-        lineageResultsMap.forEach { (topicId, partitions) =>
-          val partitionResults = new util.ArrayList[DescribeClusterMirrorsResponseData.LineagePartitionResult]()
-          partitions.forEach { (partIdx, lme) =>
-            partitionResults.add(new DescribeClusterMirrorsResponseData.LineagePartitionResult()
-              .setPartitionIndex(partIdx)
-              .setLastMirrorEpoch(lme))
-          }
-          responseData.lineageResults().add(new DescribeClusterMirrorsResponseData.LineageTopicResult()
-            .setTopicId(topicId)
-            .setPartitions(partitionResults))
-        }
-      }
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring describe mirrors request")
       responseData.setErrorCode(Errors.UNSUPPORTED_VERSION.code)
     }
 
     requestHelper.sendMaybeThrottle(request, new DescribeClusterMirrorsResponse(responseData))
+  }
+
+  /*
+   * On the source, for each (TopicId, PartitionIndex, SrcClusterId, DstClusterId) in TopicLineages:
+   * 1. Scan mirror configs to find all mirror names where mirror.source.cluster.id matches SrcClusterId OR DstClusterId
+   * 2. For those mirror names, look up LME for that specific (TopicId, PartitionIndex)
+   * 3. If multiple matches, take max LME for that partition
+   */
+  private def maybeHandleLineageResults(
+    topicLineages: util.List[DescribeClusterMirrorsRequestData.TopicLineage],
+    responseData: DescribeClusterMirrorsResponseData
+  ): Unit = {
+    if (topicLineages == null || topicLineages.isEmpty) return
+
+    val configuredMirrors = clusterMirrorCoordinator.getConfiguredMirrors().asScala.toSeq
+    val sourceClusterIds = configuredMirrors.flatMap { mirrorName =>
+      Option(clusterMirrorCoordinator.getSourceClusterId(mirrorName)).map(cid => (mirrorName, cid))
+    }
+
+    val lineageResultsMap = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+    topicLineages.forEach { lineage =>
+      val matchingMirrors = sourceClusterIds
+        .filter { case (_, cid) => cid == lineage.srcClusterId || cid == lineage.dstClusterId }
+        .map(_._1)
+
+      val topicNameOpt = metadataCache.getTopicName(lineage.topicId)
+      if (topicNameOpt.isPresent) {
+        val topicName = topicNameOpt.get
+        val partitionEpochs = lineageResultsMap.computeIfAbsent(lineage.topicId,
+          _ => new util.HashMap[Integer, Integer]())
+
+        matchingMirrors.foreach { mirrorName =>
+          val lmeMap = clusterMirrorCoordinator.getLastMirrorEpochs(mirrorName)
+          lineage.partitions.forEach { partIdx =>
+            val tp = new TopicPartition(topicName, partIdx)
+            val lme = lmeMap.getOrDefault(tp, -1)
+            partitionEpochs.merge(partIdx, lme, (a: Integer, b: Integer) => Math.max(a, b))
+          }
+        }
+      }
+    }
+
+    lineageResultsMap.forEach { (topicId, partitions) =>
+      val partitionResults = new util.ArrayList[DescribeClusterMirrorsResponseData.PartitionResult]()
+      partitions.forEach { (partIdx, lme) =>
+        partitionResults.add(new DescribeClusterMirrorsResponseData.PartitionResult()
+          .setPartitionIndex(partIdx)
+          .setLastMirrorEpoch(lme))
+      }
+      responseData.lineageResults().add(new DescribeClusterMirrorsResponseData.LineageResult()
+        .setTopicId(topicId)
+        .setPartitions(partitionResults))
+    }
   }
 
   def handleGetReplicaLogInfo(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -501,7 +501,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   /*
    * Handles TopicLineage entries by finding matching mirrors and looking up their LME
    * from the local coordinator cache. For each lineage, scans mirror configs to find
-   * mirrors whose source cluster ID matches any SrcClusterIds entry or DstClusterId.
+   * mirrors whose source cluster ID matches any KnownClusterIds entry.
    * Returns -1 for partitions not coordinated by this broker. The admin client
    * broadcasts to all brokers and takes the max LME per partition.
    */
@@ -526,9 +526,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     val topicNameToId = new util.HashMap[String, Uuid]()
 
     topicLineages.forEach { lineage =>
-      val requestedSrcIds = lineage.srcClusterIds.asScala.toSet
+      val requestedIds = lineage.srcClusterIds.asScala.toSet
       val matchingMirrors = sourceClusterIds
-        .filter { case (_, cid) => requestedSrcIds.contains(cid) || cid == lineage.dstClusterId }
+        .filter { case (_, cid) => requestedIds.contains(cid) }
         .map(_._1)
 
       val topicNameOpt = metadataCache.getTopicName(lineage.topicId)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -500,10 +500,10 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   /*
    * Handles TopicLineage entries by finding matching mirrors and looking up their LME
-   * from the coordinator. For each lineage, scans mirror configs to find mirrors whose
-   * source cluster ID matches any SrcClusterIds entry or DstClusterId. Then reads the
-   * LME from the coordinator (local cache if this broker is the coordinator, otherwise
-   * forwarded via ReadMirrorStates). Takes max LME per partition across matching mirrors.
+   * from the local coordinator cache. For each lineage, scans mirror configs to find
+   * mirrors whose source cluster ID matches any SrcClusterIds entry or DstClusterId.
+   * Returns -1 for partitions not coordinated by this broker. The admin client
+   * broadcasts to all brokers and takes the max LME per partition.
    */
   private def maybeProcessLmeLookup(
     topicLineages: util.List[DescribeClusterMirrorsRequestData.TopicLineage],

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -486,6 +486,52 @@ class KafkaApis(val requestChannel: RequestChannel,
           responseData.mirrors().add(describedMirror)
         }
       }
+
+      // Process TopicLineages for cross-mirror LME lookup
+      val topicLineages = describeMirrorsRequest.data.topicLineages
+      if (topicLineages != null && !topicLineages.isEmpty) {
+        val configuredMirrors = clusterMirrorCoordinator.getConfiguredMirrors().asScala.toSeq
+        val mirrorClusterIds = configuredMirrors.flatMap { mn =>
+          Option(clusterMirrorCoordinator.getSourceClusterId(mn)).map(cid => (mn, cid))
+        }
+
+        // Per-lineage: find matching mirrors and aggregate max LME
+        val lineageResultsMap = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+
+        topicLineages.forEach { lineage =>
+          val matchingMirrors = mirrorClusterIds
+            .filter { case (_, cid) => cid == lineage.srcClusterId || cid == lineage.dstClusterId }
+            .map(_._1)
+
+          val topicNameOpt = metadataCache.getTopicName(lineage.topicId)
+          if (topicNameOpt.isPresent) {
+            val topicName = topicNameOpt.get
+            val partitionEpochs = lineageResultsMap.computeIfAbsent(lineage.topicId,
+              _ => new util.HashMap[Integer, Integer]())
+
+            matchingMirrors.foreach { mn =>
+              val lmeMap = clusterMirrorCoordinator.getLastMirrorEpochs(mn)
+              lineage.partitions.forEach { partIdx =>
+                val tp = new TopicPartition(topicName, partIdx)
+                val lme = lmeMap.getOrDefault(tp, -1)
+                partitionEpochs.merge(partIdx, lme, (a: Integer, b: Integer) => Math.max(a, b))
+              }
+            }
+          }
+        }
+
+        lineageResultsMap.forEach { (topicId, partitions) =>
+          val partitionResults = new util.ArrayList[DescribeClusterMirrorsResponseData.LineagePartitionResult]()
+          partitions.forEach { (partIdx, lme) =>
+            partitionResults.add(new DescribeClusterMirrorsResponseData.LineagePartitionResult()
+              .setPartitionIndex(partIdx)
+              .setLastMirrorEpoch(lme))
+          }
+          responseData.lineageResults().add(new DescribeClusterMirrorsResponseData.LineageTopicResult()
+            .setTopicId(topicId)
+            .setPartitions(partitionResults))
+        }
+      }
     } else {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring describe mirrors request")
       responseData.setErrorCode(Errors.UNSUPPORTED_VERSION.code)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -494,66 +494,92 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
     }
 
-    // On the source, for each (TopicId, PartitionIndex, SrcClusterId, DstClusterId) in TopicLineages:
-    // 1. Scan mirror configs to find all mirror names where mirror.source.cluster.id matches SrcClusterId OR DstClusterId
-    // 2. For those mirror names, look up LME for that specific (TopicId, PartitionIndex)
-    // 3. If multiple matches, take max LME for that partition
-    maybeHandleLineageResults(describeMirrorsRequest.data.topicLineages, responseData)
-
-    requestHelper.sendMaybeThrottle(request, new DescribeClusterMirrorsResponse(responseData))
+    maybeProcessLmeLookup(describeMirrorsRequest.data.topicLineages, responseData,
+      () => requestHelper.sendMaybeThrottle(request, new DescribeClusterMirrorsResponse(responseData)))
   }
 
   /*
-   * On the source, for each (TopicId, PartitionIndex, SrcClusterId, DstClusterId) in TopicLineages:
-   * 1. Scan mirror configs to find all mirror names where mirror.source.cluster.id matches SrcClusterId OR DstClusterId
-   * 2. For those mirror names, look up LME for that specific (TopicId, PartitionIndex)
-   * 3. If multiple matches, take max LME for that partition
+   * Handles TopicLineage entries by finding matching mirrors and looking up their LME
+   * from the coordinator. For each lineage, scans mirror configs to find mirrors whose
+   * source cluster ID matches any SrcClusterIds entry or DstClusterId. Then reads the
+   * LME from the coordinator (local cache if this broker is the coordinator, otherwise
+   * forwarded via ReadMirrorStates). Takes max LME per partition across matching mirrors.
    */
-  private def maybeHandleLineageResults(
+  private def maybeProcessLmeLookup(
     topicLineages: util.List[DescribeClusterMirrorsRequestData.TopicLineage],
-    responseData: DescribeClusterMirrorsResponseData
+    responseData: DescribeClusterMirrorsResponseData,
+    sendResponse: Runnable
   ): Unit = {
-    if (topicLineages == null || topicLineages.isEmpty) return
+    if (topicLineages == null || topicLineages.isEmpty) {
+      sendResponse.run()
+      return
+    }
 
     val configuredMirrors = clusterMirrorCoordinator.getConfiguredMirrors().asScala.toSeq
     val sourceClusterIds = configuredMirrors.flatMap { mirrorName =>
       Option(clusterMirrorCoordinator.getSourceClusterId(mirrorName)).map(cid => (mirrorName, cid))
     }
 
-    val lineageResultsMap = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+    // Collect (mirror -> topic -> partitions) for coordinator-aware LME lookup
+    val mirrorPartitions = new util.HashMap[String, util.Map[String, util.Set[Integer]]]()
+    // Track topicId for each topicName so we can map results back
+    val topicNameToId = new util.HashMap[String, Uuid]()
+
     topicLineages.forEach { lineage =>
+      val requestedSrcIds = lineage.srcClusterIds.asScala.toSet
       val matchingMirrors = sourceClusterIds
-        .filter { case (_, cid) => cid == lineage.srcClusterId || cid == lineage.dstClusterId }
+        .filter { case (_, cid) => requestedSrcIds.contains(cid) || cid == lineage.dstClusterId }
         .map(_._1)
 
       val topicNameOpt = metadataCache.getTopicName(lineage.topicId)
       if (topicNameOpt.isPresent) {
         val topicName = topicNameOpt.get
-        val partitionEpochs = lineageResultsMap.computeIfAbsent(lineage.topicId,
-          _ => new util.HashMap[Integer, Integer]())
+        topicNameToId.put(topicName, lineage.topicId)
 
         matchingMirrors.foreach { mirrorName =>
-          val lmeMap = clusterMirrorCoordinator.getLastMirrorEpochs(mirrorName)
           lineage.partitions.forEach { partIdx =>
-            val tp = new TopicPartition(topicName, partIdx)
-            val lme = lmeMap.getOrDefault(tp, -1)
-            partitionEpochs.merge(partIdx, lme, (a: Integer, b: Integer) => Math.max(a, b))
+            mirrorPartitions
+              .computeIfAbsent(mirrorName, _ => new util.HashMap[String, util.Set[Integer]]())
+              .computeIfAbsent(topicName, _ => new util.HashSet[Integer]())
+              .add(partIdx)
           }
         }
       }
     }
 
-    lineageResultsMap.forEach { (topicId, partitions) =>
-      val partitionResults = new util.ArrayList[DescribeClusterMirrorsResponseData.PartitionResult]()
-      partitions.forEach { (partIdx, lme) =>
-        partitionResults.add(new DescribeClusterMirrorsResponseData.PartitionResult()
-          .setPartitionIndex(partIdx)
-          .setLastMirrorEpoch(lme))
-      }
-      responseData.lineageResults().add(new DescribeClusterMirrorsResponseData.LineageResult()
-        .setTopicId(topicId)
-        .setPartitions(partitionResults))
+    if (mirrorPartitions.isEmpty) {
+      sendResponse.run()
+      return
     }
+
+    clusterMirrorCoordinator.processLmeLookup(mirrorPartitions, lmeResults => {
+      val lineageResultsMap = new util.HashMap[Uuid, util.Map[Integer, Integer]]()
+
+      lmeResults.forEach { (_, tpEpochs) =>
+        tpEpochs.forEach { (tp, lme) =>
+          val topicId = topicNameToId.get(tp.topic)
+          if (topicId != null) {
+            lineageResultsMap
+              .computeIfAbsent(topicId, _ => new util.HashMap[Integer, Integer]())
+              .merge(tp.partition, lme, (a: Integer, b: Integer) => Math.max(a, b))
+          }
+        }
+      }
+
+      lineageResultsMap.forEach { (topicId, partitions) =>
+        val partitionResults = new util.ArrayList[DescribeClusterMirrorsResponseData.PartitionResult]()
+        partitions.forEach { (partIdx, lme) =>
+          partitionResults.add(new DescribeClusterMirrorsResponseData.PartitionResult()
+            .setPartitionIndex(partIdx)
+            .setLastMirrorEpoch(lme))
+        }
+        responseData.lineageResults().add(new DescribeClusterMirrorsResponseData.LineageResult()
+          .setTopicId(topicId)
+          .setPartitions(partitionResults))
+      }
+
+      sendResponse.run()
+    })
   }
 
   def handleGetReplicaLogInfo(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -282,54 +282,54 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleWriteMirrorStates(request: RequestChannel.Request): Unit = {
-    if (ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
-      if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
-        requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData()
-          .setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code).setErrorMessage(Errors.CLUSTER_AUTHORIZATION_FAILED.message)))
-        return
-      }
-      val writeMirrorStatesRequest = request.body[WriteMirrorStatesRequest]
-      val mirrorName = writeMirrorStatesRequest.data().mirrorName()
-      val partitionMetadata = new util.HashMap[String, util.Set[PartitionStateInfo]]()
-      writeMirrorStatesRequest.data().topics().forEach(topic => {
-        val partMetadata = new util.HashSet[PartitionStateInfo]()
-        topic.partitions().forEach(part => {
-          partMetadata.add(new PartitionStateInfo(part.partitionIndex(), MirrorPartitionState.fromValue(part.state()), part.lastMirrorEpoch()))
-        })
-        partitionMetadata.put(topic.name(), partMetadata)
-      })
-      clusterMirrorCoordinator.updateTopicMetadata(mirrorName, partitionMetadata, res => requestHelper.sendMaybeThrottle(request, res))
-    } else {
+    if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring write mirror states request")
       requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData()
         .setErrorCode(Errors.UNSUPPORTED_VERSION.code).setErrorMessage(Errors.UNSUPPORTED_VERSION.message)))
+      return
     }
+    if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
+      requestHelper.sendMaybeThrottle(request, new WriteMirrorStatesResponse(new WriteMirrorStatesResponseData()
+        .setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code).setErrorMessage(Errors.CLUSTER_AUTHORIZATION_FAILED.message)))
+      return
+    }
+    val writeMirrorStatesRequest = request.body[WriteMirrorStatesRequest]
+    val mirrorName = writeMirrorStatesRequest.data().mirrorName()
+    val partitionMetadata = new util.HashMap[String, util.Set[PartitionStateInfo]]()
+    writeMirrorStatesRequest.data().topics().forEach(topic => {
+      val partMetadata = new util.HashSet[PartitionStateInfo]()
+      topic.partitions().forEach(part => {
+        partMetadata.add(new PartitionStateInfo(part.partitionIndex(), MirrorPartitionState.fromValue(part.state()), part.lastMirrorEpoch()))
+      })
+      partitionMetadata.put(topic.name(), partMetadata)
+    })
+    clusterMirrorCoordinator.updateTopicMetadata(mirrorName, partitionMetadata, res => requestHelper.sendMaybeThrottle(request, res))
   }
 
   def handleReadMirrorStates(request: RequestChannel.Request): Unit = {
-    if (ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
-      if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
-        requestHelper.sendMaybeThrottle(request, new ReadMirrorStatesResponse(new ReadMirrorStatesResponseData()
-          .setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code).setErrorMessage(Errors.CLUSTER_AUTHORIZATION_FAILED.message)))
-        return
-      }
-      val readMirrorStatesRequest = request.body[ReadMirrorStatesRequest]
-      val mirrorName = readMirrorStatesRequest.data().mirrorName()
-      val partitionMetadata = new util.HashMap[String, util.Set[Integer]]()
-      readMirrorStatesRequest.data().topics().forEach(topic => {
-        val parts = new util.HashSet[Integer]()
-        topic.partitions().forEach(part => {
-          parts.add(part.partitionIndex())
-        })
-        partitionMetadata.put(topic.name(), parts)
-      })
-      clusterMirrorCoordinator.getTopicMetadata(mirrorName, partitionMetadata,
-        res => requestHelper.sendMaybeThrottle(request, res))
-    } else {
+    if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring read mirror states request")
       requestHelper.sendMaybeThrottle(request, new ReadMirrorStatesResponse(new ReadMirrorStatesResponseData()
         .setErrorCode(Errors.UNSUPPORTED_VERSION.code).setErrorMessage(Errors.UNSUPPORTED_VERSION.message)))
+      return
     }
+    if (!authorizeClusterOperation(request, CLUSTER_ACTION)) {
+      requestHelper.sendMaybeThrottle(request, new ReadMirrorStatesResponse(new ReadMirrorStatesResponseData()
+        .setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code).setErrorMessage(Errors.CLUSTER_AUTHORIZATION_FAILED.message)))
+      return
+    }
+    val readMirrorStatesRequest = request.body[ReadMirrorStatesRequest]
+    val mirrorName = readMirrorStatesRequest.data().mirrorName()
+    val partitionMetadata = new util.HashMap[String, util.Set[Integer]]()
+    readMirrorStatesRequest.data().topics().forEach(topic => {
+      val parts = new util.HashSet[Integer]()
+      topic.partitions().forEach(part => {
+        parts.add(part.partitionIndex())
+      })
+      partitionMetadata.put(topic.name(), parts)
+    })
+    clusterMirrorCoordinator.getTopicMetadata(mirrorName, partitionMetadata,
+      res => requestHelper.sendMaybeThrottle(request, res))
   }
 
   def handleStartMirrorTopics(request: RequestChannel.Request): Unit = {
@@ -388,26 +388,27 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleListClusterMirrorsRequest(request: RequestChannel.Request): Unit = {
     val responseData = new ListClusterMirrorsResponseData()
 
-    if (ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
-      val mirrors = new util.ArrayList[ListClusterMirrorsResponseData.ListedMirror]()
-      val authorizedMirrors = clusterMirrorCoordinator.getConfiguredMirrors().asScala
-        .filter(mirrorName => authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = false))
-      authorizedMirrors.foreach(mirrorName => {
-        val sourceClusterId = clusterMirrorCoordinator.getSourceClusterId(mirrorName)
-        mirrors.add(new ListClusterMirrorsResponseData.ListedMirror()
-          .setMirrorName(mirrorName)
-          .setSourceBootstrap(if (clusterMirrorCoordinator.getSourceBootstrap(mirrorName) != null)
-            clusterMirrorCoordinator.getSourceBootstrap(mirrorName) else "")
-          .setSourceClusterId(if (sourceClusterId != null) sourceClusterId else "")
-          .setTopicCount(clusterMirrorCoordinator.getActiveTopicCount(mirrorName)))
-      })
-      responseData.setMirrors(mirrors)
-      responseData.setErrorCode(Errors.NONE.code)
-    } else {
+    if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring list mirrors request")
       responseData.setErrorCode(Errors.UNSUPPORTED_VERSION.code)
+      requestHelper.sendMaybeThrottle(request, new ListClusterMirrorsResponse(responseData))
+      return
     }
 
+    val mirrors = new util.ArrayList[ListClusterMirrorsResponseData.ListedMirror]()
+    val authorizedMirrors = clusterMirrorCoordinator.getConfiguredMirrors().asScala
+      .filter(mirrorName => authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = false))
+    authorizedMirrors.foreach(mirrorName => {
+      val sourceClusterId = clusterMirrorCoordinator.getSourceClusterId(mirrorName)
+      mirrors.add(new ListClusterMirrorsResponseData.ListedMirror()
+        .setMirrorName(mirrorName)
+        .setSourceBootstrap(if (clusterMirrorCoordinator.getSourceBootstrap(mirrorName) != null)
+          clusterMirrorCoordinator.getSourceBootstrap(mirrorName) else "")
+        .setSourceClusterId(if (sourceClusterId != null) sourceClusterId else "")
+        .setTopicCount(clusterMirrorCoordinator.getActiveTopicCount(mirrorName)))
+    })
+    responseData.setMirrors(mirrors)
+    responseData.setErrorCode(Errors.NONE.code)
     requestHelper.sendMaybeThrottle(request, new ListClusterMirrorsResponse(responseData))
   }
 
@@ -415,84 +416,89 @@ class KafkaApis(val requestChannel: RequestChannel,
     val describeMirrorsRequest = request.body[DescribeClusterMirrorsRequest]
     val responseData = new DescribeClusterMirrorsResponseData()
 
-    if (ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
-      val describeAll = describeMirrorsRequest.data.mirrorNames.isEmpty
-      val requestedMirrors = if (describeAll) {
-        clusterMirrorCoordinator.getConfiguredMirrors().asScala.toSeq
-      } else {
-        describeMirrorsRequest.data.mirrorNames.asScala.toSeq
-      }
-
-      requestedMirrors.foreach { mirrorName =>
-        if (!authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = !describeAll)) {
-          if (!describeAll) {
-            responseData.mirrors().add(new DescribeClusterMirrorsResponseData.DescribedMirror()
-              .setMirrorName(mirrorName)
-              .setErrorCode(Errors.CLUSTER_MIRROR_AUTHORIZATION_FAILED.code))
-          }
-        } else {
-          val describedMirror = new DescribeClusterMirrorsResponseData.DescribedMirror()
-            .setMirrorName(mirrorName)
-            .setErrorCode(Errors.NONE.code)
-
-          if (describeMirrorsRequest.data.includeAuthorizedOperations) {
-            describedMirror.setAuthorizedOperations(authHelper.authorizedOperations(
-              request, new Resource(ResourceType.CLUSTER_MIRROR, mirrorName)))
-          }
-
-          // Each broker reports partitions it's responsible for to avoid duplicates
-          val lagInfoMap = replicaManager.getMirrorLagInfo(mirrorName)
-          val partitionStates = clusterMirrorCoordinator.getMirrorStates(mirrorName).asScala
-          val lastMirrorEpoch = clusterMirrorCoordinator.getLastMirrorEpochs(mirrorName)
-          val failedInfo = clusterMirrorCoordinator.getFailedPartitionInfo()
-
-          // Report partition if: (1) we have lag info, OR (2) we're the partition leader and have no lag info
-          val partitionsToReport = (lagInfoMap.keySet ++ partitionStates.keySet.filter { tp =>
-            !lagInfoMap.contains(tp) && replicaManager.onlinePartition(tp).exists(_.isLeader)
-          }).toSeq
-
-          if (partitionsToReport.nonEmpty) {
-            // Group partitions by topic
-            val topicsMap = scala.collection.mutable.Map[String, DescribeClusterMirrorsResponseData.TopicPartitions]()
-
-            partitionsToReport.foreach { topicPartition =>
-              val topicName = topicPartition.topic()
-              val topicPartitions = topicsMap.getOrElseUpdate(topicName, {
-                val tp = new DescribeClusterMirrorsResponseData.TopicPartitions().setTopicName(topicName)
-                tp.setPartitions(new util.ArrayList[DescribeClusterMirrorsResponseData.PartitionDetail]())
-                tp
-              })
-
-              val state = partitionStates.getOrElse(topicPartition, MirrorPartitionState.UNKNOWN)
-              val isMirroring = state == MirrorPartitionState.MIRRORING
-              val partitionDetail = new DescribeClusterMirrorsResponseData.PartitionDetail()
-                .setPartitionIndex(topicPartition.partition())
-                .setSourceOffset(if (isMirroring) lagInfoMap.get(topicPartition).map(_.sourceOffset).getOrElse(-1L) else -1L)
-                .setDestinationOffset(if (isMirroring) lagInfoMap.get(topicPartition).map(_.destinationOffset).getOrElse(-1L) else -1L)
-                .setLag(if (isMirroring) lagInfoMap.get(topicPartition).map(_.lag).getOrElse(-1L) else -1L)
-                .setStateValue(state.name())
-                .setRetryAttempt(Option(failedInfo.get(topicPartition)).map(_.retryAttempt()).getOrElse(0.toShort))
-                .setErrorMessage(Option(failedInfo.get(topicPartition)).map(_.errorMessage()).orNull)
-                .setLastMirrorEpoch(lastMirrorEpoch.getOrDefault(topicPartition, -1))
-
-              topicPartitions.partitions().add(partitionDetail)
-            }
-
-            val topicsList = new util.ArrayList[DescribeClusterMirrorsResponseData.TopicPartitions]()
-            topicsMap.values.foreach(tp => topicsList.add(tp))
-            describedMirror.setTopics(topicsList)
-          }
-
-          responseData.mirrors().add(describedMirror)
-        }
-      }
-
-      maybeHandleLineageResults(describeMirrorsRequest.data.topicLineages, responseData)
-
-    } else {
+    if (!ClusterMirrorUtils.isClusterMirroringEnabled(apiVersionManager.features.finalizedFeatures)) {
       logger.warn("Cluster Mirroring is disabled (mirror.version=0), ignoring describe mirrors request")
       responseData.setErrorCode(Errors.UNSUPPORTED_VERSION.code)
+      requestHelper.sendMaybeThrottle(request, new DescribeClusterMirrorsResponse(responseData))
+      return
     }
+
+    val describeAll = describeMirrorsRequest.data.mirrorNames.isEmpty
+    val requestedMirrors = if (describeAll) {
+      clusterMirrorCoordinator.getConfiguredMirrors().asScala.toSeq
+    } else {
+      describeMirrorsRequest.data.mirrorNames.asScala.toSeq
+    }
+
+    requestedMirrors.foreach { mirrorName =>
+      if (!authHelper.authorize(request.context, DESCRIBE, CLUSTER_MIRROR, mirrorName, logIfDenied = !describeAll)) {
+        if (!describeAll) {
+          responseData.mirrors().add(new DescribeClusterMirrorsResponseData.DescribedMirror()
+            .setMirrorName(mirrorName)
+            .setErrorCode(Errors.CLUSTER_MIRROR_AUTHORIZATION_FAILED.code))
+        }
+      } else {
+        val describedMirror = new DescribeClusterMirrorsResponseData.DescribedMirror()
+          .setMirrorName(mirrorName)
+          .setErrorCode(Errors.NONE.code)
+
+        if (describeMirrorsRequest.data.includeAuthorizedOperations) {
+          describedMirror.setAuthorizedOperations(authHelper.authorizedOperations(
+            request, new Resource(ResourceType.CLUSTER_MIRROR, mirrorName)))
+        }
+
+        // Each broker reports partitions it's responsible for to avoid duplicates
+        val lagInfoMap = replicaManager.getMirrorLagInfo(mirrorName)
+        val partitionStates = clusterMirrorCoordinator.getMirrorStates(mirrorName).asScala
+        val lastMirrorEpoch = clusterMirrorCoordinator.getLastMirrorEpochs(mirrorName)
+        val failedInfo = clusterMirrorCoordinator.getFailedPartitionInfo()
+
+        // Report partition if: (1) we have lag info, OR (2) we're the partition leader and have no lag info
+        val partitionsToReport = (lagInfoMap.keySet ++ partitionStates.keySet.filter { tp =>
+          !lagInfoMap.contains(tp) && replicaManager.onlinePartition(tp).exists(_.isLeader)
+        }).toSeq
+
+        if (partitionsToReport.nonEmpty) {
+          // Group partitions by topic
+          val topicsMap = scala.collection.mutable.Map[String, DescribeClusterMirrorsResponseData.TopicPartitions]()
+
+          partitionsToReport.foreach { topicPartition =>
+            val topicName = topicPartition.topic()
+            val topicPartitions = topicsMap.getOrElseUpdate(topicName, {
+              val tp = new DescribeClusterMirrorsResponseData.TopicPartitions().setTopicName(topicName)
+              tp.setPartitions(new util.ArrayList[DescribeClusterMirrorsResponseData.PartitionDetail]())
+              tp
+            })
+
+            val state = partitionStates.getOrElse(topicPartition, MirrorPartitionState.UNKNOWN)
+            val isMirroring = state == MirrorPartitionState.MIRRORING
+            val partitionDetail = new DescribeClusterMirrorsResponseData.PartitionDetail()
+              .setPartitionIndex(topicPartition.partition())
+              .setSourceOffset(if (isMirroring) lagInfoMap.get(topicPartition).map(_.sourceOffset).getOrElse(-1L) else -1L)
+              .setDestinationOffset(if (isMirroring) lagInfoMap.get(topicPartition).map(_.destinationOffset).getOrElse(-1L) else -1L)
+              .setLag(if (isMirroring) lagInfoMap.get(topicPartition).map(_.lag).getOrElse(-1L) else -1L)
+              .setStateValue(state.name())
+              .setRetryAttempt(Option(failedInfo.get(topicPartition)).map(_.retryAttempt()).getOrElse(0.toShort))
+              .setErrorMessage(Option(failedInfo.get(topicPartition)).map(_.errorMessage()).orNull)
+              .setLastMirrorEpoch(lastMirrorEpoch.getOrDefault(topicPartition, -1))
+
+            topicPartitions.partitions().add(partitionDetail)
+          }
+
+          val topicsList = new util.ArrayList[DescribeClusterMirrorsResponseData.TopicPartitions]()
+          topicsMap.values.foreach(tp => topicsList.add(tp))
+          describedMirror.setTopics(topicsList)
+        }
+
+        responseData.mirrors().add(describedMirror)
+      }
+    }
+
+    // On the source, for each (TopicId, PartitionIndex, SrcClusterId, DstClusterId) in TopicLineages:
+    // 1. Scan mirror configs to find all mirror names where mirror.source.cluster.id matches SrcClusterId OR DstClusterId
+    // 2. For those mirror names, look up LME for that specific (TopicId, PartitionIndex)
+    // 3. If multiple matches, take max LME for that partition
+    maybeHandleLineageResults(describeMirrorsRequest.data.topicLineages, responseData)
 
     requestHelper.sendMaybeThrottle(request, new DescribeClusterMirrorsResponse(responseData))
   }

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -233,8 +233,7 @@ public class AsyncClusterMirrorIntegrationTest {
         topicLineage
                 .setTopicId(topicId)
                 .setPartitions(List.of(0))
-                .setSrcClusterIds(List.of())
-                .setDstClusterId(srcCluster.controllers().values().stream().findFirst().get().clusterId());
+                .setSrcClusterIds(List.of(srcCluster.controllers().values().stream().findFirst().get().clusterId()));
         DescribeClusterMirrorsResult describeClusterMirrors = dstAdmin.describeClusterMirrors(List.of(reverseMirror), new DescribeClusterMirrorsOptions().topicLineages(List.of(topicLineage)));
         // verify the returned lineageEpochs should contain the epoch >= 0 for the topic partition
         Map<Uuid, Map<Integer, Integer>> lineageEpochs = describeClusterMirrors.lineageEpochs().get(30, TimeUnit.SECONDS);

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -233,7 +233,7 @@ public class AsyncClusterMirrorIntegrationTest {
         topicLineage
                 .setTopicId(topicId)
                 .setPartitions(List.of(0))
-                .setSrcClusterId("")
+                .setSrcClusterIds(List.of())
                 .setDstClusterId(srcCluster.controllers().values().stream().findFirst().get().clusterId());
         DescribeClusterMirrorsResult describeClusterMirrors = dstAdmin.describeClusterMirrors(List.of(reverseMirror), new DescribeClusterMirrorsOptions().topicLineages(List.of(topicLineage)));
         // verify the returned lineageEpochs should contain the epoch >= 0 for the topic partition

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -24,8 +24,10 @@ import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ClusterMirrorDesc;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateClusterMirrorOptions;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteClusterMirrorOptions;
 import org.apache.kafka.clients.admin.DescribeClusterMirrorsOptions;
+import org.apache.kafka.clients.admin.DescribeClusterMirrorsResult;
 import org.apache.kafka.clients.admin.ListConfigResourcesOptions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.StartMirrorTopicsOptions;
@@ -42,6 +44,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.message.DescribeClusterMirrorsRequestData;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
@@ -206,8 +209,9 @@ public class AsyncClusterMirrorIntegrationTest {
         String forwardMirror = "src-to-dst";
         String reverseMirror = "dst-to-src";
 
-        srcAdmin.createTopics(List.of(new NewTopic(topic, 1, (short) 1)))
-                .all().get(30, TimeUnit.SECONDS);
+        CreateTopicsResult createTopicsResult = srcAdmin.createTopics(List.of(new NewTopic(topic, 1, (short) 1)));
+        createTopicsResult.all().get(30, TimeUnit.SECONDS);
+        Uuid topicId = createTopicsResult.topicId(topic).get();
         produceRecords(srcCluster, topic, 0, 10);
 
         // Forward: src -> dst
@@ -223,6 +227,20 @@ public class AsyncClusterMirrorIntegrationTest {
                 .all().get(30, TimeUnit.SECONDS);
         waitForMirrorState(dstAdmin, forwardMirror, topic, "STOPPED");
         produceRecords(dstCluster, topic, 10, 5);
+
+        // sending a describeClusterMirror request with topicLineage info
+        DescribeClusterMirrorsRequestData.TopicLineage topicLineage = new DescribeClusterMirrorsRequestData.TopicLineage();
+        topicLineage
+                .setTopicId(topicId)
+                .setPartitions(List.of(0))
+                .setSrcClusterId("")
+                .setDstClusterId(srcCluster.controllers().values().stream().findFirst().get().clusterId());
+        DescribeClusterMirrorsResult describeClusterMirrors = dstAdmin.describeClusterMirrors(List.of(reverseMirror), new DescribeClusterMirrorsOptions().topicLineages(List.of(topicLineage)));
+        // verify the returned lineageEpochs should contain the epoch >= 0 for the topic partition
+        Map<Uuid, Map<Integer, Integer>> lineageEpochs = describeClusterMirrors.lineageEpochs().get(30, TimeUnit.SECONDS);
+        assertEquals(1, lineageEpochs.size(), "Should have one lineage");
+        assertEquals(1, lineageEpochs.get(topicId).size(), "Should have one partition");
+        assertTrue(lineageEpochs.get(topicId).get(0) >= 0, "Should have LME >= 0");
 
         // Failback: src mirrors from dst under a different name
         srcAdmin.createClusterMirror(reverseMirror, Map.of(

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -100,6 +100,17 @@ public class AsyncClusterMirrorIntegrationTest {
                         .setNumBrokerNodes(2)
                         .setNumControllerNodes(1)
                         .build())
+                .setConfigProp(ClusterMirrorConfig.MIRROR_NUM_REPLICA_FETCHERS_CONFIG, "2")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_METADATA_REFRESH_INTERVAL_MS_CONFIG,
+                        String.valueOf(METADATA_REFRESH_INTERVAL_MS))
+                .setConfigProp(ServerLogConfigs.AUTO_CREATE_TOPICS_ENABLE_CONFIG, "false")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_STATE_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
+                .setConfigProp(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
+                .setConfigProp(ServerConfigs.REQUEST_TIMEOUT_MS_CONFIG, "5000")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_SOCKET_TIMEOUT_MS_CONFIG, "5000")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_MAX_ATTEMPTS_CONFIG, "3")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_INITIAL_BACKOFF_MS_CONFIG, "1000")
+                .setConfigProp(ClusterMirrorConfig.MIRROR_FAILED_RETRY_MAX_BACKOFF_MS_CONFIG, "5000")
                 .setConfigProp(ServerConfigs.UNSTABLE_API_VERSIONS_ENABLE_CONFIG, "true")
                 .setConfigProp(ServerConfigs.UNSTABLE_FEATURE_VERSIONS_ENABLE_CONFIG, "true")
                 .build();
@@ -154,11 +165,11 @@ public class AsyncClusterMirrorIntegrationTest {
     }
 
     /**
-     * Tests that ASYNC replication works.
+     * Tests that ASYNC mirroring works.
      * This is a simpler smoke test for the mirror setup.
      */
     @Test
-    void testAsyncMirrorReplication() throws Exception {
+    void testAsyncMirroring() throws Exception {
         // Create topic and produce data
         srcAdmin.createTopics(List.of(
                 new NewTopic(TOPIC_NAME, 1, (short) 1)
@@ -172,7 +183,7 @@ public class AsyncClusterMirrorIntegrationTest {
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
         dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC_NAME), new StartMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(TOPIC_NAME);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, TOPIC_NAME);
 
         // Produce more data while in ASYNC mode
         produceRecords(srcCluster, TOPIC_NAME, 50, 50);
@@ -182,6 +193,47 @@ public class AsyncClusterMirrorIntegrationTest {
                 dstCluster, TOPIC_NAME, 100, null);
         assertEquals(100, records.size(),
                 "Destination should have all 100 records");
+    }
+
+    /**
+     * Failover then failback with a different mirror name.
+     * Uses TopicLineages so the destination finds the LME from the old mirror
+     * and avoids re-replicating from zero.
+     */
+    @Test
+    void testFailoverFailback() throws Exception {
+        String topic = "failback-topic";
+        String forwardMirror = "src-to-dst";
+        String reverseMirror = "dst-to-src";
+
+        srcAdmin.createTopics(List.of(new NewTopic(topic, 1, (short) 1)))
+                .all().get(30, TimeUnit.SECONDS);
+        produceRecords(srcCluster, topic, 0, 10);
+
+        // Forward: src -> dst
+        dstAdmin.createClusterMirror(forwardMirror, Map.of(
+                "bootstrap.servers", srcCluster.bootstrapServers()
+        ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        dstAdmin.startMirrorTopics(forwardMirror, Set.of(topic), new StartMirrorTopicsOptions())
+                .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(dstAdmin, forwardMirror, topic);
+
+        // Failover: stop forward mirror, produce on dst
+        dstAdmin.stopMirrorTopics(forwardMirror, Set.of(topic), new StopMirrorTopicsOptions())
+                .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorState(dstAdmin, forwardMirror, topic, "STOPPED");
+        produceRecords(dstCluster, topic, 10, 5);
+
+        // Failback: src mirrors from dst under a different name
+        srcAdmin.createClusterMirror(reverseMirror, Map.of(
+                "bootstrap.servers", dstCluster.bootstrapServers()
+        ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        srcAdmin.startMirrorTopics(reverseMirror, Set.of(topic), new StartMirrorTopicsOptions())
+                .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(srcAdmin, reverseMirror, topic);
+
+        // All 15 records should be consumable on src (10 original + 5 from dst)
+        consumeRecords(srcCluster, topic, 15);
     }
 
     /**
@@ -205,12 +257,12 @@ public class AsyncClusterMirrorIntegrationTest {
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
         dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(topic), new StartMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(topic);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, topic);
 
         // Stop the mirror topic
         dstAdmin.stopMirrorTopics(MIRROR_NAME, Set.of(topic), new StopMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorState(topic, "STOPPED");
+        waitForMirrorState(dstAdmin, MIRROR_NAME, topic, "STOPPED");
 
         // Consume all records from the destination with a stable consumer group
         consumeRecords(dstCluster, topic, recordCount, groupId);
@@ -249,7 +301,7 @@ public class AsyncClusterMirrorIntegrationTest {
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
         dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(TOPIC_NAME), new StartMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(TOPIC_NAME);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, TOPIC_NAME);
 
         // Wait for async replication
         consumeRecords(dstCluster, TOPIC_NAME, 50);
@@ -279,7 +331,7 @@ public class AsyncClusterMirrorIntegrationTest {
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "orders-.*"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(".*");
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, ".*");
 
         // Auto-discovery should find orders-us and start replication
         consumeRecords(dstCluster, ordersTopic, 30);
@@ -315,7 +367,7 @@ public class AsyncClusterMirrorIntegrationTest {
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "orders-.*",
                 ClusterMirrorConfig.MIRROR_TOPICS_EXCLUDE_CONFIG, "orders-internal"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(includedTopic);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, includedTopic);
 
         // Only orders-us should be discovered, orders-internal is excluded
         consumeRecords(dstCluster, includedTopic, 30);
@@ -348,7 +400,7 @@ public class AsyncClusterMirrorIntegrationTest {
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, ".*"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(userTopic);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, userTopic);
 
         // user-events should be discovered and replicated
         consumeRecords(dstCluster, userTopic, 25);
@@ -375,7 +427,7 @@ public class AsyncClusterMirrorIntegrationTest {
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "payments"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(topic);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, topic);
 
         consumeRecords(dstCluster, topic, 40);
     }
@@ -404,7 +456,7 @@ public class AsyncClusterMirrorIntegrationTest {
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "payments,orders-.*"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(literalTopic, regexMatchedTopic);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, literalTopic, regexMatchedTopic);
 
         consumeRecords(dstCluster, literalTopic, 20);
         consumeRecords(dstCluster, regexMatchedTopic, 15);
@@ -435,7 +487,7 @@ public class AsyncClusterMirrorIntegrationTest {
                 "bootstrap.servers", singleSourceBootstrapServer,
                 ClusterMirrorConfig.MIRROR_TOPICS_INCLUDE_CONFIG, "orders-.*"
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(topicA, topicB);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, topicA, topicB);
 
         consumeRecords(dstCluster, topicA, 20);
         consumeRecords(dstCluster, topicB, 20);
@@ -443,7 +495,7 @@ public class AsyncClusterMirrorIntegrationTest {
         // Stop orders-eu (sets mirror.name to test-mirror.stopped)
         dstAdmin.stopMirrorTopics(MIRROR_NAME, Set.of(topicB), new StopMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorState(topicB, "STOPPED");
+        waitForMirrorState(dstAdmin, MIRROR_NAME, topicB, "STOPPED");
 
         // Produce more data to both topics (only orders-us should receive new records)
         produceRecords(srcCluster, topicA, 20, 20);
@@ -479,7 +531,7 @@ public class AsyncClusterMirrorIntegrationTest {
         dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(topic),
                 new StartMirrorTopicsOptions().includePatterns(List.of("orders-.*")))
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(topic);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, topic);
 
         consumeRecords(dstCluster, topic, 30);
 
@@ -511,7 +563,7 @@ public class AsyncClusterMirrorIntegrationTest {
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
         dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(topic), new StartMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(topic);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, topic);
 
         var listConfigResult = dstAdmin.listConfigResources(Set.of(ConfigResource.Type.CLUSTER_MIRROR),
                 new ListConfigResourcesOptions()).all().get(30, TimeUnit.SECONDS);
@@ -525,7 +577,7 @@ public class AsyncClusterMirrorIntegrationTest {
         // Stop all topics (required precondition for deletion)
         dstAdmin.stopMirrorTopics(MIRROR_NAME, Set.of(topic), new StopMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorState(topic, "STOPPED");
+        waitForMirrorState(dstAdmin, MIRROR_NAME, topic, "STOPPED");
 
         dstAdmin.deleteClusterMirror(MIRROR_NAME, new DeleteClusterMirrorOptions())
                 .all().get(30, TimeUnit.SECONDS);
@@ -572,25 +624,12 @@ public class AsyncClusterMirrorIntegrationTest {
         ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
         dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(topic), new StartMirrorTopicsOptions())
                 .all().get(30, TimeUnit.SECONDS);
-        waitForMirrorLagZero(topic);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, topic);
 
         // Stop all source brokers to trigger FAILED state
         srcCluster.brokers().values().forEach(b -> b.shutdown());
 
         waitForFailedWithRetriesExhausted(topic, 2);
-    }
-
-    private void waitForFailedWithRetriesExhausted(String topicPattern, int maxAttempts) throws Exception {
-        long deadline = System.currentTimeMillis() + 120_000;
-        while (System.currentTimeMillis() < deadline) {
-            if (allPartitionsSatisfy(topicPattern,
-                    s -> "FAILED".equals(s.state()) && s.retryAttempt() >= maxAttempts)) {
-                return;
-            }
-            TimeUnit.MILLISECONDS.sleep(1_000);
-        }
-        throw new AssertionError("Mirror partitions for " + topicPattern
-                + " did not exhaust retries within timeout");
     }
 
     private void produceRecords(KafkaClusterTestKit cluster, String topic,
@@ -670,67 +709,6 @@ public class AsyncClusterMirrorIntegrationTest {
         }
     }
 
-    private boolean allPartitionsSatisfy(
-            String topicPattern, Predicate<ClusterMirrorDesc.LeaderStateDesc> condition) throws Exception {
-        var result = dstAdmin.describeClusterMirrors(
-                List.of(MIRROR_NAME), new DescribeClusterMirrorsOptions());
-        var descriptions = result.allDescriptions().get(5, TimeUnit.SECONDS);
-        ClusterMirrorDesc desc = descriptions.get(MIRROR_NAME);
-        if (desc == null) return false;
-        var pattern = java.util.regex.Pattern.compile(topicPattern);
-        var matched = desc.topics().entrySet().stream()
-                .filter(e -> pattern.matcher(e.getKey()).matches())
-                .toList();
-        return !matched.isEmpty()
-                && matched.stream().allMatch(e -> e.getValue().stream().allMatch(condition));
-    }
-
-    private void waitForMirrorState(String topicPattern, String state) throws Exception {
-        long deadline = System.currentTimeMillis() + 30_000;
-        while (System.currentTimeMillis() < deadline) {
-            if (allPartitionsSatisfy(topicPattern, s -> state.equals(s.state()))) return;
-            TimeUnit.MILLISECONDS.sleep(1_000);
-        }
-        throw new AssertionError("Mirror partitions for " + topicPattern + " did not reach state " + state + " within timeout");
-    }
-
-    private void waitForListMirrorEmpty() {
-        TestUtils.waitUntilTrue(() -> {
-            try {
-                var listMirror = dstAdmin.listClusterMirrors().all().get(30, TimeUnit.SECONDS);
-                return listMirror.isEmpty();
-            } catch (Exception e) {
-                return false;
-            }
-        }, () -> "Cluster Mirror is not deleted successfully", DEFAULT_MAX_WAIT_MS, 100);
-    }
-
-    private void waitForMirrorLagZero(String... topicPatterns) throws Exception {
-        long deadline = System.currentTimeMillis() + 30_000;
-        while (System.currentTimeMillis() < deadline) {
-            boolean allReady = true;
-            for (String pattern : topicPatterns) {
-                if (!allPartitionsSatisfy(pattern, s -> s.lag() == 0 && "MIRRORING".equals(s.state()))) {
-                    allReady = false;
-                    break;
-                }
-            }
-            if (allReady) return;
-            TimeUnit.MILLISECONDS.sleep(1_000);
-        }
-        throw new AssertionError("Mirror lag did not reach zero for " + List.of(topicPatterns) + " within timeout");
-    }
-
-    private static void closeQuietly(AutoCloseable closeable) {
-        if (closeable != null) {
-            try {
-                closeable.close();
-            } catch (Exception e) {
-                // ignore
-            }
-        }
-    }
-
     private void appendToTopicsInclude(String mirrorName, String pattern) throws Exception {
         ConfigResource mirrorResource = new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName);
         var configResult = dstAdmin.describeConfigs(List.of(mirrorResource)).all().get(30, TimeUnit.SECONDS);
@@ -750,14 +728,78 @@ public class AsyncClusterMirrorIntegrationTest {
         ))).all().get(30, TimeUnit.SECONDS);
     }
 
-    private void assertStableOffset(Admin admin, String groupId,
-                                    TopicPartition tp, long expectedOffset) throws Exception {
-        long deadline = System.currentTimeMillis() + 3 * METADATA_REFRESH_INTERVAL_MS;
+    private boolean allPartitionsSatisfy(Admin admin, String mirrorName,
+                                         String topicPattern, Predicate<ClusterMirrorDesc.LeaderStateDesc> condition) throws Exception {
+        var result = admin.describeClusterMirrors(
+                List.of(mirrorName), new DescribeClusterMirrorsOptions());
+        var descriptions = result.allDescriptions().get(5, TimeUnit.SECONDS);
+        ClusterMirrorDesc desc = descriptions.get(mirrorName);
+        if (desc == null) return false;
+        var pattern = java.util.regex.Pattern.compile(topicPattern);
+        var matched = desc.topics().entrySet().stream()
+                .filter(e -> pattern.matcher(e.getKey()).matches())
+                .toList();
+        return !matched.isEmpty()
+                && matched.stream().allMatch(e -> e.getValue().stream().allMatch(condition));
+    }
+
+    private void waitForMirrorState(Admin admin, String mirrorName, String topicPattern, String state) throws Exception {
+        long deadline = System.currentTimeMillis() + 30_000;
         while (System.currentTimeMillis() < deadline) {
-            long current = getCommittedOffset(admin, groupId, tp);
-            assertEquals(expectedOffset, current,
-                    "Consumer group offset must not be overwritten after mirror stop");
+            if (allPartitionsSatisfy(admin, mirrorName, topicPattern, s -> state.equals(s.state()))) return;
             TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+        throw new AssertionError("Mirror " + mirrorName + " did not reach state " + state + " for " + topicPattern);
+    }
+
+    private void waitForMirrorLagZero(Admin admin, String mirrorName, String... topicPatterns) throws Exception {
+        long deadline = System.currentTimeMillis() + 60_000;
+        while (System.currentTimeMillis() < deadline) {
+            boolean allReady = true;
+            for (String tp : topicPatterns) {
+                if (!allPartitionsSatisfy(admin, mirrorName, tp,
+                        s -> s.lag() == 0 && "MIRRORING".equals(s.state()))) {
+                    allReady = false;
+                    break;
+                }
+            }
+            if (allReady) return;
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+        throw new AssertionError("Mirror " + mirrorName + " lag did not reach zero for " + List.of(topicPatterns));
+    }
+
+    private void waitForFailedWithRetriesExhausted(String topicPattern, int maxAttempts) throws Exception {
+        long deadline = System.currentTimeMillis() + 120_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (allPartitionsSatisfy(dstAdmin, MIRROR_NAME, topicPattern,
+                    s -> "FAILED".equals(s.state()) && s.retryAttempt() >= maxAttempts)) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+        throw new AssertionError("Mirror partitions for " + topicPattern
+                + " did not exhaust retries within timeout");
+    }
+
+    private void waitForListMirrorEmpty() {
+        TestUtils.waitUntilTrue(() -> {
+            try {
+                var listMirror = dstAdmin.listClusterMirrors().all().get(30, TimeUnit.SECONDS);
+                return listMirror.isEmpty();
+            } catch (Exception e) {
+                return false;
+            }
+        }, () -> "Cluster Mirror is not deleted successfully", DEFAULT_MAX_WAIT_MS, 100);
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                // ignore
+            }
         }
     }
 
@@ -777,6 +819,16 @@ public class AsyncClusterMirrorIntegrationTest {
         throw new AssertionError("No committed offset for " + tp + " in group " + groupId + " within timeout");
     }
 
+    private void assertStableOffset(Admin admin, String groupId,
+                                    TopicPartition tp, long expectedOffset) throws Exception {
+        long deadline = System.currentTimeMillis() + 3 * METADATA_REFRESH_INTERVAL_MS;
+        while (System.currentTimeMillis() < deadline) {
+            long current = getCommittedOffset(admin, groupId, tp);
+            assertEquals(expectedOffset, current,
+                    "Consumer group offset must not be overwritten after mirror stop");
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+    }
     private void assertStableRecordCount(KafkaClusterTestKit cluster, String topic,
                                          int expectedCount, String message) throws Exception {
         long deadline = System.currentTimeMillis() + 3 * METADATA_REFRESH_INTERVAL_MS;

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -309,15 +309,20 @@ public class ConfigurationControlManager {
                 }
             }
 
-            if (topic.id().equals(Uuid.ZERO_UUID) && topic.numPartitions() <= 0) {
+            Uuid topicId = topic.id();
+            if (topicId.equals(Uuid.ZERO_UUID) && existingTopic != null) {
+                topicId = existingTopic.topicId();
+            }
+            if (topicId.equals(Uuid.ZERO_UUID) && topic.numPartitions() <= 0) {
                 log.warn("Topic {} for mirror {} has no topic ID or partition info and will be" +
                         " created at the next metadata refresh", topicName, mirrorName);
                 topicRes.setName(topicName);
                 topicResList.add(topicRes);
                 continue;
             }
-
-            Uuid topicId = topic.id().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : topic.id();
+            if (topicId.equals(Uuid.ZERO_UUID)) {
+                topicId = Uuid.randomUuid();
+            }
 
             if (topic.numPartitions() > 0) {
                 ApiError createError = replicationControl.createMirrorTopic(

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -296,6 +296,19 @@ public class ConfigurationControlManager {
             StartMirrorTopicsResponseData.TopicResult topicRes = new StartMirrorTopicsResponseData.TopicResult();
             String topicName = topic.name();
 
+            ReplicationControlManager.TopicControlInfo existingTopic = replicationControl.getTopicByName(topicName);
+            if (existingTopic != null) {
+                String currMirrorNameValue = existingTopic.mirrorName();
+                int currMirrorStateChange = existingTopic.mirrorState();
+                if (currMirrorNameValue != null && !currMirrorNameValue.isBlank() && currMirrorStateChange != MirrorPartitionState.STOPPED.value()) {
+                    topicRes.setErrorCode(Errors.TOPIC_ALREADY_IN_CLUSTER_MIRROR.code()).setName(topicName)
+                            .setErrorMessage("Topic '" + topicName + "' is already in mirror '" + currMirrorNameValue
+                                    + "' in " + MirrorPartitionState.fromValue((byte) currMirrorStateChange) + " state");
+                    topicResList.add(topicRes);
+                    continue;
+                }
+            }
+
             if (topic.id().equals(Uuid.ZERO_UUID) && topic.numPartitions() <= 0) {
                 log.warn("Topic {} for mirror {} has no topic ID or partition info and will be" +
                         " created at the next metadata refresh", topicName, mirrorName);
@@ -316,19 +329,6 @@ public class ConfigurationControlManager {
                 }
             }
 
-            ReplicationControlManager.TopicControlInfo topicInfo = replicationControl.getTopic(topicId);
-            if (topicInfo != null) {
-                String currMirrorNameValue = topicInfo.mirrorName();
-                int currMirrorStateChange = topicInfo.mirrorState();
-                if (currMirrorNameValue != null && !currMirrorNameValue.isBlank() && currMirrorStateChange != MirrorPartitionState.STOPPED.value()) {
-                    topicRes.setErrorCode(Errors.TOPIC_ALREADY_IN_CLUSTER_MIRROR.code()).setName(topicName)
-                            .setErrorMessage("Topic '" + topicName + "' is already in mirror '" + currMirrorNameValue
-                                    + "' in " + MirrorPartitionState.fromValue((byte) currMirrorStateChange) + " state");
-                    topicResList.add(topicRes);
-                    continue;
-                }
-            }
-
             records.add(new ApiMessageAndVersion(
                     new MirrorTopicStateChangeRecord()
                             .setTopicId(topicId)
@@ -340,6 +340,14 @@ public class ConfigurationControlManager {
             topicResList.add(topicRes);
         }
         data.setTopics(topicResList);
+
+        for (StartMirrorTopicsResponseData.TopicResult tr : topicResList) {
+            if (tr.errorCode() != Errors.NONE.code()) {
+                data.setErrorCode(tr.errorCode());
+                data.setErrorMessage(tr.errorMessage());
+                break;
+            }
+        }
 
         return ControllerResult.of(records, data);
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -295,40 +295,47 @@ public class ConfigurationControlManager {
         for (Controller.MirrorTopicMetadata topic : topics) {
             StartMirrorTopicsResponseData.TopicResult topicRes = new StartMirrorTopicsResponseData.TopicResult();
             String topicName = topic.name();
+            topicRes.setName(topicName);
 
             ReplicationControlManager.TopicControlInfo existingTopic = replicationControl.getTopicByName(topicName);
-            if (existingTopic != null) {
-                String currMirrorNameValue = existingTopic.mirrorName();
-                int currMirrorStateChange = existingTopic.mirrorState();
-                if (currMirrorNameValue != null && !currMirrorNameValue.isBlank() && currMirrorStateChange != MirrorPartitionState.STOPPED.value()) {
-                    topicRes.setErrorCode(Errors.TOPIC_ALREADY_IN_CLUSTER_MIRROR.code()).setName(topicName)
-                            .setErrorMessage("Topic '" + topicName + "' is already in mirror '" + currMirrorNameValue
-                                    + "' in " + MirrorPartitionState.fromValue((byte) currMirrorStateChange) + " state");
-                    topicResList.add(topicRes);
-                    continue;
-                }
+            boolean hasRequestTopicId = !topic.id().equals(Uuid.ZERO_UUID);
+            boolean topicIdMismatch = existingTopic != null && hasRequestTopicId
+                    && !existingTopic.topicId().equals(topic.id());
+            boolean activeInOtherMirror = existingTopic != null && existingTopic.mirrorName() != null
+                    && !existingTopic.mirrorName().isBlank()
+                    && existingTopic.mirrorState() != MirrorPartitionState.STOPPED.value();
+
+            if (topicIdMismatch) {
+                topicRes.setErrorCode(Errors.INCONSISTENT_TOPIC_ID.code())
+                        .setErrorMessage("Topic id " + topic.id() + " in the request doesn't match " +
+                                "the existing topic id " + existingTopic.topicId() + " for topic " + topicName);
+            }
+
+            if (activeInOtherMirror) {
+                topicRes.setErrorCode(Errors.TOPIC_ALREADY_IN_CLUSTER_MIRROR.code())
+                        .setErrorMessage("Topic '" + topicName + "' is already in mirror '" + existingTopic.mirrorName()
+                                + "' in " + MirrorPartitionState.fromValue((byte) existingTopic.mirrorState()) + " state");
+                topicResList.add(topicRes);
+                continue;
             }
 
             Uuid topicId = topic.id();
-            if (topicId.equals(Uuid.ZERO_UUID) && existingTopic != null) {
-                topicId = existingTopic.topicId();
-            }
-            if (topicId.equals(Uuid.ZERO_UUID) && topic.numPartitions() <= 0) {
+            boolean hasNoPartitionInfo = existingTopic == null && topic.numPartitions() <= 0;
+            if (hasNoPartitionInfo) {
                 log.warn("Topic {} for mirror {} has no topic ID or partition info and will be" +
                         " created at the next metadata refresh", topicName, mirrorName);
-                topicRes.setName(topicName);
                 topicResList.add(topicRes);
                 continue;
             }
             if (topicId.equals(Uuid.ZERO_UUID)) {
-                topicId = Uuid.randomUuid();
+                topicId = existingTopic != null ? existingTopic.topicId() : Uuid.randomUuid();
             }
 
             if (topic.numPartitions() > 0) {
                 ApiError createError = replicationControl.createMirrorTopic(
                         topicName, topicId, topic.numPartitions(), records);
                 if (createError.isFailure() && createError.error() != Errors.TOPIC_ALREADY_EXISTS) {
-                    topicRes.setErrorCode(createError.error().code()).setName(topicName);
+                    topicRes.setErrorCode(createError.error().code());
                     topicResList.add(topicRes);
                     continue;
                 }
@@ -341,7 +348,6 @@ public class ConfigurationControlManager {
                             .setDesiredState(MirrorPartitionState.MIRRORING.value()),
                     (short) 0));
 
-            topicRes.setName(topicName);
             topicResList.add(topicRes);
         }
         data.setTopics(topicResList);

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1220,6 +1220,11 @@ public class ReplicationControlManager {
         return topics.get(topicId);
     }
 
+    TopicControlInfo getTopicByName(String topicName) {
+        Uuid id = topicsByName.get(topicName);
+        return id != null ? topics.get(id) : null;
+    }
+
     Set<TopicControlInfo> getMirrorTopics() {
         return topics.values().stream()
             .filter(topicControlInfo ->

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -2202,8 +2202,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 "src_offset": item["sourceOffset"],
                 "dst_offset": item["destinationOffset"],
                 "lag": item["lag"],
-                "state": item["state"],
-                "lme": item.get("lastMirrorEpoch", -1)
+                "state": item["state"]
             }
 
         return mirrors

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -2202,7 +2202,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 "src_offset": item["sourceOffset"],
                 "dst_offset": item["destinationOffset"],
                 "lag": item["lag"],
-                "state": item["state"]
+                "state": item["state"],
+                "lme": item.get("lastMirrorEpoch", -1)
             }
 
         return mirrors

--- a/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
@@ -28,9 +28,8 @@ from kafkatest.version import (
 class ClusterMirroringFanOutTest(MirrorUtils, Test):
     """Fan-out topology test: S -> D1, S -> D2, then S crashes and D1 -> D2.
 
-    Verifies that TopicLineages-based LME lookup allows D2 to truncate
-    correctly when redirected to fetch from D1 under a new mirror name,
-    avoiding full re-replication.
+    Verifies that LME lookup allows D2 to truncate correctly when redirected
+    to fetch from D1 under a new mirror name, avoiding full re-replication.
     """
 
     def __init__(self, test_context):
@@ -184,7 +183,7 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
             err_msg="Failed to start d1-to-d2 mirror topics",
         )
 
-        self.logger.info("Wait for D2 to catch up from D1 via lineage LME lookup")
+        self.logger.info("Wait for D2 to catch up from D1 via LME lookup")
         MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest2_kafka, self.client_node,
                                          "d1-to-d2", [topic],
                                          err_msg="D2 did not catch up from D1 after fan-out redirection")
@@ -201,12 +200,12 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
                 if line:
                     self.logger.info("LME lookup log on %s: %s", node.name, line)
                     epoch = int(line.split(topic + "-0=")[1].split("}")[0])
-                    assert epoch >= 2, \
-                        "Expected LME epoch >= 2, got %d in: %s" % (epoch, line)
+                    assert epoch >= 1, \
+                        "Expected LME epoch >= 1, got %d in: %s" % (epoch, line)
                     found = True
-        assert found, "No lineage LME lookup log found on any D2 broker"
+        assert found, "No LME lookup log found on any D2 broker"
 
-        self.logger.info("Verify data completeness on D2 (15 original + 5 new)")
+        self.logger.info("Verify data completeness on D2 (10 original + 5 new)")
         count = MirrorUtils.consume_messages(self.logger, self.dest2_kafka, self.client_node, topic,
-                                             max_messages=20, expected_count=20)
-        assert count == 20, "Expected 20 messages on D2, got %d" % count
+                                             max_messages=15, expected_count=15)
+        assert count == 15, "Expected 15 messages on D2, got %d" % count

--- a/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
@@ -200,7 +200,7 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
 
         self.logger.info("Verify LME lookup: replication did not start from scratch")
         log_path = "%s/info/server.log" % self.dest2_kafka.OPERATIONAL_LOG_DIR
-        pattern = "LME lookup result for mirror d1-to-d2"
+        pattern = "LME lookup response for mirror d1-to-d2"
         found = False
         for node in self.dest2_kafka.nodes:
             for line in node.account.ssh_capture(

--- a/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
@@ -155,6 +155,7 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
         self.dest2_kafka.stop_cluster_mirror_topics(self.client_node, "s-to-d2", topic)
         MirrorUtils.wait_mirror_state(self.logger, self.dest2_kafka, self.client_node,
                                        "s-to-d2", [topic], "STOPPED")
+        MirrorUtils.wait_for_metadata_refresh(self.logger, self.dest2_kafka, self.client_node, "s-to-d2")
 
         self.logger.info("Produce new data on D1 (it is now the new source)")
         MirrorUtils.produce_messages(self.logger, self.dest1_kafka, self.client_node, topic, 5)

--- a/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
@@ -200,7 +200,7 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
 
         self.logger.info("Verify LME lookup: replication did not start from scratch")
         log_path = "%s/info/server.log" % self.dest2_kafka.OPERATIONAL_LOG_DIR
-        pattern = "Lineage LME lookup for mirror d1-to-d2"
+        pattern = "LME lookup result for mirror d1-to-d2"
         found = False
         for node in self.dest2_kafka.nodes:
             for line in node.account.ssh_capture(

--- a/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
@@ -104,9 +104,9 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
         """Verify fan-out LME lookup: S -> D1, S -> D2, then D1 -> D2 after S crashes."""
         topic = "t1"
 
-        self.logger.info("Create topic on source and produce initial data")
+        self.logger.info("Create topic on source and produce first batch")
         self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
-        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, topic, 10)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, topic, 5)
 
         self.logger.info("Create mirror s-to-d1 on D1 from S")
         s_to_d1_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
@@ -139,6 +139,24 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
         )
 
         self.logger.info("Wait for both destinations to catch up")
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest1_kafka, self.client_node,
+                                         "s-to-d1", [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest2_kafka, self.client_node,
+                                         "s-to-d2", [topic])
+
+        self.logger.info("Restart source nodes and produce to bump leader epoch")
+        for node in self.source_kafka.nodes:
+            self.source_kafka.restart_node(node)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, topic, 5)
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest1_kafka, self.client_node,
+                                         "s-to-d1", [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest2_kafka, self.client_node,
+                                         "s-to-d2", [topic])
+
+        self.logger.info("Restart source nodes again and produce to bump leader epoch further")
+        for node in self.source_kafka.nodes:
+            self.source_kafka.restart_node(node)
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, topic, 5)
         MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest1_kafka, self.client_node,
                                          "s-to-d1", [topic])
         MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest2_kafka, self.client_node,
@@ -180,17 +198,24 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
                                          "d1-to-d2", [topic],
                                          err_msg="D2 did not catch up from D1 after fan-out redirection")
 
-        self.logger.info("Verify LME was resolved via lineage (not -1 fallback)")
-        MirrorUtils.all_satisfy_in_mirror(self.logger, self.dest2_kafka, self.client_node,
-                                          "d1-to-d2", lambda p: p["lme"] >= 0, [topic])
-        output = self.dest2_kafka.describe_cluster_mirror(self.client_node)
-        mirrors = self.dest2_kafka.parse_describe_cluster_mirror(output)
-        for partition, info in mirrors["d1-to-d2"][topic].items():
-            self.logger.info("d1-to-d2 %s-%d: lme=%d", topic, partition, info["lme"])
-            assert info["lme"] >= 0, \
-                "Partition %d LME is %d (lineage lookup failed, expected >= 0)" % (partition, info["lme"])
+        self.logger.info("Verify LME lookup: replication did not start from scratch")
+        log_path = "%s/info/server.log" % self.dest2_kafka.OPERATIONAL_LOG_DIR
+        pattern = "Lineage LME lookup for mirror d1-to-d2"
+        found = False
+        for node in self.dest2_kafka.nodes:
+            for line in node.account.ssh_capture(
+                    "grep '%s' %s 2>/dev/null || true" % (pattern, log_path),
+                    allow_fail=True):
+                line = line.strip()
+                if line:
+                    self.logger.info("LME lookup log on %s: %s", node.name, line)
+                    epoch = int(line.split(topic + "-0=")[1].split("}")[0])
+                    assert epoch >= 2, \
+                        "Expected LME epoch >= 2, got %d in: %s" % (epoch, line)
+                    found = True
+        assert found, "No lineage LME lookup log found on any D2 broker"
 
-        self.logger.info("Verify data completeness on D2")
+        self.logger.info("Verify data completeness on D2 (15 original + 5 new)")
         count = MirrorUtils.consume_messages(self.logger, self.dest2_kafka, self.client_node, topic,
-                                             max_messages=15, expected_count=15)
-        assert count == 15, "Expected 15 messages on D2, got %d" % count
+                                             max_messages=20, expected_count=20)
+        assert count == 20, "Expected 20 messages on D2, got %d" % count

--- a/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
@@ -153,15 +153,6 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
         MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest2_kafka, self.client_node,
                                          "s-to-d2", [topic])
 
-        self.logger.info("Restart source nodes again and produce to bump leader epoch further")
-        for node in self.source_kafka.nodes:
-            self.source_kafka.restart_node(node)
-        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, topic, 5)
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest1_kafka, self.client_node,
-                                         "s-to-d1", [topic])
-        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest2_kafka, self.client_node,
-                                         "s-to-d2", [topic])
-
         self.logger.info("Crash source cluster S")
         for node in self.source_kafka.nodes:
             self.source_kafka.stop_node(node, clean_shutdown=False)
@@ -200,7 +191,7 @@ class ClusterMirroringFanOutTest(MirrorUtils, Test):
 
         self.logger.info("Verify LME lookup: replication did not start from scratch")
         log_path = "%s/info/server.log" % self.dest2_kafka.OPERATIONAL_LOG_DIR
-        pattern = "LME lookup response for mirror d1-to-d2"
+        pattern = "Last mirror epoch lookup response for mirror d1-to-d2"
         found = False
         for node in self.dest2_kafka.nodes:
             for line in node.account.ssh_capture(

--- a/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
+++ b/tests/kafkatest/tests/core/cluster_mirroring_fanout_test.py
@@ -1,0 +1,195 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.mark.resource import cluster
+from ducktape.mark import defaults
+from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
+from kafkatest.services.kafka import KafkaService, quorum
+from kafkatest.tests.core.cluster_mirroring_common import ClientService, MirrorConfig, MirrorUtils
+from kafkatest.version import (
+    CLUSTER_MIRRORING_METADATA_VERSION,
+    CLUSTER_MIRRORING_VERSION,
+)
+
+
+class ClusterMirroringFanOutTest(MirrorUtils, Test):
+    """Fan-out topology test: S -> D1, S -> D2, then S crashes and D1 -> D2.
+
+    Verifies that TopicLineages-based LME lookup allows D2 to truncate
+    correctly when redirected to fetch from D1 under a new mirror name,
+    avoiding full re-replication.
+    """
+
+    def __init__(self, test_context):
+        super(ClusterMirroringFanOutTest, self).__init__(test_context)
+        self.client = ClientService(test_context)
+        server_props = [
+            ["auto.create.topics.enable", "false"],
+            ["default.replication.factor", "2"],
+            ["min.insync.replicas", "1"],
+            ["offsets.topic.replication.factor", "2"],
+            ["transaction.state.log.replication.factor", "2"],
+            ["transaction.state.log.min.isr", "1"],
+            ["share.coordinator.state.topic.replication.factor", "2"],
+            ["share.coordinator.state.topic.min.isr", "1"],
+            ["mirror.state.topic.replication.factor", "2"],
+            ["mirror.metadata.refresh.interval.ms", "5000"],
+            ["mirror.num.replica.fetchers", "2"],
+            ["mirror.socket.timeout.ms", "5000"],
+        ]
+        self.source_kafka = KafkaService(
+            test_context, num_nodes=2, zk=None,
+            use_cluster_mirroring=True,
+            controller_num_nodes_override=1,
+            server_prop_overrides=server_props,
+        )
+        self.dest1_kafka = KafkaService(
+            test_context, num_nodes=2, zk=None,
+            use_cluster_mirroring=True,
+            controller_num_nodes_override=1,
+            server_prop_overrides=server_props,
+        )
+        self.dest2_kafka = KafkaService(
+            test_context, num_nodes=2, zk=None,
+            use_cluster_mirroring=True,
+            controller_num_nodes_override=1,
+            server_prop_overrides=server_props,
+        )
+
+    def setup(self):
+        self.client.start()
+        self.client_node = self.client.nodes[0]
+        self.source_kafka.start()
+        self.dest1_kafka.start()
+        self.dest2_kafka.start()
+
+        for kafka in [self.source_kafka, self.dest1_kafka, self.dest2_kafka]:
+            self.logger.info(
+                "Changing metadata.version on %s to %s", kafka, CLUSTER_MIRRORING_METADATA_VERSION
+            )
+            kafka.upgrade_metadata_version(CLUSTER_MIRRORING_METADATA_VERSION)
+            self.logger.info(
+                "Changing mirror.version on %s to %s", kafka, CLUSTER_MIRRORING_VERSION
+            )
+            kafka.run_features_command(
+                "upgrade", "mirror.version", CLUSTER_MIRRORING_VERSION
+            )
+
+    def teardown(self):
+        self.client.stop()
+        for kafka in [self.dest2_kafka, self.dest1_kafka, self.source_kafka]:
+            try:
+                kafka.stop()
+            except Exception:
+                self.logger.warning("Graceful stop failed for %s, forcing SIGKILL" % str(kafka))
+                for node in kafka.nodes:
+                    kafka.stop_node(node, clean_shutdown=False)
+
+    @cluster(num_nodes=10)
+    @defaults(metadata_quorum=[quorum.isolated_kraft])
+    def test_fanout_lme_lookup(self, metadata_quorum):
+        """Verify fan-out LME lookup: S -> D1, S -> D2, then D1 -> D2 after S crashes."""
+        topic = "t1"
+
+        self.logger.info("Create topic on source and produce initial data")
+        self.source_kafka.create_topic({"topic": topic, "partitions": 1, "replication-factor": 2})
+        MirrorUtils.produce_messages(self.logger, self.source_kafka, self.client_node, topic, 10)
+
+        self.logger.info("Create mirror s-to-d1 on D1 from S")
+        s_to_d1_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
+        wait_until(
+            lambda: self.dest1_kafka.create_cluster_mirror(
+                self.client_node, "s-to-d1", s_to_d1_cfg),
+            timeout_sec=120, backoff_sec=2,
+            err_msg="Failed to create s-to-d1 mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest1_kafka.start_cluster_mirror_topics(
+                self.client_node, "s-to-d1", topic),
+            timeout_sec=120, backoff_sec=2,
+            err_msg="Failed to start s-to-d1 mirror topics",
+        )
+
+        self.logger.info("Create mirror s-to-d2 on D2 from S")
+        s_to_d2_cfg = MirrorConfig(self.source_kafka.bootstrap_servers())
+        wait_until(
+            lambda: self.dest2_kafka.create_cluster_mirror(
+                self.client_node, "s-to-d2", s_to_d2_cfg),
+            timeout_sec=120, backoff_sec=2,
+            err_msg="Failed to create s-to-d2 mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest2_kafka.start_cluster_mirror_topics(
+                self.client_node, "s-to-d2", topic),
+            timeout_sec=120, backoff_sec=2,
+            err_msg="Failed to start s-to-d2 mirror topics",
+        )
+
+        self.logger.info("Wait for both destinations to catch up")
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest1_kafka, self.client_node,
+                                         "s-to-d1", [topic])
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest2_kafka, self.client_node,
+                                         "s-to-d2", [topic])
+
+        self.logger.info("Crash source cluster S")
+        for node in self.source_kafka.nodes:
+            self.source_kafka.stop_node(node, clean_shutdown=False)
+
+        self.logger.info("Stop mirroring on D1 and D2 (makes topics writable)")
+        self.dest1_kafka.stop_cluster_mirror_topics(self.client_node, "s-to-d1", topic)
+        MirrorUtils.wait_mirror_state(self.logger, self.dest1_kafka, self.client_node,
+                                       "s-to-d1", [topic], "STOPPED")
+        self.dest2_kafka.stop_cluster_mirror_topics(self.client_node, "s-to-d2", topic)
+        MirrorUtils.wait_mirror_state(self.logger, self.dest2_kafka, self.client_node,
+                                       "s-to-d2", [topic], "STOPPED")
+
+        self.logger.info("Produce new data on D1 (it is now the new source)")
+        MirrorUtils.produce_messages(self.logger, self.dest1_kafka, self.client_node, topic, 5)
+
+        self.logger.info("Create mirror d1-to-d2 on D2 from D1 (fan-out redirection)")
+        d1_to_d2_cfg = MirrorConfig(self.dest1_kafka.bootstrap_servers())
+        wait_until(
+            lambda: self.dest2_kafka.create_cluster_mirror(
+                self.client_node, "d1-to-d2", d1_to_d2_cfg),
+            timeout_sec=120, backoff_sec=2,
+            err_msg="Failed to create d1-to-d2 mirror",
+        )
+        wait_until(
+            lambda: "Started" in self.dest2_kafka.start_cluster_mirror_topics(
+                self.client_node, "d1-to-d2", topic),
+            timeout_sec=120, backoff_sec=2,
+            err_msg="Failed to start d1-to-d2 mirror topics",
+        )
+
+        self.logger.info("Wait for D2 to catch up from D1 via lineage LME lookup")
+        MirrorUtils.wait_mirror_lag_zero(self.logger, self.dest2_kafka, self.client_node,
+                                         "d1-to-d2", [topic],
+                                         err_msg="D2 did not catch up from D1 after fan-out redirection")
+
+        self.logger.info("Verify LME was resolved via lineage (not -1 fallback)")
+        MirrorUtils.all_satisfy_in_mirror(self.logger, self.dest2_kafka, self.client_node,
+                                          "d1-to-d2", lambda p: p["lme"] >= 0, [topic])
+        output = self.dest2_kafka.describe_cluster_mirror(self.client_node)
+        mirrors = self.dest2_kafka.parse_describe_cluster_mirror(output)
+        for partition, info in mirrors["d1-to-d2"][topic].items():
+            self.logger.info("d1-to-d2 %s-%d: lme=%d", topic, partition, info["lme"])
+            assert info["lme"] >= 0, \
+                "Partition %d LME is %d (lineage lookup failed, expected >= 0)" % (partition, info["lme"])
+
+        self.logger.info("Verify data completeness on D2")
+        count = MirrorUtils.consume_messages(self.logger, self.dest2_kafka, self.client_node, topic,
+                                             max_messages=15, expected_count=15)
+        assert count == 15, "Expected 15 messages on D2, got %d" % count


### PR DESCRIPTION
LME records in __mirror_state are keyed by mirror name. When the topology changes (failover, failback, fan-out redirection), the new mirror name has no matching LME entry on the source. The destination truncates to zero and re-replicates everything.

Add TopicLineages to the DescribeClusterMirrors request and LineageResults to the response. The destination builds lineage entries from its mirror config (sourceClusterId) and its own cluster ID, then sends them alongside the request. The source scans all mirror configs for a matching source.cluster.id (against srcClusterId or dstClusterId), looks up the max LME per partition across all matches, and returns the aggregated epochs in LineageResults.

On the destination, truncateToLastMirrorEpochs now returns Map<TopicPartition, Integer> directly, simplifying scheduleTruncation.