### PR TITLE
move inconsistent cluster id into terminal failed state

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
@@ -86,7 +86,7 @@ public class ClusterMirrorDesc {
         private final long destinationOffset;
         private final long lag;
         private final String state;
-        private final short retryAttempt;
+        private final int retryAttempt;
         private final String errorMessage;
 
         public LeaderStateDesc(TopicPartition topicPartition, long sourceOffset, long destinationOffset,
@@ -120,7 +120,7 @@ public class ClusterMirrorDesc {
             return state;
         }
 
-        public short retryAttempt() {
+        public int retryAttempt() {
             return retryAttempt;
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
@@ -90,7 +90,7 @@ public class ClusterMirrorDesc {
         private final String errorMessage;
 
         public LeaderStateDesc(TopicPartition topicPartition, long sourceOffset, long destinationOffset,
-                               long lag, String state, short retryAttempt, String errorMessage) {
+                               long lag, String state, int retryAttempt, String errorMessage) {
             this.topicPartition = topicPartition;
             this.sourceOffset = sourceOffset;
             this.destinationOffset = destinationOffset;

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
@@ -51,7 +51,7 @@
             "about": "The lag (source offset - destination offset), or -1 if not yet available." },
           { "name": "StateValue", "type": "string", "versions": "0+",
             "about": "The partition state as a string value." },
-          { "name": "RetryAttempt", "type": "int32", "versions": "0+", "default": "0",
+          { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",
             "about": "The number of automatic retry attempts while in FAILED state, or -1 for non-retryable failure." },
           { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
             "about": "The error message when in FAILED state, or null if not applicable." }

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
@@ -51,8 +51,8 @@
             "about": "The lag (source offset - destination offset), or -1 if not yet available." },
           { "name": "StateValue", "type": "string", "versions": "0+",
             "about": "The partition state as a string value." },
-          { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",
-            "about": "The number of automatic retry attempts while in FAILED state." },
+          { "name": "RetryAttempt", "type": "int32", "versions": "0+", "default": "0",
+            "about": "The number of automatic retry attempts while in FAILED state, or -1 for non-retryable failure." },
           { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
             "about": "The error message when in FAILED state, or null if not applicable." }
         ]}

--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -44,7 +44,7 @@
         { "name": "PreviousState", "type": "int8", "versions": "0+", "default": 16,
           "about": "The mirror partition state before the last transition; UNKNOWN if not recorded." },
         { "name": "RetryAttempt", "type": "int32", "versions": "0+", "default": 0,
-          "about": "The number of automatic retry attempts while in FAILED state, or -1 for terminal failure." },
+          "about": "The number of automatic retry attempts while in FAILED state, or -1 for non-retryable failure." },
         { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
           "about": "The error message, or null if there was no error." }
       ]}

--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -43,7 +43,7 @@
           "about": "The error code, or 0 if there was no error." },
         { "name": "PreviousState", "type": "int8", "versions": "0+", "default": 16,
           "about": "The mirror partition state before the last transition; UNKNOWN if not recorded." },
-        { "name": "RetryAttempt", "type": "int32", "versions": "0+", "default": 0,
+        { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": 0,
           "about": "The number of automatic retry attempts while in FAILED state, or -1 for non-retryable failure." },
         { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
           "about": "The error message, or null if there was no error." }

--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -43,8 +43,8 @@
           "about": "The error code, or 0 if there was no error." },
         { "name": "PreviousState", "type": "int8", "versions": "0+", "default": 16,
           "about": "The mirror partition state before the last transition; UNKNOWN if not recorded." },
-        { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": 0,
-          "about": "The number of automatic retry attempts while in FAILED state." },
+        { "name": "RetryAttempt", "type": "int32", "versions": "0+", "default": 0,
+          "about": "The number of automatic retry attempts while in FAILED state, or -1 for terminal failure." },
         { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
           "about": "The error message, or null if there was no error." }
       ]}

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -351,7 +351,7 @@ public class ClusterMirrorCoordinator {
         }
     }
 
-    private void restoreFailedState(TopicPartition tp, MirrorPartitionState state, short retryAttempt,
+    private void restoreFailedState(TopicPartition tp, MirrorPartitionState state, int retryAttempt,
                                     String errorMessage, MirrorPartitionState previousState) {
         if (state == MirrorPartitionState.FAILED) {
             metadataManager.failedPartitionInfo().put(tp,
@@ -365,13 +365,13 @@ public class ClusterMirrorCoordinator {
                                    MirrorPartitionState newState, String errorMessage, boolean isTerminalError) {
         if (newState == MirrorPartitionState.FAILED) {
             metadataManager.failedPartitionInfo().compute(tp, (key, existing) -> {
-                short attempt;
+                int attempt;
                 if (isTerminalError) {
                     attempt = MIRROR_TERMINAL_FAILED_ATTEMPT;
                 } else if (existing != null) {
-                    attempt = (short) (existing.retryAttempt() + 1);
+                    attempt = existing.retryAttempt() + 1;
                 } else {
-                    attempt = (short) 1;
+                    attempt = 1;
                 }
                 MirrorPartitionState previousState = existing != null ? existing.previousState() : currentState;
                 return new FailedPartitionInfo(attempt, errorMessage, previousState);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -364,10 +364,18 @@ public class ClusterMirrorCoordinator {
     private void updateFailedState(TopicPartition tp, MirrorPartitionState currentState,
                                    MirrorPartitionState newState, String errorMessage, boolean isTerminalError) {
         if (newState == MirrorPartitionState.FAILED) {
-            metadataManager.failedPartitionInfo().merge(tp,
-                    new FailedPartitionInfo((short) 1, errorMessage, currentState),
-                    (old, next) -> new FailedPartitionInfo(
-                            isTerminalError ? MIRROR_TERMINAL_FAILED_ATTEMPT : (short) (old.retryAttempt() + 1), next.errorMessage(), old.previousState()));
+            metadataManager.failedPartitionInfo().compute(tp, (key, existing) -> {
+                short attempt;
+                if (isTerminalError) {
+                    attempt = MIRROR_TERMINAL_FAILED_ATTEMPT;
+                } else if (existing != null) {
+                    attempt = (short) (existing.retryAttempt() + 1);
+                } else {
+                    attempt = (short) 1;
+                }
+                MirrorPartitionState previousState = existing != null ? existing.previousState() : currentState;
+                return new FailedPartitionInfo(attempt, errorMessage, previousState);
+            });
         } else if (newState == MirrorPartitionState.LOG_TRUNCATION
                 || newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
@@ -382,13 +390,14 @@ public class ClusterMirrorCoordinator {
             FailedPartitionInfo fpi = metadataManager.failedPartitionInfo().get(tp);
             int attempt = fpi != null ? fpi.retryAttempt() : 1;
             if (attempt == MIRROR_TERMINAL_FAILED_ATTEMPT) {
-                log.debug("Skip partition {} because it is in ternimal failed state, requires manual intervention.", tp);
+                log.debug("Skip partition {} because it is in terminal failed state, requires manual intervention.", tp);
                 return;
             }
             if (attempt >= maxAttempts) {
                 log.error("Partition {} exceeded max retry attempts ({}), requires manual intervention.", tp, maxAttempts);
                 return;
             }
+
             // Exponential backoff for FAILED state retries with 20% jitter.
             // With defaults (initial=1s, max=300s): attempt 0 ~1s, attempt 1 ~2s, attempt 2 ~4s, ..., attempt 8+ ~300s.
             ExponentialBackoff failedRetryBackoff = new ExponentialBackoff(
@@ -426,7 +435,7 @@ public class ClusterMirrorCoordinator {
                                 // TODO: handle failure, we can't retry forever
                                 log.error("Failed to update partition state for {}: {}, retrying", tp, ex.getMessage());
                                 scheduler.scheduleOnce("MirrorStateUpdateRetry-" + tp,
-                                        () -> transitionTo(mirrorName, Set.of(tp), newState, errorMessage), 100);
+                                        () -> transitionTo(mirrorName, Set.of(tp), newState, errorMessage, isTerminalError), 100);
                             } else {
                                 // successfully writes data into internal log
                                 try {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -85,6 +85,7 @@ import java.util.stream.Collectors;
 import scala.Option;
 import scala.jdk.javaapi.CollectionConverters;
 
+import static kafka.server.mirror.ClusterMirrorUtils.MIRROR_TERMINAL_FAILED_ATTEMPT;
 import static org.apache.kafka.common.utils.Utils.require;
 
 /**
@@ -148,7 +149,7 @@ public class ClusterMirrorCoordinator {
 
         metadataManager.initialize(
                 brokerConfig.mirrorConfig().metadataRefreshIntervalMs(),
-                (mirrorName, tp, state, errorMessage) -> transitionTo(mirrorName, tp, state, errorMessage),
+                (mirrorName, tp, state, errorMessage, isTerminalError) -> transitionTo(mirrorName, tp, state, errorMessage, isTerminalError),
                 this::tombstoneMirrorRecords,
                 this::getCoordinatorPartitionByKey,
                 this::getCoordinatorPartitionByName);
@@ -299,7 +300,7 @@ public class ClusterMirrorCoordinator {
                             log.error("Failed to bump leader epoch for {}", topicPartitions, ex);
                             transitionTo(mirrorName, topicPartitions, MirrorPartitionState.FAILED, ex.getMessage());
                         } else {
-                            transitionTo(mirrorName, topicPartitions, MirrorPartitionState.MIRRORING, null);
+                            transitionTo(mirrorName, topicPartitions, MirrorPartitionState.MIRRORING);
                         }
                     });
                 break;
@@ -310,7 +311,7 @@ public class ClusterMirrorCoordinator {
             case PAUSING:
                 log.info("PAUSING mirroring for topics {}.", topicPartitions);
                 replicaManager.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(topicPartitions));
-                topicPartitions.forEach(tp -> transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED, null));
+                topicPartitions.forEach(tp -> transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED));
                 break;
             case PAUSED:
                 log.info("PAUSED mirroring for topics {}.", topicPartitions);
@@ -361,12 +362,12 @@ public class ClusterMirrorCoordinator {
     }
 
     private void updateFailedState(TopicPartition tp, MirrorPartitionState currentState,
-                                   MirrorPartitionState newState, String errorMessage) {
+                                   MirrorPartitionState newState, String errorMessage, boolean isTerminalError) {
         if (newState == MirrorPartitionState.FAILED) {
             metadataManager.failedPartitionInfo().merge(tp,
                     new FailedPartitionInfo((short) 1, errorMessage, currentState),
                     (old, next) -> new FailedPartitionInfo(
-                            (short) (old.retryAttempt() + 1), next.errorMessage(), old.previousState()));
+                            isTerminalError ? MIRROR_TERMINAL_FAILED_ATTEMPT : (short) (old.retryAttempt() + 1), next.errorMessage(), old.previousState()));
         } else if (newState == MirrorPartitionState.LOG_TRUNCATION
                 || newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
@@ -380,6 +381,10 @@ public class ClusterMirrorCoordinator {
         topicPartitions.forEach(tp -> {
             FailedPartitionInfo fpi = metadataManager.failedPartitionInfo().get(tp);
             int attempt = fpi != null ? fpi.retryAttempt() : 1;
+            if (attempt == MIRROR_TERMINAL_FAILED_ATTEMPT) {
+                log.debug("Skip partition {} because it is in ternimal failed state, requires manual intervention.", tp);
+                return;
+            }
             if (attempt >= maxAttempts) {
                 log.error("Partition {} exceeded max retry attempts ({}), requires manual intervention.", tp, maxAttempts);
                 return;
@@ -394,17 +399,27 @@ public class ClusterMirrorCoordinator {
             long delay = failedRetryBackoff.backoff(attempt);
             MirrorPartitionState targetState = fpi != null ? fpi.previousState() : MirrorPartitionState.MIRRORING;
             log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
-            scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState, null), delay);
+            scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
         });
     }
 
     public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
+                             MirrorPartitionState newState) {
+        transitionTo(mirrorName, topicPartitions, newState, null, false);
+    }
+
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
                              MirrorPartitionState newState, String errorMessage) {
+        transitionTo(mirrorName, topicPartitions, newState, errorMessage, false);
+    }
+
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
+                             MirrorPartitionState newState, String errorMessage, boolean isTerminalError) {
         topicPartitions.forEach(tp -> {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
-                updateFailedState(tp, currentState, newState, errorMessage);
+                updateFailedState(tp, currentState, newState, errorMessage, isTerminalError);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
@@ -740,8 +755,8 @@ public class ClusterMirrorCoordinator {
     /** Schedules log truncation to align replicas with their last mirror epoch. */
     private void scheduleTruncation(String mirrorName, Set<TopicPartition> topicPartitions) {
         final Consumer<TopicPartition> truncateCallback =
-            partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING, null);
-        scheduler.scheduleOnce("LastMirrorEpochTruncation",
+            partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING);
+        scheduler.scheduleOnce("LastMirrorEpochsTruncation",
             () -> {
                 try {
                     metadataManager.sendLastMirrorEpochLookup(mirrorName, topicPartitions)
@@ -806,7 +821,7 @@ public class ClusterMirrorCoordinator {
                 }
             }
             if (!succeeded.isEmpty()) {
-                transitionTo(mirrorName, succeeded, MirrorPartitionState.STOPPED, null);
+                transitionTo(mirrorName, succeeded, MirrorPartitionState.STOPPED);
             }
             if (!failed.isEmpty()) {
                 scheduler.scheduleOnce("MirrorPidResetRetry", () -> writeMirrorPidResetAndStop(mirrorName, failed), 5000);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -911,7 +911,7 @@ public class ClusterMirrorCoordinator {
                 .setPartition(topicPartition.partition())
                 .setState(state.value())
                 .setPreviousState(fpi != null ? fpi.previousState().value() : MirrorPartitionState.UNKNOWN.value())
-                .setRetryAttempt(fpi != null ? fpi.retryAttempt() : 0)
+                .setRetryAttempt(fpi != null ? (short) fpi.retryAttempt() : (short) 0)
                 .setErrorMessage(fpi != null ? fpi.errorMessage() : null);
         var apiVersion = new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -390,7 +390,7 @@ public class ClusterMirrorCoordinator {
             FailedPartitionInfo fpi = metadataManager.failedPartitionInfo().get(tp);
             int attempt = fpi != null ? fpi.retryAttempt() : 1;
             if (attempt == MIRROR_TERMINAL_FAILED_ATTEMPT) {
-                log.debug("Skip partition {} because it is in terminal failed state, requires manual intervention.", tp);
+                log.debug("Skipping retry for partition {} because it is in terminal failed state, requires manual intervention.", tp);
                 return;
             }
             if (attempt >= maxAttempts) {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -85,7 +85,7 @@ import java.util.stream.Collectors;
 import scala.Option;
 import scala.jdk.javaapi.CollectionConverters;
 
-import static kafka.server.mirror.ClusterMirrorUtils.MIRROR_TERMINAL_FAILED_ATTEMPT;
+import static kafka.server.mirror.ClusterMirrorUtils.NON_RETRYABLE_ATTEMPT;
 import static org.apache.kafka.common.utils.Utils.require;
 
 /**
@@ -149,7 +149,7 @@ public class ClusterMirrorCoordinator {
 
         metadataManager.initialize(
                 brokerConfig.mirrorConfig().metadataRefreshIntervalMs(),
-                (mirrorName, tp, state, errorMessage, isTerminalError) -> transitionTo(mirrorName, tp, state, errorMessage, isTerminalError),
+                (mirrorName, tp, state, errorMessage, nonRetryable) -> transitionTo(mirrorName, tp, state, errorMessage, nonRetryable),
                 this::tombstoneMirrorRecords,
                 this::getCoordinatorPartitionByKey,
                 this::getCoordinatorPartitionByName);
@@ -362,12 +362,12 @@ public class ClusterMirrorCoordinator {
     }
 
     private void updateFailedState(TopicPartition tp, MirrorPartitionState currentState,
-                                   MirrorPartitionState newState, String errorMessage, boolean isTerminalError) {
+                                   MirrorPartitionState newState, String errorMessage, boolean nonRetryable) {
         if (newState == MirrorPartitionState.FAILED) {
             metadataManager.failedPartitionInfo().compute(tp, (key, existing) -> {
                 int attempt;
-                if (isTerminalError) {
-                    attempt = MIRROR_TERMINAL_FAILED_ATTEMPT;
+                if (nonRetryable) {
+                    attempt = NON_RETRYABLE_ATTEMPT;
                 } else if (existing != null) {
                     attempt = existing.retryAttempt() + 1;
                 } else {
@@ -383,14 +383,14 @@ public class ClusterMirrorCoordinator {
         }
     }
 
-    /** Schedules retries with exponential backoff for partitions in FAILED state, restoring their previous state. */
+    /** Schedules retries with exponential backoff for partitions in FAILED state, restoring their previous state. Skips non-retryable partitions. */
     private void scheduleFailedRetries(String mirrorName, Set<TopicPartition> topicPartitions) {
         int maxAttempts = brokerConfig.mirrorConfig().failedRetryMaxAttempts();
         topicPartitions.forEach(tp -> {
             FailedPartitionInfo fpi = metadataManager.failedPartitionInfo().get(tp);
             int attempt = fpi != null ? fpi.retryAttempt() : 1;
-            if (attempt == MIRROR_TERMINAL_FAILED_ATTEMPT) {
-                log.debug("Skipping retry for partition {} because it is in terminal failed state, requires manual intervention.", tp);
+            if (attempt == NON_RETRYABLE_ATTEMPT) {
+                log.debug("Skipping retry for partition {} because it is in non-retryable failed state, requires manual intervention.", tp);
                 return;
             }
             if (attempt >= maxAttempts) {
@@ -423,19 +423,19 @@ public class ClusterMirrorCoordinator {
     }
 
     public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
-                             MirrorPartitionState newState, String errorMessage, boolean isTerminalError) {
+                             MirrorPartitionState newState, String errorMessage, boolean nonRetryable) {
         topicPartitions.forEach(tp -> {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
                 log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
-                updateFailedState(tp, currentState, newState, errorMessage, isTerminalError);
+                updateFailedState(tp, currentState, newState, errorMessage, nonRetryable);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {
                             if (ex != null) {
                                 // TODO: handle failure, we can't retry forever
                                 log.error("Failed to update partition state for {}: {}, retrying", tp, ex.getMessage());
                                 scheduler.scheduleOnce("MirrorStateUpdateRetry-" + tp,
-                                        () -> transitionTo(mirrorName, Set.of(tp), newState, errorMessage, isTerminalError), 100);
+                                        () -> transitionTo(mirrorName, Set.of(tp), newState, errorMessage, nonRetryable), 100);
                             } else {
                                 // successfully writes data into internal log
                                 try {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
@@ -39,7 +39,7 @@ import java.util.concurrent.CompletableFuture;
 public final class ClusterMirrorUtils {
     public static final int LEADER_EPOCH_BUMP_THRESHOLD = 3;
     public static final int LEADER_EPOCH_BUMP_INCREMENT = 10;
-    public static final int MIRROR_TERMINAL_FAILED_ATTEMPT = -1;
+    public static final int NON_RETRYABLE_ATTEMPT = -1;
 
     private ClusterMirrorUtils() {}
 
@@ -88,7 +88,7 @@ public final class ClusterMirrorUtils {
     public record FailedPartitionInfo(int retryAttempt, String errorMessage, MirrorPartitionState previousState) { }
 
     interface StateTransitioner {
-        void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean isTerminalError);
+        void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean nonRetryable);
     }
 
     interface StateTransitionCallback {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
@@ -39,7 +39,7 @@ import java.util.concurrent.CompletableFuture;
 public final class ClusterMirrorUtils {
     public static final int LEADER_EPOCH_BUMP_THRESHOLD = 3;
     public static final int LEADER_EPOCH_BUMP_INCREMENT = 10;
-    public static final short MIRROR_TERMINAL_FAILED_ATTEMPT = -1;
+    public static final int MIRROR_TERMINAL_FAILED_ATTEMPT = -1;
 
     private ClusterMirrorUtils() {}
 
@@ -76,7 +76,7 @@ public final class ClusterMirrorUtils {
     public record PartitionStateInfo(int partition, MirrorPartitionState state, Integer leaderEpoch) { }
 
     public record PartitionStateLogEntry(String topic, int partition, MirrorPartitionState state,
-                                         MirrorPartitionState previousState, short retryAttempt,
+                                         MirrorPartitionState previousState, int retryAttempt,
                                          String errorMessage) { }
 
     public record PartitionKey(String mirrorName, String topic, int partition) { }
@@ -85,7 +85,7 @@ public final class ClusterMirrorUtils {
 
     public record LeaderInfo(Node node, int leaderEpoch) { }
 
-    public record FailedPartitionInfo(short retryAttempt, String errorMessage, MirrorPartitionState previousState) { }
+    public record FailedPartitionInfo(int retryAttempt, String errorMessage, MirrorPartitionState previousState) { }
 
     interface StateTransitioner {
         void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean isTerminalError);

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CompletableFuture;
 public final class ClusterMirrorUtils {
     public static final int LEADER_EPOCH_BUMP_THRESHOLD = 3;
     public static final int LEADER_EPOCH_BUMP_INCREMENT = 10;
+    public static final short MIRROR_TERMINAL_FAILED_ATTEMPT = -1;
 
     private ClusterMirrorUtils() {}
 
@@ -87,7 +88,7 @@ public final class ClusterMirrorUtils {
     public record FailedPartitionInfo(short retryAttempt, String errorMessage, MirrorPartitionState previousState) { }
 
     interface StateTransitioner {
-        void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage);
+        void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean isTerminalError);
     }
 
     interface StateTransitionCallback {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1642,7 +1642,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     FailedPartitionInfo fpi = failedPartitionInfo.get(new TopicPartition(tp, part));
                     partitionResult.setPreviousState(
                             fpi != null ? fpi.previousState().value() : MirrorPartitionState.UNKNOWN.value());
-                    partitionResult.setRetryAttempt(fpi != null ? fpi.retryAttempt() : 0);
+                    partitionResult.setRetryAttempt(fpi != null ? (short) fpi.retryAttempt() : (short) 0);
                     partitionResult.setErrorMessage(fpi != null ? fpi.errorMessage() : null);
                 }
                 partitionResults.add(partitionResult);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -564,8 +564,16 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return failedPartitionInfo;
     }
 
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state) {
+        transitionTo(mirrorName, topicPartition, state, null, false);
+    }
+
     public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage) {
-        stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state, errorMessage));
+        transitionTo(mirrorName, topicPartition, state, errorMessage, false);
+    }
+
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean isTerminalError) {
+        stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state, errorMessage, isTerminalError));
     }
 
     /**
@@ -589,29 +597,27 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private void applyStateTransition(String mirrorName, TopicPartition tp,
                                       MirrorPartitionState curState, MirrorPartitionState fetchedState,
                                       boolean stopRequested, boolean pauseRequested) {
-        stateTransitioner.ifPresent(t -> {
-            if (stopRequested) {
-                if (curState != MirrorPartitionState.STOPPED) {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPING, null);
-                } else {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED, null);
-                }
-            } else if (pauseRequested) {
-                if (curState != MirrorPartitionState.PAUSED) {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSING, null);
-                } else {
-                    t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED, null);
-                }
-            } else if (curState == MirrorPartitionState.PAUSED) {
-                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.MIRRORING, null);
-            } else if (curState == MirrorPartitionState.UNKNOWN
-                    || curState == MirrorPartitionState.STOPPED
-                    || curState == MirrorPartitionState.FAILED) {
-                t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION, null);
+        if (stopRequested) {
+            if (curState != MirrorPartitionState.STOPPED) {
+                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPING);
             } else {
-                t.transitionTo(mirrorName, Set.of(tp), fetchedState != null ? fetchedState : curState, null);
+                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED);
             }
-        });
+        } else if (pauseRequested) {
+            if (curState != MirrorPartitionState.PAUSED) {
+                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSING);
+            } else {
+                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED);
+            }
+        } else if (curState == MirrorPartitionState.PAUSED) {
+            transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.MIRRORING);
+        } else if (curState == MirrorPartitionState.UNKNOWN
+                || curState == MirrorPartitionState.STOPPED
+                || curState == MirrorPartitionState.FAILED) {
+            transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
+        } else {
+            transitionTo(mirrorName, Set.of(tp), fetchedState != null ? fetchedState : curState);
+        }
     }
 
     public void scheduleSourceMetadataSync(String mirrorName) {
@@ -670,9 +676,30 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             if (newClusterId != null && !newClusterId.isEmpty()) {
                 String previousClusterId = getSourceClusterId(mirrorName);
                 if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
-                    throw new IllegalStateException("Source cluster ID changed for mirror " + mirrorName
+                    String errMsg = "Source cluster ID changed for mirror " + mirrorName
                             + ": expected " + previousClusterId + ", got " + newClusterId
-                            + ". This may indicate a misconfiguration or that the source cluster has been replaced.");
+                            + ". This may indicate a misconfiguration or that the source cluster has been replaced. "
+                            + "Moving all partitions to terminal failed state.";
+                    log.error(errMsg);
+
+                    // get mirrored leader partitions for this mirror in this node, and move them to terminal failed state
+                    Set<String> mirroredTopics = getConfiguredTopics(mirrorName, true);
+                    if (!mirroredTopics.isEmpty()) {
+                        Set<TopicPartition> mirroredLeaderPartitions = new HashSet<>();
+                        for (String topic : mirroredTopics) {
+                            TopicImage topicImage = metadataImage.topics().getTopic(topic);
+                            if (topicImage != null) {
+                                topicImage.partitions().forEach((partitionId, partition) -> {
+                                    if (partition.leader == nodeId) {
+                                        mirroredLeaderPartitions.add(new TopicPartition(topic, partitionId));
+                                    }
+                                });
+                            }
+                        }
+                        if (!mirroredLeaderPartitions.isEmpty()) {
+                            transitionTo(mirrorName, mirroredLeaderPartitions, MirrorPartitionState.FAILED, errMsg, true);
+                        }
+                    }
                 }
             }
         } catch (IllegalStateException e) {
@@ -855,13 +882,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         getConfiguredTopics(mirrorName, true).forEach(name -> {
             if (deletedSourceTopicNames.contains(name)) {
-                log.info("Detected topic {} deleted in remote cluster {}, stopping mirror partitions", name, mirrorName);
+                log.info("Detected topic {} deleted in remote cluster {}, terminally failing the mirror partitions", name, mirrorName);
                 // snapshot keyset to avoid skipping entries during concurrent modification
                 Set.copyOf(partitionStates.keySet()).stream()
                         .filter(key -> key.mirrorName().equals(mirrorName) && key.topic().equals(name))
-                        .forEach(key -> stateTransitioner.ifPresent(t ->
-                                t.transitionTo(mirrorName, Set.of(new TopicPartition(key.topic(), key.partition())),
-                                        MirrorPartitionState.FAILED, "The source topic is deleted.")));
+                        .forEach(key -> transitionTo(mirrorName, Set.of(new TopicPartition(key.topic(), key.partition())),
+                                        MirrorPartitionState.FAILED, "The source topic is deleted.", true));
             }
         });
     }
@@ -907,7 +933,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             var partition = topicImage.partitions().get(tp.partition());
             if (partition != null && partition.leader == nodeId) {
                 log.info("Source leader for {} discovered after initial onMetadataUpdate, transitioning to LOG_TRUNCATION", tp);
-                stateTransitioner.ifPresent(t -> t.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION, null));
+                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
             }
         });
     }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -136,7 +136,6 @@ import scala.Option;
 
 import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_INCREMENT;
 import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD;
-import static kafka.server.mirror.ClusterMirrorUtils.NON_RETRYABLE_ATTEMPT;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
 
@@ -594,11 +593,20 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      *      UNKNOWN/STOPPED happens on startMirrorTopics. FAILED happens on manual restart after retries are exhausted.
      *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should
      *      continue to complete the process in previous leader
+     *
+     * If the current state is FAILED, we only allow it to enter FAILED state because if we move the FAILED state based on
+     * the "desired state", that means we ignore its previous state stored in FailedPartitionInfo.
+     * Ex: one partition failed when LOG_TRUNCATION. We should retry LOG_TRUNCATION until exhausted. But if we honor the
+     * desired state, we might move this failed state into PAUSING or STOPPING state due to user's update.
+     * This breaks the state machine diagram that a LOG_TRUNCATION state cannot move to PAUSING or STOPPING state.
      */
     private void applyStateTransition(String mirrorName, TopicPartition tp,
                                       MirrorPartitionState curState, MirrorPartitionState fetchedState,
                                       boolean stopRequested, boolean pauseRequested) {
-        if (stopRequested) {
+        // todo: come up with a better way to handle "manual" failure recovery way
+        if (curState == MirrorPartitionState.FAILED) {
+            transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED);
+        } else if (stopRequested) {
             if (curState != MirrorPartitionState.STOPPED) {
                 transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPING);
             } else {
@@ -613,13 +621,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         } else if (curState == MirrorPartitionState.PAUSED) {
             transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.MIRRORING);
         } else if (curState == MirrorPartitionState.UNKNOWN
-                || curState == MirrorPartitionState.STOPPED
-                || curState == MirrorPartitionState.FAILED) {
-            FailedPartitionInfo fpi = failedPartitionInfo.get(tp);
-            if (fpi != null && fpi.retryAttempt() == NON_RETRYABLE_ATTEMPT) {
-                log.debug("Skipping state transition for partition {} because it is in non-retryable failed state, requires manual intervention.", tp);
-                return;
-            }
+                || curState == MirrorPartitionState.STOPPED) {
             transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
         } else {
             transitionTo(mirrorName, Set.of(tp), fetchedState != null ? fetchedState : curState);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -617,7 +617,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 || curState == MirrorPartitionState.FAILED) {
             FailedPartitionInfo fpi = failedPartitionInfo.get(tp);
             if (fpi != null && fpi.retryAttempt() == MIRROR_TERMINAL_FAILED_ATTEMPT) {
-                log.debug("Skip partition {} because it is in terminal failed state, requires manual intervention.", tp);
+                log.debug("Skipping state transition for partition {} because it is in terminal failed state, requires manual intervention.", tp);
                 return;
             }
             transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -136,7 +136,7 @@ import scala.Option;
 
 import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_INCREMENT;
 import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD;
-import static kafka.server.mirror.ClusterMirrorUtils.MIRROR_TERMINAL_FAILED_ATTEMPT;
+import static kafka.server.mirror.ClusterMirrorUtils.NON_RETRYABLE_ATTEMPT;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
 
@@ -573,8 +573,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         transitionTo(mirrorName, topicPartition, state, errorMessage, false);
     }
 
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean isTerminalError) {
-        stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state, errorMessage, isTerminalError));
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
+        stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state, errorMessage, nonRetryable));
     }
 
     /**
@@ -616,8 +616,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 || curState == MirrorPartitionState.STOPPED
                 || curState == MirrorPartitionState.FAILED) {
             FailedPartitionInfo fpi = failedPartitionInfo.get(tp);
-            if (fpi != null && fpi.retryAttempt() == MIRROR_TERMINAL_FAILED_ATTEMPT) {
-                log.debug("Skipping state transition for partition {} because it is in terminal failed state, requires manual intervention.", tp);
+            if (fpi != null && fpi.retryAttempt() == NON_RETRYABLE_ATTEMPT) {
+                log.debug("Skipping state transition for partition {} because it is in non-retryable failed state, requires manual intervention.", tp);
                 return;
             }
             transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
@@ -685,10 +685,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     String errMsg = "Source cluster ID changed for mirror " + mirrorName
                             + ": expected " + previousClusterId + ", got " + newClusterId
                             + ". This may indicate a misconfiguration or that the source cluster has been replaced. "
-                            + "Moving all partitions to terminal failed state.";
+                            + "Moving all partitions to non-retryable failed state.";
                     log.error(errMsg);
 
-                    // get mirrored leader partitions for this mirror in this node, and move them to terminal failed state
+                    // Get mirrored leader partitions for this mirror in this node, and move them to non-retryable failed state
                     Set<String> mirroredTopics = getConfiguredTopics(mirrorName, true);
                     if (!mirroredTopics.isEmpty()) {
                         Set<TopicPartition> mirroredLeaderPartitions = new HashSet<>();
@@ -888,7 +888,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         getConfiguredTopics(mirrorName, true).forEach(name -> {
             if (deletedSourceTopicNames.contains(name)) {
-                log.info("Detected topic {} deleted in remote cluster {}, terminally failing the mirror partitions", name, mirrorName);
+                log.info("Detected topic {} deleted in remote cluster {}, marking mirror partitions as non-retryable", name, mirrorName);
                 // snapshot keyset to avoid skipping entries during concurrent modification
                 Set.copyOf(partitionStates.keySet()).stream()
                         .filter(key -> key.mirrorName().equals(mirrorName) && key.topic().equals(name))

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -136,6 +136,7 @@ import scala.Option;
 
 import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_INCREMENT;
 import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD;
+import static kafka.server.mirror.ClusterMirrorUtils.MIRROR_TERMINAL_FAILED_ATTEMPT;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
 
@@ -614,6 +615,11 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         } else if (curState == MirrorPartitionState.UNKNOWN
                 || curState == MirrorPartitionState.STOPPED
                 || curState == MirrorPartitionState.FAILED) {
+            FailedPartitionInfo fpi = failedPartitionInfo.get(tp);
+            if (fpi != null && fpi.retryAttempt() == MIRROR_TERMINAL_FAILED_ATTEMPT) {
+                log.debug("Skip partition {} because it is in terminal failed state, requires manual intervention.", tp);
+                return;
+            }
             transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
         } else {
             transitionTo(mirrorName, Set.of(tp), fetchedState != null ? fetchedState : curState);

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -484,7 +484,7 @@ class KafkaApis(val requestChannel: RequestChannel,
               .setDestinationOffset(if (isMirroring) lagInfoMap.get(topicPartition).map(_.destinationOffset).getOrElse(-1L) else -1L)
               .setLag(if (isMirroring) lagInfoMap.get(topicPartition).map(_.lag).getOrElse(-1L) else -1L)
               .setStateValue(state.name())
-              .setRetryAttempt(Option(failedInfo.get(topicPartition)).map(_.retryAttempt()).getOrElse(0.toShort))
+              .setRetryAttempt(Option(failedInfo.get(topicPartition)).map(_.retryAttempt().toShort).getOrElse(0.toShort))
               .setErrorMessage(Option(failedInfo.get(topicPartition)).map(_.errorMessage()).orNull)
 
             topicPartitions.partitions().add(partitionDetail)

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -649,6 +649,42 @@ public class AsyncClusterMirrorIntegrationTest {
         waitForFailedWithRetriesExhausted(topic, 2);
     }
 
+    /**
+     * Tests that deleting a source topic moves mirror partitions to non-retryable FAILED
+     * and that they remain in that state across metadata refresh cycles.
+     */
+    @Test
+    void testDeletedSourceTopicMovesToNonRetryableFailed() throws Exception {
+        String topic = "non-retryable-topic";
+
+        srcAdmin.createTopics(List.of(
+                new NewTopic(topic, 1, (short) 1)
+        )).all().get(30, TimeUnit.SECONDS);
+
+        produceRecords(srcCluster, topic, 0, 20);
+
+        dstAdmin.createClusterMirror(MIRROR_NAME, Map.of(
+                "bootstrap.servers", singleSourceBootstrapServer
+        ), new CreateClusterMirrorOptions()).all().get(30, TimeUnit.SECONDS);
+        dstAdmin.startMirrorTopics(MIRROR_NAME, Set.of(topic), new StartMirrorTopicsOptions())
+                .all().get(30, TimeUnit.SECONDS);
+        waitForMirrorLagZero(dstAdmin, MIRROR_NAME, topic);
+
+        // Delete source topic to trigger non-retryable failure
+        srcAdmin.deleteTopics(List.of(topic)).all().get(30, TimeUnit.SECONDS);
+
+        waitForNonRetryableFailed(topic);
+
+        // Verify partitions stay in FAILED across multiple refresh cycles
+        long deadline = System.currentTimeMillis() + 3 * METADATA_REFRESH_INTERVAL_MS;
+        while (System.currentTimeMillis() < deadline) {
+            assertTrue(allPartitionsSatisfy(dstAdmin, MIRROR_NAME, topic,
+                    s -> "FAILED".equals(s.state()) && s.retryAttempt() == -1),
+                    "Non-retryable partitions must not be restarted by metadata refresh");
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+    }
+
     private void produceRecords(KafkaClusterTestKit cluster, String topic,
                                 int startIndex, int count) {
         Properties props = new Properties();
@@ -797,6 +833,19 @@ public class AsyncClusterMirrorIntegrationTest {
         }
         throw new AssertionError("Mirror partitions for " + topicPattern
                 + " did not exhaust retries within timeout");
+    }
+
+    private void waitForNonRetryableFailed(String topicPattern) throws Exception {
+        long deadline = System.currentTimeMillis() + 120_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (allPartitionsSatisfy(dstAdmin, MIRROR_NAME, topicPattern,
+                    s -> "FAILED".equals(s.state()) && s.retryAttempt() == -1)) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(1_000);
+        }
+        throw new AssertionError("Mirror partitions for " + topicPattern
+                + " did not reach non-retryable failed state within timeout");
     }
 
     private void waitForListMirrorEmpty() {

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
@@ -33,7 +33,7 @@
     { "name": "PreviousState", "type": "int8",  "versions": "0+", "default": 16,
       "about": "The mirror partition state before this transition; UNKNOWN if not recorded." },
     { "name": "RetryAttempt", "type": "int32", "versions": "0+", "default": "0",
-      "about": "The number of automatic retry attempts while in FAILED state, or -1 for terminal failure." },
+      "about": "The number of automatic retry attempts while in FAILED state, or -1 for non-retryable failure." },
     { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "The error message when in FAILED state, or null if not applicable." }
   ]

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
@@ -32,7 +32,7 @@
       "about": "The mirror partition state." },
     { "name": "PreviousState", "type": "int8",  "versions": "0+", "default": 16,
       "about": "The mirror partition state before this transition; UNKNOWN if not recorded." },
-    { "name": "RetryAttempt", "type": "int32", "versions": "0+", "default": "0",
+    { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",
       "about": "The number of automatic retry attempts while in FAILED state, or -1 for non-retryable failure." },
     { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "The error message when in FAILED state, or null if not applicable." }

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
@@ -32,8 +32,8 @@
       "about": "The mirror partition state." },
     { "name": "PreviousState", "type": "int8",  "versions": "0+", "default": 16,
       "about": "The mirror partition state before this transition; UNKNOWN if not recorded." },
-    { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",
-      "about": "The number of automatic retry attempts while in FAILED state." },
+    { "name": "RetryAttempt", "type": "int32", "versions": "0+", "default": "0",
+      "about": "The number of automatic retry attempts while in FAILED state, or -1 for terminal failure." },
     { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "The error message when in FAILED state, or null if not applicable." }
   ]

--- a/server/src/main/java/org/apache/kafka/server/config/ClusterMirrorConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/ClusterMirrorConfig.java
@@ -37,6 +37,7 @@ import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
 import static org.apache.kafka.common.config.ConfigDef.Importance.LOW;
 import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+import static org.apache.kafka.common.config.ConfigDef.Range.between;
 import static org.apache.kafka.common.config.ConfigDef.Type.INT;
 import static org.apache.kafka.common.config.ConfigDef.Type.LIST;
 import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
@@ -524,7 +525,7 @@ public final class ClusterMirrorConfig {
                 .define(MIRROR_METADATA_REFRESH_INTERVAL_MS_CONFIG, LONG, MIRROR_METADATA_REFRESH_INTERVAL_MS_DEFAULT, atLeast(0L), MEDIUM, MIRROR_METADATA_REFRESH_INTERVAL_MS_DOC)
                 .define(MIRROR_FAILED_RETRY_INITIAL_BACKOFF_MS_CONFIG, LONG, MIRROR_FAILED_RETRY_INITIAL_BACKOFF_MS_DEFAULT, atLeast(1L), MEDIUM, MIRROR_FAILED_RETRY_INITIAL_BACKOFF_MS_DOC)
                 .define(MIRROR_FAILED_RETRY_MAX_BACKOFF_MS_CONFIG, LONG, MIRROR_FAILED_RETRY_MAX_BACKOFF_MS_DEFAULT, atLeast(1L), MEDIUM, MIRROR_FAILED_RETRY_MAX_BACKOFF_MS_DOC)
-                .define(MIRROR_FAILED_RETRY_MAX_ATTEMPTS_CONFIG, INT, MIRROR_FAILED_RETRY_MAX_ATTEMPTS_DEFAULT, atLeast(0), MEDIUM, MIRROR_FAILED_RETRY_MAX_ATTEMPTS_DOC)
+                .define(MIRROR_FAILED_RETRY_MAX_ATTEMPTS_CONFIG, INT, MIRROR_FAILED_RETRY_MAX_ATTEMPTS_DEFAULT, between(0, Short.MAX_VALUE), MEDIUM, MIRROR_FAILED_RETRY_MAX_ATTEMPTS_DOC)
                 .define(MIRROR_FETCH_BACKOFF_MS_CONFIG, LONG, MIRROR_FETCH_BACKOFF_MS_DEFAULT, atLeast(0L), MEDIUM, MIRROR_FETCH_BACKOFF_MS_DOC)
                 .define(MIRROR_FETCH_WAIT_MAX_MS_CONFIG, INT, MIRROR_FETCH_WAIT_MAX_MS_DEFAULT, atLeast(0), MEDIUM, MIRROR_FETCH_WAIT_MAX_MS_DOC)
                 .define(MIRROR_FETCH_MIN_BYTES_CONFIG, INT, MIRROR_FETCH_MIN_BYTES_DEFAULT, atLeast(0), MEDIUM, MIRROR_FETCH_MIN_BYTES_DOC)

--- a/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
@@ -348,7 +348,8 @@ public abstract class ClusterMirrorCommand {
                 if (error.length() > maxError) {
                     error = error.substring(0, maxError - 3) + "...";
                 }
-                String retry = info.retryAttempt() + "/" + maxRetryAttempts;
+                String retry = info.retryAttempt() == -1
+                    ? "TERMINAL" : info.retryAttempt() + "/" + maxRetryAttempts;
                 System.out.printf("%-30s %-40s %-10d %-7s %s%n",
                     truncateLeft(info.mirror(), 30),
                     truncateLeft(info.topic(), 40),

--- a/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
@@ -403,7 +403,7 @@ public abstract class ClusterMirrorCommand {
 
         private record PartitionInfo(String mirror, String topic, int partition,
                                      long sourceOffset, long destinationOffset, long lag,
-                                     String state, short retryAttempt, String errorMessage) { }
+                                     String state, int retryAttempt, String errorMessage) { }
     }
 
     private static final class MirrorCommandOptions extends CommandDefaultOptions {

--- a/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
@@ -349,7 +349,7 @@ public abstract class ClusterMirrorCommand {
                     error = error.substring(0, maxError - 3) + "...";
                 }
                 String retry = info.retryAttempt() == -1
-                    ? "TERMINAL" : info.retryAttempt() + "/" + maxRetryAttempts;
+                    ? "NonRetryable" : info.retryAttempt() + "/" + maxRetryAttempts;
                 System.out.printf("%-30s %-40s %-10d %-7s %s%n",
                     truncateLeft(info.mirror(), 30),
                     truncateLeft(info.topic(), 40),


### PR DESCRIPTION
1. Add `MIRROR_TERMINAL_FAILED_ATTEMPT = -1` as an identifier for terminal failure. By default the `RetryAttempt` is 0 and we always increment it, so using -1 as an identifier.
2. When validate cluster id failure, moving all mirrored partitions into terminal failed states
3. When source topic is deleted, moving partitions into terminal failed states
4. Minor refactor for non-FAILED states to invoke `transitionTo` without `null` error message.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
