### PR TITLE
remove lme from describeClusterMirrorResponse

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ClusterMirrorDesc.java
@@ -88,10 +88,9 @@ public class ClusterMirrorDesc {
         private final String state;
         private final short retryAttempt;
         private final String errorMessage;
-        private final int lastMirrorEpoch;
 
         public LeaderStateDesc(TopicPartition topicPartition, long sourceOffset, long destinationOffset,
-                               long lag, String state, short retryAttempt, String errorMessage, int lastMirrorEpoch) {
+                               long lag, String state, short retryAttempt, String errorMessage) {
             this.topicPartition = topicPartition;
             this.sourceOffset = sourceOffset;
             this.destinationOffset = destinationOffset;
@@ -99,7 +98,6 @@ public class ClusterMirrorDesc {
             this.state = state;
             this.retryAttempt = retryAttempt;
             this.errorMessage = errorMessage;
-            this.lastMirrorEpoch = lastMirrorEpoch;
         }
 
         public TopicPartition topicPartition() {
@@ -130,10 +128,6 @@ public class ClusterMirrorDesc {
             return errorMessage;
         }
 
-        public int lastMirrorEpoch() {
-            return lastMirrorEpoch;
-        }
-
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -143,7 +137,6 @@ public class ClusterMirrorDesc {
                    destinationOffset == that.destinationOffset &&
                    lag == that.lag &&
                    retryAttempt == that.retryAttempt &&
-                   lastMirrorEpoch == that.lastMirrorEpoch &&
                    Objects.equals(topicPartition, that.topicPartition) &&
                    Objects.equals(state, that.state) &&
                    Objects.equals(errorMessage, that.errorMessage);
@@ -151,7 +144,7 @@ public class ClusterMirrorDesc {
 
         @Override
         public int hashCode() {
-            return Objects.hash(topicPartition, sourceOffset, destinationOffset, lag, state, retryAttempt, errorMessage, lastMirrorEpoch);
+            return Objects.hash(topicPartition, sourceOffset, destinationOffset, lag, state, retryAttempt, errorMessage);
         }
 
         @Override
@@ -164,7 +157,6 @@ public class ClusterMirrorDesc {
                    ", state='" + state + '\'' +
                    ", retryAttempt=" + retryAttempt +
                    ", errorMessage='" + errorMessage + '\'' +
-                   ", lastMirrorEpoch=" + lastMirrorEpoch +
                    '}';
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5434,8 +5434,7 @@ public class KafkaAdminClient extends AdminClient {
                                         partition.lag(),
                                         partition.stateValue(),
                                         partition.retryAttempt(),
-                                        partition.errorMessage(),
-                                        partition.lastMirrorEpoch()
+                                        partition.errorMessage()
                                 );
                         partitions.add(leaderState);
                     }

--- a/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeClusterMirrorsResponse.json
@@ -54,10 +54,7 @@
           { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",
             "about": "The number of automatic retry attempts while in FAILED state." },
           { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
-            "about": "The error message when in FAILED state, or null if not applicable." },
-          { "name": "LastMirrorEpoch", "type": "int32", "versions": "0+", "default": "-1",
-            "about": "The last mirror leader epoch, or -1 if not available."
-          }
+            "about": "The error message when in FAILED state, or null if not applicable." }
         ]}
       ]}
     ]},

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1290,7 +1290,6 @@ public class RequestResponseTest {
                                         .setPartitionIndex(0)
                                         .setStateValue("MIRRORING")
                                         .setLag(100L)
-                                        .setLastMirrorEpoch(0)
                                         .setDestinationOffset(0)
                                         .setSourceOffset(100)
                                 ))

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -457,7 +457,6 @@ class KafkaApis(val requestChannel: RequestChannel,
         // Each broker reports partitions it's responsible for to avoid duplicates
         val lagInfoMap = replicaManager.getMirrorLagInfo(mirrorName)
         val partitionStates = clusterMirrorCoordinator.getMirrorStates(mirrorName).asScala
-        val lastMirrorEpoch = clusterMirrorCoordinator.getLastMirrorEpochs(mirrorName)
         val failedInfo = clusterMirrorCoordinator.getFailedPartitionInfo()
 
         // Report partition if: (1) we have lag info, OR (2) we're the partition leader and have no lag info
@@ -487,7 +486,6 @@ class KafkaApis(val requestChannel: RequestChannel,
               .setStateValue(state.name())
               .setRetryAttempt(Option(failedInfo.get(topicPartition)).map(_.retryAttempt()).getOrElse(0.toShort))
               .setErrorMessage(Option(failedInfo.get(topicPartition)).map(_.errorMessage()).orNull)
-              .setLastMirrorEpoch(lastMirrorEpoch.getOrDefault(topicPartition, -1))
 
             topicPartitions.partitions().add(partitionDetail)
           }

--- a/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClusterMirrorCommand.java
@@ -314,8 +314,7 @@ public abstract class ClusterMirrorCommand {
                             mirrorName, topic,
                             state.topicPartition().partition(),
                             state.sourceOffset(), state.destinationOffset(), state.lag(),
-                            state.state(), state.retryAttempt(), state.errorMessage(),
-                            state.lastMirrorEpoch()));
+                            state.state(), state.retryAttempt(), state.errorMessage()));
                     }
                 }
             }
@@ -403,8 +402,7 @@ public abstract class ClusterMirrorCommand {
 
         private record PartitionInfo(String mirror, String topic, int partition,
                                      long sourceOffset, long destinationOffset, long lag,
-                                     String state, short retryAttempt, String errorMessage,
-                                     int lastMirrorEpoch) { }
+                                     String state, short retryAttempt, String errorMessage) { }
     }
 
     private static final class MirrorCommandOptions extends CommandDefaultOptions {


### PR DESCRIPTION
Since we have `TopicLineageResults` now, we don't have to return `LastMirrorEpoch` in `DescribedMirror` response.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
