### PR TITLE
Use composite key for CM records

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -265,7 +265,11 @@ public class ClusterMirrorCoordinator {
                                                 new PartitionKey(clusterName, topicName.get(), key.partition()), lastMirrorEpoch);
                                     }
                                 } else {
-                                    metadataManager.removeLastMirrorEpochs(clusterName);
+                                    Optional<String> topicName = metadataCache.getTopicName(key.topicId());
+                                    if (topicName.isPresent()) {
+                                        PartitionKey pk = new PartitionKey(clusterName, topicName.get(), key.partition());
+                                        metadataManager.removePartitionState(pk);
+                                    }
                                 }
                             } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
                                 MirrorPartitionStateKey key = readMirrorPartitionStateKey(record.key());
@@ -672,7 +676,6 @@ public class ClusterMirrorCoordinator {
 
         // Update in-memory cache once with all offsets
         metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets);
-
 
         // Write to local coordinator partitions (one append per coordinator partition)
         if (!localByCoordPartition.isEmpty()) {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -277,7 +277,11 @@ public class ClusterMirrorCoordinator {
                                                 MirrorPartitionState.fromValue(value.previousState()));
                                     }
                                 } else {
-                                    metadataManager.removeMirrorStates(clusterName);
+                                    Optional<String> topicName = metadataCache.getTopicName(key.topicId());
+                                    if (topicName.isPresent()) {
+                                        PartitionKey pk = new PartitionKey(clusterName, topicName.get(), key.partition());
+                                        metadataManager.removePartitionState(pk);
+                                    }
                                 }
                             } else {
                                 throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);
@@ -1071,7 +1075,11 @@ public class ClusterMirrorCoordinator {
 
     private MirrorPartitionStateKey readMirrorPartitionStateKey(ByteBuffer buffer) {
         short version = buffer.getShort();
-        return new MirrorPartitionStateKey(new ByteBufferAccessor(buffer), version);
+        if (version <= MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION && version >= MirrorPartitionStateValue.LOWEST_SUPPORTED_VERSION) {
+            return new MirrorPartitionStateKey(new ByteBufferAccessor(buffer), version);
+        } else {
+            throw new IllegalStateException("Unsupported partition state key version: " + version);
+        }
     }
 
     private MirrorPartitionStateValue readMirrorPartitionStateValue(ByteBuffer buffer) {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -263,14 +263,18 @@ public class ClusterMirrorCoordinator {
                                     metadataManager.removeLastMirrorEpochs(clusterName);
                                 }
                             } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
-                                String clusterName = readMirrorNameFromKey(record.key());
+                                MirrorPartitionStateKey key = readMirrorPartitionStateKey(record.key());
+                                String clusterName = key.mirrorName();
                                 if (record.hasValue()) {
-                                    ClusterMirrorUtils.PartitionStateLogEntry value = readMirrorPartitionStateValue(record.value());
-                                    if (value != null) {
-                                        PartitionKey pk = new PartitionKey(clusterName, value.topic(), value.partition());
-                                        metadataManager.updatePartitionState(pk, value.state());
-                                        TopicPartition tp = new TopicPartition(value.topic(), value.partition());
-                                        restoreFailedState(tp, value.state(), value.retryAttempt(), value.errorMessage(), value.previousState());
+                                    MirrorPartitionStateValue value = readMirrorPartitionStateValue(record.value());
+                                    Optional<String> topicName = metadataCache.getTopicName(key.topicId());
+                                    if (topicName.isPresent()) {
+                                        MirrorPartitionState state = MirrorPartitionState.fromValue(value.state());
+                                        PartitionKey pk = new PartitionKey(clusterName, topicName.get(), key.partition());
+                                        metadataManager.updatePartitionState(pk, state);
+                                        TopicPartition tp = new TopicPartition(topicName.get(), key.partition());
+                                        restoreFailedState(tp, state, value.retryAttempt(), value.errorMessage(),
+                                                MirrorPartitionState.fromValue(value.previousState()));
                                     }
                                 } else {
                                     metadataManager.removeMirrorStates(clusterName);
@@ -931,10 +935,11 @@ public class ClusterMirrorCoordinator {
 
     private CoordinatorRecord buildPartitionStateRecord(String mirrorName, TopicPartition topicPartition, MirrorPartitionState state) {
         FailedPartitionInfo fpi = metadataManager.failedPartitionInfo().get(topicPartition);
-        var key = new MirrorPartitionStateKey().setMirrorName(mirrorName);
-        var val = new MirrorPartitionStateValue()
+        var key = new MirrorPartitionStateKey()
+                .setMirrorName(mirrorName)
                 .setTopicId(metadataCache.getTopicId(topicPartition.topic()))
-                .setPartition(topicPartition.partition())
+                .setPartition(topicPartition.partition());
+        var val = new MirrorPartitionStateValue()
                 .setState(state.value())
                 .setPreviousState(fpi != null ? fpi.previousState().value() : MirrorPartitionState.UNKNOWN.value())
                 .setRetryAttempt(fpi != null ? (short) fpi.retryAttempt() : (short) 0)
@@ -989,19 +994,25 @@ public class ClusterMirrorCoordinator {
         }
 
         var timestamp = time.milliseconds();
-        var stateTombstone = CoordinatorRecord.tombstone(new MirrorPartitionStateKey().setMirrorName(mirrorName));
         var lmeTombstone = CoordinatorRecord.tombstone(new LastMirrorEpochsKey().setMirrorName(mirrorName));
 
-        // Write one partition state tombstone and one offset tombstone per coordinator partition
+        // Write one partition state tombstone per mirrored topic partition, plus one offset
+        // tombstone per coordinator partition
         for (Map.Entry<Integer, Set<TopicPartition>> entry : coordPartitionToMirrorPartitions.entrySet()) {
             int coordPartition = entry.getKey();
             Set<TopicPartition> tps = entry.getValue();
             var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, coordPartition);
             var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
-            var memRecord = MemoryRecords.withRecords(Compression.NONE,
-                new SimpleRecord(timestamp, serde.serializeKey(stateTombstone), serde.serializeValue(stateTombstone)),
-                new SimpleRecord(timestamp, serde.serializeKey(lmeTombstone), serde.serializeValue(lmeTombstone))
-            );
+            List<SimpleRecord> simpleRecords = new ArrayList<>();
+            for (TopicPartition tp : tps) {
+                var stateTombstone = CoordinatorRecord.tombstone(new MirrorPartitionStateKey()
+                        .setMirrorName(mirrorName)
+                        .setTopicId(metadataCache.getTopicId(tp.topic()))
+                        .setPartition(tp.partition()));
+                simpleRecords.add(new SimpleRecord(timestamp, serde.serializeKey(stateTombstone), serde.serializeValue(stateTombstone)));
+            }
+            simpleRecords.add(new SimpleRecord(timestamp, serde.serializeKey(lmeTombstone), serde.serializeValue(lmeTombstone)));
+            var memRecord = MemoryRecords.withRecords(Compression.NONE, simpleRecords.toArray(new SimpleRecord[0]));
             replicaManager.appendRecords(
                 Duration.ofSeconds(5).toMillis(),
                 (short) -1,
@@ -1058,16 +1069,15 @@ public class ClusterMirrorCoordinator {
         return offsets;
     }
 
-    private ClusterMirrorUtils.PartitionStateLogEntry readMirrorPartitionStateValue(ByteBuffer buffer) {
+    private MirrorPartitionStateKey readMirrorPartitionStateKey(ByteBuffer buffer) {
+        short version = buffer.getShort();
+        return new MirrorPartitionStateKey(new ByteBufferAccessor(buffer), version);
+    }
+
+    private MirrorPartitionStateValue readMirrorPartitionStateValue(ByteBuffer buffer) {
         short version = buffer.getShort();
         if (version <= MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION && version >= MirrorPartitionStateValue.LOWEST_SUPPORTED_VERSION) {
-            MirrorPartitionStateValue value = new MirrorPartitionStateValue(new ByteBufferAccessor(buffer), version);
-            Optional<String> topicName = metadataCache.getTopicName(value.topicId());
-            if (topicName.isEmpty()) return null;
-            return new ClusterMirrorUtils.PartitionStateLogEntry(topicName.get(), value.partition(),
-                    MirrorPartitionState.fromValue(value.state()),
-                    MirrorPartitionState.fromValue(value.previousState()), value.retryAttempt(),
-                    value.errorMessage());
+            return new MirrorPartitionStateValue(new ByteBufferAccessor(buffer), version);
         } else {
             throw new IllegalStateException("Unsupported partition state value version: " + version);
         }

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -20,6 +20,7 @@ import kafka.server.KafkaConfig;
 import kafka.server.ReplicaManager;
 import kafka.server.mirror.ClusterMirrorUtils.FailedPartitionInfo;
 import kafka.server.mirror.ClusterMirrorUtils.PartitionKey;
+import kafka.server.mirror.ClusterMirrorUtils.PartitionStateInfo;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.ClusterMirrorListing;
@@ -272,7 +273,7 @@ public class ClusterMirrorCoordinator {
                                     Optional<String> topicName = metadataCache.getTopicName(key.topicId());
                                     if (topicName.isPresent()) {
                                         PartitionKey pk = new PartitionKey(clusterName, topicName.get(), key.partition());
-                                        metadataManager.removePartitionState(pk);
+                                        metadataManager.removeLastMirrorEpoch(pk);
                                     }
                                 }
                             } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
@@ -575,7 +576,7 @@ public class ClusterMirrorCoordinator {
 
     /** Write partition state and offset updates to the internal topic. */
     public void updateTopicMetadata(String mirrorName,
-                                    Map<String, Set<ClusterMirrorUtils.PartitionStateInfo>> topicMetadata,
+                                    Map<String, Set<PartitionStateInfo>> topicMetadata,
                                     Consumer<WriteMirrorStatesResponse> callback) {
         List<CompletableFuture<Optional<TopicPartition>>> updateMirrorPartitionStateFutures = new ArrayList<>();
 
@@ -649,31 +650,12 @@ public class ClusterMirrorCoordinator {
         return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
-    // check if the all LME writing completes and decide if the future should complete successfully or exceptionally with retry.
-    private void maybeFinishLmeWriting(String mirrorName,
-                                       AtomicInteger remaining,
-                                       AtomicReference<Throwable> firstError,
-                                       Map<String, Map<Integer, Integer>> failedOffsets,
-                                       CompletableFuture<Void> future) {
-        if (remaining.decrementAndGet() == 0) {
-            if (!failedOffsets.isEmpty()) {
-                // TODO: handle failure, we can't retry forever
-                log.error("Failed to write LMEs for mirror {} partitions {}, retrying", mirrorName, failedOffsets);
-                scheduler.scheduleOnce("LmeWriteRetry-" + mirrorName,
-                        () -> updateLastMirrorEpochs(mirrorName, failedOffsets), 100);
-                future.completeExceptionally(firstError.get());
-            } else {
-                future.complete(null);
-            }
-        }
-    };
-
     /** Persists last mirror epochs to local or remote coordinators. */
     public CompletableFuture<Void> updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         // Separate partitions into local and remote coordinator groups
         Map<Integer, Set<TopicPartition>> localByCoordPartition = new HashMap<>();
-        Map<String, Set<ClusterMirrorUtils.PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
+        Map<String, Set<PartitionStateInfo>> remoteTopicMetadata = new HashMap<>();
 
         partitionOffsets.forEach((topic, offsetMap) -> {
             offsetMap.forEach((par, off) -> {
@@ -686,7 +668,7 @@ public class ClusterMirrorCoordinator {
                 } else {
                     remoteTopicMetadata
                             .computeIfAbsent(topic, k -> new HashSet<>())
-                            .add(new ClusterMirrorUtils.PartitionStateInfo(par, null, off));
+                            .add(new PartitionStateInfo(par, null, off));
                 }
             });
         });
@@ -700,10 +682,10 @@ public class ClusterMirrorCoordinator {
         // Update in-memory cache once with all offsets
         metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets);
 
-        // Track completion number across every outstanding write (one unit per local coordinator partition batch,
-        // for remote write, one topic-partition is one unit)
+        // Track completion number across every outstanding write (one unit per local
+        // coordinator partition batch, for remote write, one topic-partition is one unit)
         int totalUnits = localByCoordPartition.size();
-        for (Set<ClusterMirrorUtils.PartitionStateInfo> parts : remoteTopicMetadata.values()) {
+        for (Set<PartitionStateInfo> parts : remoteTopicMetadata.values()) {
             totalUnits += parts.size();
         }
 
@@ -747,7 +729,7 @@ public class ClusterMirrorCoordinator {
                                 tps.forEach(tp -> failedOffsets.computeIfAbsent(tp.topic(), k -> new ConcurrentHashMap<>())
                                         .put(tp.partition(), partitionOffsets.get(tp.topic()).get(tp.partition())));
                             }
-                            maybeFinishLmeWriting(mirrorName, remaining, firstError, failedOffsets, future);
+                            completeLmeWriteIfDone(mirrorName, remaining, firstError, failedOffsets, future);
                             return null;
                         });
                         return null;
@@ -771,13 +753,34 @@ public class ClusterMirrorCoordinator {
                                     .put(partitionResult.partitionIndex(),
                                             partitionOffsets.get(topicResult.name()).get(partitionResult.partitionIndex()));
                         }
-                        maybeFinishLmeWriting(mirrorName, remaining, firstError, failedOffsets, future);
+                        completeLmeWriteIfDone(mirrorName, remaining, firstError, failedOffsets, future);
                     });
                 });
             });
         }
 
         return future;
+    }
+
+    /**
+     * Decrements the outstanding write counter and, when all writes have reported, completes the
+     * future. On partial failure, only the failed offsets are scheduled for retry.
+     */
+    private void completeLmeWriteIfDone(String mirrorName,
+                                       AtomicInteger remaining,
+                                       AtomicReference<Throwable> firstError,
+                                       Map<String, Map<Integer, Integer>> failedOffsets,
+                                       CompletableFuture<Void> future) {
+        if (remaining.decrementAndGet() == 0) {
+            if (!failedOffsets.isEmpty()) {
+                // TODO: handle failure, we can't retry forever
+                log.error("Failed to write LMEs for mirror {} partitions {}, retrying", mirrorName, failedOffsets);
+                scheduler.scheduleOnce("LmeWriteRetry-" + mirrorName, () -> updateLastMirrorEpochs(mirrorName, failedOffsets), 100);
+                future.completeExceptionally(firstError.get());
+            } else {
+                future.complete(null);
+            }
+        }
     }
 
     private CompletableFuture<Optional<TopicPartition>> updateMirrorPartitionState(
@@ -827,8 +830,8 @@ public class ClusterMirrorCoordinator {
             );
         } else {
             // write state data to remote coordinator (async network operation)
-            Map<String, Set<ClusterMirrorUtils.PartitionStateInfo>> topicMetadata =
-                    Map.of(topicPartition.topic(), Set.of(new ClusterMirrorUtils.PartitionStateInfo(topicPartition.partition(), newState, -1)));
+            Map<String, Set<PartitionStateInfo>> topicMetadata =
+                    Map.of(topicPartition.topic(), Set.of(new PartitionStateInfo(topicPartition.partition(), newState, -1)));
             metadataManager.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
                     res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
                         if (par.errorCode() == Errors.NONE.code()) {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -86,7 +86,10 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -206,6 +209,7 @@ public class ClusterMirrorCoordinator {
     }
 
     // Replays the mirror state log to rebuild in-memory partition states, epochs, and retry metadata.
+    @SuppressWarnings({ "CyclomaticComplexity" })
     private void loadMirrorMetadata(TopicPartition topicPartition) {
         log.info("Loading mirror metadata from {}.", topicPartition);
         long logEndOffset = replicaManager.getLogEndOffset(topicPartition).getOrElse(() -> -1L);
@@ -645,6 +649,25 @@ public class ClusterMirrorCoordinator {
         return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
+    // check if the all LME writing completes and decide if the future should complete successfully or exceptionally with retry.
+    private void maybeFinishLmeWriting(String mirrorName,
+                                       AtomicInteger remaining,
+                                       AtomicReference<Throwable> firstError,
+                                       Map<String, Map<Integer, Integer>> failedOffsets,
+                                       CompletableFuture<Void> future) {
+        if (remaining.decrementAndGet() == 0) {
+            if (!failedOffsets.isEmpty()) {
+                // TODO: handle failure, we can't retry forever
+                log.error("Failed to write LMEs for mirror {} partitions {}, retrying", mirrorName, failedOffsets);
+                scheduler.scheduleOnce("LmeWriteRetry-" + mirrorName,
+                        () -> updateLastMirrorEpochs(mirrorName, failedOffsets), 100);
+                future.completeExceptionally(firstError.get());
+            } else {
+                future.complete(null);
+            }
+        }
+    };
+
     /** Persists last mirror epochs to local or remote coordinators. */
     public CompletableFuture<Void> updateLastMirrorEpochs(String mirrorName, Map<String, Map<Integer, Integer>> partitionOffsets) {
         CompletableFuture<Void> future = new CompletableFuture<>();
@@ -677,6 +700,17 @@ public class ClusterMirrorCoordinator {
         // Update in-memory cache once with all offsets
         metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets);
 
+        // Track completion number across every outstanding write (one unit per local coordinator partition batch,
+        // for remote write, one topic-partition is one unit)
+        int totalUnits = localByCoordPartition.size();
+        for (Set<ClusterMirrorUtils.PartitionStateInfo> parts : remoteTopicMetadata.values()) {
+            totalUnits += parts.size();
+        }
+
+        AtomicInteger remaining = new AtomicInteger(totalUnits);
+        Map<String, Map<Integer, Integer>> failedOffsets = new ConcurrentHashMap<>();
+        AtomicReference<Throwable> firstError = new AtomicReference<>();
+
         // Write to local coordinator partitions (one append per coordinator partition)
         if (!localByCoordPartition.isEmpty()) {
             var timestamp = time.milliseconds();
@@ -703,16 +737,17 @@ public class ClusterMirrorCoordinator {
                     CollectionConverters.asScala(entriesPerPartition),
                     response -> {
                         response.foreach(res -> {
+                            TopicIdPartition tip = res._1();
                             ProduceResponse.PartitionResponse partitionRes = res._2;
+                            int coordPartition = tip.partition();
+                            Set<TopicPartition> tps = localByCoordPartition.get(coordPartition);
                             if (partitionRes.error.code() != Errors.NONE.code()) {
-                                // TODO: handle failure, we can't retry forever
-                                log.error("Failed to write LMEs to coordinator: {}, retrying", partitionRes.error.message());
-                                scheduler.scheduleOnce("LmeWriteRetry-" + mirrorName,
-                                        () -> updateLastMirrorEpochs(mirrorName, partitionOffsets), 100);
-                                future.completeExceptionally(partitionRes.error.exception());
-                            } else {
-                                future.complete(null);
+                                log.error("Failed to write LMEs to coordinator partition {}: {}", coordPartition, partitionRes.error.message());
+                                firstError.compareAndSet(null, partitionRes.error.exception());
+                                tps.forEach(tp -> failedOffsets.computeIfAbsent(tp.topic(), k -> new ConcurrentHashMap<>())
+                                        .put(tp.partition(), partitionOffsets.get(tp.topic()).get(tp.partition())));
                             }
+                            maybeFinishLmeWriting(mirrorName, remaining, firstError, failedOffsets, future);
                             return null;
                         });
                         return null;
@@ -729,14 +764,14 @@ public class ClusterMirrorCoordinator {
                 res.data().topics().forEach(topicResult -> {
                     topicResult.partitions().forEach(partitionResult -> {
                         if (partitionResult.errorCode() != Errors.NONE.code()) {
-                            // TODO: handle failure, we can't retry forever
-                            log.error("Failed to write LMEs to remote coordinator: {}, retrying", partitionResult.errorCode());
-                            scheduler.scheduleOnce("LmeWriteRetry-" + mirrorName,
-                                    () -> updateLastMirrorEpochs(mirrorName, partitionOffsets), 100);
-                            future.completeExceptionally(Errors.forCode(partitionResult.errorCode()).exception());
-                        } else {
-                            future.complete(null);
+                            log.error("Failed to write LMEs to remote coordinator for {}-{}: {}",
+                                    topicResult.name(), partitionResult.partitionIndex(), partitionResult.errorCode());
+                            firstError.compareAndSet(null, Errors.forCode(partitionResult.errorCode()).exception());
+                            failedOffsets.computeIfAbsent(topicResult.name(), k -> new ConcurrentHashMap<>())
+                                    .put(partitionResult.partitionIndex(),
+                                            partitionOffsets.get(topicResult.name()).get(partitionResult.partitionIndex()));
                         }
+                        maybeFinishLmeWriting(mirrorName, remaining, firstError, failedOffsets, future);
                     });
                 });
             });

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -255,10 +255,15 @@ public class ClusterMirrorCoordinator {
                             require(record.hasKey(), "Mirror log's key should not be null");
                             short version = record.key().getShort();
                             if (version == CoordinatorRecordType.LAST_MIRROR_EPOCHS.id()) {
-                                String clusterName = readMirrorNameFromKey(record.key());
+                                LastMirrorEpochsKey key = readLastMirrorEpochsKey(record.key());
+                                String clusterName = key.mirrorName();
                                 if (record.hasValue()) {
-                                    Map<String, Map<Integer, Integer>> offsets = readLastMirrorEpochsValue(record.value());
-                                    metadataManager.updateLastMirrorEpochs(clusterName, offsets);
+                                    int lastMirrorEpoch = readLastMirrorEpochsValue(record.value());
+                                    Optional<String> topicName = metadataCache.getTopicName(key.topicId());
+                                    if (topicName.isPresent()) {
+                                        metadataManager.updateLastMirrorEpoch(
+                                                new PartitionKey(clusterName, topicName.get(), key.partition()), lastMirrorEpoch);
+                                    }
                                 } else {
                                     metadataManager.removeLastMirrorEpochs(clusterName);
                                 }
@@ -666,17 +671,25 @@ public class ClusterMirrorCoordinator {
         }
 
         // Update in-memory cache once with all offsets
-        var updatedOffsets = metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets);
+        metadataManager.updateLastMirrorEpochs(mirrorName, partitionOffsets);
+
 
         // Write to local coordinator partitions (one append per coordinator partition)
-        localByCoordPartition.forEach((coordPartition, tps) -> {
-            var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, coordPartition);
-            var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
-            var record = buildLastMirrorEpochsRecord(mirrorName, updatedOffsets);
-            var keyBytes = serde.serializeKey(record);
-            var valueBytes = serde.serializeValue(record);
+        if (!localByCoordPartition.isEmpty()) {
             var timestamp = time.milliseconds();
-            var memRecord = MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(timestamp, keyBytes, valueBytes));
+            Map<TopicIdPartition, MemoryRecords> entriesPerPartition = new HashMap<>();
+            localByCoordPartition.forEach((coordPartition, tps) -> {
+                var mirrorTopicPartition = new TopicPartition(Topic.MIRROR_STATE_TOPIC_NAME, coordPartition);
+                var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
+                List<SimpleRecord> simpleRecords = new ArrayList<>();
+                tps.forEach(tp -> {
+                    int epoch = partitionOffsets.get(tp.topic()).get(tp.partition());
+                    var record = buildLastMirrorEpochsRecord(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition(), epoch);
+                    simpleRecords.add(new SimpleRecord(timestamp, serde.serializeKey(record), serde.serializeValue(record)));
+                });
+                entriesPerPartition.put(mirrorTopicIdPartition,
+                        MemoryRecords.withRecords(Compression.NONE, simpleRecords.toArray(new SimpleRecord[0])));
+            });
 
             replicaManager.appendRecords(
                     // TODO: replace this with Cluster Mirror specific timeout
@@ -684,7 +697,7 @@ public class ClusterMirrorCoordinator {
                     (short) -1, // request ack from all ISR
                     true,
                     AppendOrigin.COORDINATOR,
-                    CollectionConverters.asScala(Map.of(mirrorTopicIdPartition, memRecord)),
+                    CollectionConverters.asScala(entriesPerPartition),
                     response -> {
                         response.foreach(res -> {
                             ProduceResponse.PartitionResponse partitionRes = res._2;
@@ -705,7 +718,7 @@ public class ClusterMirrorCoordinator {
                     RequestLocal.noCaching(),
                     CollectionConverters.asScala(Map.of())
             );
-        });
+        }
 
         // Write to remote coordinator (batched by coordinator node internally)
         if (!remoteTopicMetadata.isEmpty()) {
@@ -952,22 +965,12 @@ public class ClusterMirrorCoordinator {
         return CoordinatorRecord.record(key, apiVersion);
     }
 
-    private CoordinatorRecord buildLastMirrorEpochsRecord(String mirrorName, Map<PartitionKey, Integer> offsets) {
-        Map<Uuid, Map<Integer, Integer>> grouped = new HashMap<>();
-        offsets.forEach((pk, value) -> grouped.computeIfAbsent(metadataCache.getTopicId(pk.topic()), k -> new HashMap<>()).put(pk.partition(), value));
-
-        var key = new LastMirrorEpochsKey().setMirrorName(mirrorName);
-        var val = new LastMirrorEpochsValue();
-        var topics = new ArrayList<LastMirrorEpochsValue.Topic>();
-        grouped.forEach((topicId, partitionOffsets) -> {
-            var top = new LastMirrorEpochsValue.Topic().setTopicId(topicId);
-            List<LastMirrorEpochsValue.Partition> partitions = new ArrayList<>();
-            partitionOffsets.forEach((partition, offset) ->
-                    partitions.add(new LastMirrorEpochsValue.Partition().setPartitionIndex(partition).setLastMirrorEpoch(offset)));
-            top.setPartitions(partitions);
-            topics.add(top);
-        });
-        val.setTopics(topics);
+    private CoordinatorRecord buildLastMirrorEpochsRecord(String mirrorName, Uuid topicId, int partition, int epoch) {
+        var key = new LastMirrorEpochsKey()
+                .setMirrorName(mirrorName)
+                .setTopicId(topicId)
+                .setPartition(partition);
+        var val = new LastMirrorEpochsValue().setLastMirrorEpoch(epoch);
         var apiVersion = new ApiMessageAndVersion(val, LastMirrorEpochsValue.HIGHEST_SUPPORTED_VERSION);
         return CoordinatorRecord.record(key, apiVersion);
     }
@@ -998,10 +1001,8 @@ public class ClusterMirrorCoordinator {
         }
 
         var timestamp = time.milliseconds();
-        var lmeTombstone = CoordinatorRecord.tombstone(new LastMirrorEpochsKey().setMirrorName(mirrorName));
 
-        // Write one partition state tombstone per mirrored topic partition, plus one offset
-        // tombstone per coordinator partition
+        // Write one partition state tombstone and one LME tombstone per mirrored topic partition
         for (Map.Entry<Integer, Set<TopicPartition>> entry : coordPartitionToMirrorPartitions.entrySet()) {
             int coordPartition = entry.getKey();
             Set<TopicPartition> tps = entry.getValue();
@@ -1009,13 +1010,18 @@ public class ClusterMirrorCoordinator {
             var mirrorTopicIdPartition = replicaManager.topicIdPartition(mirrorTopicPartition);
             List<SimpleRecord> simpleRecords = new ArrayList<>();
             for (TopicPartition tp : tps) {
+                Uuid topicId = metadataCache.getTopicId(tp.topic());
                 var stateTombstone = CoordinatorRecord.tombstone(new MirrorPartitionStateKey()
                         .setMirrorName(mirrorName)
-                        .setTopicId(metadataCache.getTopicId(tp.topic()))
+                        .setTopicId(topicId)
                         .setPartition(tp.partition()));
                 simpleRecords.add(new SimpleRecord(timestamp, serde.serializeKey(stateTombstone), serde.serializeValue(stateTombstone)));
+                var lmeTombstone = CoordinatorRecord.tombstone(new LastMirrorEpochsKey()
+                        .setMirrorName(mirrorName)
+                        .setTopicId(topicId)
+                        .setPartition(tp.partition()));
+                simpleRecords.add(new SimpleRecord(timestamp, serde.serializeKey(lmeTombstone), serde.serializeValue(lmeTombstone)));
             }
-            simpleRecords.add(new SimpleRecord(timestamp, serde.serializeKey(lmeTombstone), serde.serializeValue(lmeTombstone)));
             var memRecord = MemoryRecords.withRecords(Compression.NONE, simpleRecords.toArray(new SimpleRecord[0]));
             replicaManager.appendRecords(
                 Duration.ofSeconds(5).toMillis(),
@@ -1044,33 +1050,18 @@ public class ClusterMirrorCoordinator {
         }
     }
 
-    private String readMirrorNameFromKey(ByteBuffer buffer) {
+    private LastMirrorEpochsKey readLastMirrorEpochsKey(ByteBuffer buffer) {
         short version = buffer.getShort();
-        if (version == CoordinatorRecordType.LAST_MIRROR_EPOCHS.id()) {
-            return new LastMirrorEpochsKey(new ByteBufferAccessor(buffer), version).mirrorName();
-        } else if (version == CoordinatorRecordType.MIRROR_PARTITION_STATE.id()) {
-            return new MirrorPartitionStateKey(new ByteBufferAccessor(buffer), version).mirrorName();
-        } else {
-            throw new IllegalArgumentException("Unknown cluster mirror log key version " + version);
-        }
+        return new LastMirrorEpochsKey(new ByteBufferAccessor(buffer), version);
     }
 
-    private Map<String, Map<Integer, Integer>> readLastMirrorEpochsValue(ByteBuffer buffer) {
-        Map<String, Map<Integer, Integer>> offsets = new HashMap<>();
+    private int readLastMirrorEpochsValue(ByteBuffer buffer) {
         short version = buffer.getShort();
         if (version <= LastMirrorEpochsValue.HIGHEST_SUPPORTED_VERSION && version >= LastMirrorEpochsValue.LOWEST_SUPPORTED_VERSION) {
-            LastMirrorEpochsValue value = new LastMirrorEpochsValue(new ByteBufferAccessor(buffer), version);
-            value.topics().forEach(t -> {
-                Optional<String> topicName = metadataCache.getTopicName(t.topicId());
-                if (topicName.isEmpty()) return;
-                Map<Integer, Integer> partitions = new HashMap<>();
-                t.partitions().forEach(p -> partitions.put(p.partitionIndex(), p.lastMirrorEpoch()));
-                offsets.put(topicName.get(), partitions);
-            });
+            return new LastMirrorEpochsValue(new ByteBufferAccessor(buffer), version).lastMirrorEpoch();
         } else {
             throw new IllegalStateException("Unsupported last mirrored epochs value version: " + version);
         }
-        return offsets;
     }
 
     private MirrorPartitionStateKey readMirrorPartitionStateKey(ByteBuffer buffer) {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorUtils.java
@@ -75,10 +75,6 @@ public final class ClusterMirrorUtils {
 
     public record PartitionStateInfo(int partition, MirrorPartitionState state, Integer leaderEpoch) { }
 
-    public record PartitionStateLogEntry(String topic, int partition, MirrorPartitionState state,
-                                         MirrorPartitionState previousState, int retryAttempt,
-                                         String errorMessage) { }
-
     public record PartitionKey(String mirrorName, String topic, int partition) { }
 
     public record LeaderEpochBump(CompletableFuture<Void> future, Map<TopicPartition, Integer> partitionToEpoch) { }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -2420,15 +2420,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return result;
     }
 
-    /** Upserts added partitions, returning the full epoch map for record serialization. */
-    Map<PartitionKey, Integer> updateLastMirrorEpochs(
-            String clusterName, Map<String, Map<Integer, Integer>> addedEpochs) {
-        addedEpochs.forEach((topic, partitionOffsets) -> {
-            partitionOffsets.forEach((partition, offset) -> {
-                lastMirrorEpochs.put(new PartitionKey(clusterName, topic, partition), offset);
-            });
-        });
-        return lastMirrorEpochs;
+    void updateLastMirrorEpochs(String clusterName, Map<String, Map<Integer, Integer>> addedEpochs) {
+        addedEpochs.forEach((topic, partitionOffsets) ->
+            partitionOffsets.forEach((partition, offset) ->
+                    lastMirrorEpochs.put(new PartitionKey(clusterName, topic, partition), offset)));
+    }
+
+    void updateLastMirrorEpoch(PartitionKey key, int epoch) {
+        lastMirrorEpochs.put(key, epoch);
     }
 
     private record TimeoutHandler(Logger log) implements ControllerRequestCompletionHandler {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -1823,6 +1823,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         lastMirrorEpochs.keySet().removeIf(key -> key.mirrorName().equals(mirrorName));
     }
 
+    void removeLastMirrorEpoch(PartitionKey key) {
+        lastMirrorEpochs.remove(key);
+    }
+
     void removeStateForPartitions(Set<TopicPartition> partitions) {
         partitions.forEach(tp -> {
             pendingPartitionStates.remove(tp);

--- a/mirror-coordinator/src/main/resources/common/message/LastMirrorEpochsKey.json
+++ b/mirror-coordinator/src/main/resources/common/message/LastMirrorEpochsKey.json
@@ -16,7 +16,8 @@
 // Cluster Mirror is in development. This schema is subject to non-backwards-compatible changes.
 //
 // LastMirrorEpochs record tracks the latest successfully mirrored epoch for each partition.
-// The key identifies the source cluster by mirror name, while the value stores per-partition epochs for failback support.
+// The key identifies the source cluster mirror name, topic id, and partition; the value stores
+// that partition's last mirror epoch for failback support.
 {
   "apiKey": 1,
   "type": "coordinator-key",
@@ -25,6 +26,10 @@
   "flexibleVersions": "none",
   "fields": [
     { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
-      "about": "The cluster mirror name."}
+      "about": "The cluster mirror name."},
+    { "name": "TopicId", "type": "uuid", "versions": "0+",
+      "about": "The topic id."},
+    { "name": "Partition", "type": "int32", "versions": "0+",
+      "about": "The partition index."}
   ]
 }

--- a/mirror-coordinator/src/main/resources/common/message/LastMirrorEpochsValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/LastMirrorEpochsValue.json
@@ -16,7 +16,8 @@
 // Cluster Mirror is in development. This schema is subject to non-backwards-compatible changes.
 //
 // LastMirrorEpochs record tracks the latest successfully mirrored epoch for each partition.
-// The key identifies the source cluster by mirror name, while the value stores per-partition epochs for failback support.
+// The key identifies the source cluster mirror name, topic id, and partition; the value stores
+// that partition's last mirror epoch for failback support.
 {
   "apiKey": 1,
   "type": "coordinator-value",
@@ -24,17 +25,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "Topics", "type": "[]Topic", "versions": "0+",
-      "about": "The mirror topics for which we want to store the last mirror epochs.",  "fields": [
-      { "name": "TopicId", "type": "uuid", "versions": "0+",
-        "about": "The topic id." },
-      { "name": "Partitions", "type": "[]Partition", "versions": "0+",
-        "about": "Each partition to record the last mirror epochs.", "fields": [
-        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
-          "about": "The partition index." },
-        { "name": "LastMirrorEpoch", "type": "int32", "versions": "0+",
-          "about": "The last mirror leader epoch for this partition." }
-      ]}
-    ]}
+    { "name": "LastMirrorEpoch", "type": "int32", "versions": "0+",
+      "about": "The last mirror leader epoch for this partition." }
   ]
 }

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateKey.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateKey.json
@@ -25,6 +25,10 @@
   "flexibleVersions": "none",
   "fields": [
     { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
-      "about": "The cluster mirror name."}
+      "about": "The cluster mirror name."},
+    { "name": "TopicId", "type": "uuid", "versions": "0+",
+      "about": "The topic id."},
+    { "name": "Partition", "type": "int32", "versions": "0+",
+      "about": "The partition index."}
   ]
 }

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateKey.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateKey.json
@@ -15,8 +15,7 @@
 
 // Cluster Mirror is in development. This schema is subject to non-backwards-compatible changes.
 //
-// MirrorTopics record stores the list of topics being mirrored from a source cluster.
-// The key identifies the source cluster by mirror name, while the value contains topic names to replicate.
+// The key identifies the source cluster mirror name, topic id, and partition.
 {
   "apiKey": 2,
   "type": "coordinator-key",

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
@@ -24,10 +24,6 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "TopicId", "type": "uuid", "versions": "0+",
-      "about": "The topic id."},
-    { "name": "Partition", "type": "int32", "versions": "0+",
-      "about": "The partition index."},
     { "name": "State", "type": "int8", "versions": "0+",
       "about": "The mirror partition state." },
     { "name": "PreviousState", "type": "int8",  "versions": "0+", "default": 16,


### PR DESCRIPTION
use composite key for LME record to avoid only data loss after data compaction due to the key is mirrorName only.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
