### PR TITLE
Add LeaderEpoch to PartitionChangeRecord

### DIFF
--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -430,8 +430,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 }
                 pendingPartitionStates.remove(tp);
                 pendingLeaderEpochBumps.removeIf(bump -> {
-                    if (bump.partitionToEpoch().containsKey(tp)) {
-                        bump.future().completeExceptionally(new IllegalStateException("Not leader anymore for " + tp));
+                    bump.partitionToEpoch().remove(tp);
+                    if (bump.partitionToEpoch().isEmpty()) {
+                        bump.future().complete(null);
                         return true;
                     }
                     return false;

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -173,7 +173,6 @@ class ControllerApis(
   }
 
   def handleBumpLeaderEpoch(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    // luke
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     val bumpLeaderEpochRequest = request.body[BumpLeaderEpochsRequest]
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,

--- a/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
@@ -57,6 +57,7 @@ class LocalLeaderEndPointTest extends Logging {
   var endPoint: LeaderEndPoint = _
   var quotaManager: QuotaManagers = _
   var image: MetadataImage = _
+  var currentLeaderEpoch: Int = 0
 
   @BeforeEach
   def setUp(): Unit = {
@@ -254,11 +255,13 @@ class LocalLeaderEndPointTest extends Logging {
   }
 
   private def bumpLeaderEpoch(): Unit = {
+    currentLeaderEpoch += 1
     val delta = new MetadataDelta(image)
     delta.replay(new PartitionChangeRecord()
       .setTopicId(topicId)
       .setPartitionId(partition)
       .setLeader(sourceBroker.id)
+      .setLeaderEpoch(currentLeaderEpoch)
     )
 
     image = delta.apply(MetadataProvenance.EMPTY)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -5030,6 +5030,7 @@ class ReplicaManagerTest {
         .setReplicas(util.Arrays.asList(localId, localId + 1, localId + 2))
         .setIsr(util.Arrays.asList(localId, localId + 1, localId + 2))
         .setLeader(localId + 2)
+        .setLeaderEpoch(1)
       )
 
       followerMetadataImage = imageFromTopics(followerTopicsDelta.apply())
@@ -5163,6 +5164,7 @@ class ReplicaManagerTest {
         .setReplicas(util.Arrays.asList(localId, localId + 1))
         .setIsr(util.Arrays.asList(localId + 1))
         .setLeader(localId + 1)
+        .setLeaderEpoch(1)
       )
       topicsDelta.replay(new PartitionChangeRecord()
         .setPartitionId(1)
@@ -5170,6 +5172,7 @@ class ReplicaManagerTest {
         .setReplicas(util.Arrays.asList(localId, localId + 1))
         .setIsr(util.Arrays.asList(localId))
         .setLeader(NO_LEADER)
+        .setLeaderEpoch(1)
       )
       metadataImage = imageFromTopics(topicsDelta.apply())
       replicaManager.applyDelta(topicsDelta, metadataImage)
@@ -5319,13 +5322,14 @@ class ReplicaManagerTest {
     delta
   }
 
-  private def partitionChangeRecord(startId: Int, leader: Int) = {
+  private def partitionChangeRecord(startId: Int, leader: Int, leaderEpoch: Int = 1) = {
     new PartitionChangeRecord()
       .setPartitionId(0)
       .setTopicId(FOO_UUID)
       .setReplicas(util.Arrays.asList(startId, startId + 1))
       .setIsr(util.Arrays.asList(startId, startId + 1))
       .setLeader(leader)
+      .setLeaderEpoch(leaderEpoch)
   }
 
   private def topicsDeleteDelta(topicsImage: TopicsImage): TopicsDelta = {

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -486,10 +486,11 @@ public class PartitionChangeBuilder {
      * Only sets the explicit LeaderEpoch field on v3+ records. Older metadata versions
      * rely on implicit derivation in PartitionRegistration.merge() (leader change = +1).
      *
-     * If targetLeaderEpoch is set (bump leader epoch request), the new epoch is at least
-     * targetLeaderEpoch + 1, ensuring the destination leader epoch stays above the source.
-     * If a leader change was triggered by election, reassignment, or ISR shrink, the epoch
-     * increments by 1. Otherwise, the epoch is left unchanged (default -1).
+     * If targetLeaderEpoch is set (bump leader epoch request), the caller already
+     * verified that currentLeaderEpoch <= targetLeaderEpoch, so the new epoch is
+     * targetLeaderEpoch + 1. If a leader change was triggered by election, reassignment,
+     * or ISR shrink, the epoch increments by 1. Otherwise, the epoch is left unchanged
+     * (default -1).
      */
     private void computeLeaderEpoch(PartitionChangeRecord record) {
         if (metadataVersion.partitionChangeRecordVersion() < 3) {

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -497,7 +497,7 @@ public class PartitionChangeBuilder {
             return;
         }
         if (targetLeaderEpoch >= 0) {
-            record.setLeaderEpoch(Math.max(targetLeaderEpoch + 1, partition.leaderEpoch + 1));
+            record.setLeaderEpoch(Math.max(targetLeaderEpoch + 1, partition.leaderEpoch));
         } else if (record.leader() != NO_LEADER_CHANGE) {
             record.setLeaderEpoch(partition.leaderEpoch + 1);
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -483,12 +483,18 @@ public class PartitionChangeBuilder {
      * mutations (election, reassignment, ISR shrink) so that record.leader() reflects
      * whether a leader change was triggered.
      *
+     * Only sets the explicit LeaderEpoch field on v3+ records. Older metadata versions
+     * rely on implicit derivation in PartitionRegistration.merge() (leader change = +1).
+     *
      * If targetLeaderEpoch is set (bump leader epoch request), the new epoch is at least
      * targetLeaderEpoch + 1, ensuring the destination leader epoch stays above the source.
      * If a leader change was triggered by election, reassignment, or ISR shrink, the epoch
      * increments by 1. Otherwise, the epoch is left unchanged (default -1).
      */
     private void computeLeaderEpoch(PartitionChangeRecord record) {
+        if (metadataVersion.partitionChangeRecordVersion() < 3) {
+            return;
+        }
         if (targetLeaderEpoch >= 0) {
             record.setLeaderEpoch(Math.max(targetLeaderEpoch + 1, partition.leaderEpoch + 1));
         } else if (record.leader() != NO_LEADER_CHANGE) {

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -60,7 +60,7 @@ public class PartitionChangeBuilder {
         if (record.removingReplicas() != null) return false;
         if (record.addingReplicas() != null) return false;
         if (record.leaderRecoveryState() != LeaderRecoveryState.NO_CHANGE) return false;
-        if (record.minLeaderEpoch() != -1) return false;
+        if (record.leaderEpoch() != -1) return false;
         return record.directories() == null;
     }
 
@@ -100,7 +100,7 @@ public class PartitionChangeBuilder {
     private LeaderRecoveryState targetLeaderRecoveryState;
     private boolean eligibleLeaderReplicasEnabled;
     private DefaultDirProvider defaultDirProvider;
-    private int minLeaderEpoch = -1;
+    private int targetLeaderEpoch = -1;
 
     // Whether allow electing last known leader in a Balanced recovery. Note, the last known leader will be stored in the
     // lastKnownElr field if enabled.
@@ -199,8 +199,8 @@ public class PartitionChangeBuilder {
         return this;
     }
 
-    public PartitionChangeBuilder setMinLeaderEpoch(int leaderEpoch) {
-        this.minLeaderEpoch = leaderEpoch;
+    public PartitionChangeBuilder setTargetLeaderEpoch(int leaderEpoch) {
+        this.targetLeaderEpoch = leaderEpoch;
         return this;
     }
 
@@ -438,8 +438,7 @@ public class PartitionChangeBuilder {
     public Optional<ApiMessageAndVersion> build() {
         PartitionChangeRecord record = new PartitionChangeRecord().
             setTopicId(topicId).
-            setPartitionId(partitionId).
-            setMinLeaderEpoch(minLeaderEpoch);
+            setPartitionId(partitionId);
         completeReassignmentIfNeeded();
 
         maybePopulateTargetElr();
@@ -462,6 +461,8 @@ public class PartitionChangeBuilder {
 
         triggerLeaderEpochBumpForIsrShrinkIfNeeded(record);
 
+        computeLeaderEpoch(record);
+
         maybeUpdateLastKnownLeader(record);
 
         setAssignmentChanges(record);
@@ -474,6 +475,24 @@ public class PartitionChangeBuilder {
             return Optional.empty();
         } else {
             return Optional.of(new ApiMessageAndVersion(record, metadataVersion.partitionChangeRecordVersion()));
+        }
+    }
+
+    /**
+     * Compute the final leader epoch and set it on the record. Called after all other
+     * mutations (election, reassignment, ISR shrink) so that record.leader() reflects
+     * whether a leader change was triggered.
+     *
+     * If targetLeaderEpoch is set (bump leader epoch request), the new epoch is at least
+     * targetLeaderEpoch + 1, ensuring the destination leader epoch stays above the source.
+     * If a leader change was triggered by election, reassignment, or ISR shrink, the epoch
+     * increments by 1. Otherwise, the epoch is left unchanged (default -1).
+     */
+    private void computeLeaderEpoch(PartitionChangeRecord record) {
+        if (targetLeaderEpoch >= 0) {
+            record.setLeaderEpoch(Math.max(targetLeaderEpoch + 1, partition.leaderEpoch + 1));
+        } else if (record.leader() != NO_LEADER_CHANGE) {
+            record.setLeaderEpoch(partition.leaderEpoch + 1);
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -762,7 +762,7 @@ public class ReplicationControlManager {
             String topicName = info.name;
             leaderEpochs.forEach((partitionId, leaderEpoch) -> {
                 PartitionRegistration partition = info.parts.get(partitionId);
-                // only bump the leader epoch when local leader epoch is <= required min leader epoch
+                // Skip if the current epoch already exceeds the requested value
                 if (partition.leaderEpoch <= leaderEpoch) {
                     PartitionChangeBuilder builder = new PartitionChangeBuilder(
                             partition,
@@ -774,7 +774,6 @@ public class ReplicationControlManager {
                     )
                             .setTargetLeaderEpoch(leaderEpochs.getOrDefault(partitionId, NO_PARTITION_LEADER_EPOCH))
                             .setDefaultDirProvider(clusterDescriber);
-
                     builder.build().ifPresent(records::add);
                     log.debug("Updating partition {} leader epoch for topic {} from {} to {}: {}", partitionId, topicName, partition.leaderEpoch, leaderEpoch, records);
                 } else {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -772,8 +772,7 @@ public class ReplicationControlManager {
                             featureControl.metadataVersionOrThrow(),
                             getTopicEffectiveMinIsr(topicName)
                     )
-                            // set the min leader epoch for each partition
-                            .setMinLeaderEpoch(leaderEpochs.getOrDefault(partitionId, NO_PARTITION_LEADER_EPOCH))
+                            .setTargetLeaderEpoch(leaderEpochs.getOrDefault(partitionId, NO_PARTITION_LEADER_EPOCH))
                             .setDefaultDirProvider(clusterDescriber);
 
                     builder.build().ifPresent(records::add);

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -258,10 +258,13 @@ public class PartitionRegistration {
             newLeader = record.leader();
         }
 
-        // The leader epoch is computed by the controller and stored explicitly in the
-        // record. When set (!= -1), use it directly. When not set, keep the current epoch.
+        // For v3+ records, the controller sets leaderEpoch explicitly. For older records
+        // (v0-v2), leaderEpoch defaults to -1 and we fall back to implicit derivation:
+        // leader change = epoch + 1, no leader change = epoch unchanged.
         if (record.leaderEpoch() != -1) {
             newLeaderEpoch = record.leaderEpoch();
+        } else if (record.leader() != NO_LEADER_CHANGE) {
+            newLeaderEpoch = leaderEpoch + 1;
         } else {
             newLeaderEpoch = leaderEpoch;
         }

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
 
 public class PartitionRegistration {
@@ -255,18 +254,16 @@ public class PartitionRegistration {
 
         if (record.leader() == NO_LEADER_CHANGE) {
             newLeader = leader;
-            newLeaderEpoch = leaderEpoch;
         } else {
             newLeader = record.leader();
-            newLeaderEpoch = leaderEpoch + 1;
         }
 
-        // We should bump the leader epoch when leaderEpoch is assigned (from bump_leader_epoch request), even if no_leader_change
-        if (record.minLeaderEpoch() != NO_PARTITION_LEADER_EPOCH) {
-            // If it's coming from bump leader epoch request, we should bump to a leader epoch >= record.minLeaderEpoch(), ex:
-            // current leader epoch is 0, record.minLeaderEpoch is 2, we should bump to 3
-            // current leader epoch is 2, record.minLeaderEpoch is 0, we should bump to 2
-            newLeaderEpoch = Math.max(record.minLeaderEpoch() + 1, newLeaderEpoch);
+        // The leader epoch is computed by the controller and stored explicitly in the
+        // record. When set (!= -1), use it directly. When not set, keep the current epoch.
+        if (record.leaderEpoch() != -1) {
+            newLeaderEpoch = record.leaderEpoch();
+        } else {
+            newLeaderEpoch = leaderEpoch;
         }
 
         LeaderRecoveryState newLeaderRecoveryState = leaderRecoveryState.changeTo(record.leaderRecoveryState());

--- a/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
@@ -19,7 +19,7 @@
   "name": "PartitionChangeRecord",
   // Version 1 adds Directories for KIP-858.
   // Version 2 implements Eligible Leader Replicas and LastKnownElr as described in KIP-966.
-  // Version 3 adds MinLeaderEpoch as described in KIP-1279.
+  // Version 3 adds LeaderEpoch as described in KIP-1279.
   "validVersions": "0-3",
   "flexibleVersions": "0+",
   "fields": [
@@ -53,6 +53,6 @@
     { "name": "LastKnownElr", "type": "[]int32", "default": "null", "entityType": "brokerId",
       "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 7,
       "about": "null if the LastKnownElr didn't change; the last known eligible leader replicas otherwise." },
-    { "name": "MinLeaderEpoch", "type": "int32", "versions": "3+", "default": -1, "about": "The minimum leader epoch requested."}
+    { "name": "LeaderEpoch", "type": "int32", "versions": "3+", "default": -1, "about": "-1 if the leader epoch did not change; the new leader epoch otherwise."}
   ]
 }

--- a/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
@@ -33,6 +33,8 @@
     { "name": "Leader", "type": "int32", "default": "-2", "entityType": "brokerId",
       "versions": "0+", "taggedVersions": "0+", "tag": 1,
       "about": "-1 if there is now no leader; -2 if the leader didn't change; the new leader otherwise." },
+    { "name": "LeaderEpoch", "type": "int32", "versions": "3+", "default": -1,
+      "about": "-1 if the leader epoch did not change; the new leader epoch otherwise."},
     { "name": "Replicas", "type": "[]int32", "default": "null", "entityType": "brokerId",
       "versions": "0+", "nullableVersions": "0+", "taggedVersions": "0+", "tag": 2,
       "about": "null if the replicas didn't change; the new replicas otherwise." },
@@ -52,7 +54,6 @@
       "about": "null if the ELR didn't change; the new eligible leader replicas otherwise." },
     { "name": "LastKnownElr", "type": "[]int32", "default": "null", "entityType": "brokerId",
       "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 7,
-      "about": "null if the LastKnownElr didn't change; the last known eligible leader replicas otherwise." },
-    { "name": "LeaderEpoch", "type": "int32", "versions": "3+", "default": -1, "about": "-1 if the leader epoch did not change; the new leader epoch otherwise."}
+      "about": "null if the LastKnownElr didn't change; the last known eligible leader replicas otherwise." }
   ]
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -432,12 +432,15 @@ public class PartitionChangeBuilderTest {
     @ParameterizedTest
     @MethodSource("partitionChangeRecordVersions")
     public void testIsrChangeAndLeaderChange(short version) {
-        assertEquals(Optional.of(new ApiMessageAndVersion(new PartitionChangeRecord().
+        PartitionChangeRecord expectedRecord = new PartitionChangeRecord().
                 setTopicId(FOO_ID).
                 setPartitionId(0).
                 setIsr(List.of(2, 3)).
-                setLeader(2).
-                setLeaderEpoch(101), version)),
+                setLeader(2);
+        if (version >= 3) {
+            expectedRecord.setLeaderEpoch(101);
+        }
+        assertEquals(Optional.of(new ApiMessageAndVersion(expectedRecord, version)),
             createFooBuilder(version).setTargetIsrWithBrokerStates(AlterPartitionRequest.
                 newIsrToSimpleNewIsrWithBrokerEpochs(List.of(2, 3))).build());
     }
@@ -466,9 +469,11 @@ public class PartitionChangeBuilderTest {
                 setReplicas(List.of(2, 3, 4)).
                 setIsr(List.of(2, 3, 4)).
                 setLeader(2).
-                setLeaderEpoch(101).
                 setRemovingReplicas(List.of()).
                 setAddingReplicas(List.of());
+        if (version >= 3) {
+            expectedRecord.setLeaderEpoch(101);
+        }
         if (version >= 1) {
             Map<Integer, Uuid> dirs = DirectoryId.createAssignmentMap(BAR.replicas, BAR.directories);
             expectedRecord.setDirectories(List.of(dirs.get(2), dirs.get(3), dirs.get(4)));
@@ -489,12 +494,14 @@ public class PartitionChangeBuilderTest {
                 setPartitionId(0).
                 setReplicas(List.of(1, 2, 3)).
                 setLeader(1).
-                setLeaderEpoch(101).
                 setRemovingReplicas(List.of()).
                 setAddingReplicas(List.of());
         if (version >= 1) {
             Map<Integer, Uuid> dirs = DirectoryId.createAssignmentMap(BAR.replicas, BAR.directories);
             expectedRecord.setDirectories(List.of(dirs.get(1), dirs.get(2), dirs.get(3)));
+        }
+        if (version >= 3) {
+            expectedRecord.setLeaderEpoch(101);
         }
         assertEquals(Optional.of(new ApiMessageAndVersion(expectedRecord, version)),
             createBarBuilder(version).
@@ -518,11 +525,13 @@ public class PartitionChangeBuilderTest {
                 setPartitionId(0).
                 setReplicas(List.of(1, 2)).
                 setIsr(List.of(2, 1)).
-                setLeader(1).
-                setLeaderEpoch(101);
+                setLeader(1);
         if (version >= 1) {
             Map<Integer, Uuid> dirs = DirectoryId.createAssignmentMap(FOO.replicas, FOO.directories);
             expectedRecord.setDirectories(List.of(dirs.get(1), dirs.get(2)));
+        }
+        if (version >= 3) {
+            expectedRecord.setLeaderEpoch(101);
         }
         assertEquals(Optional.of(new ApiMessageAndVersion(expectedRecord, version)),
             createFooBuilder(version).
@@ -558,16 +567,16 @@ public class PartitionChangeBuilderTest {
     @ParameterizedTest
     @MethodSource("partitionChangeRecordVersions")
     public void testUncleanLeaderElection(short version) {
-        ApiMessageAndVersion expectedRecord = new ApiMessageAndVersion(
-            new PartitionChangeRecord()
+        PartitionChangeRecord fooRecord = new PartitionChangeRecord()
                 .setTopicId(FOO_ID)
                 .setPartitionId(0)
                 .setIsr(List.of(2))
                 .setLeader(2)
-                .setLeaderEpoch(101)
-                .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()),
-            version
-        );
+                .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value());
+        if (version >= 3) {
+            fooRecord.setLeaderEpoch(101);
+        }
+        ApiMessageAndVersion expectedRecord = new ApiMessageAndVersion(fooRecord, version);
         assertEquals(
             Optional.of(expectedRecord),
             createFooBuilder(version).setElection(Election.UNCLEAN)
@@ -579,8 +588,10 @@ public class PartitionChangeBuilderTest {
             .setPartitionId(0)
             .setIsr(List.of(1))
             .setLeader(1)
-            .setLeaderEpoch(101)
             .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value());
+        if (version >= 3) {
+            record.setLeaderEpoch(101);
+        }
 
         if (version >= 2) {
             // The test partition has ELR, so unclean election will clear these fields.
@@ -774,8 +785,7 @@ public class PartitionChangeBuilderTest {
                 setIsr(List.of(2, 3)).
                 setRemovingReplicas(List.of()).
                 setAddingReplicas(List.of()).
-                setLeader(NO_LEADER).
-                setLeaderEpoch(1),
+                setLeader(NO_LEADER),
                 (short) 0)),
             partitionChangeBuilder.setTargetIsr(List.of(0, 1, 2, 3)).
                 build());
@@ -1007,7 +1017,6 @@ public class PartitionChangeBuilderTest {
                         setTopicId(FOO_ID).
                         setPartitionId(0).
                         setLeader(1).
-                        setLeaderEpoch(101).
                         setReplicas(List.of(3, 1, 5, 4)).
                         setDirectories(List.of(
                                 Uuid.fromString("fM5NKyWTQHqEihjIkUl99Q"),
@@ -1089,7 +1098,6 @@ public class PartitionChangeBuilderTest {
                 .setIsr(List.of(3))
                 .setEligibleLeaderReplicas(List.of(1))
                 .setLeader(3)
-                .setLeaderEpoch(101)
                 .setLeaderRecoveryState(LeaderRecoveryState.NO_CHANGE),
             version
         );
@@ -1137,7 +1145,6 @@ public class PartitionChangeBuilderTest {
             .setPartitionId(0)
             .setIsr(List.of())
             .setLeader(-1)
-            .setLeaderEpoch(101)
             .setLeaderRecoveryState(LeaderRecoveryState.NO_CHANGE)
             .setEligibleLeaderReplicas(List.of(1, 2, 3, 4));
 
@@ -1197,7 +1204,6 @@ public class PartitionChangeBuilderTest {
                 .setPartitionId(0)
                 .setIsr(List.of(1))
                 .setLeader(1)
-                .setLeaderEpoch(101)
                 .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value())
                 .setLastKnownElr(List.of()),
             version

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -436,7 +436,8 @@ public class PartitionChangeBuilderTest {
                 setTopicId(FOO_ID).
                 setPartitionId(0).
                 setIsr(List.of(2, 3)).
-                setLeader(2), version)),
+                setLeader(2).
+                setLeaderEpoch(101), version)),
             createFooBuilder(version).setTargetIsrWithBrokerStates(AlterPartitionRequest.
                 newIsrToSimpleNewIsrWithBrokerEpochs(List.of(2, 3))).build());
     }
@@ -465,6 +466,7 @@ public class PartitionChangeBuilderTest {
                 setReplicas(List.of(2, 3, 4)).
                 setIsr(List.of(2, 3, 4)).
                 setLeader(2).
+                setLeaderEpoch(101).
                 setRemovingReplicas(List.of()).
                 setAddingReplicas(List.of());
         if (version >= 1) {
@@ -487,6 +489,7 @@ public class PartitionChangeBuilderTest {
                 setPartitionId(0).
                 setReplicas(List.of(1, 2, 3)).
                 setLeader(1).
+                setLeaderEpoch(101).
                 setRemovingReplicas(List.of()).
                 setAddingReplicas(List.of());
         if (version >= 1) {
@@ -515,7 +518,8 @@ public class PartitionChangeBuilderTest {
                 setPartitionId(0).
                 setReplicas(List.of(1, 2)).
                 setIsr(List.of(2, 1)).
-                setLeader(1);
+                setLeader(1).
+                setLeaderEpoch(101);
         if (version >= 1) {
             Map<Integer, Uuid> dirs = DirectoryId.createAssignmentMap(FOO.replicas, FOO.directories);
             expectedRecord.setDirectories(List.of(dirs.get(1), dirs.get(2)));
@@ -560,6 +564,7 @@ public class PartitionChangeBuilderTest {
                 .setPartitionId(0)
                 .setIsr(List.of(2))
                 .setLeader(2)
+                .setLeaderEpoch(101)
                 .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()),
             version
         );
@@ -574,6 +579,7 @@ public class PartitionChangeBuilderTest {
             .setPartitionId(0)
             .setIsr(List.of(1))
             .setLeader(1)
+            .setLeaderEpoch(101)
             .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value());
 
         if (version >= 2) {
@@ -768,7 +774,8 @@ public class PartitionChangeBuilderTest {
                 setIsr(List.of(2, 3)).
                 setRemovingReplicas(List.of()).
                 setAddingReplicas(List.of()).
-                setLeader(NO_LEADER),
+                setLeader(NO_LEADER).
+                setLeaderEpoch(1),
                 (short) 0)),
             partitionChangeBuilder.setTargetIsr(List.of(0, 1, 2, 3)).
                 build());
@@ -1000,6 +1007,7 @@ public class PartitionChangeBuilderTest {
                         setTopicId(FOO_ID).
                         setPartitionId(0).
                         setLeader(1).
+                        setLeaderEpoch(101).
                         setReplicas(List.of(3, 1, 5, 4)).
                         setDirectories(List.of(
                                 Uuid.fromString("fM5NKyWTQHqEihjIkUl99Q"),
@@ -1081,6 +1089,7 @@ public class PartitionChangeBuilderTest {
                 .setIsr(List.of(3))
                 .setEligibleLeaderReplicas(List.of(1))
                 .setLeader(3)
+                .setLeaderEpoch(101)
                 .setLeaderRecoveryState(LeaderRecoveryState.NO_CHANGE),
             version
         );
@@ -1128,6 +1137,7 @@ public class PartitionChangeBuilderTest {
             .setPartitionId(0)
             .setIsr(List.of())
             .setLeader(-1)
+            .setLeaderEpoch(101)
             .setLeaderRecoveryState(LeaderRecoveryState.NO_CHANGE)
             .setEligibleLeaderReplicas(List.of(1, 2, 3, 4));
 
@@ -1187,6 +1197,7 @@ public class PartitionChangeBuilderTest {
                 .setPartitionId(0)
                 .setIsr(List.of(1))
                 .setLeader(1)
+                .setLeaderEpoch(101)
                 .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value())
                 .setLastKnownElr(List.of()),
             version

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -1904,6 +1904,7 @@ public class ReplicationControlManagerTest {
                         Uuid.fromString("TESTBROKER00003DIRAAAA")
                 )).
                 setLeader(3).
+                setLeaderEpoch(1).
                 setRemovingReplicas(List.of()).
                 setAddingReplicas(List.of()), MetadataVersion.latestTesting().partitionChangeRecordVersion())),
             new AlterPartitionReassignmentsResponseData().setErrorMessage(null).setResponses(List.of(
@@ -2407,6 +2408,7 @@ public class ReplicationControlManagerTest {
                 new PartitionChangeRecord().setTopicId(barId).
                     setPartitionId(0).
                     setLeader(4).
+                    setLeaderEpoch(1).
                     setReplicas(List.of(2, 3, 4)).
                     setDirectories(List.of(
                             Uuid.fromString("TESTBROKER00002DIRAAAA"),
@@ -2756,13 +2758,15 @@ public class ReplicationControlManagerTest {
                     new PartitionChangeRecord().
                         setPartitionId(0).
                         setTopicId(fooId).
-                        setLeader(1),
+                        setLeader(1).
+                        setLeaderEpoch(1),
                     MetadataVersion.latestTesting().partitionChangeRecordVersion()),
                 new ApiMessageAndVersion(
                     new PartitionChangeRecord().
                         setPartitionId(2).
                         setTopicId(fooId).
-                        setLeader(0),
+                        setLeader(0).
+                        setLeaderEpoch(1),
                     MetadataVersion.latestTesting().partitionChangeRecordVersion())),
             election2Result.records());
     }
@@ -2805,7 +2809,8 @@ public class ReplicationControlManagerTest {
         PartitionChangeRecord expectedChangeRecord = new PartitionChangeRecord()
             .setPartitionId(0)
             .setTopicId(fooId)
-            .setLeader(1);
+            .setLeader(1)
+            .setLeaderEpoch(1);
         assertEquals(List.of(new ApiMessageAndVersion(expectedChangeRecord, MetadataVersion.latestTesting().partitionChangeRecordVersion())), balanceResult.records());
         assertTrue(replication.arePartitionLeadersImbalanced());
         assertFalse(balanceResult.response());
@@ -2837,7 +2842,8 @@ public class ReplicationControlManagerTest {
         expectedChangeRecord = new PartitionChangeRecord()
             .setPartitionId(2)
             .setTopicId(fooId)
-            .setLeader(0);
+            .setLeader(0)
+            .setLeaderEpoch(1);
         assertEquals(List.of(new ApiMessageAndVersion(expectedChangeRecord, MetadataVersion.latestTesting().partitionChangeRecordVersion())), balanceResult.records());
         assertFalse(replication.arePartitionLeadersImbalanced());
         assertFalse(balanceResult.response());
@@ -3036,7 +3042,8 @@ public class ReplicationControlManagerTest {
                 .setPartitionId(0)
                 .setTopicId(topicId)
                 .setIsr(List.of(1, 2))
-                .setLeader(1),
+                .setLeader(1)
+                .setLeaderEpoch(1),
             (short) 0));
 
         assertEquals(expectedRecords, result.records());
@@ -3324,10 +3331,10 @@ public class ReplicationControlManagerTest {
                 //   - b-1 which has been assigned to an offline directory.
                 new ApiMessageAndVersion(
                         new PartitionChangeRecord().setTopicId(topicA).setPartitionId(2).
-                                setIsr(List.of(2)).setLeader(2), recordVersion),
+                                setIsr(List.of(2)).setLeader(2).setLeaderEpoch(1), recordVersion),
                 new ApiMessageAndVersion(
                         new PartitionChangeRecord().setTopicId(topicB).setPartitionId(1).
-                                setIsr(List.of(2)).setLeader(2), recordVersion)
+                                setIsr(List.of(2)).setLeader(2).setLeaderEpoch(1), recordVersion)
         )), sortPartitionChangeRecords(controllerResult.records()));
 
         ctx.replay(controllerResult.records());
@@ -3383,9 +3390,9 @@ public class ReplicationControlManagerTest {
         assertEquals(
             sortPartitionChangeRecords(List.of(
                 new ApiMessageAndVersion(new PartitionChangeRecord().setTopicId(topicA).setPartitionId(0)
-                        .setLeader(b2).setIsr(List.of(b2)), partitionChangeRecordVersion),
+                        .setLeader(b2).setLeaderEpoch(1).setIsr(List.of(b2)), partitionChangeRecordVersion),
                 new ApiMessageAndVersion(new PartitionChangeRecord().setTopicId(topicB).setPartitionId(0)
-                        .setLeader(b2).setIsr(List.of(b2)), partitionChangeRecordVersion)
+                        .setLeader(b2).setLeaderEpoch(1).setIsr(List.of(b2)), partitionChangeRecordVersion)
             )),
             sortPartitionChangeRecords(filter(records, PartitionChangeRecord.class))
         );

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -3042,8 +3042,7 @@ public class ReplicationControlManagerTest {
                 .setPartitionId(0)
                 .setTopicId(topicId)
                 .setIsr(List.of(1, 2))
-                .setLeader(1)
-                .setLeaderEpoch(1),
+                .setLeader(1),
             (short) 0));
 
         assertEquals(expectedRecords, result.records());

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -134,7 +134,7 @@ public class TopicsImageTest {
         // change topic
         DELTA1_RECORDS.add(new ApiMessageAndVersion(new PartitionChangeRecord().
             setTopicId(BAR_UUID).
-            setPartitionId(0).setLeader(1),
+            setPartitionId(0).setLeader(1).setLeaderEpoch(2),
             PARTITION_CHANGE_RECORD.highestSupportedVersion()));
         // add topic
         DELTA1_RECORDS.add(new ApiMessageAndVersion(new TopicRecord().
@@ -727,14 +727,14 @@ public class TopicsImageTest {
         // zoo-0 - follower to leader
         topicRecords.add(
             new ApiMessageAndVersion(
-                new PartitionChangeRecord().setTopicId(zooId).setPartitionId(0).setLeader(localId),
+                new PartitionChangeRecord().setTopicId(zooId).setPartitionId(0).setLeader(localId).setLeaderEpoch(2),
                 PARTITION_CHANGE_RECORD.highestSupportedVersion()
             )
         );
         // zoo-1 - leader to follower
         topicRecords.add(
             new ApiMessageAndVersion(
-                new PartitionChangeRecord().setTopicId(zooId).setPartitionId(1).setLeader(1),
+                new PartitionChangeRecord().setTopicId(zooId).setPartitionId(1).setLeader(1).setLeaderEpoch(2),
                 PARTITION_CHANGE_RECORD.highestSupportedVersion()
             )
         );
@@ -756,6 +756,7 @@ public class TopicsImageTest {
                   .setTopicId(zooId)
                   .setPartitionId(3)
                   .setLeader(0)
+                  .setLeaderEpoch(2)
                   .setIsr(List.of(0, 1, 2))
                   .setReplicas(List.of(0, 1, 2)),
                 PARTITION_CHANGE_RECORD.highestSupportedVersion()
@@ -768,6 +769,7 @@ public class TopicsImageTest {
                   .setTopicId(zooId)
                   .setPartitionId(4)
                   .setLeader(localId)
+                  .setLeaderEpoch(2)
                   .setIsr(List.of(localId, 1, 2))
                   .setReplicas(List.of(localId, 1, 2)),
                 PARTITION_CHANGE_RECORD.highestSupportedVersion()

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -72,7 +72,7 @@ public class PartitionRegistrationTest {
             setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
             setIsr(new int[]{1}).setLastKnownElr(new int[]{3}).setElr(new int[]{2}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).build();
         assertEquals(b, a.merge(new PartitionChangeRecord().
-            setLeader(3).setIsr(List.of(3))));
+            setLeader(3).setLeaderEpoch(1).setIsr(List.of(3))));
         assertEquals("isr: [1, 2] -> [3], leader: 1 -> 3, leaderEpoch: 0 -> 1, partitionEpoch: 0 -> 1",
             b.diff(a));
         assertEquals("isr: [1, 2] -> [1], elr: [] -> [2], lastKnownElr: [] -> [3], partitionEpoch: 0 -> 1",


### PR DESCRIPTION
Currently, PartitionChangeRecord uses a MinLeaderEpoch field as a hint for the bump leader epoch flow (KIP-1279). Each node that replays the record derives the actual leader epoch implicitly in PartitionRegistration.merge(): if the leader changed, increment by 1; then if MinLeaderEpoch is set, take max(minLeaderEpoch + 1, derivedEpoch). We want the controller to compute the final epoch once, write it into a dedicated LeaderEpoch field, and have all nodes just read it.
