### PR TITLE
write mirrorName to null when deletion and describeClusterMirror validation

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -480,6 +480,13 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     val describeAll = describeMirrorsRequest.data.mirrorNames.isEmpty
+    if (!describeAll && (describeMirrorsRequest.data.clusterId != null || !describeMirrorsRequest.data.lastMirrorEpochLookups().isEmpty)) {
+      responseData.setErrorCode(Errors.INVALID_REQUEST.code)
+        .setErrorMessage("When specifying clusterId or lastMirrorEpochLookups the mirrors should be empty to query all mirrors.")
+      requestHelper.sendMaybeThrottle(request, new DescribeClusterMirrorsResponse(responseData))
+      return
+    }
+
     val requestedMirrors = if (describeAll) {
       clusterMirrorCoordinator.getConfiguredMirrors().asScala.toSeq
     } else {

--- a/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
+++ b/core/src/test/java/kafka/server/AsyncClusterMirrorIntegrationTest.java
@@ -239,7 +239,7 @@ public class AsyncClusterMirrorIntegrationTest {
                 .setTopicId(topicId)
                 .setPartitions(List.of(0));
         String srcClusterId = srcCluster.controllers().values().stream().findFirst().get().clusterId();
-        DescribeClusterMirrorsResult describeClusterMirrors = dstAdmin.describeClusterMirrors(List.of(reverseMirror),
+        DescribeClusterMirrorsResult describeClusterMirrors = dstAdmin.describeClusterMirrors(List.of(),
                 new DescribeClusterMirrorsOptions().clusterId(srcClusterId).lastMirrorEpochLookups(List.of(lastMirrorEpochLookup)));
         Map<Uuid, Map<Integer, Integer>> lookupEpochs = describeClusterMirrors.lookupEpochs().get(30, TimeUnit.SECONDS);
         assertEquals(1, lookupEpochs.size(), "Should have one lookup result");

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -666,7 +666,7 @@ public class ConfigurationControlManager {
                 records.add(new ApiMessageAndVersion(
                     new MirrorTopicStateChangeRecord()
                         .setTopicId(topicInfo.topicId())
-                        .setMirrorName("")
+                        .setMirrorName(null)
                         .setDesiredState(MirrorPartitionState.UNKNOWN.value()),
                     (short) 0));
             }

--- a/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
@@ -37,7 +37,7 @@ import java.util.Map.Entry;
  */
 public record TopicImage(String name, Uuid id, String mirrorName, int desiredMirrorState, Map<Integer, PartitionRegistration> partitions) {
     public TopicImage(String name, Uuid id, Map<Integer, PartitionRegistration> partitions) {
-        this(name, id, "", MirrorPartitionState.UNKNOWN.value(), partitions);
+        this(name, id, null, MirrorPartitionState.UNKNOWN.value(), partitions);
     }
 
     public TopicImage {

--- a/metadata/src/main/resources/common/metadata/MirrorTopicStateChangeRecord.json
+++ b/metadata/src/main/resources/common/metadata/MirrorTopicStateChangeRecord.json
@@ -22,7 +22,7 @@
   "fields": [
     { "name": "TopicId", "type": "uuid", "versions": "0+",
       "about": "The unique topic ID." },
-    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName",
+    { "name": "MirrorName", "type": "string", "versions": "0+", "entityType": "mirrorName", "nullableVersions": "0+",
       "about": "The cluster mirror name." },
     { "name": "DesiredState", "type": "int8", "versions": "0+",
       "about": "The desired state for all mirror partitions." }


### PR DESCRIPTION
JR49: default and write mirrorName to null when deletion
JR30.2: Only allow empty mirrorName when clusterId or lastMirrorEpochLookups is set

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
