### PR TITLE
Fixes for PlainAdminIntegrationTest#testAlterShareGroupOffsets

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2921,7 +2921,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     val testTopicName = "test_topic"
     val testGroupId = "test_group_id"
     val testClientId = "test_client_id"
-    val fakeGroupId = "fake_group_id"
+    val nonexistentGroupId = "nonexistent_group_id"
     val fakeTopicName = "foo"
 
     val tp1 = new TopicPartition(testTopicName, 0)
@@ -2955,12 +2955,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         assertFutureThrows(classOf[GroupNotEmptyException], offsetAlterResult.partitionResult(tp1))
         assertFutureThrows(classOf[GroupNotEmptyException], offsetAlterResult.partitionResult(tp2))
 
-        // Test the fake group ID
-        val fakeAlterResult = client.alterShareGroupOffsets(fakeGroupId, util.Map.of(tp1, 0, tp2, 0))
+        // Test the non-existent group ID
+        val nonexistentAlterResult = client.alterShareGroupOffsets(nonexistentGroupId, util.Map.of(tp1, 0, tp2, 0))
 
-        assertFutureThrows(classOf[GroupIdNotFoundException], fakeAlterResult.all())
-        assertFutureThrows(classOf[GroupIdNotFoundException], fakeAlterResult.partitionResult(tp1))
-        assertFutureThrows(classOf[GroupIdNotFoundException], fakeAlterResult.partitionResult(tp2))
+        assertFutureThrows(classOf[UnknownTopicOrPartitionException], nonexistentAlterResult.all())
+        assertNull(nonexistentAlterResult.partitionResult(tp1).get())
+        assertFutureThrows(classOf[UnknownTopicOrPartitionException], nonexistentAlterResult.partitionResult(tp2))
       }
 
       // Test offset alter when group is empty

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -779,10 +779,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     }
 
     /**
-     * Make the following checks to make sure the AlterShareGroupOffsetsRequest request is valid:
-     * 1. Checks whether the provided group is empty
-     * 2. Checks the requested topics are presented in the metadataImage
-     * 3. Checks the corresponding share partitions in AlterShareGroupOffsetsRequest are existing
+     * Alters the offsets for a share group.
      *
      * @param groupId - The group ID
      * @param alterShareGroupOffsetsRequestData - The request data for AlterShareGroupOffsetsRequestData
@@ -793,19 +790,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         String groupId,
         AlterShareGroupOffsetsRequestData alterShareGroupOffsetsRequestData
     ) {
-        List<CoordinatorRecord> records = new ArrayList<>();
-        ShareGroup group = groupMetadataManager.shareGroup(groupId);
-        group.validateOffsetsAlterable();
-
-        Map.Entry<AlterShareGroupOffsetsResponseData, InitializeShareGroupStateParameters> response = groupMetadataManager.completeAlterShareGroupOffsets(
-            groupId,
-            alterShareGroupOffsetsRequestData,
-            records
-        );
-        return new CoordinatorResult<>(
-            records,
-            response
-        );
+        return groupMetadataManager.alterShareGroupOffsets(groupId, alterShareGroupOffsetsRequestData.topics());
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -794,7 +794,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         AlterShareGroupOffsetsRequestData alterShareGroupOffsetsRequestData
     ) {
         List<CoordinatorRecord> records = new ArrayList<>();
-        ShareGroup group = groupMetadataManager.shareGroup(groupId, Long.MAX_VALUE, true);
+        ShareGroup group = groupMetadataManager.shareGroup(groupId);
         group.validateOffsetsAlterable();
 
         Map.Entry<AlterShareGroupOffsetsResponseData, InitializeShareGroupStateParameters> response = groupMetadataManager.completeAlterShareGroupOffsets(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -800,8 +800,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Map.Entry<AlterShareGroupOffsetsResponseData, InitializeShareGroupStateParameters> response = groupMetadataManager.completeAlterShareGroupOffsets(
             groupId,
             alterShareGroupOffsetsRequestData,
-            records,
-            group
+            records
         );
         return new CoordinatorResult<>(
             records,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1171,11 +1171,10 @@ public class GroupMetadataManager {
         String groupId,
         long committedOffset
     ) throws GroupIdNotFoundException {
-        // Get or create the share group. If the group exists, check that it's empty. If it is created, it is empty.
-        final ShareGroup group = getOrMaybeCreateShareGroup(groupId, true);
+        Group group = group(groupId, committedOffset);
 
         if (group.type() == SHARE) {
-            return group;
+            return (ShareGroup) group;
         } else {
             // We don't support upgrading/downgrading between protocols at the moment so
             // we throw an exception if a group exists with the wrong type.
@@ -8191,10 +8190,10 @@ public class GroupMetadataManager {
     public Map.Entry<AlterShareGroupOffsetsResponseData, InitializeShareGroupStateParameters> completeAlterShareGroupOffsets(
         String groupId,
         AlterShareGroupOffsetsRequestData alterShareGroupOffsetsRequest,
-        List<CoordinatorRecord> records,
-        ShareGroup group
+        List<CoordinatorRecord> records
     ) {
         final long currentTimeMs = time.milliseconds();
+        Group group = groups.get(groupId);
         AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection alterShareGroupOffsetsResponseTopics = new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection();
 
         Map<Uuid, InitMapValue> initializingTopics = new HashMap<>();
@@ -8257,7 +8256,7 @@ public class GroupMetadataManager {
         return Map.entry(
             new AlterShareGroupOffsetsResponseData()
                 .setResponses(alterShareGroupOffsetsResponseTopics),
-            buildInitializeShareGroupState(groupId, group.groupEpoch(), offsetByTopicPartitions)
+            buildInitializeShareGroupState(groupId, ((ShareGroup) group).groupEpoch(), offsetByTopicPartitions)
         );
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.FencedMemberEpochException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupMaxSizeReachedException;
+import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.InconsistentGroupProtocolException;
 import org.apache.kafka.common.errors.InvalidRequestException;
@@ -1496,6 +1497,21 @@ public class GroupMetadataManager {
         if (group.numMembers() >= config.shareGroupMaxSize() && (memberId.isEmpty() || !group.hasMember(memberId))) {
             throw new GroupMaxSizeReachedException("The share group has reached its maximum capacity of "
                 + config.shareGroupMaxSize() + " members.");
+        }
+    }
+
+    /**
+     * Checks whether the share group is empty.
+     *
+     * @param group     The share group.
+     *
+     * @throws GroupNotEmptyException if the group is not empty.
+     */
+    private void throwIfShareGroupIsNotEmpty(
+        ShareGroup group
+    ) throws GroupNotEmptyException {
+        if (group.numMembers() > 0) {
+            throw new GroupNotEmptyException(Errors.NON_EMPTY_GROUP.message());
         }
     }
 
@@ -8187,19 +8203,37 @@ public class GroupMetadataManager {
         return deleteShareGroupStateRequestTopicsData;
     }
 
-    public Map.Entry<AlterShareGroupOffsetsResponseData, InitializeShareGroupStateParameters> completeAlterShareGroupOffsets(
+    /**
+     * Handles an AlterShareGroupOffsets request.
+     *
+     * Make the following checks to make sure the AlterShareGroupOffsetsRequest request is valid:
+     * 1. Checks whether the provided group is empty
+     * 2. Checks the requested topics are presented in the metadataImage
+     * 3. Checks the corresponding share partitions in AlterShareGroupOffsetsRequest are existing
+     *
+     * @param groupId   The group id from the request.
+     * @param topics    The topic information for altering the share group's offsets from the request.
+     *
+     * @return A Result containing a pair of ShareGroupHeartbeat response and maybe InitializeShareGroupStateParameters
+     *         and a list of records to update the state machine.
+     */
+    public CoordinatorResult<Map.Entry<AlterShareGroupOffsetsResponseData, InitializeShareGroupStateParameters>, CoordinatorRecord> alterShareGroupOffsets(
         String groupId,
-        AlterShareGroupOffsetsRequestData alterShareGroupOffsetsRequest,
-        List<CoordinatorRecord> records
-    ) {
+        AlterShareGroupOffsetsRequestData.AlterShareGroupOffsetsRequestTopicCollection topics
+    ) throws ApiException {
         final long currentTimeMs = time.milliseconds();
-        Group group = groups.get(groupId);
+        final List<CoordinatorRecord> records = new ArrayList<>();
+
+        // Get or create the share group. If the group exists, check that it's empty. If it is created, it is empty.
+        final ShareGroup group = getOrMaybeCreateShareGroup(groupId, true);
+        throwIfShareGroupIsNotEmpty(group);
+
         AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection alterShareGroupOffsetsResponseTopics = new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection();
 
         Map<Uuid, InitMapValue> initializingTopics = new HashMap<>();
         Map<Uuid, Map<Integer, Long>> offsetByTopicPartitions = new HashMap<>();
 
-        alterShareGroupOffsetsRequest.topics().forEach(topic -> {
+        topics.forEach(topic -> {
             Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOpt = metadataImage.topicMetadata(topic.topicName());
             if (topicMetadataOpt.isPresent()) {
                 var topicMetadata = topicMetadataOpt.get();
@@ -8253,10 +8287,13 @@ public class GroupMetadataManager {
         });
 
         addInitializingTopicsRecords(groupId, records, initializingTopics);
-        return Map.entry(
-            new AlterShareGroupOffsetsResponseData()
-                .setResponses(alterShareGroupOffsetsResponseTopics),
-            buildInitializeShareGroupState(groupId, ((ShareGroup) group).groupEpoch(), offsetByTopicPartitions)
+        return new CoordinatorResult<>(
+            records,
+            Map.entry(
+                new AlterShareGroupOffsetsResponseData()
+                    .setResponses(alterShareGroupOffsetsResponseTopics),
+                buildInitializeShareGroupState(groupId, group.groupEpoch(), offsetByTopicPartitions)
+            )
         );
     }
 
@@ -8319,7 +8356,7 @@ public class GroupMetadataManager {
         return new CoordinatorResult<>(records);
     }
 
-    /*
+    /**
      * Returns a list of {@link DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic} corresponding to the
      * topics for which persister delete share group state request was successful
      * @param groupId                    group ID of the share group

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1171,23 +1171,11 @@ public class GroupMetadataManager {
         String groupId,
         long committedOffset
     ) throws GroupIdNotFoundException {
-        return shareGroup(groupId, committedOffset, false);
-    }
+        // Get or create the share group. If the group exists, check that it's empty. If it is created, it is empty.
+        final ShareGroup group = getOrMaybeCreateShareGroup(groupId, true);
 
-    public ShareGroup shareGroup(
-            String groupId,
-            long committedOffset,
-            boolean createIfNotExists
-    ) throws GroupIdNotFoundException {
-        Group group;
-        if (createIfNotExists) {
-            // Get or create the share group. If the group exists, check that it's empty. If it is created, it is empty.
-            group = getOrMaybeCreateShareGroup(groupId, true);
-        } else {
-            group = group(groupId, committedOffset);
-        }
         if (group.type() == SHARE) {
-            return (ShareGroup) group;
+            return group;
         } else {
             // We don't support upgrading/downgrading between protocols at the moment so
             // we throw an exception if a group exists with the wrong type.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroup.java
@@ -244,10 +244,6 @@ public class ShareGroup extends ModernGroup<ShareGroupMember> {
         validateEmptyGroup();
     }
 
-    public void validateOffsetsAlterable() throws ApiException {
-        validateEmptyGroup();
-    }
-
     public void validateEmptyGroup() {
         if (state() != ShareGroupState.EMPTY) {
             throw Errors.NON_EMPTY_GROUP.exception();

--- a/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
@@ -196,22 +196,8 @@ public class ConnectPluginPath {
         LIST, SYNC_MANIFESTS
     }
 
-    private static class Config {
-        private final Command command;
-        private final Set<Path> locations;
-        private final boolean dryRun;
-        private final boolean keepNotFound;
-        private final PrintStream out;
-        private final PrintStream err;
-
-        private Config(Command command, Set<Path> locations, boolean dryRun, boolean keepNotFound, PrintStream out, PrintStream err) {
-            this.command = command;
-            this.locations = locations;
-            this.dryRun = dryRun;
-            this.keepNotFound = keepNotFound;
-            this.out = out;
-            this.err = err;
-        }
+    private record Config(Command command, Set<Path> locations, boolean dryRun, boolean keepNotFound, PrintStream out,
+                          PrintStream err) {
 
         @Override
         public String toString() {
@@ -262,16 +248,9 @@ public class ConnectPluginPath {
      * <p>This is unique to the (source, class, type) tuple, and contains additional pre-computed information
      * that pertains to this specific plugin.
      */
-    private static class Row {
-        private final ManifestWorkspace.SourceWorkspace<?> workspace;
-        private final String className;
-        private final PluginType type;
-        private final String version;
-        private final List<String> aliases;
-        private final boolean loadable;
-        private final boolean hasManifest;
-
-        public Row(ManifestWorkspace.SourceWorkspace<?> workspace, String className, PluginType type, String version, List<String> aliases, boolean loadable, boolean hasManifest) {
+    private record Row(ManifestWorkspace.SourceWorkspace<?> workspace, String className, PluginType type,
+                       String version, List<String> aliases, boolean loadable, boolean hasManifest) {
+        private Row(ManifestWorkspace.SourceWorkspace<?> workspace, String className, PluginType type, String version, List<String> aliases, boolean loadable, boolean hasManifest) {
             this.workspace = Objects.requireNonNull(workspace, "workspace must be non-null");
             this.className = Objects.requireNonNull(className, "className must be non-null");
             this.version = Objects.requireNonNull(version, "version must be non-null");
@@ -279,10 +258,6 @@ public class ConnectPluginPath {
             this.aliases = Objects.requireNonNull(aliases, "aliases must be non-null");
             this.loadable = loadable;
             this.hasManifest = hasManifest;
-        }
-
-        private boolean loadable() {
-            return loadable;
         }
 
         private boolean compatible() {

--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -65,7 +65,6 @@ import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
-import static java.util.Arrays.asList;
 
 /**
  * A tool for describing quorum status
@@ -206,7 +205,7 @@ public class MetadataQuorumCommand {
         rows.addAll(quorumInfoToRows(leader, quorumInfo.observers().stream(), "Observer", humanReadable));
 
         ToolsUtils.prettyPrintTable(
-            asList("NodeId", "DirectoryId", "LogEndOffset", "Lag", "LastFetchTimestamp", "LastCaughtUpTimestamp", "Status"),
+            List.of("NodeId", "DirectoryId", "LogEndOffset", "Lag", "LastFetchTimestamp", "LastCaughtUpTimestamp", "Status"),
             rows,
             System.out
         );

--- a/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
@@ -292,14 +292,7 @@ public class OAuthCompatibilityTool {
 
     }
 
-    private static class ConfigHandler {
-
-        private final Namespace namespace;
-
-
-        private ConfigHandler(Namespace namespace) {
-            this.namespace = namespace;
-        }
+    private record ConfigHandler(Namespace namespace) {
 
         private Map<String, ?> getConfigs() {
             Map<String, Object> m = new HashMap<>();

--- a/tools/src/main/java/org/apache/kafka/tools/OffsetsUtils.java
+++ b/tools/src/main/java/org/apache/kafka/tools/OffsetsUtils.java
@@ -500,16 +500,7 @@ public class OffsetsUtils {
 
     public interface LogOffsetResult { }
 
-    public static class LogOffset implements LogOffsetResult {
-        final long value;
-
-        public LogOffset(long value) {
-            this.value = value;
-        }
-
-        public long value() {
-            return value;
-        }
+    public record LogOffset(long value) implements LogOffsetResult {
     }
 
     public static class Unknown implements LogOffsetResult { }

--- a/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
@@ -240,86 +240,19 @@ public class PushHttpMetricsReporter implements MetricsReporter {
         }
     }
 
-    private static class MetricsReport {
-        private final MetricClientInfo client;
-        private final Collection<MetricValue> metrics;
-
-        MetricsReport(MetricClientInfo client, Collection<MetricValue> metrics) {
-            this.client = client;
-            this.metrics = metrics;
-        }
-
-        @JsonProperty
-        public MetricClientInfo client() {
-            return client;
-        }
-
-        @JsonProperty
-        public Collection<MetricValue> metrics() {
-            return metrics;
-        }
+    private record MetricsReport(@JsonProperty("client") MetricClientInfo client, 
+                                @JsonProperty("metrics") Collection<MetricValue> metrics) {
     }
 
-    private static class MetricClientInfo {
-        private final String host;
-        private final String clientId;
-        private final long time;
-
-        MetricClientInfo(String host, String clientId, long time) {
-            this.host = host;
-            this.clientId = clientId;
-            this.time = time;
-        }
-
-        @JsonProperty
-        public String host() {
-            return host;
-        }
-
-        @JsonProperty("client_id")
-        public String clientId() {
-            return clientId;
-        }
-
-        @JsonProperty
-        public long time() {
-            return time;
-        }
+    private record MetricClientInfo(@JsonProperty("host") String host, 
+                                   @JsonProperty("client_id") String clientId, 
+                                   @JsonProperty("time") long time) {
     }
 
-    private static class MetricValue {
-
-        private final String name;
-        private final String group;
-        private final Map<String, String> tags;
-        private final Object value;
-
-        MetricValue(String name, String group, Map<String, String> tags, Object value) {
-            this.name = name;
-            this.group = group;
-            this.tags = tags;
-            this.value = value;
-        }
-
-        @JsonProperty
-        public String name() {
-            return name;
-        }
-
-        @JsonProperty
-        public String group() {
-            return group;
-        }
-
-        @JsonProperty
-        public Map<String, String> tags() {
-            return tags;
-        }
-
-        @JsonProperty
-        public Object value() {
-            return value;
-        }
+    private record MetricValue(@JsonProperty("name") String name, 
+                              @JsonProperty("group") String group, 
+                              @JsonProperty("tags") Map<String, String> tags, 
+                              @JsonProperty("value") Object value) {
     }
 
     // The signature for getInt changed from returning int to Integer so to remain compatible with 0.8.2.2 jars

--- a/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
@@ -348,18 +348,7 @@ public class ReplicaVerificationTool {
         }
     }
 
-    private static class MessageInfo {
-        final int replicaId;
-        final long offset;
-        final long nextOffset;
-        final long checksum;
-
-        MessageInfo(int replicaId, long offset, long nextOffset, long checksum) {
-            this.replicaId = replicaId;
-            this.offset = offset;
-            this.nextOffset = nextOffset;
-            this.checksum = checksum;
-        }
+    private record MessageInfo(int replicaId, long offset, long nextOffset, long checksum) {
     }
 
     protected static class ReplicaBuffer {

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionsCommand.java
@@ -63,7 +63,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static java.util.Arrays.asList;
 import static net.sourceforge.argparse4j.impl.Arguments.store;
 
 public abstract class TransactionsCommand {
@@ -288,7 +287,7 @@ public abstract class TransactionsCommand {
     }
 
     static class DescribeProducersCommand extends TransactionsCommand {
-        static final List<String> HEADERS = asList(
+        static final List<String> HEADERS = List.of(
             "ProducerId",
             "ProducerEpoch",
             "LatestCoordinatorEpoch",
@@ -360,7 +359,7 @@ public abstract class TransactionsCommand {
                         String.valueOf(producerState.currentTransactionStartOffset().getAsLong()) :
                         "None";
 
-                return asList(
+                return List.of(
                     String.valueOf(producerState.producerId()),
                     String.valueOf(producerState.producerEpoch()),
                     String.valueOf(producerState.coordinatorEpoch().orElse(-1)),
@@ -375,7 +374,7 @@ public abstract class TransactionsCommand {
     }
 
     static class DescribeTransactionsCommand extends TransactionsCommand {
-        static final List<String> HEADERS = asList(
+        static final List<String> HEADERS = List.of(
             "CoordinatorId",
             "TransactionalId",
             "ProducerId",
@@ -436,7 +435,7 @@ public abstract class TransactionsCommand {
                 transactionDurationMsColumnValue = "None";
             }
 
-            List<String> row = asList(
+            List<String> row = List.of(
                 String.valueOf(result.coordinatorId()),
                 transactionalId,
                 String.valueOf(result.producerId()),
@@ -453,7 +452,7 @@ public abstract class TransactionsCommand {
     }
 
     static class ListTransactionsCommand extends TransactionsCommand {
-        static final List<String> HEADERS = asList(
+        static final List<String> HEADERS = List.of(
             "TransactionalId",
             "Coordinator",
             "ProducerId",
@@ -510,7 +509,7 @@ public abstract class TransactionsCommand {
                 Collection<TransactionListing> listings = brokerListingsEntry.getValue();
 
                 for (TransactionListing listing : listings) {
-                    rows.add(asList(
+                    rows.add(List.of(
                         listing.transactionalId(),
                         coordinatorIdString,
                         String.valueOf(listing.producerId()),
@@ -526,7 +525,7 @@ public abstract class TransactionsCommand {
     static class FindHangingTransactionsCommand extends TransactionsCommand {
         private static final int MAX_BATCH_SIZE = 500;
 
-        static final List<String> HEADERS = asList(
+        static final List<String> HEADERS = List.of(
             "Topic",
             "Partition",
             "ProducerId",
@@ -709,7 +708,7 @@ public abstract class TransactionsCommand {
                 long transactionDurationMinutes = TimeUnit.MILLISECONDS.toMinutes(
                     currentTimeMs - transaction.producerState.lastTimestamp());
 
-                rows.add(asList(
+                rows.add(List.of(
                     transaction.topicPartition.topic(),
                     String.valueOf(transaction.topicPartition.partition()),
                     String.valueOf(transaction.producerState.producerId()),
@@ -848,17 +847,7 @@ public abstract class TransactionsCommand {
             return candidateTransactions;
         }
 
-        private static class OpenTransaction {
-            private final TopicPartition topicPartition;
-            private final ProducerState producerState;
-
-            private OpenTransaction(
-                TopicPartition topicPartition,
-                ProducerState producerState
-            ) {
-                this.topicPartition = topicPartition;
-                this.producerState = producerState;
-            }
+        private record OpenTransaction(TopicPartition topicPartition, ProducerState producerState) {
         }
 
         private void collectCandidateOpenTransactions(
@@ -1024,7 +1013,7 @@ public abstract class TransactionsCommand {
         PrintStream out,
         Time time
     ) throws Exception {
-        List<TransactionsCommand> commands = asList(
+        List<TransactionsCommand> commands = List.of(
             new ListTransactionsCommand(time),
             new DescribeTransactionsCommand(time),
             new DescribeProducersCommand(time),

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/CoordinatorRecordMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/CoordinatorRecordMessageFormatter.java
@@ -82,6 +82,7 @@ public abstract class CoordinatorRecordMessageFormatter implements MessageFormat
 
         try {
             output.write(json.toString().getBytes(UTF_8));
+            output.write('\n');
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -347,20 +347,20 @@ public class ConsumerGroupCommand {
                         for (PartitionAssignmentState consumerAssignment : consumerAssignments) {
                             if (verbose) {
                                 System.out.printf(format,
-                                    consumerAssignment.group,
-                                    consumerAssignment.topic.orElse(MISSING_COLUMN_VALUE), consumerAssignment.partition.map(Object::toString).orElse(MISSING_COLUMN_VALUE),
-                                    consumerAssignment.leaderEpoch.map(Object::toString).orElse(MISSING_COLUMN_VALUE),
-                                    consumerAssignment.offset.map(Object::toString).orElse(MISSING_COLUMN_VALUE), consumerAssignment.logEndOffset.map(Object::toString).orElse(MISSING_COLUMN_VALUE),
-                                    consumerAssignment.lag.map(Object::toString).orElse(MISSING_COLUMN_VALUE), consumerAssignment.consumerId.orElse(MISSING_COLUMN_VALUE),
-                                    consumerAssignment.host.orElse(MISSING_COLUMN_VALUE), consumerAssignment.clientId.orElse(MISSING_COLUMN_VALUE)
+                                    consumerAssignment.group(),
+                                    consumerAssignment.topic().orElse(MISSING_COLUMN_VALUE), consumerAssignment.partition().map(Object::toString).orElse(MISSING_COLUMN_VALUE),
+                                    consumerAssignment.leaderEpoch().map(Object::toString).orElse(MISSING_COLUMN_VALUE),
+                                    consumerAssignment.offset().map(Object::toString).orElse(MISSING_COLUMN_VALUE), consumerAssignment.logEndOffset().map(Object::toString).orElse(MISSING_COLUMN_VALUE),
+                                    consumerAssignment.lag().map(Object::toString).orElse(MISSING_COLUMN_VALUE), consumerAssignment.consumerId().orElse(MISSING_COLUMN_VALUE),
+                                    consumerAssignment.host().orElse(MISSING_COLUMN_VALUE), consumerAssignment.clientId().orElse(MISSING_COLUMN_VALUE)
                                 );
                             } else {
                                 System.out.printf(format,
-                                    consumerAssignment.group,
-                                    consumerAssignment.topic.orElse(MISSING_COLUMN_VALUE), consumerAssignment.partition.map(Object::toString).orElse(MISSING_COLUMN_VALUE),
-                                    consumerAssignment.offset.map(Object::toString).orElse(MISSING_COLUMN_VALUE), consumerAssignment.logEndOffset.map(Object::toString).orElse(MISSING_COLUMN_VALUE),
-                                    consumerAssignment.lag.map(Object::toString).orElse(MISSING_COLUMN_VALUE), consumerAssignment.consumerId.orElse(MISSING_COLUMN_VALUE),
-                                    consumerAssignment.host.orElse(MISSING_COLUMN_VALUE), consumerAssignment.clientId.orElse(MISSING_COLUMN_VALUE)
+                                    consumerAssignment.group(),
+                                    consumerAssignment.topic().orElse(MISSING_COLUMN_VALUE), consumerAssignment.partition().map(Object::toString).orElse(MISSING_COLUMN_VALUE),
+                                    consumerAssignment.offset().map(Object::toString).orElse(MISSING_COLUMN_VALUE), consumerAssignment.logEndOffset().map(Object::toString).orElse(MISSING_COLUMN_VALUE),
+                                    consumerAssignment.lag().map(Object::toString).orElse(MISSING_COLUMN_VALUE), consumerAssignment.consumerId().orElse(MISSING_COLUMN_VALUE),
+                                    consumerAssignment.host().orElse(MISSING_COLUMN_VALUE), consumerAssignment.clientId().orElse(MISSING_COLUMN_VALUE)
                                 );
                             }
                         }
@@ -379,10 +379,10 @@ public class ConsumerGroupCommand {
             if (assignments.isPresent()) {
                 Collection<PartitionAssignmentState> consumerAssignments = assignments.get();
                 for (PartitionAssignmentState consumerAssignment : consumerAssignments) {
-                    maxGroupLen = Math.max(maxGroupLen, consumerAssignment.group.length());
-                    maxTopicLen = Math.max(maxTopicLen, consumerAssignment.topic.orElse(MISSING_COLUMN_VALUE).length());
-                    maxConsumerIdLen = Math.max(maxConsumerIdLen, consumerAssignment.consumerId.orElse(MISSING_COLUMN_VALUE).length());
-                    maxHostLen = Math.max(maxHostLen, consumerAssignment.host.orElse(MISSING_COLUMN_VALUE).length());
+                    maxGroupLen = Math.max(maxGroupLen, consumerAssignment.group().length());
+                    maxTopicLen = Math.max(maxTopicLen, consumerAssignment.topic().orElse(MISSING_COLUMN_VALUE).length());
+                    maxConsumerIdLen = Math.max(maxConsumerIdLen, consumerAssignment.consumerId().orElse(MISSING_COLUMN_VALUE).length());
+                    maxHostLen = Math.max(maxHostLen, consumerAssignment.host().orElse(MISSING_COLUMN_VALUE).length());
 
                 }
             }
@@ -408,20 +408,20 @@ public class ConsumerGroupCommand {
                     // find proper columns width
                     if (assignments.isPresent()) {
                         for (MemberAssignmentState memberAssignment : assignments.get()) {
-                            maxGroupLen = Math.max(maxGroupLen, memberAssignment.group.length());
-                            maxConsumerIdLen = Math.max(maxConsumerIdLen, memberAssignment.consumerId.length());
-                            maxGroupInstanceIdLen =  Math.max(maxGroupInstanceIdLen, memberAssignment.groupInstanceId.length());
-                            maxHostLen = Math.max(maxHostLen, memberAssignment.host.length());
-                            maxClientIdLen = Math.max(maxClientIdLen, memberAssignment.clientId.length());
-                            includeGroupInstanceId = includeGroupInstanceId || !memberAssignment.groupInstanceId.isEmpty();
-                            String currentAssignment = memberAssignment.assignment.isEmpty() ?
-                                MISSING_COLUMN_VALUE : getAssignmentString(memberAssignment.assignment);
-                            String targetAssignment = memberAssignment.targetAssignment.isEmpty() ?
-                                MISSING_COLUMN_VALUE : getAssignmentString(memberAssignment.targetAssignment);
+                            maxGroupLen = Math.max(maxGroupLen, memberAssignment.group().length());
+                            maxConsumerIdLen = Math.max(maxConsumerIdLen, memberAssignment.consumerId().length());
+                            maxGroupInstanceIdLen =  Math.max(maxGroupInstanceIdLen, memberAssignment.groupInstanceId().length());
+                            maxHostLen = Math.max(maxHostLen, memberAssignment.host().length());
+                            maxClientIdLen = Math.max(maxClientIdLen, memberAssignment.clientId().length());
+                            includeGroupInstanceId = includeGroupInstanceId || !memberAssignment.groupInstanceId().isEmpty();
+                            String currentAssignment = memberAssignment.assignment().isEmpty() ?
+                                MISSING_COLUMN_VALUE : getAssignmentString(memberAssignment.assignment());
+                            String targetAssignment = memberAssignment.targetAssignment().isEmpty() ?
+                                MISSING_COLUMN_VALUE : getAssignmentString(memberAssignment.targetAssignment());
                             maxCurrentAssignment = Math.max(maxCurrentAssignment, currentAssignment.length());
                             maxTargetAssignment = Math.max(maxTargetAssignment, targetAssignment.length());
-                            hasClassicMember = hasClassicMember || (memberAssignment.upgraded.isPresent() && !memberAssignment.upgraded.get());
-                            hasConsumerMember = hasConsumerMember || (memberAssignment.upgraded.isPresent() && memberAssignment.upgraded.get());
+                            hasClassicMember = hasClassicMember || (memberAssignment.upgraded().isPresent() && !memberAssignment.upgraded().get());
+                            hasConsumerMember = hasConsumerMember || (memberAssignment.upgraded().isPresent() && memberAssignment.upgraded().get());
                         }
                     }
                 }
@@ -465,23 +465,23 @@ public class ConsumerGroupCommand {
         ) {
             for (MemberAssignmentState memberAssignment : memberAssignments) {
                 if (includeGroupInstanceId) {
-                    System.out.printf(formatWithGroupInstanceId, memberAssignment.group, memberAssignment.consumerId,
-                        memberAssignment.groupInstanceId, memberAssignment.host, memberAssignment.clientId,
-                        memberAssignment.numPartitions);
+                    System.out.printf(formatWithGroupInstanceId, memberAssignment.group(), memberAssignment.consumerId(),
+                        memberAssignment.groupInstanceId(), memberAssignment.host(), memberAssignment.clientId(),
+                        memberAssignment.numPartitions());
                 } else {
-                    System.out.printf(formatWithoutGroupInstanceId, memberAssignment.group, memberAssignment.consumerId,
-                        memberAssignment.host, memberAssignment.clientId, memberAssignment.numPartitions);
+                    System.out.printf(formatWithoutGroupInstanceId, memberAssignment.group(), memberAssignment.consumerId(),
+                        memberAssignment.host(), memberAssignment.clientId(), memberAssignment.numPartitions());
                 }
                 if (verbose) {
-                    String currentEpoch = memberAssignment.currentEpoch.map(Object::toString).orElse(MISSING_COLUMN_VALUE);
-                    String currentAssignment = memberAssignment.assignment.isEmpty() ?
-                        MISSING_COLUMN_VALUE : getAssignmentString(memberAssignment.assignment);
-                    String targetEpoch = memberAssignment.targetEpoch.map(Object::toString).orElse(MISSING_COLUMN_VALUE);
-                    String targetAssignment = memberAssignment.targetAssignment.isEmpty() ?
-                        MISSING_COLUMN_VALUE : getAssignmentString(memberAssignment.targetAssignment);
+                    String currentEpoch = memberAssignment.currentEpoch().map(Object::toString).orElse(MISSING_COLUMN_VALUE);
+                    String currentAssignment = memberAssignment.assignment().isEmpty() ?
+                        MISSING_COLUMN_VALUE : getAssignmentString(memberAssignment.assignment());
+                    String targetEpoch = memberAssignment.targetEpoch().map(Object::toString).orElse(MISSING_COLUMN_VALUE);
+                    String targetAssignment = memberAssignment.targetAssignment().isEmpty() ?
+                        MISSING_COLUMN_VALUE : getAssignmentString(memberAssignment.targetAssignment());
                     if (hasMigrationMember) {
                         System.out.printf(formatWithUpgrade, currentEpoch, currentAssignment, targetEpoch, targetAssignment,
-                            memberAssignment.upgraded.map(Object::toString).orElse(MISSING_COLUMN_VALUE));
+                            memberAssignment.upgraded().map(Object::toString).orElse(MISSING_COLUMN_VALUE));
                     } else {
                         System.out.printf(formatWithoutUpgrade, currentEpoch, currentAssignment, targetEpoch, targetAssignment);
                     }
@@ -511,23 +511,23 @@ public class ConsumerGroupCommand {
 
         private void printStates(Map<String, GroupInformation> states, boolean verbose) {
             states.forEach((groupId, state) -> {
-                if (shouldPrintMemberState(groupId, Optional.of(state.groupState), Optional.of(1))) {
-                    String coordinator = state.coordinator.host() + ":" + state.coordinator.port() + "  (" + state.coordinator.idString() + ")";
+                if (shouldPrintMemberState(groupId, Optional.of(state.groupState()), Optional.of(1))) {
+                    String coordinator = state.coordinator().host() + ":" + state.coordinator().port() + "  (" + state.coordinator().idString() + ")";
                     int coordinatorColLen = Math.max(25, coordinator.length());
-                    int groupColLen = Math.max(15, state.group.length());
+                    int groupColLen = Math.max(15, state.group().length());
 
-                    String assignmentStrategy = state.assignmentStrategy.isEmpty() ? MISSING_COLUMN_VALUE : state.assignmentStrategy;
+                    String assignmentStrategy = state.assignmentStrategy().isEmpty() ? MISSING_COLUMN_VALUE : state.assignmentStrategy();
 
                     if (verbose) {
                         String format = "\n%" + -groupColLen + "s %" + -coordinatorColLen + "s %-20s %-20s %-15s %-25s %s";
                         System.out.printf(format, "GROUP", "COORDINATOR (ID)", "ASSIGNMENT-STRATEGY", "STATE",
                             "GROUP-EPOCH", "TARGET-ASSIGNMENT-EPOCH", "#MEMBERS");
-                        System.out.printf(format, state.group, coordinator, assignmentStrategy, state.groupState,
-                            state.groupEpoch.map(Object::toString).orElse(MISSING_COLUMN_VALUE), state.targetAssignmentEpoch.map(Object::toString).orElse(MISSING_COLUMN_VALUE), state.numMembers);
+                        System.out.printf(format, state.group(), coordinator, assignmentStrategy, state.groupState(),
+                            state.groupEpoch().map(Object::toString).orElse(MISSING_COLUMN_VALUE), state.targetAssignmentEpoch().map(Object::toString).orElse(MISSING_COLUMN_VALUE), state.numMembers());
                     } else {
                         String format = "\n%" + -groupColLen + "s %" + -coordinatorColLen + "s %-20s %-20s %s";
                         System.out.printf(format, "GROUP", "COORDINATOR (ID)", "ASSIGNMENT-STRATEGY", "STATE", "#MEMBERS");
-                        System.out.printf(format, state.group, coordinator, assignmentStrategy, state.groupState, state.numMembers);
+                        System.out.printf(format, state.group(), coordinator, assignmentStrategy, state.groupState(), state.numMembers());
                     }
                     System.out.println();
                 }
@@ -623,8 +623,8 @@ public class ConsumerGroupCommand {
             // concat the data and then sort them
             return Stream.concat(existLeaderAssignments.stream(), noneLeaderAssignments.stream())
                     .sorted(Comparator.<PartitionAssignmentState, String>comparing(
-                            state -> state.topic.orElse(""), String::compareTo)
-                            .thenComparingInt(state -> state.partition.orElse(-1)))
+                            state -> state.topic().orElse(""), String::compareTo)
+                            .thenComparingInt(state -> state.partition().orElse(-1)))
                     .collect(Collectors.toList());
         }
 

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/GroupInformation.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/GroupInformation.java
@@ -21,30 +21,6 @@ import org.apache.kafka.common.Node;
 
 import java.util.Optional;
 
-class GroupInformation {
-    final String group;
-    final Node coordinator;
-    final String assignmentStrategy;
-    final GroupState groupState;
-    final int numMembers;
-    final Optional<Integer> groupEpoch;
-    final Optional<Integer> targetAssignmentEpoch;
-
-    GroupInformation(
-        String group,
-        Node coordinator,
-        String assignmentStrategy,
-        GroupState groupState,
-        int numMembers,
-        Optional<Integer> groupEpoch,
-        Optional<Integer> targetAssignmentEpoch
-    ) {
-        this.group = group;
-        this.coordinator = coordinator;
-        this.assignmentStrategy = assignmentStrategy;
-        this.groupState = groupState;
-        this.numMembers = numMembers;
-        this.groupEpoch = groupEpoch;
-        this.targetAssignmentEpoch = targetAssignmentEpoch;
-    }
+record GroupInformation(String group, Node coordinator, String assignmentStrategy, GroupState groupState,
+                        int numMembers, Optional<Integer> groupEpoch, Optional<Integer> targetAssignmentEpoch) {
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/MemberAssignmentState.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/MemberAssignmentState.java
@@ -21,42 +21,8 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.List;
 import java.util.Optional;
 
-class MemberAssignmentState {
-    final String group;
-    final String consumerId;
-    final String host;
-    final String clientId;
-    final String groupInstanceId;
-    final int numPartitions;
-    final List<TopicPartition> assignment;
-    final List<TopicPartition> targetAssignment;
-    final Optional<Integer> currentEpoch;
-    final Optional<Integer> targetEpoch;
-    final Optional<Boolean> upgraded;
-
-    MemberAssignmentState(
-        String group,
-        String consumerId,
-        String host,
-        String clientId,
-        String groupInstanceId,
-        int numPartitions,
-        List<TopicPartition> assignment,
-        List<TopicPartition> targetAssignment,
-        Optional<Integer> currentEpoch,
-        Optional<Integer> targetEpoch,
-        Optional<Boolean> upgraded
-    ) {
-        this.group = group;
-        this.consumerId = consumerId;
-        this.host = host;
-        this.clientId = clientId;
-        this.groupInstanceId = groupInstanceId;
-        this.numPartitions = numPartitions;
-        this.assignment = assignment;
-        this.targetAssignment = targetAssignment;
-        this.currentEpoch = currentEpoch;
-        this.targetEpoch = targetEpoch;
-        this.upgraded = upgraded;
-    }
+record MemberAssignmentState(String group, String consumerId, String host, String clientId, String groupInstanceId,
+                             int numPartitions, List<TopicPartition> assignment, List<TopicPartition> targetAssignment,
+                             Optional<Integer> currentEpoch, Optional<Integer> targetEpoch,
+                             Optional<Boolean> upgraded) {
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/PartitionAssignmentState.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/PartitionAssignmentState.java
@@ -20,42 +20,8 @@ import org.apache.kafka.common.Node;
 
 import java.util.Optional;
 
-class PartitionAssignmentState {
-    final String group;
-    final Optional<Node> coordinator;
-    final Optional<String> topic;
-    final Optional<Integer> partition;
-    final Optional<Long> offset;
-    final Optional<Long> lag;
-    final Optional<String> consumerId;
-    final Optional<String> host;
-    final Optional<String> clientId;
-    final Optional<Long> logEndOffset;
-    final Optional<Integer> leaderEpoch;
-
-    PartitionAssignmentState(
-        String group,
-        Optional<Node> coordinator,
-        Optional<String> topic,
-        Optional<Integer> partition,
-        Optional<Long> offset,
-        Optional<Long> lag,
-        Optional<String> consumerId,
-        Optional<String> host,
-        Optional<String> clientId,
-        Optional<Long> logEndOffset,
-        Optional<Integer> leaderEpoch
-    ) {
-        this.group = group;
-        this.coordinator = coordinator;
-        this.topic = topic;
-        this.partition = partition;
-        this.offset = offset;
-        this.lag = lag;
-        this.consumerId = consumerId;
-        this.host = host;
-        this.clientId = clientId;
-        this.logEndOffset = logEndOffset;
-        this.leaderEpoch = leaderEpoch;
-    }
+record PartitionAssignmentState(String group, Optional<Node> coordinator, Optional<String> topic,
+                                Optional<Integer> partition, Optional<Long> offset, Optional<Long> lag,
+                                Optional<String> consumerId, Optional<String> host, Optional<String> clientId,
+                                Optional<Long> logEndOffset, Optional<Integer> leaderEpoch) {
 }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
@@ -418,18 +418,6 @@ public class ShareGroupCommand {
 
             if (opts.options.has(opts.topicOpt)) {
                 partitionsToReset = offsetsUtils.parseTopicPartitionsToReset(opts.options.valuesOf(opts.topicOpt));
-                Set<String> subscribedTopics = offsetsByTopicPartitions.keySet().stream()
-                    .map(TopicPartition::topic)
-                    .collect(Collectors.toSet());
-                Set<String> resetTopics = partitionsToReset.stream()
-                    .map(TopicPartition::topic)
-                    .collect(Collectors.toSet());
-                if (!subscribedTopics.containsAll(resetTopics)) {
-                    CommandLineUtils
-                        .printErrorAndExit(String.format("Share group '%s' is not subscribed to topic '%s'.",
-                            groupId, resetTopics.stream().filter(topic -> !subscribedTopics.contains(topic)).collect(Collectors.joining(", "))));
-                    return null;
-                }
             } else {
                 partitionsToReset = offsetsByTopicPartitions.keySet();
             }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
@@ -656,25 +656,7 @@ public class ShareGroupCommand {
         }
     }
 
-    static class SharePartitionOffsetInformation {
-        final String group;
-        final String topic;
-        final int partition;
-        final Optional<Long> offset;
-        final Optional<Integer> leaderEpoch;
-
-        SharePartitionOffsetInformation(
-            String group,
-            String topic,
-            int partition,
-            Optional<Long> offset,
-            Optional<Integer> leaderEpoch
-        ) {
-            this.group = group;
-            this.topic = topic;
-            this.partition = partition;
-            this.offset = offset;
-            this.leaderEpoch = leaderEpoch;
-        }
+    record SharePartitionOffsetInformation(String group, String topic, int partition, Optional<Long> offset,
+                                           Optional<Integer> leaderEpoch) {
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ActiveMoveState.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ActiveMoveState.java
@@ -17,44 +17,15 @@
 
 package org.apache.kafka.tools.reassign;
 
-import java.util.Objects;
-
 /**
  * A replica log directory move state where the move is in progress.
+ * @param currentLogDir The current log directory.
+ * @param futureLogDir  The log directory that the replica is moving to.
+ * @param targetLogDir  The log directory that we wanted the replica to move to.
  */
-final class ActiveMoveState implements LogDirMoveState {
-    public final String currentLogDir;
-
-    public final String targetLogDir;
-
-    public final String futureLogDir;
-
-    /**
-     * @param currentLogDir       The current log directory.
-     * @param futureLogDir        The log directory that the replica is moving to.
-     * @param targetLogDir        The log directory that we wanted the replica to move to.
-     */
-    public ActiveMoveState(String currentLogDir, String targetLogDir, String futureLogDir) {
-        this.currentLogDir = currentLogDir;
-        this.targetLogDir = targetLogDir;
-        this.futureLogDir = futureLogDir;
-    }
-
+record ActiveMoveState(String currentLogDir, String targetLogDir, String futureLogDir) implements LogDirMoveState {
     @Override
     public boolean done() {
         return false;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ActiveMoveState that = (ActiveMoveState) o;
-        return Objects.equals(currentLogDir, that.currentLogDir) && Objects.equals(targetLogDir, that.targetLogDir) && Objects.equals(futureLogDir, that.futureLogDir);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(currentLogDir, targetLogDir, futureLogDir);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/CancelledMoveState.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/CancelledMoveState.java
@@ -17,41 +17,15 @@
 
 package org.apache.kafka.tools.reassign;
 
-import java.util.Objects;
-
 /**
  * A replica log directory move state where there is no move in progress, but we did not
  * reach the target log directory.
+ * @param currentLogDir The current log directory.
+ * @param targetLogDir  The log directory that we wanted the replica to move to.
  */
-final class CancelledMoveState implements LogDirMoveState {
-    public final String currentLogDir;
-
-    public final String targetLogDir;
-
-    /**
-     * @param currentLogDir       The current log directory.
-     * @param targetLogDir        The log directory that we wanted the replica to move to.
-     */
-    public CancelledMoveState(String currentLogDir, String targetLogDir) {
-        this.currentLogDir = currentLogDir;
-        this.targetLogDir = targetLogDir;
-    }
-
+record CancelledMoveState(String currentLogDir, String targetLogDir) implements LogDirMoveState {
     @Override
     public boolean done() {
         return true;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CancelledMoveState that = (CancelledMoveState) o;
-        return Objects.equals(currentLogDir, that.currentLogDir) && Objects.equals(targetLogDir, that.targetLogDir);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(currentLogDir, targetLogDir);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/CompletedMoveState.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/CompletedMoveState.java
@@ -17,36 +17,13 @@
 
 package org.apache.kafka.tools.reassign;
 
-import java.util.Objects;
-
 /**
  * The completed replica log directory move state.
+ * @param targetLogDir The log directory that we wanted the replica to move to.
  */
-final class CompletedMoveState implements LogDirMoveState {
-    public final String targetLogDir;
-
-    /**
-     * @param targetLogDir        The log directory that we wanted the replica to move to.
-     */
-    public CompletedMoveState(String targetLogDir) {
-        this.targetLogDir = targetLogDir;
-    }
-
+record CompletedMoveState(String targetLogDir) implements LogDirMoveState {
     @Override
     public boolean done() {
         return true;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CompletedMoveState that = (CompletedMoveState) o;
-        return Objects.equals(targetLogDir, that.targetLogDir);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(targetLogDir);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/MissingLogDirMoveState.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/MissingLogDirMoveState.java
@@ -17,36 +17,13 @@
 
 package org.apache.kafka.tools.reassign;
 
-import java.util.Objects;
-
 /**
  * A replica log directory move state where the source replica is missing.
+ * @param targetLogDir The log directory that we wanted the replica to move to.
  */
-final class MissingLogDirMoveState implements LogDirMoveState {
-    public final String targetLogDir;
-
-    /**
-     * @param targetLogDir        The log directory that we wanted the replica to move to.
-     */
-    public MissingLogDirMoveState(String targetLogDir) {
-        this.targetLogDir = targetLogDir;
-    }
-
+record MissingLogDirMoveState(String targetLogDir) implements LogDirMoveState {
     @Override
     public boolean done() {
         return false;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        MissingLogDirMoveState that = (MissingLogDirMoveState) o;
-        return Objects.equals(targetLogDir, that.targetLogDir);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(targetLogDir);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/MissingReplicaMoveState.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/MissingReplicaMoveState.java
@@ -17,36 +17,13 @@
 
 package org.apache.kafka.tools.reassign;
 
-import java.util.Objects;
-
 /**
  * A replica log directory move state where the source log directory is missing.
+ * @param targetLogDir The log directory that we wanted the replica to move to.
  */
-final class MissingReplicaMoveState implements LogDirMoveState {
-    public final String targetLogDir;
-
-    /**
-     * @param targetLogDir        The log directory that we wanted the replica to move to.
-     */
-    public MissingReplicaMoveState(String targetLogDir) {
-        this.targetLogDir = targetLogDir;
-    }
-
+record MissingReplicaMoveState(String targetLogDir) implements LogDirMoveState {
     @Override
     public boolean done() {
         return false;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        MissingReplicaMoveState that = (MissingReplicaMoveState) o;
-        return Objects.equals(targetLogDir, that.targetLogDir);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(targetLogDir);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -467,8 +467,8 @@ public class ReassignPartitionsCommand {
                 bld.add("Partition " + replica.topic() + "-" + replica.partition() + " cannot be found " +
                     "in any live log directory on broker " + replica.brokerId() + ".");
             } else if (state instanceof ActiveMoveState) {
-                String targetLogDir = ((ActiveMoveState) state).targetLogDir;
-                String futureLogDir = ((ActiveMoveState) state).futureLogDir;
+                String targetLogDir = ((ActiveMoveState) state).targetLogDir();
+                String futureLogDir = ((ActiveMoveState) state).futureLogDir();
                 if (targetLogDir.equals(futureLogDir)) {
                     bld.add("Reassignment of replica " + replica + " is still in progress.");
                 } else {
@@ -477,8 +477,8 @@ public class ReassignPartitionsCommand {
                         "instead of " + targetLogDir + ".");
                 }
             } else if (state instanceof CancelledMoveState) {
-                String targetLogDir = ((CancelledMoveState) state).targetLogDir;
-                String currentLogDir = ((CancelledMoveState) state).currentLogDir;
+                String targetLogDir = ((CancelledMoveState) state).targetLogDir();
+                String currentLogDir = ((CancelledMoveState) state).currentLogDir();
                 bld.add("Partition " + replica.topic() + "-" + replica.partition() + " on broker " +
                     replica.brokerId() + " is not being moved from log dir " + currentLogDir + " to " +
                     targetLogDir + ".");
@@ -1292,7 +1292,7 @@ public class ReassignPartitionsCommand {
         Map<TopicPartitionReplica, String> curMovingParts = new HashMap<>();
         findLogDirMoveStates(adminClient, targetReplicas).forEach((part, moveState) -> {
             if (moveState instanceof ActiveMoveState)
-                curMovingParts.put(part, ((ActiveMoveState) moveState).currentLogDir);
+                curMovingParts.put(part, ((ActiveMoveState) moveState).currentLogDir());
         });
         if (curMovingParts.isEmpty()) {
             System.out.print("None of the specified partition moves are active.");

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -881,6 +881,7 @@ public class StreamsGroupCommand {
                 List<String> topics = opts.options.valuesOf(opts.inputTopicOpt);
 
                 List<TopicPartition> partitions = offsetsUtils.parseTopicPartitionsToReset(topics);
+                offsetsUtils.checkAllTopicPartitionsValid(partitions);
                 // if the user specified topics that do not belong to this group, we filter them out
                 partitions = filterExistingGroupTopics(groupId, partitions);
                 return partitions;

--- a/tools/src/test/java/org/apache/kafka/tools/ConnectPluginPathTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConnectPluginPathTest.java
@@ -444,13 +444,7 @@ public class ConnectPluginPathTest {
         MULTI_JAR
     }
 
-    private static class PluginLocation {
-        private final Path path;
-
-        private PluginLocation(Path path) {
-            this.path = path;
-        }
-
+    private record PluginLocation(Path path) {
         @Override
         public String toString() {
             return path.toString();
@@ -504,15 +498,7 @@ public class ConnectPluginPathTest {
         }
     }
 
-    private static class PluginPathElement {
-        private final Path root;
-        private final List<PluginLocation> locations;
-
-        private PluginPathElement(Path root, List<PluginLocation> locations) {
-            this.root = root;
-            this.locations = locations;
-        }
-
+    private record PluginPathElement(Path root, List<PluginLocation> locations) {
         @Override
         public String toString() {
             return root.toString();
@@ -535,14 +521,7 @@ public class ConnectPluginPathTest {
         return new PluginPathElement(path, locations);
     }
 
-    private static class WorkerConfig {
-        private final Path configFile;
-        private final List<PluginPathElement> pluginPathElements;
-
-        private WorkerConfig(Path configFile, List<PluginPathElement> pluginPathElements) {
-            this.configFile = configFile;
-            this.pluginPathElements = pluginPathElements;
-        }
+    private record WorkerConfig(Path configFile, List<PluginPathElement> pluginPathElements) {
 
         @Override
         public String toString() {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupServiceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupServiceTest.java
@@ -183,13 +183,13 @@ public class ConsumerGroupServiceTest {
 
         Map<TopicPartition, Optional<Long>> returnedOffsets = assignments.map(results ->
             results.stream().collect(Collectors.toMap(
-                assignment -> new TopicPartition(assignment.topic.get(), assignment.partition.get()),
-                assignment -> assignment.offset))
+                assignment -> new TopicPartition(assignment.topic().get(), assignment.partition().get()),
+                assignment -> assignment.offset()))
         ).orElse(Map.of());
         Map<TopicPartition, Optional<Integer>> returnedLeaderEpoch = assignments.map(results ->
             results.stream().collect(Collectors.toMap(
-                assignment -> new TopicPartition(assignment.topic.get(), assignment.partition.get()),
-                assignment -> assignment.leaderEpoch))
+                assignment -> new TopicPartition(assignment.topic().get(), assignment.partition().get()),
+                assignment -> assignment.leaderEpoch()))
         ).orElse(Map.of());
 
         Map<TopicPartition, Optional<Long>> expectedOffsets = Map.of(

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/DeleteConsumerGroupsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/DeleteConsumerGroupsTest.java
@@ -322,7 +322,7 @@ public class DeleteConsumerGroupsTest {
     }
 
     private boolean checkGroupState(ConsumerGroupCommand.ConsumerGroupService service, String groupId, GroupState state) throws Exception {
-        return Objects.equals(service.collectGroupState(groupId).groupState, state);
+        return Objects.equals(service.collectGroupState(groupId).groupState(), state);
     }
 
     private ConsumerGroupCommand.ConsumerGroupService getConsumerGroupService(String[] args) {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
@@ -896,10 +896,10 @@ public class ResetConsumerGroupOffsetTest {
     private void awaitConsumerGroupInactive(ConsumerGroupCommand.ConsumerGroupService service,
                                             String group) throws Exception {
         TestUtils.waitForCondition(() -> {
-            GroupState state = service.collectGroupState(group).groupState;
+            GroupState state = service.collectGroupState(group).groupState();
             return Objects.equals(state, GroupState.EMPTY) || Objects.equals(state, GroupState.DEAD);
         }, "Expected that consumer group is inactive. Actual state: " +
-                service.collectGroupState(group).groupState);
+            service.collectGroupState(group).groupState());
     }
 
     private void resetAndAssertOffsetsCommitted(ClusterInstance cluster,

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandTest.java
@@ -1373,7 +1373,7 @@ public class ShareGroupCommandTest {
     }
     
     @Test
-    public void testAlterShareGroupFailureFailureWithNonExistentTopic() {
+    public void testAlterShareGroupFailureWithNonExistentTopic() {
         String group = "share-group";
         String topic = "none";
         String bootstrapServer = "localhost:9092";

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
@@ -624,16 +624,7 @@ public class ReassignPartitionsCommandTest {
         }));
     }
 
-    static class LogDirReassignment {
-        final String json;
-        final String currentDir;
-        final String targetDir;
-
-        public LogDirReassignment(String json, String currentDir, String targetDir) {
-            this.json = json;
-            this.currentDir = currentDir;
-            this.targetDir = targetDir;
-        }
+    record LogDirReassignment(String json, String currentDir, String targetDir) {
     }
 
     private LogDirReassignment buildLogDirReassignment(TopicPartition topicPartition,


### PR DESCRIPTION
Reverts #161 and #155 and brings in changes from upstream/trunk. The main one is KAFKA-19662 and the proceeding ones are required for the cherry-pick to apply cleanly