### PR TITLE
Extract MirrorSourceSyncer from MirrorMetadataManager

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -157,8 +157,7 @@ public class ClusterMirrorCoordinator {
         log.info("Starting up.");
 
         metadataManager.initialize(
-                brokerConfig.mirrorConfig().metadataRefreshIntervalMs(),
-                (mirrorName, tp, state, errorMessage, nonRetryable) -> transitionTo(mirrorName, tp, state, errorMessage, nonRetryable),
+                this::transitionTo,
                 this::tombstoneMirrorRecords,
                 this::getCoordinatorPartitionByKey,
                 this::getCoordinatorPartitionByName);
@@ -290,7 +289,7 @@ public class ClusterMirrorCoordinator {
                     MirrorPartitionState state = MirrorPartitionState.fromValue(psv.state());
                     MirrorPartitionState previousState = MirrorPartitionState.fromValue(psv.previousState());
                     metadataManager.updatePartitionState(pk, state);
-                    restoreFailedState(key.mirrorName(), pk, state, psv.retryAttempt(), psv.errorMessage(), previousState);
+                    restoreFailedState(pk, state, psv.retryAttempt(), psv.errorMessage(), previousState);
                 });
             } else {
                 metadataManager.removePartitionState(pk);
@@ -365,7 +364,7 @@ public class ClusterMirrorCoordinator {
         }
     }
 
-    private void restoreFailedState(String mirrorName, ClusterMirrorRecordKey pk, MirrorPartitionState state,
+    private void restoreFailedState(ClusterMirrorRecordKey pk, MirrorPartitionState state,
                                     int retryAttempt, String errorMessage, MirrorPartitionState previousState) {
         if (state == MirrorPartitionState.FAILED) {
             metadataManager.setFailedInfo(pk, new FailedPartitionInfo(retryAttempt, errorMessage, previousState));

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -24,49 +24,19 @@ import kafka.server.mirror.ClusterMirrorUtils.FailedPartitionInfo;
 import kafka.server.mirror.ClusterMirrorUtils.LeaderEpochBump;
 import kafka.server.mirror.ClusterMirrorUtils.LeaderInfo;
 import kafka.server.mirror.ClusterMirrorUtils.PartitionCacheEntry;
+import kafka.server.mirror.ClusterMirrorUtils.StateTransitioner;
 
-import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.ClusterMirrorDescription;
 import org.apache.kafka.clients.admin.ClusterMirrorListing;
-import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.clients.admin.DescribeClusterMirrorsOptions;
-import org.apache.kafka.clients.admin.DescribeClusterMirrorsResult;
-import org.apache.kafka.clients.admin.GroupListing;
-import org.apache.kafka.clients.admin.ListClusterMirrorsOptions;
-import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
-import org.apache.kafka.clients.admin.ListGroupsOptions;
-import org.apache.kafka.clients.admin.ListShareGroupOffsetsSpec;
-import org.apache.kafka.clients.admin.StartMirrorTopicsOptions;
-import org.apache.kafka.clients.admin.StopMirrorTopicsOptions;
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.Endpoint;
-import org.apache.kafka.common.GroupState;
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.acl.AclBinding;
-import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.errors.SecurityDisabledException;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.apache.kafka.common.message.BumpLeaderEpochsRequestData;
-import org.apache.kafka.common.message.CreateAclsRequestData;
-import org.apache.kafka.common.message.CreatePartitionsRequestData;
-import org.apache.kafka.common.message.CreateTopicsRequestData;
-import org.apache.kafka.common.message.DeleteAclsRequestData;
 import org.apache.kafka.common.message.DeleteClusterMirrorRequestData;
-import org.apache.kafka.common.message.DescribeClusterMirrorsRequestData;
-import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.PauseMirrorTopicsRequestData;
 import org.apache.kafka.common.message.ReadMirrorStatesRequestData;
@@ -79,19 +49,11 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.network.ChannelBuilders;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.BumpLeaderEpochsRequest;
-import org.apache.kafka.common.requests.CreateAclsRequest;
-import org.apache.kafka.common.requests.CreatePartitionsRequest;
-import org.apache.kafka.common.requests.CreateTopicsRequest;
-import org.apache.kafka.common.requests.CreateTopicsResponse;
-import org.apache.kafka.common.requests.DeleteAclsRequest;
-import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.ReadMirrorStatesRequest;
 import org.apache.kafka.common.requests.ReadMirrorStatesResponse;
 import org.apache.kafka.common.requests.WriteMirrorStatesRequest;
 import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
-import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -103,16 +65,12 @@ import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.loader.LoaderManifest;
 import org.apache.kafka.image.publisher.MetadataPublisher;
 import org.apache.kafka.metadata.MetadataCache;
-import org.apache.kafka.metadata.authorizer.StandardAcl;
-import org.apache.kafka.server.common.ControllerRequestCompletionHandler;
 import org.apache.kafka.server.common.MirrorPartitionState;
 import org.apache.kafka.server.common.NodeToControllerChannelManager;
 import org.apache.kafka.server.config.ClusterMirrorConfig;
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 import org.apache.kafka.server.util.KafkaScheduler;
-import org.apache.kafka.server.util.MirrorFilterUtils;
 import org.apache.kafka.server.util.RequestAndCompletionHandler;
-import org.apache.kafka.storage.internals.log.UnifiedLog;
 
 import org.slf4j.Logger;
 
@@ -129,37 +87,28 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import scala.Option;
-
-import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_INCREMENT;
-import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
 
 /**
- * Manages source cluster communication and metadata synchronization for Cluster Mirroring.
+ * Central component for Cluster Mirroring on each broker.
  *
- * <p>Implements {@link MetadataPublisher} to react to leadership and config changes, triggering
- * mirror partition state transitions. Periodically syncs topic metadata, configs, group offsets,
- * and ACLs from source clusters. Routes state reads and writes to the appropriate coordinator
+ * <p>Implements {@link MetadataPublisher} to react to KRaft leadership and config changes,
+ * triggering mirror partition state transitions (LOG_TRUNCATION, EPOCH_FENCING, MIRRORING,
+ * PAUSING, STOPPING, etc.). Routes state reads and writes to the appropriate coordinator
  * broker via {@link MirrorStateSender}.
  *
- * <p>Source topic state sync (leader caches, deletion detection, missed partition recovery)
- * runs on every broker. Topic creation and partition scaling run only on the coordinator.
- * Coordinator-level sync (configs, offsets, ACLs, pattern discovery) runs only on the broker
- * that leads the {@code __mirror_state} partition for a given mirror name.
+ * <p>Periodic source cluster synchronization (topic metadata, configs, group offsets, ACLs,
+ * pattern discovery, epoch bumping) is handled by {@link MirrorSourceSyncer}, which is
+ * created during {@link #initialize} and accesses shared state through this manager.
  */
 @SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
 public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
@@ -171,34 +120,34 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Logger log;
     private volatile boolean isInitialized = false;
     private final String name;
-    private final String clusterId;
+    final String clusterId;
     private final KafkaConfig brokerConfig;
-    private final int nodeId;
+    final int nodeId;
 
+    private volatile MirrorSourceSyncer sourceSyncer;
     private final NodeToControllerChannelManager channelManager;
-    private final Supplier<ReplicaManager> replicaManagerSupplier;
+    final Supplier<ReplicaManager> replicaManagerSupplier;
     private volatile MetadataImage metadataImage = MetadataImage.EMPTY;
     private final MetadataCache metadataCache;
     private final KafkaScheduler scheduler;
     private final Metrics metrics;
     private final Time time;
-    private volatile ScheduledFuture<?> metadataRefreshFuture;
 
     // Network communication
-    private volatile MirrorStateSender mirrorStateSender; // Raw WriteMirrorStates and ReadMirrorStates RPCs to coord brokers
-    private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>(); // Source cluster metadata discovery (one per mirror)
-    private volatile Admin dstAdmin; // Group offset and ACLs sync
+    private volatile MirrorStateSender mirrorStateSender;
+    final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>();
+    private volatile Admin dstAdmin;
 
     // Local cache
-    private final Map<String, Map<TopicPartition, LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
-    private final Map<ClusterMirrorRecordKey, PartitionCacheEntry> partitionCache = new ConcurrentHashMap<>();
-    private final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
+    final Map<String, Map<TopicPartition, LeaderInfo>> sourceLeaders = new ConcurrentHashMap<>();
+    final Map<ClusterMirrorRecordKey, PartitionCacheEntry> partitionCache = new ConcurrentHashMap<>();
+    final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
     private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
-    private final Set<LeaderEpochBump> pendingLeaderEpochBumps = ConcurrentHashMap.newKeySet();
+    final Set<LeaderEpochBump> pendingLeaderEpochBumps = ConcurrentHashMap.newKeySet();
 
     // Functions
-    private Optional<ClusterMirrorUtils.StateTransitioner> stateTransitioner = Optional.empty();
-    private Optional<Consumer<String>> tombstoneWriter = Optional.empty();
+    private Optional<StateTransitioner> stateTransitioner = Optional.empty();
+    Optional<Consumer<String>> tombstoneWriter = Optional.empty();
     private Optional<Function<ClusterMirrorRecordKey, Integer>> coordPartitionFinderByKey = Optional.empty();
     private Optional<Function<String, Integer>> coordPartitionFinderByName = Optional.empty();
 
@@ -260,7 +209,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Hashes by mirror name only, so all mirror-level work (source sync, config sync) is handled
      * by a single broker per mirror.
      */
-    private boolean isLocalCoordinator(String mirrorName) {
+    boolean isLocalCoordinator(String mirrorName) {
         if (coordPartitionFinderByName.isPresent() && metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME) != null) {
             int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
                     .partitions().get(coordPartitionFinderByName.get().apply(mirrorName)).leader;
@@ -288,29 +237,33 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Called by ClusterMirrorCoordinator on startup.
      * Creates and starts the MirrorStateSender used for WriteMirrorStates and ReadMirrorStates RPCs.
      * Wires in the state transitioner, tombstone handler, and coordinator partition finders.
+     * Creates the {@link MirrorSourceSyncer} and schedules periodic metadata refresh.
      */
-    public void initialize(long metadataRefreshIntervalMs,
-                           ClusterMirrorUtils.StateTransitioner stateTransitioner,
-                           Consumer<String> tombStoneHandler,
+    public void initialize(StateTransitioner stateTransitioner,
+                           Consumer<String> tombstoneWriter,
                            Function<ClusterMirrorRecordKey, Integer> coordPartitionByKeyFinder,
                            Function<String, Integer> coordPartitionByNameFinder) {
         if (mirrorStateSender == null) {
-            mirrorStateSender = new MirrorStateSender(MirrorStateSender.class.getSimpleName(),
+            this.mirrorStateSender = new MirrorStateSender(MirrorStateSender.class.getSimpleName(),
                     NetworkUtils.buildNetworkClient(MirrorMetadataManager.class.getSimpleName(), brokerConfig, metrics, time, new LogContext(name())),
                     brokerConfig.requestTimeoutMs(), Time.SYSTEM);
             mirrorStateSender.start();
         }
 
+        this.sourceSyncer = new MirrorSourceSyncer(brokerConfig, this, channelManager,
+                metadataCache, scheduler, metadataRefreshError, topicConfigSyncError,
+                consumerGroupOffsetSyncError, shareGroupOffsetSyncError, aclSyncError);
+        sourceSyncer.scheduleMetadataRefresh(brokerConfig.mirrorConfig().metadataRefreshIntervalMs());
+
         this.stateTransitioner = Optional.of(stateTransitioner);
-        this.tombstoneWriter = Optional.of(tombStoneHandler);
+        this.tombstoneWriter = Optional.of(tombstoneWriter);
         this.coordPartitionFinderByKey = Optional.of(coordPartitionByKeyFinder);
         this.coordPartitionFinderByName = Optional.of(coordPartitionByNameFinder);
-        scheduleMetadataRefresh(metadataRefreshIntervalMs);
 
         this.isInitialized = true;
     }
 
-    private Admin getOrCreateSourceAdmin(String mirrorName) {
+    Admin getOrCreateSourceAdmin(String mirrorName) {
         return srcAdmins.computeIfAbsent(mirrorName, k -> {
             Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, k));
             props.put(AdminClientConfig.CLIENT_ID_CONFIG, "mirror-src-admin-" + k + "-" + nodeId);
@@ -318,7 +271,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    private Admin getOrCreateDestAdmin() {
+    Admin getOrCreateDestAdmin() {
         if (dstAdmin == null) {
             Properties props = buildDestAdminClientProps(brokerConfig);
             // Fall back to metadataCache when the advertised port is unresolved (e.g. ephemeral port 0 in tests)
@@ -332,9 +285,65 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return dstAdmin;
     }
 
+    // Visible for testing
+    static Properties buildDestAdminClientProps(KafkaConfig brokerConfig) {
+        ListenerName mirrorAdminListener = brokerConfig.mirrorAdminListenerName();
+        Endpoint endpoint = (Endpoint) brokerConfig.effectiveAdvertisedBrokerListeners()
+                .filter(e -> e.listener().equals(mirrorAdminListener.value()))
+                .head();
+
+        Properties props = new Properties();
+        props.put(BOOTSTRAP_SERVERS_CONFIG, endpoint.host() + ":" + endpoint.port());
+        props.put(AdminClientConfig.CLIENT_ID_CONFIG, "mirror-dst-admin-" + brokerConfig.nodeId());
+
+        SecurityProtocol securityProtocol = endpoint.securityProtocol();
+        props.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, securityProtocol.name);
+
+        Map<String, ?> configs = ChannelBuilders.channelBuilderConfigs(brokerConfig, mirrorAdminListener);
+
+        // Get all the security configs
+        ConfigDef securityConfigDef = new ConfigDef().withClientSaslSupport().withClientSslSupport();
+        Set<String> securityConfigs = new HashSet<>(securityConfigDef.configKeys().keySet());
+
+        String mirrorAdminSaslMechanism = brokerConfig.saslMechanismMirrorAdminProtocol();
+        if (securityProtocol == SecurityProtocol.SASL_SSL || securityProtocol == SecurityProtocol.SASL_PLAINTEXT) {
+            props.put(SaslConfigs.SASL_MECHANISM, mirrorAdminSaslMechanism);
+        }
+
+        String saslMechanismConfigPrefix = mirrorAdminListener.saslMechanismConfigPrefix(mirrorAdminSaslMechanism);
+        Map<String, ?> saslMechanismConfigs = brokerConfig.originalsWithPrefix(saslMechanismConfigPrefix, true);
+
+        securityConfigs.forEach(key -> {
+            if (key.equals(SaslConfigs.SASL_MECHANISM)) return;
+            if (saslMechanismConfigs.containsKey(key)) {
+                props.put(key, saslMechanismConfigs.get(key));
+            } else if (configs.containsKey(key)) {
+                Object value = configs.get(key);
+                if (value == null) {
+                    return;
+                }
+                props.put(key, value);
+            }
+        });
+
+        return props;
+    }
+
     @Override
     public String name() {
         return name;
+    }
+
+    MetadataImage metadataImage() {
+        return metadataImage;
+    }
+
+    String clusterId() {
+        return clusterId;
+    }
+
+    Supplier<ReplicaManager> replicaManagerSupplier() {
+        return replicaManagerSupplier;
     }
 
     /**
@@ -342,7 +351,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Detects mirror partition leadership changes and triggers state transitions via batched coordinator reads.
      * On connection config changes, source connections are recreated, source metadata is fetched eagerly,
      * and fetchers are re-created for affected MIRRORING partitions.
-     *
+     * <p>
      * This method must be called after ReplicaManager#applyDelta.
      * The metadataCache can't be used here because it is updated concurrently.
      */
@@ -558,36 +567,24 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         pendingPartitionStates.clear();
     }
 
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state) {
-        transitionTo(mirrorName, topicPartition, state, null, false);
-    }
-
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage) {
-        transitionTo(mirrorName, topicPartition, state, errorMessage, false);
-    }
-
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
-        stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state, errorMessage, nonRetryable));
-    }
-
     /**
      * Applies the appropriate state transition based on current state and stop flag.
-     *
+     * <p>
      * stopRequested: it means the partition should head to STOPPED state. When it is true (i.e. users stopMirrorTopics):
      *   1. if it's already in STOPPED state, then keep the state
      *   2. else, move the state to STOPPING state
-     *
+     * <p>
      * pauseRequested: it means the partition should head to PAUSED state. When it is true (i.e. users pause it):
      *   1. if it's already in PAUSED state, then keep the state
      *   2. else, move the state to PAUSING state
-     *
+     * <p>
      * When stopRequested=false and pauseRequested=false:
      *   1. if it's in PAUSED state, we should move it to MIRRORING state. It will happen when users resume mirroring
      *   2. if it's in UNKNOWN, STOPPED, or FAILED state, we should move it to LOG_TRUNCATION state.
      *      UNKNOWN/STOPPED happens on startMirrorTopics. FAILED happens on manual restart after retries are exhausted.
      *   3. else, keep the same state as is. This could happen like leadership change, and the new leader should
      *      continue to complete the process in previous leader
-     *
+     * <p>
      * If the current state is FAILED, we only allow it to enter FAILED state because if we move the FAILED state based on
      * the "desired state", that means we ignore its previous state stored in FailedPartitionInfo.
      * Ex: one partition failed when LOG_TRUNCATION. We should retry LOG_TRUNCATION until exhausted. But if we honor the
@@ -597,7 +594,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private void applyStateTransition(String mirrorName, TopicPartition tp,
                                       MirrorPartitionState curState, MirrorPartitionState fetchedState,
                                       boolean stopRequested, boolean pauseRequested) {
-        // todo: come up with a better way to handle "manual" failure recovery way
         if (curState == MirrorPartitionState.FAILED) {
             transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED);
         } else if (stopRequested) {
@@ -622,914 +618,29 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    /** Schedules an immediate one-shot source topic state sync for the given mirror. */
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state) {
+        transitionTo(mirrorName, topicPartition, state, null, false);
+    }
+
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage) {
+        transitionTo(mirrorName, topicPartition, state, errorMessage, false);
+    }
+
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
+        stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state, errorMessage, nonRetryable));
+    }
+
     public void scheduleSourceTopicStateSync(String mirrorName) {
-        scheduler.scheduleOnce("SourceTopicStateSync", () -> {
-            syncSourceTopicState(mirrorName);
-        });
+        sourceSyncer.scheduleSourceTopicStateSync(mirrorName);
     }
 
-    /**
-     * Periodic source sync callback. Every broker syncs topic state from the source
-     * (needed for source leader caches, deletion detection, and missed partition recovery).
-     * Only the coordinator syncs configs, group offsets, and ACLs.
-     */
-    void runMetadataRefresh() {
-        // Retry the pending tombstone writes first to make
-        // sure they are all clean up even if no mirror existed
-        retryPendingTombstoneWrites();
-
-        Set<String> mirrors = getConfiguredMirrors();
-        if (mirrors.isEmpty()) {
-            return;
-        }
-
-        log.info("Refreshing metadata for mirrors: {}", mirrors);
-
-        for (String mirrorName : mirrors) {
-            try {
-                validateSourceClusterId(mirrorName);
-                var topicState = syncSourceTopicState(mirrorName);
-                syncSourceConfigsAndOffsets(mirrorName, topicState);
-            } catch (Exception e) {
-                log.error("Failed to refresh metadata for mirror {}", mirrorName, e);
-            }
-        }
-
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        metadataRefreshError.incrementAndGet();
-    }
-
-    private void retryPendingTombstoneWrites() {
-        if (tombstoneWriter.isEmpty()) {
-            log.warn("Mirror deletion handler not configured. Tombstone record writes will be skipped.");
-            return;
-        }
-        Set<String> configuredMirrors = getConfiguredMirrors();
-        Set<String> staleMirrors = partitionCache.keySet().stream()
-                .map(ClusterMirrorRecordKey::mirrorName)
-                .filter(name -> !configuredMirrors.contains(name))
-                .collect(Collectors.toSet());
-        for (String mirrorName : staleMirrors) {
-            log.info("Found stale partition states for deleted mirror '{}'. Writing tombstones.", mirrorName);
-            tombstoneWriter.ifPresent(h -> h.accept(mirrorName));
-        }
-    }
-
-    private void validateSourceClusterId(String mirrorName) {
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-        try {
-            var clusterResult = srcAdmin.describeCluster();
-            String newClusterId = clusterResult.clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-            if (newClusterId != null && !newClusterId.isEmpty()) {
-                String previousClusterId = getSourceClusterId(mirrorName);
-                if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
-                    String errMsg = "Source cluster ID changed for mirror " + mirrorName
-                            + ": expected " + previousClusterId + ", got " + newClusterId
-                            + ". This may indicate a misconfiguration or that the source cluster has been replaced. "
-                            + "Moving all partitions to non-retryable failed state.";
-                    log.error(errMsg);
-
-                    // Get mirrored leader partitions for this mirror in this node, and move them to non-retryable failed state
-                    Set<String> mirroredTopics = getConfiguredTopics(mirrorName, true);
-                    if (!mirroredTopics.isEmpty()) {
-                        Set<TopicPartition> mirroredLeaderPartitions = new HashSet<>();
-                        for (String topic : mirroredTopics) {
-                            TopicImage topicImage = metadataImage.topics().getTopic(topic);
-                            if (topicImage != null) {
-                                topicImage.partitions().forEach((partitionId, partition) -> {
-                                    if (partition.leader == nodeId) {
-                                        mirroredLeaderPartitions.add(new TopicPartition(topic, partitionId));
-                                    }
-                                });
-                            }
-                        }
-                        if (!mirroredLeaderPartitions.isEmpty()) {
-                            transitionTo(mirrorName, mirroredLeaderPartitions, MirrorPartitionState.FAILED, errMsg, true);
-                        }
-                    }
-                }
-            }
-        } catch (IllegalStateException e) {
-            throw e;
-        } catch (Exception e) {
-            log.warn("Failed to describe source cluster for mirror {}", mirrorName, e);
-        }
-    }
-
-    /**
-     * Lists the cluster mirrors configured on the source cluster, including their active topic names.
-     * Used before mirroring to detect mirror loops and during truncation to validate that source
-     * partitions are stopped.
-     *
-     * @param mirrorName the name of the local mirror whose source cluster to query
-     * @return the cluster mirror listings from the source cluster, or an empty list if the source
-     *         cluster does not support the ListClusterMirrors API
-     * @throws IllegalStateException if the request fails
-     */
-    Collection<ClusterMirrorListing> listSourceClusterMirrors(String mirrorName) {
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-        try {
-            // list the mirrors in the source cluster including topics not in STOPPING/STOPPED
-            return srcAdmin
-                    .listClusterMirrors(new ListClusterMirrorsOptions().shouldIncludeTopicNames(true))
-                    .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            if (e.getCause() instanceof UnsupportedVersionException) {
-                log.info("Source cluster does not support listClusterMirrors for mirror {}. Skipping mirror loop check.", mirrorName);
-                return List.of();
-            }
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            throw new IllegalStateException("Failed to list cluster mirrors from source for mirror "
-                    + mirrorName + ": " + cause.getMessage(), cause);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Failed to list cluster mirrors from source for mirror "
-                    + mirrorName + ": " + e.getMessage(), e);
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to list cluster mirrors from source for mirror "
-                    + mirrorName + ": " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Checks whether mirroring the given partitions from the source cluster would create
-     * a mirror loop, based on the mirrors currently configured on the source cluster.
-     *
-     * @param mirrorName      the local mirror being started
-     * @param topicPartitions the partitions about to be mirrored
-     * @param sourceMirrors   mirrors configured on the source cluster, as returned by
-     *                        {@link #listSourceClusterMirrors(String)}
-     * @return true if the given partitions would create a mirror loop, false otherwise
-     */
     boolean hasMirrorLoop(String mirrorName, Set<TopicPartition> topicPartitions,
                           Collection<ClusterMirrorListing> sourceMirrors) {
-        if (sourceMirrors.isEmpty()) {
-            return false;
-        }
-
-        Set<String> topicNames = topicPartitions.stream()
-                .map(TopicPartition::topic)
-                .collect(Collectors.toSet());
-
-        // for each mirror, find the mirror loop if:
-        // 1. the cluster id is the same as the local cluster id
-        // 2. the mirrored topics overlap with the topics to be mirrored
-        for (ClusterMirrorListing sourceMirror : sourceMirrors) {
-            if (!clusterId.equals(sourceMirror.sourceClusterId())) {
-                continue;
-            }
-            Set<String> overlapping = new HashSet<>(sourceMirror.topics());
-            overlapping.retainAll(topicNames);
-            if (!overlapping.isEmpty()) {
-                log.error("Mirror loop detected for mirror {}: source mirror {} is already mirroring topic(s) {}",
-                        mirrorName, sourceMirror.mirrorName(), overlapping);
-                return true;
-            }
-        }
-        return false;
+        return sourceSyncer.hasMirrorLoop(mirrorName, topicPartitions, sourceMirrors);
     }
 
-    /**
-     * Fetches topics metadata from the source cluster via Admin.describeTopics.
-     * Runs on every broker to keep partition leaders, topic creation, topic deletion, and partition counts in sync.
-     */
-    private Optional<List<SourceTopicState>> syncSourceTopicState(String mirrorName) {
-        log.info("Syncing source topic state for mirror {}", mirrorName);
-        Set<String> topics = getConfiguredTopics(mirrorName, false);
-        if (topics.isEmpty()) {
-            return Optional.empty();
-        }
-
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        try {
-            Map<String, KafkaFuture<TopicDescription>> futures = srcAdmin.describeTopics(topics).topicNameValues();
-            List<SourceTopicState> result = new ArrayList<>();
-
-            for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : futures.entrySet()) {
-                try {
-                    TopicDescription td = entry.getValue().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-                    List<SourcePartitionState> partitions = td.partitions().stream()
-                            .map(pi -> new SourcePartitionState(
-                                    new TopicPartition(td.name(), pi.partition()),
-                                    pi.leader(),
-                                    pi.leaderEpoch()))
-                            .toList();
-                    result.add(new SourceTopicState(td.name(), td.topicId(), true, partitions));
-                } catch (ExecutionException e) {
-                    if (e.getCause() instanceof UnknownTopicOrPartitionException) {
-                        result.add(new SourceTopicState(entry.getKey(), Uuid.ZERO_UUID, false, List.of()));
-                    } else {
-                        log.warn("Failed to describe topic {} for mirror {}", entry.getKey(), mirrorName, e.getCause());
-                    }
-                }
-            }
-
-            processSourceTopicState(mirrorName, result);
-            return Optional.of(result);
-        } catch (Exception e) {
-            log.warn("Failed to sync source topic state for mirror {}", mirrorName, e);
-            return Optional.empty();
-        }
-    }
-
-    private void processSourceTopicState(String mirrorName, List<SourceTopicState> sourceTopicStates) {
-        var creatableTopics = new ArrayList<CreateTopicsRequestData.CreatableTopic>();
-        var createPartitionsTopics = new CreatePartitionsRequestData.CreatePartitionsTopicCollection();
-
-        sourceTopicStates.forEach(ti -> {
-            // Use ConcurrentHashMap for thread-safe access from scheduler and fetcher threads
-            var partitionLeaders = sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
-
-            int sourcePartitionCount = ti.partitions().size();
-
-            // Skip partitions with no leader (source broker may be restarting)
-            ti.partitions().forEach(pi -> {
-                if (pi.leader() != null) {
-                    partitionLeaders.put(pi.topicPartition(),
-                            new LeaderInfo(pi.leader(), pi.leaderEpoch().orElse(0)));
-                }
-            });
-
-            // Pre-KIP-516 sources (Kafka < 2.8) return ZERO_UUID; fall back to name-based lookup
-            TopicImage destTopic = !ti.topicId().equals(Uuid.ZERO_UUID)
-                    ? metadataImage.topics().getTopic(ti.topicId())
-                    : metadataImage.topics().getTopic(ti.topic());
-
-            if (destTopic != null && destTopic.partitions().size() < sourcePartitionCount) {
-                createPartitionsTopics.add(new CreatePartitionsRequestData.CreatePartitionsTopic()
-                        .setName(ti.topic())
-                        .setCount(sourcePartitionCount)
-                        .setAssignments(null)
-                );
-            } else if (destTopic == null &&
-                    metadataImage.topics().getTopic(ti.topic()) == null &&
-                    ti.exists() && sourcePartitionCount > 0) {
-                if (pendingTopicCreations.add(ti.topic())) {
-                    creatableTopics.add(new CreateTopicsRequestData.CreatableTopic()
-                            .setName(ti.topic())
-                            .setNumPartitions(sourcePartitionCount)
-                            .setReplicationFactor(CreateTopicsRequest.NO_REPLICATION_FACTOR)
-                            .setMirrorInfo(new CreateTopicsRequestData.MirrorInfo().setTopicId(
-                                    ti.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : ti.topicId())));
-                }
-            } else if (destTopic == null &&
-                    metadataImage.topics().getTopic(ti.topic()) != null &&
-                    ti.exists()) {
-                log.error("Mirror topic {} exists on destination with TopicId {} but source has TopicId {}. "
-                                + "Delete the topic on destination and let auto-creation recreate it with the correct TopicId.",
-                        ti.topic(), metadataImage.topics().getTopic(ti.topic()).id(), ti.topicId());
-            }
-        });
-
-        // Only the coordinator creates topics and scales partitions to avoid
-        // multiple brokers racing with identical controller requests.
-        if (isLocalCoordinator(mirrorName)) {
-            if (!creatableTopics.isEmpty()) {
-                createMirrorTopics(creatableTopics);
-            }
-            maybeScalePartitions(createPartitionsTopics);
-        }
-
-        maybeFailDeletedTopics(mirrorName, sourceTopicStates);
-        maybeStartMissedPartitions(mirrorName);
-    }
-
-    /**
-     * Creates mirror topics on the destination with the source's TopicId,
-     * preserving topic identity across clusters. Called during periodic metadata
-     * sync when topics have mirror.name config but don't exist on the destination yet.
-     * Once created, onMetadataUpdate will detect them and start the mirror state machine.
-     */
-    private void createMirrorTopics(List<CreateTopicsRequestData.CreatableTopic> creatableTopics) {
-        var topicNames = creatableTopics.stream().map(CreateTopicsRequestData.CreatableTopic::name).toList();
-        creatableTopics.forEach(t -> log.info("Creating mirror topic {} on destination (partitions={}, topicId={})",
-                t.name(), t.numPartitions(), t.mirrorInfo().topicId()));
-        var createTopicsData = new CreateTopicsRequestData().setTimeoutMs(brokerConfig.requestTimeoutMs());
-        creatableTopics.forEach(createTopicsData.topics()::add);
-        ControllerRequestCompletionHandler requestCompletionHandler = new ControllerRequestCompletionHandler() {
-            @Override
-            public void onTimeout() {
-                topicNames.forEach(pendingTopicCreations::remove);
-                log.warn("Create mirror topics timed out for {}", topicNames);
-            }
-
-            @Override
-            public void onComplete(ClientResponse response) {
-                topicNames.forEach(pendingTopicCreations::remove);
-                if (response.responseBody() instanceof CreateTopicsResponse createTopicsResponse) {
-                    createTopicsResponse.data().topics().forEach(topic -> {
-                        Errors error = Errors.forCode(topic.errorCode());
-                        if (error != Errors.NONE) {
-                            log.warn("Failed to create mirror topic {}: {}", topic.name(), error.message());
-                        }
-                    });
-                }
-            }
-        };
-        channelManager.sendRequest(
-                new CreateTopicsRequest.Builder(createTopicsData),
-                requestCompletionHandler);
-    }
-
-    private void maybeScalePartitions(CreatePartitionsRequestData.CreatePartitionsTopicCollection topics) {
-        if (!topics.isEmpty()) {
-            log.debug("Detected partition count change, sending CreatePartitionsRequest: {}", topics);
-            channelManager.sendRequest(new CreatePartitionsRequest.Builder(
-                    new CreatePartitionsRequestData()
-                            .setTopics(topics)
-                            .setValidateOnly(false)
-                            .setTimeoutMs(3000)
-            ), new TimeoutHandler(log));
-        }
-    }
-
-    private void maybeFailDeletedTopics(String mirrorName, List<SourceTopicState> sourceTopicStates) {
-        List<String> deletedSourceTopicNames = new ArrayList<>(sourceTopicStates.stream()
-                .filter(ti -> !ti.exists())
-                .map(SourceTopicState::topic).toList());
-
-        if (deletedSourceTopicNames.isEmpty()) {
-            return;
-        }
-
-        // In old cluster, it is possible the broker metadata update in progress, and the returned metadata response is stale.
-        // list topic again to make sure it is indeed deleted.
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-        try {
-            Set<String> allTopics = srcAdmin.listTopics().names().get();
-            log.debug("Source topic name list: {}", allTopics);
-            deletedSourceTopicNames.removeAll(allTopics);
-        } catch (Exception e) {
-            log.warn("Failed to list topics for mirror {}, skipping deleted topic detection: {}", mirrorName, e.getMessage());
-            return;
-        }
-
-        getConfiguredTopics(mirrorName, true).forEach(name -> {
-            if (deletedSourceTopicNames.contains(name)) {
-                log.info("Detected topic {} deleted in remote cluster {}, marking mirror partitions as non-retryable", name, mirrorName);
-                TopicImage topicImage = metadataImage.topics().getTopic(name);
-                if (topicImage != null) {
-                    topicImage.partitions().forEach((partitionId, partition) ->
-                            transitionTo(mirrorName, Set.of(new TopicPartition(name, partitionId)),
-                                    MirrorPartitionState.FAILED, "The source topic is deleted.", true));
-                }
-            }
-        });
-    }
-
-    /**
-     * Transitions partitions stuck in UNKNOWN because their source leader was not yet known
-     * when onMetadataUpdate first ran.
-     *
-     * The race: processSourceTopicState creates a mirror topic on the destination, which
-     * triggers onMetadataUpdate. That callback needs the source leader in sourceLeaders to
-     * transition the partition to LOG_TRUNCATION. If the source has not elected a leader yet
-     * (or the Admin describeTopics response arrived without one), the partition stays in
-     * UNKNOWN. Since onMetadataUpdate only fires on destination metadata changes, it will
-     * not retry on its own.
-     *
-     * This is more likely against older source clusters (e.g. Kafka 2.1 with ZK) where
-     * Admin.describeTopics goes through three round trips before returning topic metadata:
-     * describeCluster (node discovery), DescribeTopicPartitions (rejected with
-     * UnsupportedVersionException), then MetadataRequest (fallback). The extra latency
-     * widens the window in which the source leader is not yet known.
-     */
-    private void maybeStartMissedPartitions(String mirrorName) {
-        var partitionLeaders = sourceLeaders.get(mirrorName);
-        if (partitionLeaders == null) {
-            return;
-        }
-        partitionLeaders.keySet().forEach(tp -> {
-            ClusterMirrorRecordKey key = ClusterMirrorRecordKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
-            PartitionCacheEntry cachedEntry = partitionCache.get(key);
-            if (cachedEntry != null && cachedEntry.state() != null && cachedEntry.state() != MirrorPartitionState.UNKNOWN) {
-                return;
-            }
-            TopicImage topicImage = metadataImage.topics().getTopic(tp.topic());
-            if (topicImage == null) {
-                return;
-            }
-            // Skip stopped/paused topics: if the partition cache was cleared (e.g. coordinator
-            // leadership change), the state defaults to UNKNOWN and would be restarted here.
-            byte desiredState = topicImage.desiredMirrorState();
-            if (desiredState == MirrorPartitionState.STOPPED.value()
-                    || desiredState == MirrorPartitionState.PAUSED.value()) {
-                return;
-            }
-            var partition = topicImage.partitions().get(tp.partition());
-            if (partition != null && partition.leader == nodeId) {
-                log.info("Source leader for {} discovered after initial onMetadataUpdate, transitioning to LOG_TRUNCATION", tp);
-                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
-            }
-        });
-    }
-
-    /**
-     * Syncs topic configurations, consumer/share group offsets, ACLs, and topic patterns
-     * from the source cluster. Runs only on the coordinator broker for each mirror.
-     */
-    private void syncSourceConfigsAndOffsets(String mirrorName, Optional<List<SourceTopicState>> sourceTopicStates) {
-        if (!isLocalCoordinator(mirrorName)) {
-            return;
-        }
-
-        log.info("Syncing source configs and offsets for mirror {}", mirrorName);
-
-        try {
-            ClusterMirrorConfig mirrorConfig = ClusterMirrorConfig.fromProperties(
-                    metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName)));
-            syncTopicConfigs(mirrorName, mirrorConfig);
-            syncGroupOffsets(mirrorName, mirrorConfig);
-            syncAcls(mirrorName, mirrorConfig);
-            if (!getConfiguredTopics(mirrorName, false, false).isEmpty()) {
-                maybeBumpLeaderEpochs(mirrorName, sourceTopicStates, Set.of());
-            }
-            discoverTopicsByPattern(mirrorName, mirrorConfig);
-            enforceExcludePatterns(mirrorName, mirrorConfig);
-        } catch (Exception e) {
-            log.error("Failed to sync mirror metadata for mirror {}", mirrorName, e);
-        }
-    }
-
-    private void syncTopicConfigs(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        Set<String> topics = getConfiguredTopics(mirrorName, false);
-        log.debug("Describing topic configs for topics: {}", topics);
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        topicConfigSyncError.incrementAndGet();
-
-        Collection<ConfigResource> resources = topics.stream()
-                .map(topic -> new ConfigResource(ConfigResource.Type.TOPIC, topic))
-                .toList();
-
-        try {
-            Map<ConfigResource, Config> sourceConfigs = srcAdmin.describeConfigs(resources)
-                    .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-            Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(sourceConfigs, mirrorConfig);
-            applyConfigurationChanges(configsToChange);
-        } catch (Exception e) {
-            log.warn("Failed to describe topic configs for mirror {}: {}", mirrorName, e.getMessage());
-        }
-    }
-
-    private Map<String, Map<String, String>> detectConfigurationChanges(
-            Map<ConfigResource, Config> sourceConfigs, ClusterMirrorConfig mirrorConfig) {
-        Map<String, Map<String, String>> configsToChange = new HashMap<>();
-        Pattern excludePattern = mirrorConfig.topicPropertiesExcludePattern();
-
-        sourceConfigs.forEach((resource, config) -> {
-            if (resource.type() == ConfigResource.Type.TOPIC) {
-                Properties props = metadataCache.topicConfig(resource.name());
-                Map<String, String> conChange = new HashMap<>();
-
-                config.entries().forEach(entry -> {
-                    if (entry.source() == ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG
-                            && (excludePattern == null || !excludePattern.matcher(entry.name()).matches())) {
-                        if (props.containsKey(entry.name())) {
-                            if (!props.get(entry.name()).equals(entry.value())) {
-                                conChange.put(entry.name(), entry.value());
-                            }
-                        } else {
-                            conChange.put(entry.name(), entry.value());
-                        }
-                    }
-                });
-
-                if (!conChange.isEmpty()) {
-                    configsToChange.put(resource.name(), conChange);
-                }
-            }
-        });
-
-        return configsToChange;
-    }
-
-    private void applyConfigurationChanges(Map<String, Map<String, String>> configsToChange) {
-        log.debug("Applying config change: {}", configsToChange);
-
-        Map<ConfigResource, Collection<AlterConfigOp>> configOps = new HashMap<>();
-        configsToChange.forEach((name, changes) -> {
-            var changeList = changes.entrySet().stream()
-                    .map(entry -> new AlterConfigOp(new ConfigEntry(entry.getKey(), entry.getValue()), AlterConfigOp.OpType.SET))
-                    .toList();
-            configOps.put(new ConfigResource(ConfigResource.Type.TOPIC, name), changeList);
-        });
-
-        if (!configOps.isEmpty()) {
-            IncrementalAlterConfigsRequestData data = new IncrementalAlterConfigsRequestData().setValidateOnly(false);
-            for (Map.Entry<ConfigResource, Collection<AlterConfigOp>> entry : configOps.entrySet()) {
-                ConfigResource resource = entry.getKey();
-                IncrementalAlterConfigsRequestData.AlterableConfigCollection alterableConfigSet =
-                        new IncrementalAlterConfigsRequestData.AlterableConfigCollection();
-                for (AlterConfigOp configEntry : configOps.get(resource))
-                    alterableConfigSet.add(new IncrementalAlterConfigsRequestData.AlterableConfig()
-                            .setName(configEntry.configEntry().name())
-                            .setValue(configEntry.configEntry().value())
-                            .setConfigOperation(configEntry.opType().id()));
-                IncrementalAlterConfigsRequestData.AlterConfigsResource alterConfigsResource =
-                        new IncrementalAlterConfigsRequestData.AlterConfigsResource();
-                alterConfigsResource.setResourceType(resource.type().id())
-                        .setResourceName(resource.name()).setConfigs(alterableConfigSet);
-                data.resources().add(alterConfigsResource);
-            }
-            channelManager.sendRequest(new IncrementalAlterConfigsRequest.Builder(data), new TimeoutHandler(log));
-        }
-    }
-
-    /**
-     * Syncs group offsets from the source cluster to the destination in two phases:
-     * consumer groups first, then share groups. Keeping them separate avoids cross-type
-     * conflicts where a consumer group on the source could overwrite a share group with
-     * the same name on the destination (or vice versa).
-     */
-    private void syncGroupOffsets(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        Set<String> mirrorTopics = getConfiguredTopics(mirrorName, false, false);
-        if (mirrorTopics.isEmpty()) {
-            return;
-        }
-
-        Pattern groupsIncludePattern = mirrorConfig.groupsIncludePattern();
-        Pattern groupsExcludePattern = mirrorConfig.groupsExcludePattern();
-
-        syncConsumerGroupOffsets(srcAdmin, mirrorName, mirrorTopics, groupsIncludePattern, groupsExcludePattern);
-        syncShareGroupOffsets(srcAdmin, mirrorName, mirrorTopics, groupsIncludePattern, groupsExcludePattern);
-    }
-
-    private void syncConsumerGroupOffsets(Admin srcAdmin, String mirrorName, Set<String> mirrorTopics,
-                                          Pattern groupsIncludePattern, Pattern groupsExcludePattern) {
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        consumerGroupOffsetSyncError.incrementAndGet();
-        try {
-            List<String> sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forConsumerGroups(),
-                    groupsIncludePattern, groupsExcludePattern);
-            if (sourceGroupIds.isEmpty()) {
-                return;
-            }
-            log.info("Syncing consumer group offsets for mirror {}, groups={}", mirrorName, sourceGroupIds);
-
-            Map<String, ListConsumerGroupOffsetsSpec> groupSpecs = sourceGroupIds.stream()
-                    .collect(Collectors.toMap(id -> id, id -> new ListConsumerGroupOffsetsSpec()));
-            Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets = srcAdmin
-                    .listConsumerGroupOffsets(groupSpecs).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            Optional<Set<String>> activeDestGroups = getActiveDestinationGroupIds(ListGroupsOptions.forConsumerGroups());
-            if (activeDestGroups.isEmpty()) {
-                return;
-            }
-
-            for (var entry : allOffsets.entrySet()) {
-                String groupId = entry.getKey();
-                if (activeDestGroups.get().contains(groupId)) {
-                    log.warn("Skipping consumer group offset sync for group {} in mirror {}: active on destination", groupId, mirrorName);
-                    continue;
-                }
-
-                Map<TopicPartition, OffsetAndMetadata> filtered = new HashMap<>();
-                entry.getValue().entrySet().stream()
-                        .filter(e -> mirrorTopics.contains(e.getKey().topic()))
-                        .forEach(ent -> {
-                            TopicPartition topicPartition = ent.getKey();
-                            Option<Long> logStartOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
-                            Option<Long> logEndOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
-                            if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
-                                log.debug("Cannot get the log start offset or log end offset for partition {}, skip consumer group sync for it.", topicPartition);
-                                return;
-                            }
-                            OffsetAndMetadata sourceGroupOffsetAndMetadata = ent.getValue();
-
-                            // Committing to the range [local logStartOffset ~ local logEndOffset]
-                            long finalOffset = Math.max(logStartOffset.get(), Math.min(sourceGroupOffsetAndMetadata.offset(), logEndOffset.get()));
-
-                            if (finalOffset == sourceGroupOffsetAndMetadata.offset()) {
-                                filtered.put(topicPartition, sourceGroupOffsetAndMetadata);
-                            } else if (finalOffset == logEndOffset.get()) {
-                                int logEndEpoch = replicaManagerSupplier.get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logEndOffset.get()).orElse(-1)).getOrElse(() -> -1);
-                                if (logEndEpoch < 0) {
-                                    log.debug("Cannot get the log end epoch for partition {}, skip consumer group sync for it.", topicPartition);
-                                } else {
-                                    filtered.put(topicPartition, new OffsetAndMetadata(logEndOffset.get(), Optional.of(logEndEpoch), ""));
-                                }
-                            } else {
-                                // finalOffset == logStartOffset
-                                int logStartEpoch = replicaManagerSupplier.get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logStartOffset.get()).orElse(-1)).getOrElse(() -> -1);
-                                if (logStartEpoch < 0) {
-                                    log.debug("Cannot get the log start epoch for partition {}, skip consumer group sync for it.", topicPartition);
-                                } else {
-                                    filtered.put(topicPartition, new OffsetAndMetadata(logStartOffset.get(), Optional.of(logStartEpoch), ""));
-                                }
-                            }
-                        });
-
-                if (filtered.isEmpty()) {
-                    continue;
-                }
-
-                try {
-                    log.debug("Committing consumer group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
-                    getOrCreateDestAdmin().alterConsumerGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-                } catch (Exception e) {
-                    log.warn("Failed to commit consumer group offsets for group {} in mirror {}: {}", groupId, mirrorName, e.getMessage());
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Failed to sync consumer group offsets for mirror {}: {}", mirrorName, e.getMessage());
-        }
-    }
-
-    private void syncShareGroupOffsets(Admin srcAdmin, String mirrorName, Set<String> mirrorTopics,
-                                       Pattern groupsIncludePattern, Pattern groupsExcludePattern) {
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        shareGroupOffsetSyncError.incrementAndGet();
-        try {
-            List<String> sourceGroupIds;
-            try {
-                sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forShareGroups(),
-                        groupsIncludePattern, groupsExcludePattern);
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnsupportedVersionException) {
-                    log.debug("The source cluster doesn't support share group, skipping share group offset sync");
-                    return;
-                } else {
-                    throw e;
-                }
-            }
-            if (sourceGroupIds.isEmpty()) {
-                return;
-            }
-            log.info("Syncing share group offsets for mirror {}, groups={}", mirrorName, sourceGroupIds);
-
-            Map<String, ListShareGroupOffsetsSpec> groupSpecs = sourceGroupIds.stream()
-                    .collect(Collectors.toMap(id -> id, id -> new ListShareGroupOffsetsSpec()));
-            Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets = srcAdmin
-                    .listShareGroupOffsets(groupSpecs).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            Optional<Set<String>> activeDestGroups = getActiveDestinationGroupIds(ListGroupsOptions.forShareGroups());
-            if (activeDestGroups.isEmpty()) {
-                return;
-            }
-
-            for (var entry : allOffsets.entrySet()) {
-                String groupId = entry.getKey();
-                if (activeDestGroups.get().contains(groupId)) {
-                    log.warn("Skipping share group offset sync for group {} in mirror {}: active on destination", groupId, mirrorName);
-                    continue;
-                }
-
-                Map<TopicPartition, Long> filtered = new  HashMap<>();
-                entry.getValue().entrySet().stream()
-                        .filter(e -> mirrorTopics.contains(e.getKey().topic()))
-                        .forEach(ent -> {
-                            TopicPartition topicPartition = ent.getKey();
-                            Option<Long> logStartOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
-                            Option<Long> logEndOffset = replicaManagerSupplier.get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
-                            if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
-                                log.debug("Cannot get the log start offset or log end offset for partition {}, skip share group offset sync for it.", topicPartition);
-                                return;
-                            }
-                            OffsetAndMetadata sourceGroupOffsetAndMetadata = ent.getValue();
-                            // Committing to the range [local logStartOffset ~ local logEndOffset]
-                            long finalOffset = Math.max(logStartOffset.get(), Math.min(sourceGroupOffsetAndMetadata.offset(), logEndOffset.get()));
-                            filtered.put(topicPartition, finalOffset);
-                        });
-                if (filtered.isEmpty()) {
-                    continue;
-                }
-
-                try {
-                    log.debug("Committing share group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
-                    getOrCreateDestAdmin().alterShareGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-                } catch (Exception e) {
-                    log.warn("Failed to commit share group offsets for group {} in mirror {}: {}", groupId, mirrorName, e);
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Failed to sync share group offsets for mirror {}: {}", mirrorName, e);
-        }
-    }
-
-    private List<String> listSourceGroupIds(Admin srcAdmin, ListGroupsOptions options,
-                                            Pattern groupsIncludePattern, Pattern groupsExcludePattern) throws Exception {
-        return srcAdmin.listGroups(options).all()
-                .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
-                .map(GroupListing::groupId)
-                .filter(id -> groupsIncludePattern == null || groupsIncludePattern.matcher(id).matches())
-                .filter(id -> groupsExcludePattern == null || !groupsExcludePattern.matcher(id).matches())
-                .toList();
-    }
-
-    /**
-     * Returns the set of destination group IDs that should not be overwritten during offset sync
-     * (groups in STABLE, PREPARING_REBALANCE, COMPLETING_REBALANCE, ASSIGNING, or RECONCILING state).
-     *
-     * @return the group IDs to skip, or empty Optional on failure so the caller can skip the sync cycle
-     */
-    private Optional<Set<String>> getActiveDestinationGroupIds(ListGroupsOptions typeFilter) {
-        try {
-            var options = typeFilter.inGroupStates(Set.of(
-                    GroupState.STABLE,
-                    GroupState.PREPARING_REBALANCE,
-                    GroupState.COMPLETING_REBALANCE,
-                    GroupState.ASSIGNING,
-                    GroupState.RECONCILING));
-            return Optional.of(getOrCreateDestAdmin().listGroups(options).all()
-                    .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
-                    .map(GroupListing::groupId)
-                    .collect(Collectors.toSet()));
-        } catch (Exception e) {
-            log.warn("Failed to list destination groups, skipping offset sync cycle.", e);
-            return Optional.empty();
-        }
-    }
-
-    private void syncAcls(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        // TODO: We currently mirror all ACLs from the source to the target.
-        //       Any ACLs added/removed directly on the target will be overwritten
-        //       on the next sync to match the source.
-        //
-        // TODO: How do we disambiguate ACLs that reference the same resource name
-        //       when multiple cluster mirrors exist?
-
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
-        aclSyncError.incrementAndGet();
-
-        try {
-            Collection<AclBinding> sourceAcls = srcAdmin.describeAcls(AclBindingFilter.ANY)
-                    .values().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            log.debug("Describe ACLs response from remote cluster {}: {}", mirrorName, sourceAcls);
-
-            List<MirrorFilterUtils.AclRule> aclIncludeRules = mirrorConfig.aclIncludeRules();
-            var allRemoteAcls = sourceAcls.stream()
-                    .filter(acl -> aclIncludeRules.stream().anyMatch(rule -> rule.matches(acl)))
-                    .toList();
-            var aclChanges = detectAclChanges(allRemoteAcls);
-            applyAclChanges(mirrorName, aclChanges);
-        } catch (ExecutionException e) {
-            if (e.getCause() instanceof SecurityDisabledException) {
-                log.debug("ACL sync skipped for mirror {}: {}", mirrorName, e.getCause().getMessage());
-            } else {
-                log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
-            }
-        } catch (Exception e) {
-            log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
-        }
-    }
-
-    private SourceAclChanges detectAclChanges(List<AclBinding> sourceAcls) {
-        var addACLsList = new ArrayList<AclBinding>();
-        var deleteACLsList = new ArrayList<AclBinding>();
-        var current = metadataImage.acls().acls().values();
-
-        // collect missing acls list
-        sourceAcls.forEach(acl -> {
-            if (current.stream().map(StandardAcl::toBinding).noneMatch(a -> a.equals(acl))) {
-                addACLsList.add(acl);
-            }
-        });
-
-        // collect remove acls list (skip CLUSTER_MIRROR ACLs as they are destination-specific)
-        metadataImage.acls().acls().values().forEach(acl -> {
-            if (acl.resourceType() != ResourceType.CLUSTER_MIRROR && !sourceAcls.contains(acl.toBinding())) {
-                deleteACLsList.add(acl.toBinding());
-            }
-        });
-
-        return new SourceAclChanges(addACLsList, deleteACLsList);
-    }
-
-    private void applyAclChanges(String mirrorName, SourceAclChanges aclChanges) {
-        // send createAcls request
-        if (!aclChanges.aclsToAdd().isEmpty()) {
-            log.debug("Adding {} ACLs from remote cluster {}", aclChanges.aclsToAdd().size(), mirrorName);
-            var requestData = aclChanges.aclsToAdd().stream().map(
-                            aclBinding -> new CreateAclsRequestData.AclCreation()
-                                    .setResourceType(aclBinding.pattern().resourceType().code())
-                                    .setResourceName(aclBinding.pattern().name())
-                                    .setResourcePatternType(aclBinding.pattern().patternType().code())
-                                    .setPrincipal(aclBinding.entry().principal())
-                                    .setHost(aclBinding.entry().host())
-                                    .setOperation(aclBinding.entry().operation().code())
-                                    .setPermissionType(aclBinding.entry().permissionType().code()))
-                    .toList();
-            channelManager.sendRequest(
-                    new CreateAclsRequest.Builder(new CreateAclsRequestData().setCreations(requestData)),
-                    new TimeoutHandler(log)
-            );
-        }
-
-        // send deleteAcls request
-        if (!aclChanges.aclsToDelete().isEmpty()) {
-            log.debug("Removing {} ACLs from remote cluster {}", aclChanges.aclsToDelete().size(), mirrorName);
-            var requestData = aclChanges.aclsToDelete().stream().map(
-                            aclBinding -> new DeleteAclsRequestData.DeleteAclsFilter()
-                                    .setResourceTypeFilter(aclBinding.pattern().resourceType().code())
-                                    .setResourceNameFilter(aclBinding.pattern().name())
-                                    .setPatternTypeFilter(aclBinding.pattern().patternType().code())
-                                    .setPrincipalFilter(aclBinding.entry().principal())
-                                    .setHostFilter(aclBinding.entry().host())
-                                    .setOperation(aclBinding.entry().operation().code())
-                                    .setPermissionType(aclBinding.entry().permissionType().code()))
-                    .toList();
-            channelManager.sendRequest(
-                    new DeleteAclsRequest.Builder(new DeleteAclsRequestData().setFilters(requestData)),
-                    new TimeoutHandler(log)
-            );
-        }
-    }
-
-    private void discoverTopicsByPattern(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        final Pattern topicsIncludePattern = mirrorConfig.topicsIncludePattern();
-        if (topicsIncludePattern == null) {
-            return;
-        }
-
-        Admin srcAdmin = getOrCreateSourceAdmin(mirrorName);
-
-        Set<String> configuredTopics = getConfiguredTopics(mirrorName, true);
-        final Pattern topicsExcludePattern = mirrorConfig.topicsExcludePattern();
-
-        List<StartMirrorTopicsRequestData.TopicMetadata> newTopics;
-        try {
-            Set<String> allSourceTopics = srcAdmin.listTopics()
-                    .names().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            List<String> candidates = allSourceTopics.stream()
-                    .filter(name -> topicsIncludePattern.matcher(name).matches())
-                    .filter(name -> topicsExcludePattern == null || !topicsExcludePattern.matcher(name).matches())
-                    .filter(name -> !configuredTopics.contains(name))
-                    .toList();
-
-            if (candidates.isEmpty()) {
-                return;
-            }
-
-            Map<String, TopicDescription> descriptions = srcAdmin.describeTopics(candidates)
-                    .allTopicNames().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-
-            cacheSourceLeaders(mirrorName, descriptions.values());
-
-            newTopics = descriptions.values().stream()
-                    .map(td -> new StartMirrorTopicsRequestData.TopicMetadata()
-                            .setTopicName(td.name())
-                            .setTopicId(td.topicId())
-                            .setNumPartitions(td.partitions().size()))
-                    .toList();
-        } catch (Exception e) {
-            log.warn("Failed to discover topics by pattern for mirror {}", mirrorName, e);
-            return;
-        }
-
-        if (newTopics.isEmpty()) {
-            return;
-        }
-
-        log.info("Discovered {} new topic(s) matching mirror.topics.include pattern for mirror {}: {}",
-                newTopics.size(), mirrorName, newTopics.stream().map(StartMirrorTopicsRequestData.TopicMetadata::topicName).toList());
-
-        // TODO: creation failures from auto-discovery are silently lost here (fire-and-forget).
-        //  Add per-topic status tracking so describeMirror can surface failed topics to users.
-        try {
-            getOrCreateDestAdmin().startMirrorTopics(
-                    mirrorName,
-                    newTopics.stream().map(StartMirrorTopicsRequestData.TopicMetadata::topicName).collect(Collectors.toSet()),
-                    new StartMirrorTopicsOptions()).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            log.warn("Failed to start discovered topics for mirror {}: {}", mirrorName, e.getMessage());
-        }
-    }
-
-    /**
-     * Checks if any active mirror topics now match the exclude pattern and sends
-     * StopMirrorTopicsRequest to stop them. Catches cases where exclude was updated
-     * via incrementalAlterConfigs outside of the startMirrorTopics/stopMirrorTopics flow.
-     */
-    private void enforceExcludePatterns(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Pattern excludePattern = mirrorConfig.topicsExcludePattern();
-        if (excludePattern == null) return;
-
-        Set<String> activeTopics = getConfiguredTopics(mirrorName, false, false);
-        Set<String> excludedTopics = activeTopics.stream()
-                .filter(topic -> excludePattern.matcher(topic).matches())
-                .collect(Collectors.toSet());
-
-        if (excludedTopics.isEmpty()) return;
-
-        log.info("Stopping {} topic(s) matching mirror.topics.exclude for mirror {}: {}",
-                excludedTopics.size(), mirrorName, excludedTopics);
-
-        try {
-            getOrCreateDestAdmin().stopMirrorTopics(mirrorName, excludedTopics, new StopMirrorTopicsOptions())
-                    .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            log.warn("Failed to stop excluded topics for mirror {}: {}", mirrorName, e.getMessage());
-        }
+    Collection<ClusterMirrorListing> listSourceClusterMirrors(String mirrorName) {
+        return sourceSyncer.listSourceClusterMirrors(mirrorName);
     }
 
     /**
@@ -1561,6 +672,88 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             log.warn("Exception while getting mirror coordinator", e);
             return Node.noNode();
         }
+    }
+
+    /**
+     * Reads partition states from remote coordinators, batching requests per coordinator node.
+     * Updates local cache (partitionCache) with each response.
+     */
+    void readStatesFromRemoteCoordinator(String mirrorName,
+                                         Map<String, Set<Integer>> partitions,
+                                         Consumer<ReadMirrorStatesResponse> callback) {
+        log.debug("Reading states from remote coordinator: {} {}", mirrorName, partitions);
+
+        // Group partitions by coordinator node for batching
+        Map<Node, Map<String, List<ReadMirrorStatesRequestData.PartitionData>>> nodeToTopicPartitions = new HashMap<>();
+
+        partitions.forEach((topic, parts) -> {
+            parts.forEach(part -> {
+                ClusterMirrorRecordKey key = ClusterMirrorRecordKey.of(mirrorName, metadataCache.getTopicId(topic), part);
+                Node coordinatorNode = findCoordinatorNode(key);
+                if (coordinatorNode.equals(Node.noNode())) {
+                    log.warn("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, part);
+                    return;
+                }
+
+                ReadMirrorStatesRequestData.PartitionData partitionData = new ReadMirrorStatesRequestData.PartitionData();
+                partitionData.setPartitionIndex(part);
+
+                nodeToTopicPartitions
+                        .computeIfAbsent(coordinatorNode, k -> new HashMap<>())
+                        .computeIfAbsent(topic, k -> new ArrayList<>())
+                        .add(partitionData);
+            });
+        });
+
+        // Send one batched request per coordinator node
+        nodeToTopicPartitions.forEach((node, topicPartitionsMap) -> {
+            ReadMirrorStatesRequestData data = new ReadMirrorStatesRequestData().setMirrorName(mirrorName);
+            List<ReadMirrorStatesRequestData.TopicMetadata> topicDataList = new ArrayList<>();
+
+            topicPartitionsMap.forEach((topic, partitionDataList) ->
+                    topicDataList.add(new ReadMirrorStatesRequestData.TopicMetadata()
+                            .setName(topic)
+                            .setPartitions(partitionDataList)));
+
+            data.setTopics(topicDataList);
+
+            mirrorStateSender.enqueue(new RequestAndCompletionHandler(
+                    time.milliseconds(),
+                    node,
+                    new ReadMirrorStatesRequest.Builder(data),
+                    response -> {
+                        if (response.responseBody() instanceof ReadMirrorStatesResponse readMirrorStatesResponse) {
+                            log.debug("Read states from remote coordinator completed: {}", response.responseBody());
+
+                            readMirrorStatesResponse.data().topics().forEach(topic -> {
+                                topic.partitions().forEach(partition -> {
+                                    ClusterMirrorRecordKey mpk = ClusterMirrorRecordKey.of(
+                                            mirrorName, metadataCache.getTopicId(topic.name()), partition.partitionIndex());
+                                    partitionCache.compute(mpk, (k, existing) -> {
+                                        MirrorPartitionState state = existing != null ? existing.state() : MirrorPartitionState.UNKNOWN;
+                                        int epoch = existing != null ? existing.lastMirrorEpoch() : -1;
+                                        FailedPartitionInfo fpi = existing != null ? existing.failedInfo() : null;
+                                        if (partition.lastMirrorEpoch() != -1) {
+                                            epoch = partition.lastMirrorEpoch();
+                                        }
+                                        if (partition.state() != -1) {
+                                            state = MirrorPartitionState.fromValue(partition.state());
+                                        }
+                                        if (partition.state() == MirrorPartitionState.FAILED.value()) {
+                                            fpi = new FailedPartitionInfo(
+                                                    partition.retryAttempt(), partition.errorMessage(),
+                                                    MirrorPartitionState.fromValue(partition.previousState()));
+                                        }
+                                        return new PartitionCacheEntry(state, epoch, fpi);
+                                    });
+                                });
+                            });
+
+                            callback.accept(readMirrorStatesResponse);
+                        }
+                    }
+            ));
+        });
     }
 
     /** Writes partition states to remote coordinators, batching requests per coordinator node. */
@@ -1621,91 +814,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    /**
-     * Reads partition states from remote coordinators, batching requests per coordinator node.
-     * Updates local cache (partitionCache) with each response.
-     */
-    void readStatesFromRemoteCoordinator(String mirrorName,
-                                         Map<String, Set<Integer>> partitions,
-                                         Consumer<ReadMirrorStatesResponse> callback) {
-        log.debug("Reading states from remote coordinator: {} {}", mirrorName, partitions);
-
-        // Group partitions by coordinator node for batching
-        Map<Node, Map<String, List<ReadMirrorStatesRequestData.PartitionData>>> nodeToTopicPartitions = new HashMap<>();
-
-        partitions.forEach((topic, parts) -> {
-            parts.forEach(part -> {
-                ClusterMirrorRecordKey key = ClusterMirrorRecordKey.of(mirrorName, metadataCache.getTopicId(topic), part);
-                Node coordinatorNode = findCoordinatorNode(key);
-                if (coordinatorNode.equals(Node.noNode())) {
-                    log.warn("Coordinator is not available for mirror {} partition {}-{}", mirrorName, topic, part);
-                    return;
-                }
-
-                ReadMirrorStatesRequestData.PartitionData partitionData = new ReadMirrorStatesRequestData.PartitionData();
-                partitionData.setPartitionIndex(part);
-
-                nodeToTopicPartitions
-                    .computeIfAbsent(coordinatorNode, k -> new HashMap<>())
-                    .computeIfAbsent(topic, k -> new ArrayList<>())
-                    .add(partitionData);
-            });
-        });
-
-        // Send one batched request per coordinator node
-        nodeToTopicPartitions.forEach((node, topicPartitionsMap) -> {
-            ReadMirrorStatesRequestData data = new ReadMirrorStatesRequestData().setMirrorName(mirrorName);
-            List<ReadMirrorStatesRequestData.TopicMetadata> topicDataList = new ArrayList<>();
-
-            topicPartitionsMap.forEach((topic, partitionDataList) ->
-                topicDataList.add(new ReadMirrorStatesRequestData.TopicMetadata()
-                    .setName(topic)
-                    .setPartitions(partitionDataList)));
-
-            data.setTopics(topicDataList);
-
-            mirrorStateSender.enqueue(new RequestAndCompletionHandler(
-                time.milliseconds(),
-                node,
-                new ReadMirrorStatesRequest.Builder(data),
-                response -> {
-                    if (response.responseBody() instanceof ReadMirrorStatesResponse readMirrorStatesResponse) {
-                        log.debug("Read states from remote coordinator completed: {}", response.responseBody());
-
-                        readMirrorStatesResponse.data().topics().forEach(topic -> {
-                            topic.partitions().forEach(partition -> {
-                                ClusterMirrorRecordKey mpk = ClusterMirrorRecordKey.of(
-                                        mirrorName, metadataCache.getTopicId(topic.name()), partition.partitionIndex());
-                                partitionCache.compute(mpk, (k, existing) -> {
-                                    MirrorPartitionState state = existing != null ? existing.state() : MirrorPartitionState.UNKNOWN;
-                                    int epoch = existing != null ? existing.lastMirrorEpoch() : -1;
-                                    FailedPartitionInfo fpi = existing != null ? existing.failedInfo() : null;
-                                    if (partition.lastMirrorEpoch() != -1) {
-                                        epoch = partition.lastMirrorEpoch();
-                                    }
-                                    if (partition.state() != -1) {
-                                        state = MirrorPartitionState.fromValue(partition.state());
-                                    }
-                                    if (partition.state() == MirrorPartitionState.FAILED.value()) {
-                                        fpi = new FailedPartitionInfo(
-                                                partition.retryAttempt(), partition.errorMessage(),
-                                                MirrorPartitionState.fromValue(partition.previousState()));
-                                    }
-                                    return new PartitionCacheEntry(state, epoch, fpi);
-                                });
-                            });
-                        });
-
-                        callback.accept(readMirrorStatesResponse);
-                    }
-                }
-            ));
-        });
-    }
-
     /** Reads partition states and offsets from local cache. Used when this broker is the coordinator. */
-    void getTopicMetadata(String mirrorName,
-                          Map<String, Set<Integer>> partitions,
+    void getTopicMetadata(String mirrorName, Map<String, Set<Integer>> partitions,
                           Consumer<ReadMirrorStatesResponse> responseCallback) {
         ReadMirrorStatesResponseData data = new ReadMirrorStatesResponseData();
         List<ReadMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
@@ -1737,50 +847,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
         data.setTopics(topicResults);
         responseCallback.accept(new ReadMirrorStatesResponse(data));
-    }
-
-    // Visible for testing
-    static Properties buildDestAdminClientProps(KafkaConfig brokerConfig) {
-        ListenerName mirrorAdminListener = brokerConfig.mirrorAdminListenerName();
-        Endpoint endpoint = (Endpoint) brokerConfig.effectiveAdvertisedBrokerListeners()
-                .filter(e -> e.listener().equals(mirrorAdminListener.value()))
-                .head();
-
-        Properties props = new Properties();
-        props.put(BOOTSTRAP_SERVERS_CONFIG, endpoint.host() + ":" + endpoint.port());
-        props.put(AdminClientConfig.CLIENT_ID_CONFIG, "mirror-dst-admin-" + brokerConfig.nodeId());
-
-        SecurityProtocol securityProtocol = endpoint.securityProtocol();
-        props.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, securityProtocol.name);
-
-        Map<String, ?> configs = ChannelBuilders.channelBuilderConfigs(brokerConfig, mirrorAdminListener);
-
-        // Get all the security configs
-        ConfigDef securityConfigDef = new ConfigDef().withClientSaslSupport().withClientSslSupport();
-        Set<String> securityConfigs = new HashSet<>(securityConfigDef.configKeys().keySet());
-
-        String mirrorAdminSaslMechanism = brokerConfig.saslMechanismMirrorAdminProtocol();
-        if (securityProtocol == SecurityProtocol.SASL_SSL || securityProtocol == SecurityProtocol.SASL_PLAINTEXT) {
-            props.put(SaslConfigs.SASL_MECHANISM, mirrorAdminSaslMechanism);
-        }
-
-        String saslMechanismConfigPrefix = mirrorAdminListener.saslMechanismConfigPrefix(mirrorAdminSaslMechanism);
-        Map<String, ?> saslMechanismConfigs = brokerConfig.originalsWithPrefix(saslMechanismConfigPrefix, true);
-
-        securityConfigs.forEach(key -> {
-            if (key.equals(SaslConfigs.SASL_MECHANISM)) return;
-            if (saslMechanismConfigs.containsKey(key)) {
-                props.put(key, saslMechanismConfigs.get(key));
-            } else if (configs.containsKey(key)) {
-                Object value = configs.get(key);
-                if (value == null) {
-                    return;
-                }
-                props.put(key, value);
-            }
-        });
-
-        return props;
     }
 
     /** Updates cached source leader for a specific partition. */
@@ -1817,7 +883,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     void removeStateForPartitions(Set<TopicPartition> partitions) {
-        partitions.forEach(tp -> pendingPartitionStates.remove(tp));
+        partitions.forEach(pendingPartitionStates::remove);
         pendingLeaderEpochBumps.removeIf(bump -> {
             bump.partitionToEpoch().keySet().removeAll(partitions);
             if (bump.partitionToEpoch().isEmpty()) {
@@ -1841,78 +907,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return entry != null ? entry.state() : null;
     }
 
-    /** Schedules a source topic state sync followed by a leader epoch bump request. */
+    /** Delegates to {@link MirrorSourceSyncer#scheduleBumpLeaderEpochs}. */
     public CompletableFuture<Void> scheduleBumpLeaderEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        scheduler.scheduleOnce("bump-leader-epoch", () -> {
-            Optional<List<SourceTopicState>> sourceTopicStates = syncSourceTopicState(mirrorName);
-            maybeBumpLeaderEpochs(mirrorName, sourceTopicStates, topicPartitions)
-                    .whenComplete((v, ex) -> {
-                        if (ex != null) {
-                            future.completeExceptionally(ex);
-                        } else {
-                            future.complete(null);
-                        }
-                    });
-        });
-        return future;
+        return sourceSyncer.scheduleBumpLeaderEpochs(mirrorName, topicPartitions);
     }
 
-    private CompletableFuture<Void> maybeBumpLeaderEpochs(String mirrorName, Optional<List<SourceTopicState>> sourceTopicStates, Set<TopicPartition> topicPartitions) {
-        if (sourceTopicStates.isPresent()) {
-            return sendBumpLeaderEpochs(buildSourceEpochBumpTargets(mirrorName, sourceTopicStates.get(), topicPartitions))
-                    .whenComplete((v, ex) -> {
-                        if (ex != null) log.warn("Failed to bump leader epoch for mirror {}", mirrorName, ex);
-                    });
-        }
-        return CompletableFuture.completedFuture(null);
-    }
-
-    /** Sends an AlterPartition request to bump leader epochs on the destination. */
+    /** Delegates to {@link MirrorSourceSyncer#sendBumpLeaderEpochs}. */
     public CompletableFuture<Void> sendBumpLeaderEpochs(Map<TopicPartition, Integer> partitionMinEpochs) {
-        if (partitionMinEpochs.isEmpty()) {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        log.info("Sending bump leader epoch request: {}", partitionMinEpochs);
-        CompletableFuture<Void> future = new CompletableFuture<>();
-
-        List<BumpLeaderEpochsRequestData.TopicState> topicStates = new ArrayList<>();
-        Map<String, Set<Integer>> partitions = new HashMap<>();
-        partitionMinEpochs.keySet().forEach(tp -> {
-            partitions.computeIfAbsent(tp.topic(), key -> new HashSet<>()).add(tp.partition());
-        });
-        partitions.forEach((topic, parts) -> {
-            BumpLeaderEpochsRequestData.TopicState topicState = new BumpLeaderEpochsRequestData.TopicState();
-            List<BumpLeaderEpochsRequestData.LeaderEpochState> topicLeaderEpoch = new ArrayList<>();
-            parts.forEach(partitionId -> {
-                TopicPartition tp = new TopicPartition(topic, partitionId);
-                topicLeaderEpoch.add(new BumpLeaderEpochsRequestData.LeaderEpochState().setMinLeaderEpoch(partitionMinEpochs.get(tp)).setPartitionIndex(partitionId));
-            });
-            topicState.setTopicId(metadataCache.getTopicId(topic)).setPartitions(topicLeaderEpoch);
-            topicStates.add(topicState);
-        });
-
-        pendingLeaderEpochBumps.add(new LeaderEpochBump(future, new ConcurrentHashMap<>(partitionMinEpochs)));
-        maybeCompletePendingEpochBumps(); // already-met condition is detected immediately (e.g. epoch 11 vs target 0)
-
-        channelManager.sendRequest(new BumpLeaderEpochsRequest.Builder(
-                new BumpLeaderEpochsRequestData().setTopics(topicStates)
-        ), new ControllerRequestCompletionHandler() {
-            @Override
-            public void onComplete(ClientResponse response) {
-                log.debug("Bump leader epoch response: {}", response);
-            }
-
-            @Override
-            public void onTimeout() {
-                log.warn("BumpLeaderEpoch request timed out");
-            }
-        });
-        return future;
+        return sourceSyncer.sendBumpLeaderEpochs(partitionMinEpochs);
     }
 
-    private void maybeCompletePendingEpochBumps() {
+    void maybeCompletePendingEpochBumps() {
         pendingLeaderEpochBumps.removeIf(bumpLeaderEpoch -> {
             Set<TopicPartition> pendingPartitions = bumpLeaderEpoch.partitionToEpoch().entrySet().stream().filter(entry -> {
                 TopicPartition tp = entry.getKey();
@@ -1933,78 +938,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    private Map<TopicPartition, Integer> buildSourceEpochBumpTargets(String mirrorName, List<SourceTopicState> sourceTopicStates, Set<TopicPartition> topicPartitions) {
-        Set<String> mirrorTopics = topicPartitions.isEmpty() ? getConfiguredTopics(mirrorName, false) : Set.of();
-        Map<TopicPartition, Integer> leaderEpochFromMetadata = new HashMap<>();
-        for (SourceTopicState ts : sourceTopicStates) {
-            if (!ts.exists()) {
-                continue;
-            }
-            if (!mirrorTopics.isEmpty() && !mirrorTopics.contains(ts.topic())) {
-                continue;
-            }
-            collectEpochBumpTargets(ts, topicPartitions, leaderEpochFromMetadata);
-        }
-        if (!leaderEpochFromMetadata.isEmpty()) {
-            log.info("Bumping leader epoch for partitions {}", leaderEpochFromMetadata);
-        }
-        return leaderEpochFromMetadata;
-    }
-
-    private void collectEpochBumpTargets(SourceTopicState topicInfo,
-                                         Set<TopicPartition> topicPartitions,
-                                         Map<TopicPartition, Integer> leaderEpochFromMetadata) {
-        for (SourcePartitionState ps : topicInfo.partitions()) {
-            TopicPartition tp = ps.topicPartition();
-            if (!topicPartitions.isEmpty() && !topicPartitions.contains(tp)) {
-                continue;
-            }
-            if (ps.leaderEpoch().isEmpty()) {
-                continue;
-            }
-            TopicImage topicImage = metadataImage.topics().getTopic(tp.topic());
-            if (topicImage == null || topicImage.partitions().get(tp.partition()) == null) {
-                continue;
-            }
-            int epoch = ps.leaderEpoch().get();
-            int localEpoch = topicImage.partitions().get(tp.partition()).leaderEpoch;
-            if (epoch > localEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
-                int newEpoch = Math.addExact(epoch, LEADER_EPOCH_BUMP_INCREMENT);
-                leaderEpochFromMetadata.put(tp, newEpoch);
-            }
-        }
-    }
-
-    /**
-     * Pre-populates sourceLeaders for discovered topics so that when onMetadataUpdate fires
-     * after the destination topic is created, the fetcher can connect to the correct source
-     * broker immediately. Without this, the fetcher starts with a bootstrap broker, gets a
-     * redirect it cannot resolve, and cycles through FAILED/retry until the next periodic
-     * syncSourceTopicState populates the cache.
-     */
-    private void cacheSourceLeaders(String mirrorName, Collection<TopicDescription> descriptions) {
-        var partitionLeaders = sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
-        descriptions.forEach(td -> td.partitions().forEach(pi -> {
-            if (pi.leader() != null) {
-                partitionLeaders.put(new TopicPartition(td.name(), pi.partition()),
-                        new LeaderInfo(pi.leader(), pi.leaderEpoch().orElse(0)));
-            }
-        }));
-    }
-
-    /**
-     * Schedules (or reschedules) the periodic source sync at the given interval.
-     * Each tick validates the source cluster ID, then on the coordinator broker
-     * syncs topic state, configs, group offsets, ACLs, and topic patterns.
-     */
+    /** Delegates to {@link MirrorSourceSyncer#scheduleMetadataRefresh}. */
     void scheduleMetadataRefresh(long intervalMs) {
-        ScheduledFuture<?> oldFuture = metadataRefreshFuture;
-        if (oldFuture != null) {
-            oldFuture.cancel(false);
-        }
-        metadataRefreshFuture = scheduler.schedule("MirrorMetadataRefresh",
-                this::runMetadataRefresh, intervalMs, intervalMs);
-        log.info("Scheduled metadata refresh with interval {} ms", intervalMs);
+        sourceSyncer.scheduleMetadataRefresh(intervalMs);
     }
 
     /** Returns the source cluster ID from the mirror config, or null if not yet resolved. */
@@ -2061,8 +997,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     if (!mirrorName.equals(topicMirrorName)) return false;
                     byte state = topicInfo.desiredMirrorState();
                     if (!includeStopped && state == MirrorPartitionState.STOPPED.value()) return false;
-                    if (!includePaused && state == MirrorPartitionState.PAUSED.value()) return false;
-                    return true;
+                    return includePaused || state != MirrorPartitionState.PAUSED.value();
                 })
                 .map(TopicImage::name)
                 .collect(Collectors.toSet());
@@ -2085,10 +1020,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     public FailedPartitionInfo getFailedInfo(ClusterMirrorRecordKey key) {
         PartitionCacheEntry entry = partitionCache.get(key);
         return entry != null ? entry.failedInfo() : null;
-    }
-
-    public FailedPartitionInfo getFailedInfo(String mirrorName, TopicPartition tp) {
-        return getFailedInfo(ClusterMirrorRecordKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition()));
     }
 
     public void setFailedInfo(ClusterMirrorRecordKey key, FailedPartitionInfo info) {
@@ -2149,7 +1080,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         Set<String> topics = getConfiguredTopics(data.mirrorName(), true, true);
         validateMirrorStates(data.mirrorName(), topics,
                 Set.of(MirrorPartitionState.STOPPED), false,
-                offset -> data.setStateValidationOffset(offset), callback);
+                data::setStateValidationOffset, callback);
     }
 
     void validateStartMirrorStates(StartMirrorTopicsRequestData data, Consumer<Optional<Errors>> callback) {
@@ -2157,7 +1088,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .map(StartMirrorTopicsRequestData.TopicMetadata::topicName).collect(Collectors.toSet());
         validateMirrorStates(data.mirrorName(), topics,
                 Set.of(MirrorPartitionState.STOPPED, MirrorPartitionState.UNKNOWN), true,
-                offset -> data.setStateValidationOffset(offset), callback);
+                data::setStateValidationOffset, callback);
     }
 
     void validateStopMirrorStates(StopMirrorTopicsRequestData data, Consumer<Optional<Errors>> callback) {
@@ -2165,7 +1096,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .map(StopMirrorTopicsRequestData.TopicMetadata::topicName).collect(Collectors.toSet());
         validateMirrorStates(data.mirrorName(), topics,
                 Set.of(MirrorPartitionState.MIRRORING, MirrorPartitionState.PAUSED), false,
-                offset -> data.setStateValidationOffset(offset), callback);
+                data::setStateValidationOffset, callback);
     }
 
     void validatePauseMirrorStates(PauseMirrorTopicsRequestData data, Consumer<Optional<Errors>> callback) {
@@ -2173,7 +1104,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .map(PauseMirrorTopicsRequestData.TopicMetadata::topicName).collect(Collectors.toSet());
         validateMirrorStates(data.mirrorName(), topics,
                 Set.of(MirrorPartitionState.MIRRORING), false,
-                offset -> data.setStateValidationOffset(offset), callback);
+                data::setStateValidationOffset, callback);
     }
 
     void validateResumeMirrorStates(ResumeMirrorTopicsRequestData data, Consumer<Optional<Errors>> callback) {
@@ -2181,7 +1112,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .map(ResumeMirrorTopicsRequestData.TopicMetadata::topicName).collect(Collectors.toSet());
         validateMirrorStates(data.mirrorName(), topics,
                 Set.of(MirrorPartitionState.PAUSED), false,
-                offset -> data.setStateValidationOffset(offset), callback);
+                data::setStateValidationOffset, callback);
     }
 
     /**
@@ -2305,111 +1236,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return Optional.empty();
     }
 
-    /**
-     * Validates that all partitions about to be mirrored are in STOPPED state on the source cluster,
-     * for any source mirror that was previously mirroring from this local cluster. This prevents
-     * starting replication while the reverse direction is still active.
-     *
-     * @param sourceDescription   described mirrors from the source cluster
-     * @param sourceMirrors       listed mirrors from the source cluster
-     * @param topicPartitionToBeMirrored partitions about to start mirroring
-     * @throws IllegalStateException if any partition is not STOPPED
-     */
-    private void validateSourcePartitionsAreStopped(
-            Map<String, ClusterMirrorDescription> sourceDescription,
-            Collection<ClusterMirrorListing> sourceMirrors,
-            Set<TopicPartition> topicPartitionToBeMirrored) {
-        Set<TopicPartition> partitionsNotStopped = new HashSet<>();
-        // Get all source cluster mirror names that the source cluster id is local cluster id
-        List<String> localClusterSourceMirrors = sourceMirrors.stream()
-                .filter(sm -> sm.sourceClusterId().equals(clusterId))
-                .map(ClusterMirrorListing::mirrorName)
-                .toList();
-
-        for (String mirrorName : localClusterSourceMirrors) {
-            ClusterMirrorDescription desc = sourceDescription.get(mirrorName);
-            if (desc == null) {
-                continue;
-            }
-            // Validate each partition state is in STOPPED state
-            for (TopicPartition tp : topicPartitionToBeMirrored) {
-                Set<ClusterMirrorDescription.LeaderStateDescription> leaderStates = desc.topics().get(tp.topic());
-                if (leaderStates == null) {
-                    continue;
-                }
-                boolean notStopped = leaderStates.stream()
-                        .anyMatch(lsd -> lsd.topicPartition().equals(tp)
-                                && (!MirrorPartitionState.STOPPED.name().equals(lsd.state())));
-                if (notStopped) {
-                    partitionsNotStopped.add(tp);
-                }
-            }
-        }
-
-        if (!partitionsNotStopped.isEmpty()) {
-            log.error("Source mirror(s) {} mirroring from this cluster ({}) have not stopped for partition(s) {}",
-                    localClusterSourceMirrors, clusterId, partitionsNotStopped);
-            throw new IllegalStateException("Source mirror(s) " + localClusterSourceMirrors
-                    + " mirroring from this cluster (" + clusterId + ") have not stopped for partition(s) "
-                    + partitionsNotStopped + ".");
-        }
-    }
-
-    /** Looks up last mirror epochs from the source cluster for failback truncation. */
     CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(
             String mirrorName, Set<TopicPartition> topicPartitionSet, Collection<ClusterMirrorListing> sourceMirrors) {
-        Admin admin = getOrCreateSourceAdmin(mirrorName);
-        List<DescribeClusterMirrorsRequestData.LastMirrorEpochLookup> lookups = buildLastMirrorEpochLookups(topicPartitionSet);
-        log.info("Last mirror epoch lookup request for mirror {}: {}", mirrorName, lookups);
-        DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
-                .clusterId(clusterId)
-                .lastMirrorEpochLookups(lookups);
-        // Describe for all mirrors and last mirror epoch lookups
-        DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(), options);
-
-        var describeFuture = result.allDescriptions().toCompletionStage().toCompletableFuture();
-        var lookupEpochsFuture = result.lookupEpochs().toCompletionStage().toCompletableFuture();
-        return describeFuture.thenApply(desc -> {
-            validateSourcePartitionsAreStopped(desc, sourceMirrors, topicPartitionSet);
-            return null;
-        })
-            .thenCompose(__ -> lookupEpochsFuture)
-            .thenApply(lookupEpochs -> {
-                Map<TopicPartition, Integer> epochs = new HashMap<>();
-                if (!lookupEpochs.isEmpty()) {
-                    lookupEpochs.forEach((topicId, partitionEpochs) -> {
-                        Optional<String> topicName = metadataCache.getTopicName(topicId);
-                        topicName.ifPresent(name ->
-                                partitionEpochs.forEach((partIdx, lme) ->
-                                        epochs.put(new TopicPartition(name, partIdx), lme)));
-                    });
-                }
-                log.info("Last mirror epoch lookup response for mirror {}: {}", mirrorName, epochs);
-                return epochs;
-            })
-            .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * Builds LME lookup entries with only this cluster's own ID.
-     * The source matches this against its mirror configs to find cases
-     * where it previously mirrored from us (direct failback).
-     */
-    private List<DescribeClusterMirrorsRequestData.LastMirrorEpochLookup> buildLastMirrorEpochLookups(
-            Set<TopicPartition> topicPartitionSet) {
-        Map<Uuid, List<Integer>> partitionsByTopicId = new HashMap<>();
-        for (TopicPartition tp : topicPartitionSet) {
-            Uuid topicId = metadataCache.getTopicId(tp.topic());
-            partitionsByTopicId.computeIfAbsent(topicId, k -> new ArrayList<>()).add(tp.partition());
-        }
-
-        List<DescribeClusterMirrorsRequestData.LastMirrorEpochLookup> lookups = new ArrayList<>();
-        for (Map.Entry<Uuid, List<Integer>> entry : partitionsByTopicId.entrySet()) {
-            lookups.add(new DescribeClusterMirrorsRequestData.LastMirrorEpochLookup()
-                    .setTopicId(entry.getKey())
-                    .setPartitions(entry.getValue()));
-        }
-        return lookups;
+        return sourceSyncer.sendLastMirrorEpochLookup(mirrorName, topicPartitionSet, sourceMirrors);
     }
 
     /**
@@ -2452,20 +1281,4 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             });
         });
     }
-
-    private record TimeoutHandler(Logger log) implements ControllerRequestCompletionHandler {
-        @Override
-        public void onTimeout() {
-            log.warn("Controller request timed out");
-        }
-
-        @Override
-        public void onComplete(ClientResponse response) {
-            log.debug("Controller request completed: {}", response);
-        }
-    }
-
-    private record SourceTopicState(String topic, Uuid topicId, boolean exists, List<SourcePartitionState> partitions) { }
-    private record SourcePartitionState(TopicPartition topicPartition, Node leader, Optional<Integer> leaderEpoch) { }
-    private record SourceAclChanges(List<AclBinding> aclsToAdd, List<AclBinding> aclsToDelete) { }
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -120,13 +120,13 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private final Logger log;
     private volatile boolean isInitialized = false;
     private final String name;
-    final String clusterId;
+    private final String clusterId;
     private final KafkaConfig brokerConfig;
-    final int nodeId;
+    private final int nodeId;
 
     private volatile MirrorSourceSyncer sourceSyncer;
     private final NodeToControllerChannelManager channelManager;
-    final Supplier<ReplicaManager> replicaManagerSupplier;
+    private final Supplier<ReplicaManager> replicaManagerSupplier;
     private volatile MetadataImage metadataImage = MetadataImage.EMPTY;
     private final MetadataCache metadataCache;
     private final KafkaScheduler scheduler;
@@ -135,7 +135,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     // Network communication
     private volatile MirrorStateSender mirrorStateSender;
-    final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>();
+    private final Map<String, Admin> srcAdmins = new ConcurrentHashMap<>();
     private volatile Admin dstAdmin;
 
     // Local cache

--- a/core/src/main/java/kafka/server/mirror/MirrorSourceSyncer.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorSourceSyncer.java
@@ -1,0 +1,1315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server.mirror;
+
+import kafka.server.KafkaConfig;
+import kafka.server.mirror.ClusterMirrorUtils.LeaderInfo;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ClusterMirrorDescription;
+import org.apache.kafka.clients.admin.ClusterMirrorListing;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeClusterMirrorsOptions;
+import org.apache.kafka.clients.admin.DescribeClusterMirrorsResult;
+import org.apache.kafka.clients.admin.GroupListing;
+import org.apache.kafka.clients.admin.ListClusterMirrorsOptions;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
+import org.apache.kafka.clients.admin.ListGroupsOptions;
+import org.apache.kafka.clients.admin.ListShareGroupOffsetsSpec;
+import org.apache.kafka.clients.admin.StartMirrorTopicsOptions;
+import org.apache.kafka.clients.admin.StopMirrorTopicsOptions;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.BumpLeaderEpochsRequestData;
+import org.apache.kafka.common.message.CreateAclsRequestData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData;
+import org.apache.kafka.common.message.CreateTopicsRequestData;
+import org.apache.kafka.common.message.DeleteAclsRequestData;
+import org.apache.kafka.common.message.DescribeClusterMirrorsRequestData;
+import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
+import org.apache.kafka.common.message.StartMirrorTopicsRequestData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.BumpLeaderEpochsRequest;
+import org.apache.kafka.common.requests.CreateAclsRequest;
+import org.apache.kafka.common.requests.CreatePartitionsRequest;
+import org.apache.kafka.common.requests.CreateTopicsRequest;
+import org.apache.kafka.common.requests.CreateTopicsResponse;
+import org.apache.kafka.common.requests.DeleteAclsRequest;
+import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.mirror.ClusterMirrorRecordKey;
+import org.apache.kafka.image.TopicImage;
+import org.apache.kafka.metadata.MetadataCache;
+import org.apache.kafka.metadata.authorizer.StandardAcl;
+import org.apache.kafka.server.common.ControllerRequestCompletionHandler;
+import org.apache.kafka.server.common.MirrorPartitionState;
+import org.apache.kafka.server.common.NodeToControllerChannelManager;
+import org.apache.kafka.server.config.ClusterMirrorConfig;
+import org.apache.kafka.server.util.KafkaScheduler;
+import org.apache.kafka.server.util.MirrorFilterUtils;
+import org.apache.kafka.storage.internals.log.UnifiedLog;
+
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import scala.Option;
+
+import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_INCREMENT;
+import static kafka.server.mirror.ClusterMirrorUtils.LEADER_EPOCH_BUMP_THRESHOLD;
+
+/**
+ * Periodically syncs topic metadata, configurations, group offsets, and ACLs from
+ * source clusters for Cluster Mirroring.
+ *
+ * <p>Runs on the {@link KafkaScheduler} thread. Source topic state sync (leader caches,
+ * deletion detection, missed partition recovery) runs on every broker. Topic creation,
+ * partition scaling, config sync, offset sync, ACL sync, and pattern discovery run only
+ * on the coordinator broker for a given mirror.
+ */
+@SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
+class MirrorSourceSyncer {
+    private final Logger log;
+    private final MirrorMetadataManager manager;
+    private final KafkaConfig brokerConfig;
+    private final int nodeId;
+    private final NodeToControllerChannelManager channelManager;
+    private final MetadataCache metadataCache;
+    private final KafkaScheduler scheduler;
+    private volatile ScheduledFuture<?> metadataRefreshFuture;
+
+    // Sync error metrics
+    private final AtomicLong metadataRefreshError;
+    private final AtomicLong topicConfigSyncError;
+    private final AtomicLong consumerGroupOffsetSyncError;
+    private final AtomicLong shareGroupOffsetSyncError;
+    private final AtomicLong aclSyncError;
+
+    MirrorSourceSyncer(
+        KafkaConfig brokerConfig,
+        MirrorMetadataManager manager,
+        NodeToControllerChannelManager channelManager,
+        MetadataCache metadataCache,
+        KafkaScheduler scheduler,
+        AtomicLong metadataRefreshError,
+        AtomicLong topicConfigSyncError,
+        AtomicLong consumerGroupOffsetSyncError,
+        AtomicLong shareGroupOffsetSyncError,
+        AtomicLong aclSyncError
+    ) {
+        this.manager = manager;
+        this.brokerConfig = brokerConfig;
+        this.nodeId = brokerConfig.nodeId();
+        this.channelManager = channelManager;
+        this.metadataCache = metadataCache;
+        this.scheduler = scheduler;
+        this.metadataRefreshError = metadataRefreshError;
+        this.topicConfigSyncError = topicConfigSyncError;
+        this.consumerGroupOffsetSyncError = consumerGroupOffsetSyncError;
+        this.shareGroupOffsetSyncError = shareGroupOffsetSyncError;
+        this.aclSyncError = aclSyncError;
+
+        String prefix = "[" + MirrorSourceSyncer.class.getSimpleName() + " id=" + nodeId + "] ";
+        this.log = new LogContext(prefix).logger(MirrorSourceSyncer.class);
+    }
+
+    /**
+     * Schedules (or reschedules) the periodic source sync at the given interval.
+     * Each tick validates the source cluster ID, then on the coordinator broker
+     * syncs topic state, configs, group offsets, ACLs, and topic patterns.
+     */
+    void scheduleMetadataRefresh(long intervalMs) {
+        ScheduledFuture<?> oldFuture = metadataRefreshFuture;
+        if (oldFuture != null) {
+            oldFuture.cancel(false);
+        }
+        metadataRefreshFuture = scheduler.schedule("MirrorMetadataRefresh",
+                this::runMetadataRefresh, intervalMs, intervalMs);
+        log.info("Scheduled metadata refresh with interval {} ms", intervalMs);
+    }
+
+    /**
+     * Periodic source sync callback. Every broker syncs topic state from the source
+     * (needed for source leader caches, deletion detection, and missed partition recovery).
+     * Only the coordinator syncs configs, group offsets, and ACLs.
+     */
+    private void runMetadataRefresh() {
+        retryPendingTombstoneWrites();
+
+        Set<String> mirrors = manager.getConfiguredMirrors();
+        if (mirrors.isEmpty()) {
+            return;
+        }
+
+        log.info("Refreshing metadata for mirrors: {}", mirrors);
+
+        for (String mirrorName : mirrors) {
+            try {
+                validateSourceClusterId(mirrorName);
+                var topicState = syncSourceTopicState(mirrorName);
+                syncSourceConfigsAndOffsets(mirrorName, topicState);
+            } catch (Exception e) {
+                log.error("Failed to refresh metadata for mirror {}", mirrorName, e);
+            }
+        }
+
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        metadataRefreshError.incrementAndGet();
+    }
+
+    private void retryPendingTombstoneWrites() {
+        if (manager.tombstoneWriter.isEmpty()) {
+            log.warn("Mirror deletion handler not configured. Tombstone record writes will be skipped.");
+            return;
+        }
+        Set<String> configuredMirrors = manager.getConfiguredMirrors();
+        Set<String> staleMirrors = manager.partitionCache.keySet().stream()
+                .map(ClusterMirrorRecordKey::mirrorName)
+                .filter(name -> !configuredMirrors.contains(name))
+                .collect(Collectors.toSet());
+        for (String mirrorName : staleMirrors) {
+            log.info("Found stale partition states for deleted mirror '{}'. Writing tombstones.", mirrorName);
+            manager.tombstoneWriter.ifPresent(h -> h.accept(mirrorName));
+        }
+    }
+
+    private void validateSourceClusterId(String mirrorName) {
+        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        try {
+            var clusterResult = srcAdmin.describeCluster();
+            String newClusterId = clusterResult.clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            if (newClusterId != null && !newClusterId.isEmpty()) {
+                String previousClusterId = manager.getSourceClusterId(mirrorName);
+                if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
+                    String errMsg = "Source cluster ID changed for mirror " + mirrorName
+                            + ": expected " + previousClusterId + ", got " + newClusterId
+                            + ". This may indicate a misconfiguration or that the source cluster has been replaced. "
+                            + "Moving all partitions to non-retryable failed state.";
+                    log.error(errMsg);
+
+                    Set<String> mirroredTopics = manager.getConfiguredTopics(mirrorName, true);
+                    if (!mirroredTopics.isEmpty()) {
+                        Set<TopicPartition> mirroredLeaderPartitions = new HashSet<>();
+                        for (String topic : mirroredTopics) {
+                            TopicImage topicImage = manager.metadataImage().topics().getTopic(topic);
+                            if (topicImage != null) {
+                                topicImage.partitions().forEach((partitionId, partition) -> {
+                                    if (partition.leader == nodeId) {
+                                        mirroredLeaderPartitions.add(new TopicPartition(topic, partitionId));
+                                    }
+                                });
+                            }
+                        }
+                        if (!mirroredLeaderPartitions.isEmpty()) {
+                            manager.transitionTo(mirrorName, mirroredLeaderPartitions, MirrorPartitionState.FAILED, errMsg, true);
+                        }
+                    }
+                }
+            }
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Failed to describe source cluster for mirror {}", mirrorName, e);
+        }
+    }
+
+    /**
+     * Lists the cluster mirrors configured on the source cluster, including their active topic names.
+     * Used before mirroring to detect mirror loops and during truncation to validate that source
+     * partitions are stopped.
+     *
+     * @param mirrorName the name of the local mirror whose source cluster to query
+     * @return the cluster mirror listings from the source cluster, or an empty list if the source
+     *         cluster does not support the ListClusterMirrors API
+     * @throws IllegalStateException if the request fails
+     */
+    Collection<ClusterMirrorListing> listSourceClusterMirrors(String mirrorName) {
+        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        try {
+            return srcAdmin
+                    .listClusterMirrors(new ListClusterMirrorsOptions().shouldIncludeTopicNames(true))
+                    .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof UnsupportedVersionException) {
+                log.info("Source cluster does not support listClusterMirrors for mirror {}. Skipping mirror loop check.", mirrorName);
+                return List.of();
+            }
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            throw new IllegalStateException("Failed to list cluster mirrors from source for mirror "
+                    + mirrorName + ": " + cause.getMessage(), cause);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Failed to list cluster mirrors from source for mirror "
+                    + mirrorName + ": " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to list cluster mirrors from source for mirror "
+                    + mirrorName + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Checks whether mirroring the given partitions from the source cluster would create
+     * a mirror loop, based on the mirrors currently configured on the source cluster.
+     *
+     * @param mirrorName      the local mirror being started
+     * @param topicPartitions the partitions about to be mirrored
+     * @param sourceMirrors   mirrors configured on the source cluster, as returned by
+     *                        {@link #listSourceClusterMirrors(String)}
+     * @return true if the given partitions would create a mirror loop, false otherwise
+     */
+    boolean hasMirrorLoop(String mirrorName, Set<TopicPartition> topicPartitions,
+                          Collection<ClusterMirrorListing> sourceMirrors) {
+        if (sourceMirrors.isEmpty()) {
+            return false;
+        }
+
+        Set<String> topicNames = topicPartitions.stream()
+                .map(TopicPartition::topic)
+                .collect(Collectors.toSet());
+
+        for (ClusterMirrorListing sourceMirror : sourceMirrors) {
+            if (!manager.clusterId().equals(sourceMirror.sourceClusterId())) {
+                continue;
+            }
+            Set<String> overlapping = new HashSet<>(sourceMirror.topics());
+            overlapping.retainAll(topicNames);
+            if (!overlapping.isEmpty()) {
+                log.error("Mirror loop detected for mirror {}: source mirror {} is already mirroring topic(s) {}",
+                        mirrorName, sourceMirror.mirrorName(), overlapping);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Schedules an immediate one-shot source topic state sync for the given mirror. */
+    void scheduleSourceTopicStateSync(String mirrorName) {
+        scheduler.scheduleOnce("SourceTopicStateSync", () -> syncSourceTopicState(mirrorName));
+    }
+
+    /**
+     * Fetches topics metadata from the source cluster via Admin.describeTopics.
+     * Runs on every broker to keep partition leaders, topic creation, topic deletion, and partition counts in sync.
+     */
+    Optional<List<SourceTopicState>> syncSourceTopicState(String mirrorName) {
+        log.info("Syncing source topic state for mirror {}", mirrorName);
+        Set<String> topics = manager.getConfiguredTopics(mirrorName, false);
+        if (topics.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+
+        try {
+            Map<String, KafkaFuture<TopicDescription>> futures = srcAdmin.describeTopics(topics).topicNameValues();
+            List<SourceTopicState> result = new ArrayList<>();
+
+            for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : futures.entrySet()) {
+                try {
+                    TopicDescription td = entry.getValue().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                    List<SourcePartitionState> partitions = td.partitions().stream()
+                            .map(pi -> new SourcePartitionState(
+                                    new TopicPartition(td.name(), pi.partition()),
+                                    pi.leader(),
+                                    pi.leaderEpoch()))
+                            .toList();
+                    result.add(new SourceTopicState(td.name(), td.topicId(), true, partitions));
+                } catch (ExecutionException e) {
+                    if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                        result.add(new SourceTopicState(entry.getKey(), Uuid.ZERO_UUID, false, List.of()));
+                    } else {
+                        log.warn("Failed to describe topic {} for mirror {}", entry.getKey(), mirrorName, e.getCause());
+                    }
+                }
+            }
+
+            processSourceTopicState(mirrorName, result);
+            return Optional.of(result);
+        } catch (Exception e) {
+            log.warn("Failed to sync source topic state for mirror {}", mirrorName, e);
+            return Optional.empty();
+        }
+    }
+
+    private void processSourceTopicState(String mirrorName, List<SourceTopicState> sourceTopicStates) {
+        var creatableTopics = new ArrayList<CreateTopicsRequestData.CreatableTopic>();
+        var createPartitionsTopics = new CreatePartitionsRequestData.CreatePartitionsTopicCollection();
+
+        sourceTopicStates.forEach(ti -> {
+            var partitionLeaders = manager.sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
+
+            int sourcePartitionCount = ti.partitions().size();
+
+            ti.partitions().forEach(pi -> {
+                if (pi.leader() != null) {
+                    partitionLeaders.put(pi.topicPartition(),
+                            new LeaderInfo(pi.leader(), pi.leaderEpoch().orElse(0)));
+                }
+            });
+
+            // Pre-KIP-516 sources (Kafka < 2.8) return ZERO_UUID; fall back to name-based lookup
+            TopicImage destTopic = !ti.topicId().equals(Uuid.ZERO_UUID)
+                    ? manager.metadataImage().topics().getTopic(ti.topicId())
+                    : manager.metadataImage().topics().getTopic(ti.topic());
+
+            if (destTopic != null && destTopic.partitions().size() < sourcePartitionCount) {
+                createPartitionsTopics.add(new CreatePartitionsRequestData.CreatePartitionsTopic()
+                        .setName(ti.topic())
+                        .setCount(sourcePartitionCount)
+                        .setAssignments(null)
+                );
+            } else if (destTopic == null &&
+                    manager.metadataImage().topics().getTopic(ti.topic()) == null &&
+                    ti.exists() && sourcePartitionCount > 0) {
+                if (manager.pendingTopicCreations.add(ti.topic())) {
+                    creatableTopics.add(new CreateTopicsRequestData.CreatableTopic()
+                            .setName(ti.topic())
+                            .setNumPartitions(sourcePartitionCount)
+                            .setReplicationFactor(CreateTopicsRequest.NO_REPLICATION_FACTOR)
+                            .setMirrorInfo(new CreateTopicsRequestData.MirrorInfo().setTopicId(
+                                    ti.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : ti.topicId())));
+                }
+            } else if (destTopic == null &&
+                    manager.metadataImage().topics().getTopic(ti.topic()) != null &&
+                    ti.exists()) {
+                log.error("Mirror topic {} exists on destination with TopicId {} but source has TopicId {}. "
+                                + "Delete the topic on destination and let auto-creation recreate it with the correct TopicId.",
+                        ti.topic(), manager.metadataImage().topics().getTopic(ti.topic()).id(), ti.topicId());
+            }
+        });
+
+        if (manager.isLocalCoordinator(mirrorName)) {
+            if (!creatableTopics.isEmpty()) {
+                createMirrorTopics(creatableTopics);
+            }
+            maybeScalePartitions(createPartitionsTopics);
+        }
+
+        maybeFailDeletedTopics(mirrorName, sourceTopicStates);
+        maybeStartMissedPartitions(mirrorName);
+    }
+
+    /**
+     * Creates mirror topics on the destination with the source's TopicId,
+     * preserving topic identity across clusters. Called during periodic metadata
+     * sync when topics have mirror.name config but don't exist on the destination yet.
+     * Once created, onMetadataUpdate will detect them and start the mirror state machine.
+     */
+    private void createMirrorTopics(List<CreateTopicsRequestData.CreatableTopic> creatableTopics) {
+        var topicNames = creatableTopics.stream().map(CreateTopicsRequestData.CreatableTopic::name).toList();
+        creatableTopics.forEach(t -> log.info("Creating mirror topic {} on destination (partitions={}, topicId={})",
+                t.name(), t.numPartitions(), t.mirrorInfo().topicId()));
+        var createTopicsData = new CreateTopicsRequestData().setTimeoutMs(brokerConfig.requestTimeoutMs());
+        creatableTopics.forEach(createTopicsData.topics()::add);
+        ControllerRequestCompletionHandler requestCompletionHandler = new ControllerRequestCompletionHandler() {
+            @Override
+            public void onTimeout() {
+                topicNames.forEach(manager.pendingTopicCreations::remove);
+                log.warn("Create mirror topics timed out for {}", topicNames);
+            }
+
+            @Override
+            public void onComplete(ClientResponse response) {
+                topicNames.forEach(manager.pendingTopicCreations::remove);
+                if (response.responseBody() instanceof CreateTopicsResponse createTopicsResponse) {
+                    createTopicsResponse.data().topics().forEach(topic -> {
+                        var error = Errors.forCode(topic.errorCode());
+                        if (error != Errors.NONE) {
+                            log.warn("Failed to create mirror topic {}: {}", topic.name(), error.message());
+                        }
+                    });
+                }
+            }
+        };
+        channelManager.sendRequest(
+                new CreateTopicsRequest.Builder(createTopicsData),
+                requestCompletionHandler);
+    }
+
+    private void maybeScalePartitions(CreatePartitionsRequestData.CreatePartitionsTopicCollection topics) {
+        if (!topics.isEmpty()) {
+            log.debug("Detected partition count change, sending CreatePartitionsRequest: {}", topics);
+            channelManager.sendRequest(new CreatePartitionsRequest.Builder(
+                    new CreatePartitionsRequestData()
+                            .setTopics(topics)
+                            .setValidateOnly(false)
+                            .setTimeoutMs(3000)
+            ), new TimeoutHandler(log));
+        }
+    }
+
+    private void maybeFailDeletedTopics(String mirrorName, List<SourceTopicState> sourceTopicStates) {
+        List<String> deletedSourceTopicNames = new ArrayList<>(sourceTopicStates.stream()
+                .filter(ti -> !ti.exists())
+                .map(SourceTopicState::topic).toList());
+
+        if (deletedSourceTopicNames.isEmpty()) {
+            return;
+        }
+
+        // In old cluster, it is possible the broker metadata update in progress, and the returned metadata response is stale.
+        // list topic again to make sure it is indeed deleted.
+        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        try {
+            Set<String> allTopics = srcAdmin.listTopics().names().get();
+            log.debug("Source topic name list: {}", allTopics);
+            deletedSourceTopicNames.removeAll(allTopics);
+        } catch (Exception e) {
+            log.warn("Failed to list topics for mirror {}, skipping deleted topic detection: {}", mirrorName, e.getMessage());
+            return;
+        }
+
+        manager.getConfiguredTopics(mirrorName, true).forEach(name -> {
+            if (deletedSourceTopicNames.contains(name)) {
+                log.info("Detected topic {} deleted in remote cluster {}, marking mirror partitions as non-retryable", name, mirrorName);
+                TopicImage topicImage = manager.metadataImage().topics().getTopic(name);
+                if (topicImage != null) {
+                    topicImage.partitions().forEach((partitionId, partition) ->
+                            manager.transitionTo(mirrorName, Set.of(new TopicPartition(name, partitionId)),
+                                    MirrorPartitionState.FAILED, "The source topic is deleted.", true));
+                }
+            }
+        });
+    }
+
+    /**
+     * Transitions partitions stuck in UNKNOWN because their source leader was not yet known
+     * when onMetadataUpdate first ran.
+     * <p>
+     * The race: processSourceTopicState creates a mirror topic on the destination, which
+     * triggers onMetadataUpdate. That callback needs the source leader in sourceLeaders to
+     * transition the partition to LOG_TRUNCATION. If the source has not elected a leader yet
+     * (or the Admin describeTopics response arrived without one), the partition stays in
+     * UNKNOWN. Since onMetadataUpdate only fires on destination metadata changes, it will
+     * not retry on its own.
+     * <p>
+     * This is more likely against older source clusters (e.g. Kafka 2.1 with ZK) where
+     * Admin.describeTopics goes through three round trips before returning topic metadata:
+     * describeCluster (node discovery), DescribeTopicPartitions (rejected with
+     * UnsupportedVersionException), then MetadataRequest (fallback). The extra latency
+     * widens the window in which the source leader is not yet known.
+     */
+    private void maybeStartMissedPartitions(String mirrorName) {
+        var partitionLeaders = manager.sourceLeaders.get(mirrorName);
+        if (partitionLeaders == null) {
+            return;
+        }
+        partitionLeaders.keySet().forEach(tp -> {
+            var key = ClusterMirrorRecordKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
+            var cachedEntry = manager.partitionCache.get(key);
+            if (cachedEntry != null && cachedEntry.state() != null && cachedEntry.state() != MirrorPartitionState.UNKNOWN) {
+                return;
+            }
+            TopicImage topicImage = manager.metadataImage().topics().getTopic(tp.topic());
+            if (topicImage == null) {
+                return;
+            }
+            byte desiredState = topicImage.desiredMirrorState();
+            if (desiredState == MirrorPartitionState.STOPPED.value()
+                    || desiredState == MirrorPartitionState.PAUSED.value()) {
+                return;
+            }
+            var partition = topicImage.partitions().get(tp.partition());
+            if (partition != null && partition.leader == nodeId) {
+                log.info("Source leader for {} discovered after initial onMetadataUpdate, transitioning to LOG_TRUNCATION", tp);
+                manager.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
+            }
+        });
+    }
+
+    /**
+     * Syncs topic configurations, consumer/share group offsets, ACLs, and topic patterns
+     * from the source cluster. Runs only on the coordinator broker for each mirror.
+     */
+    private void syncSourceConfigsAndOffsets(String mirrorName, Optional<List<SourceTopicState>> sourceTopicStates) {
+        if (!manager.isLocalCoordinator(mirrorName)) {
+            return;
+        }
+
+        log.info("Syncing source configs and offsets for mirror {}", mirrorName);
+
+        try {
+            ClusterMirrorConfig mirrorConfig = ClusterMirrorConfig.fromProperties(
+                    metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName)));
+            syncTopicConfigs(mirrorName, mirrorConfig);
+            syncGroupOffsets(mirrorName, mirrorConfig);
+            syncAcls(mirrorName, mirrorConfig);
+            if (!manager.getConfiguredTopics(mirrorName, false, false).isEmpty()) {
+                maybeBumpLeaderEpochs(mirrorName, sourceTopicStates, Set.of());
+            }
+            discoverTopicsByPattern(mirrorName, mirrorConfig);
+            enforceExcludePatterns(mirrorName, mirrorConfig);
+        } catch (Exception e) {
+            log.error("Failed to sync mirror metadata for mirror {}", mirrorName, e);
+        }
+    }
+
+    private void syncTopicConfigs(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+
+        Set<String> topics = manager.getConfiguredTopics(mirrorName, false);
+        log.debug("Describing topic configs for topics: {}", topics);
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        topicConfigSyncError.incrementAndGet();
+
+        Collection<ConfigResource> resources = topics.stream()
+                .map(topic -> new ConfigResource(ConfigResource.Type.TOPIC, topic))
+                .toList();
+
+        try {
+            Map<ConfigResource, Config> sourceConfigs = srcAdmin.describeConfigs(resources)
+                    .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+            Map<String, Map<String, String>> configsToChange = detectConfigurationChanges(sourceConfigs, mirrorConfig);
+            applyConfigurationChanges(configsToChange);
+        } catch (Exception e) {
+            log.warn("Failed to describe topic configs for mirror {}: {}", mirrorName, e.getMessage());
+        }
+    }
+
+    private Map<String, Map<String, String>> detectConfigurationChanges(
+            Map<ConfigResource, Config> sourceConfigs, ClusterMirrorConfig mirrorConfig) {
+        Map<String, Map<String, String>> configsToChange = new HashMap<>();
+        Pattern excludePattern = mirrorConfig.topicPropertiesExcludePattern();
+
+        sourceConfigs.forEach((resource, config) -> {
+            if (resource.type() == ConfigResource.Type.TOPIC) {
+                Properties props = metadataCache.topicConfig(resource.name());
+                Map<String, String> conChange = new HashMap<>();
+
+                config.entries().forEach(entry -> {
+                    if (entry.source() == ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG
+                            && (excludePattern == null || !excludePattern.matcher(entry.name()).matches())) {
+                        if (props.containsKey(entry.name())) {
+                            if (!props.get(entry.name()).equals(entry.value())) {
+                                conChange.put(entry.name(), entry.value());
+                            }
+                        } else {
+                            conChange.put(entry.name(), entry.value());
+                        }
+                    }
+                });
+
+                if (!conChange.isEmpty()) {
+                    configsToChange.put(resource.name(), conChange);
+                }
+            }
+        });
+
+        return configsToChange;
+    }
+
+    private void applyConfigurationChanges(Map<String, Map<String, String>> configsToChange) {
+        log.debug("Applying config change: {}", configsToChange);
+
+        Map<ConfigResource, Collection<AlterConfigOp>> configOps = new HashMap<>();
+        configsToChange.forEach((name, changes) -> {
+            var changeList = changes.entrySet().stream()
+                    .map(entry -> new AlterConfigOp(new ConfigEntry(entry.getKey(), entry.getValue()), AlterConfigOp.OpType.SET))
+                    .toList();
+            configOps.put(new ConfigResource(ConfigResource.Type.TOPIC, name), changeList);
+        });
+
+        if (!configOps.isEmpty()) {
+            IncrementalAlterConfigsRequestData data = new IncrementalAlterConfigsRequestData().setValidateOnly(false);
+            for (Map.Entry<ConfigResource, Collection<AlterConfigOp>> entry : configOps.entrySet()) {
+                ConfigResource resource = entry.getKey();
+                IncrementalAlterConfigsRequestData.AlterableConfigCollection alterableConfigSet =
+                        new IncrementalAlterConfigsRequestData.AlterableConfigCollection();
+                for (AlterConfigOp configEntry : configOps.get(resource))
+                    alterableConfigSet.add(new IncrementalAlterConfigsRequestData.AlterableConfig()
+                            .setName(configEntry.configEntry().name())
+                            .setValue(configEntry.configEntry().value())
+                            .setConfigOperation(configEntry.opType().id()));
+                IncrementalAlterConfigsRequestData.AlterConfigsResource alterConfigsResource =
+                        new IncrementalAlterConfigsRequestData.AlterConfigsResource();
+                alterConfigsResource.setResourceType(resource.type().id())
+                        .setResourceName(resource.name()).setConfigs(alterableConfigSet);
+                data.resources().add(alterConfigsResource);
+            }
+            channelManager.sendRequest(new IncrementalAlterConfigsRequest.Builder(data), new TimeoutHandler(log));
+        }
+    }
+
+    /**
+     * Syncs group offsets from the source cluster to the destination in two phases:
+     * consumer groups first, then share groups. Keeping them separate avoids cross-type
+     * conflicts where a consumer group on the source could overwrite a share group with
+     * the same name on the destination (or vice versa).
+     */
+    private void syncGroupOffsets(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+
+        Set<String> mirrorTopics = manager.getConfiguredTopics(mirrorName, false, false);
+        if (mirrorTopics.isEmpty()) {
+            return;
+        }
+
+        Pattern groupsIncludePattern = mirrorConfig.groupsIncludePattern();
+        Pattern groupsExcludePattern = mirrorConfig.groupsExcludePattern();
+
+        syncConsumerGroupOffsets(srcAdmin, mirrorName, mirrorTopics, groupsIncludePattern, groupsExcludePattern);
+        syncShareGroupOffsets(srcAdmin, mirrorName, mirrorTopics, groupsIncludePattern, groupsExcludePattern);
+    }
+
+    private void syncConsumerGroupOffsets(Admin srcAdmin, String mirrorName, Set<String> mirrorTopics,
+                                          Pattern groupsIncludePattern, Pattern groupsExcludePattern) {
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        consumerGroupOffsetSyncError.incrementAndGet();
+        try {
+            List<String> sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forConsumerGroups(),
+                    groupsIncludePattern, groupsExcludePattern);
+            if (sourceGroupIds.isEmpty()) {
+                return;
+            }
+            log.info("Syncing consumer group offsets for mirror {}, groups={}", mirrorName, sourceGroupIds);
+
+            Map<String, ListConsumerGroupOffsetsSpec> groupSpecs = sourceGroupIds.stream()
+                    .collect(Collectors.toMap(id -> id, id -> new ListConsumerGroupOffsetsSpec()));
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets = srcAdmin
+                    .listConsumerGroupOffsets(groupSpecs).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            Optional<Set<String>> activeDestGroups = getActiveDestinationGroupIds(ListGroupsOptions.forConsumerGroups());
+            if (activeDestGroups.isEmpty()) {
+                return;
+            }
+
+            for (var entry : allOffsets.entrySet()) {
+                String groupId = entry.getKey();
+                if (activeDestGroups.get().contains(groupId)) {
+                    log.warn("Skipping consumer group offset sync for group {} in mirror {}: active on destination", groupId, mirrorName);
+                    continue;
+                }
+
+                Map<TopicPartition, OffsetAndMetadata> filtered = new HashMap<>();
+                entry.getValue().entrySet().stream()
+                        .filter(e -> mirrorTopics.contains(e.getKey().topic()))
+                        .forEach(ent -> {
+                            TopicPartition topicPartition = ent.getKey();
+                            Option<Long> logStartOffset = manager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
+                            Option<Long> logEndOffset = manager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
+                            if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
+                                log.debug("Cannot get the log start offset or log end offset for partition {}, skip consumer group sync for it.", topicPartition);
+                                return;
+                            }
+                            OffsetAndMetadata sourceGroupOffsetAndMetadata = ent.getValue();
+
+                            // Committing to the range [local logStartOffset ~ local logEndOffset]
+                            long finalOffset = Math.max(logStartOffset.get(), Math.min(sourceGroupOffsetAndMetadata.offset(), logEndOffset.get()));
+
+                            if (finalOffset == sourceGroupOffsetAndMetadata.offset()) {
+                                filtered.put(topicPartition, sourceGroupOffsetAndMetadata);
+                            } else if (finalOffset == logEndOffset.get()) {
+                                int logEndEpoch = manager.replicaManagerSupplier().get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logEndOffset.get()).orElse(-1)).getOrElse(() -> -1);
+                                if (logEndEpoch < 0) {
+                                    log.debug("Cannot get the log end epoch for partition {}, skip consumer group sync for it.", topicPartition);
+                                } else {
+                                    filtered.put(topicPartition, new OffsetAndMetadata(logEndOffset.get(), Optional.of(logEndEpoch), ""));
+                                }
+                            } else {
+                                // finalOffset == logStartOffset
+                                int logStartEpoch = manager.replicaManagerSupplier().get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logStartOffset.get()).orElse(-1)).getOrElse(() -> -1);
+                                if (logStartEpoch < 0) {
+                                    log.debug("Cannot get the log start epoch for partition {}, skip consumer group sync for it.", topicPartition);
+                                } else {
+                                    filtered.put(topicPartition, new OffsetAndMetadata(logStartOffset.get(), Optional.of(logStartEpoch), ""));
+                                }
+                            }
+                        });
+
+                if (filtered.isEmpty()) {
+                    continue;
+                }
+
+                try {
+                    log.debug("Committing consumer group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
+                    manager.getOrCreateDestAdmin().alterConsumerGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                } catch (Exception e) {
+                    log.warn("Failed to commit consumer group offsets for group {} in mirror {}: {}", groupId, mirrorName, e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to sync consumer group offsets for mirror {}: {}", mirrorName, e.getMessage());
+        }
+    }
+
+    private void syncShareGroupOffsets(Admin srcAdmin, String mirrorName, Set<String> mirrorTopics,
+                                       Pattern groupsIncludePattern, Pattern groupsExcludePattern) {
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        shareGroupOffsetSyncError.incrementAndGet();
+        try {
+            List<String> sourceGroupIds;
+            try {
+                sourceGroupIds = listSourceGroupIds(srcAdmin, ListGroupsOptions.forShareGroups(),
+                        groupsIncludePattern, groupsExcludePattern);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnsupportedVersionException) {
+                    log.debug("The source cluster doesn't support share group, skipping share group offset sync");
+                    return;
+                } else {
+                    throw e;
+                }
+            }
+            if (sourceGroupIds.isEmpty()) {
+                return;
+            }
+            log.info("Syncing share group offsets for mirror {}, groups={}", mirrorName, sourceGroupIds);
+
+            Map<String, ListShareGroupOffsetsSpec> groupSpecs = sourceGroupIds.stream()
+                    .collect(Collectors.toMap(id -> id, id -> new ListShareGroupOffsetsSpec()));
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets = srcAdmin
+                    .listShareGroupOffsets(groupSpecs).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            Optional<Set<String>> activeDestGroups = getActiveDestinationGroupIds(ListGroupsOptions.forShareGroups());
+            if (activeDestGroups.isEmpty()) {
+                return;
+            }
+
+            for (var entry : allOffsets.entrySet()) {
+                String groupId = entry.getKey();
+                if (activeDestGroups.get().contains(groupId)) {
+                    log.warn("Skipping share group offset sync for group {} in mirror {}: active on destination", groupId, mirrorName);
+                    continue;
+                }
+
+                Map<TopicPartition, Long> filtered = new  HashMap<>();
+                entry.getValue().entrySet().stream()
+                        .filter(e -> mirrorTopics.contains(e.getKey().topic()))
+                        .forEach(ent -> {
+                            TopicPartition topicPartition = ent.getKey();
+                            Option<Long> logStartOffset = manager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
+                            Option<Long> logEndOffset = manager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
+                            if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
+                                log.debug("Cannot get the log start offset or log end offset for partition {}, skip share group offset sync for it.", topicPartition);
+                                return;
+                            }
+                            OffsetAndMetadata sourceGroupOffsetAndMetadata = ent.getValue();
+                            // Committing to the range [local logStartOffset ~ local logEndOffset]
+                            long finalOffset = Math.max(logStartOffset.get(), Math.min(sourceGroupOffsetAndMetadata.offset(), logEndOffset.get()));
+                            filtered.put(topicPartition, finalOffset);
+                        });
+                if (filtered.isEmpty()) {
+                    continue;
+                }
+
+                try {
+                    log.debug("Committing share group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
+                    manager.getOrCreateDestAdmin().alterShareGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                } catch (Exception e) {
+                    log.warn("Failed to commit share group offsets for group {} in mirror {}: {}", groupId, mirrorName, e);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to sync share group offsets for mirror {}: {}", mirrorName, e);
+        }
+    }
+
+    private List<String> listSourceGroupIds(Admin srcAdmin, ListGroupsOptions options,
+                                            Pattern groupsIncludePattern, Pattern groupsExcludePattern) throws Exception {
+        return srcAdmin.listGroups(options).all()
+                .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
+                .map(GroupListing::groupId)
+                .filter(id -> groupsIncludePattern == null || groupsIncludePattern.matcher(id).matches())
+                .filter(id -> groupsExcludePattern == null || !groupsExcludePattern.matcher(id).matches())
+                .toList();
+    }
+
+    /**
+     * Returns the set of destination group IDs that should not be overwritten during offset sync
+     * (groups in STABLE, PREPARING_REBALANCE, COMPLETING_REBALANCE, ASSIGNING, or RECONCILING state).
+     *
+     * @return the group IDs to skip, or empty Optional on failure so the caller can skip the sync cycle
+     */
+    private Optional<Set<String>> getActiveDestinationGroupIds(ListGroupsOptions typeFilter) {
+        try {
+            var options = typeFilter.inGroupStates(Set.of(
+                    GroupState.STABLE,
+                    GroupState.PREPARING_REBALANCE,
+                    GroupState.COMPLETING_REBALANCE,
+                    GroupState.ASSIGNING,
+                    GroupState.RECONCILING));
+            return Optional.of(manager.getOrCreateDestAdmin().listGroups(options).all()
+                    .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
+                    .map(GroupListing::groupId)
+                    .collect(Collectors.toSet()));
+        } catch (Exception e) {
+            log.warn("Failed to list destination groups, skipping offset sync cycle.", e);
+            return Optional.empty();
+        }
+    }
+
+    private void syncAcls(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        // TODO: We currently mirror all ACLs from the source to the target.
+        //       Any ACLs added/removed directly on the target will be overwritten
+        //       on the next sync to match the source.
+        //
+        // TODO: How do we disambiguate ACLs that reference the same resource name
+        //       when multiple cluster mirrors exist?
+
+        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+
+        // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
+        aclSyncError.incrementAndGet();
+
+        try {
+            Collection<AclBinding> sourceAcls = srcAdmin.describeAcls(AclBindingFilter.ANY)
+                    .values().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            log.debug("Describe ACLs response from remote cluster {}: {}", mirrorName, sourceAcls);
+
+            List<MirrorFilterUtils.AclRule> aclIncludeRules = mirrorConfig.aclIncludeRules();
+            var allRemoteAcls = sourceAcls.stream()
+                    .filter(acl -> aclIncludeRules.stream().anyMatch(rule -> rule.matches(acl)))
+                    .toList();
+            var aclChanges = detectAclChanges(allRemoteAcls);
+            applyAclChanges(mirrorName, aclChanges);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof SecurityDisabledException) {
+                log.debug("ACL sync skipped for mirror {}: {}", mirrorName, e.getCause().getMessage());
+            } else {
+                log.warn("Failed to describe ACLs for mirror {}: {}", mirrorName, e.getMessage());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to sync ACLs for mirror {}: {}", mirrorName, e.getMessage());
+        }
+    }
+
+    private SourceAclChanges detectAclChanges(List<AclBinding> sourceAcls) {
+        var addACLsList = new ArrayList<AclBinding>();
+        var deleteACLsList = new ArrayList<AclBinding>();
+        var current = manager.metadataImage().acls().acls().values();
+
+        sourceAcls.forEach(acl -> {
+            if (current.stream().map(StandardAcl::toBinding).noneMatch(a -> a.equals(acl))) {
+                addACLsList.add(acl);
+            }
+        });
+
+        manager.metadataImage().acls().acls().values().forEach(acl -> {
+            if (acl.resourceType() != ResourceType.CLUSTER_MIRROR && !sourceAcls.contains(acl.toBinding())) {
+                deleteACLsList.add(acl.toBinding());
+            }
+        });
+
+        return new SourceAclChanges(addACLsList, deleteACLsList);
+    }
+
+    private void applyAclChanges(String mirrorName, SourceAclChanges aclChanges) {
+        if (!aclChanges.aclsToAdd().isEmpty()) {
+            log.debug("Adding {} ACLs from remote cluster {}", aclChanges.aclsToAdd().size(), mirrorName);
+            var requestData = aclChanges.aclsToAdd().stream().map(
+                            aclBinding -> new CreateAclsRequestData.AclCreation()
+                                    .setResourceType(aclBinding.pattern().resourceType().code())
+                                    .setResourceName(aclBinding.pattern().name())
+                                    .setResourcePatternType(aclBinding.pattern().patternType().code())
+                                    .setPrincipal(aclBinding.entry().principal())
+                                    .setHost(aclBinding.entry().host())
+                                    .setOperation(aclBinding.entry().operation().code())
+                                    .setPermissionType(aclBinding.entry().permissionType().code()))
+                    .toList();
+            channelManager.sendRequest(
+                    new CreateAclsRequest.Builder(new CreateAclsRequestData().setCreations(requestData)),
+                    new TimeoutHandler(log)
+            );
+        }
+
+        if (!aclChanges.aclsToDelete().isEmpty()) {
+            log.debug("Removing {} ACLs from remote cluster {}", aclChanges.aclsToDelete().size(), mirrorName);
+            var requestData = aclChanges.aclsToDelete().stream().map(
+                            aclBinding -> new org.apache.kafka.common.message.DeleteAclsRequestData.DeleteAclsFilter()
+                                    .setResourceTypeFilter(aclBinding.pattern().resourceType().code())
+                                    .setResourceNameFilter(aclBinding.pattern().name())
+                                    .setPatternTypeFilter(aclBinding.pattern().patternType().code())
+                                    .setPrincipalFilter(aclBinding.entry().principal())
+                                    .setHostFilter(aclBinding.entry().host())
+                                    .setOperation(aclBinding.entry().operation().code())
+                                    .setPermissionType(aclBinding.entry().permissionType().code()))
+                    .toList();
+            channelManager.sendRequest(
+                    new DeleteAclsRequest.Builder(new DeleteAclsRequestData().setFilters(requestData)),
+                    new TimeoutHandler(log)
+            );
+        }
+    }
+
+    private void discoverTopicsByPattern(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        final Pattern topicsIncludePattern = mirrorConfig.topicsIncludePattern();
+        if (topicsIncludePattern == null) {
+            return;
+        }
+
+        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+
+        Set<String> configuredTopics = manager.getConfiguredTopics(mirrorName, true);
+        final Pattern topicsExcludePattern = mirrorConfig.topicsExcludePattern();
+
+        List<StartMirrorTopicsRequestData.TopicMetadata> newTopics;
+        try {
+            Set<String> allSourceTopics = srcAdmin.listTopics()
+                    .names().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            List<String> candidates = allSourceTopics.stream()
+                    .filter(name -> topicsIncludePattern.matcher(name).matches())
+                    .filter(name -> topicsExcludePattern == null || !topicsExcludePattern.matcher(name).matches())
+                    .filter(name -> !configuredTopics.contains(name))
+                    .toList();
+
+            if (candidates.isEmpty()) {
+                return;
+            }
+
+            Map<String, TopicDescription> descriptions = srcAdmin.describeTopics(candidates)
+                    .allTopicNames().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            cacheSourceLeaders(mirrorName, descriptions.values());
+
+            newTopics = descriptions.values().stream()
+                    .map(td -> new StartMirrorTopicsRequestData.TopicMetadata()
+                            .setTopicName(td.name())
+                            .setTopicId(td.topicId())
+                            .setNumPartitions(td.partitions().size()))
+                    .toList();
+        } catch (Exception e) {
+            log.warn("Failed to discover topics by pattern for mirror {}", mirrorName, e);
+            return;
+        }
+
+        if (newTopics.isEmpty()) {
+            return;
+        }
+
+        log.info("Discovered {} new topic(s) matching mirror.topics.include pattern for mirror {}: {}",
+                newTopics.size(), mirrorName, newTopics.stream().map(StartMirrorTopicsRequestData.TopicMetadata::topicName).toList());
+
+        // TODO: creation failures from auto-discovery are silently lost here (fire-and-forget).
+        //  Add per-topic status tracking so describeMirror can surface failed topics to users.
+        try {
+            manager.getOrCreateDestAdmin().startMirrorTopics(
+                    mirrorName,
+                    newTopics.stream().map(StartMirrorTopicsRequestData.TopicMetadata::topicName).collect(Collectors.toSet()),
+                    new StartMirrorTopicsOptions()).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            log.warn("Failed to start discovered topics for mirror {}: {}", mirrorName, e.getMessage());
+        }
+    }
+
+    /**
+     * Checks if any active mirror topics now match the exclude pattern and sends
+     * StopMirrorTopicsRequest to stop them. Catches cases where exclude was updated
+     * via incrementalAlterConfigs outside of the startMirrorTopics/stopMirrorTopics flow.
+     */
+    private void enforceExcludePatterns(String mirrorName, ClusterMirrorConfig mirrorConfig) {
+        Pattern excludePattern = mirrorConfig.topicsExcludePattern();
+        if (excludePattern == null) return;
+
+        Set<String> activeTopics = manager.getConfiguredTopics(mirrorName, false, false);
+        Set<String> excludedTopics = activeTopics.stream()
+                .filter(topic -> excludePattern.matcher(topic).matches())
+                .collect(Collectors.toSet());
+
+        if (excludedTopics.isEmpty()) return;
+
+        log.info("Stopping {} topic(s) matching mirror.topics.exclude for mirror {}: {}",
+                excludedTopics.size(), mirrorName, excludedTopics);
+
+        try {
+            manager.getOrCreateDestAdmin().stopMirrorTopics(mirrorName, excludedTopics, new StopMirrorTopicsOptions())
+                    .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            log.warn("Failed to stop excluded topics for mirror {}: {}", mirrorName, e.getMessage());
+        }
+    }
+
+    /** Schedules a source topic state sync followed by a leader epoch bump request. */
+    CompletableFuture<Void> scheduleBumpLeaderEpochs(String mirrorName, Set<TopicPartition> topicPartitions) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        scheduler.scheduleOnce("bump-leader-epoch", () -> {
+            Optional<List<SourceTopicState>> sourceTopicStates = syncSourceTopicState(mirrorName);
+            maybeBumpLeaderEpochs(mirrorName, sourceTopicStates, topicPartitions)
+                    .whenComplete((v, ex) -> {
+                        if (ex != null) {
+                            future.completeExceptionally(ex);
+                        } else {
+                            future.complete(null);
+                        }
+                    });
+        });
+        return future;
+    }
+
+    private CompletableFuture<Void> maybeBumpLeaderEpochs(String mirrorName, Optional<List<SourceTopicState>> sourceTopicStates, Set<TopicPartition> topicPartitions) {
+        return sourceTopicStates
+                .map(topicStates -> sendBumpLeaderEpochs(buildSourceEpochBumpTargets(mirrorName, topicStates, topicPartitions))
+                .whenComplete((v, ex) -> {
+                    if (ex != null) log.warn("Failed to bump leader epoch for mirror {}", mirrorName, ex);
+                })).orElseGet(() -> CompletableFuture.completedFuture(null));
+    }
+
+    /** Sends an AlterPartition request to bump leader epochs on the destination. */
+    CompletableFuture<Void> sendBumpLeaderEpochs(Map<TopicPartition, Integer> partitionMinEpochs) {
+        if (partitionMinEpochs.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        log.info("Sending bump leader epoch request: {}", partitionMinEpochs);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        List<BumpLeaderEpochsRequestData.TopicState> topicStates = new ArrayList<>();
+        Map<String, Set<Integer>> partitions = new HashMap<>();
+        partitionMinEpochs.keySet().forEach(tp -> {
+            partitions.computeIfAbsent(tp.topic(), key -> new HashSet<>()).add(tp.partition());
+        });
+        partitions.forEach((topic, parts) -> {
+            BumpLeaderEpochsRequestData.TopicState topicState = new BumpLeaderEpochsRequestData.TopicState();
+            List<BumpLeaderEpochsRequestData.LeaderEpochState> topicLeaderEpoch = new ArrayList<>();
+            parts.forEach(partitionId -> {
+                TopicPartition tp = new TopicPartition(topic, partitionId);
+                topicLeaderEpoch.add(new BumpLeaderEpochsRequestData.LeaderEpochState().setMinLeaderEpoch(partitionMinEpochs.get(tp)).setPartitionIndex(partitionId));
+            });
+            topicState.setTopicId(metadataCache.getTopicId(topic)).setPartitions(topicLeaderEpoch);
+            topicStates.add(topicState);
+        });
+
+        manager.pendingLeaderEpochBumps.add(new ClusterMirrorUtils.LeaderEpochBump(future, new ConcurrentHashMap<>(partitionMinEpochs)));
+        manager.maybeCompletePendingEpochBumps();
+
+        channelManager.sendRequest(new BumpLeaderEpochsRequest.Builder(
+                new BumpLeaderEpochsRequestData().setTopics(topicStates)
+        ), new ControllerRequestCompletionHandler() {
+            @Override
+            public void onComplete(ClientResponse response) {
+                log.debug("Bump leader epoch response: {}", response);
+            }
+
+            @Override
+            public void onTimeout() {
+                log.warn("BumpLeaderEpoch request timed out");
+            }
+        });
+        return future;
+    }
+
+    private Map<TopicPartition, Integer> buildSourceEpochBumpTargets(String mirrorName, List<SourceTopicState> sourceTopicStates, Set<TopicPartition> topicPartitions) {
+        Set<String> mirrorTopics = topicPartitions.isEmpty() ? manager.getConfiguredTopics(mirrorName, false) : Set.of();
+        Map<TopicPartition, Integer> leaderEpochFromMetadata = new HashMap<>();
+        for (SourceTopicState ts : sourceTopicStates) {
+            if (!ts.exists()) {
+                continue;
+            }
+            if (!mirrorTopics.isEmpty() && !mirrorTopics.contains(ts.topic())) {
+                continue;
+            }
+            collectEpochBumpTargets(ts, topicPartitions, leaderEpochFromMetadata);
+        }
+        if (!leaderEpochFromMetadata.isEmpty()) {
+            log.info("Bumping leader epoch for partitions {}", leaderEpochFromMetadata);
+        }
+        return leaderEpochFromMetadata;
+    }
+
+    private void collectEpochBumpTargets(SourceTopicState topicInfo,
+                                         Set<TopicPartition> topicPartitions,
+                                         Map<TopicPartition, Integer> leaderEpochFromMetadata) {
+        for (SourcePartitionState ps : topicInfo.partitions()) {
+            TopicPartition tp = ps.topicPartition();
+            if (!topicPartitions.isEmpty() && !topicPartitions.contains(tp)) {
+                continue;
+            }
+            if (ps.leaderEpoch().isEmpty()) {
+                continue;
+            }
+            TopicImage topicImage = manager.metadataImage().topics().getTopic(tp.topic());
+            if (topicImage == null || topicImage.partitions().get(tp.partition()) == null) {
+                continue;
+            }
+            int epoch = ps.leaderEpoch().get();
+            int localEpoch = topicImage.partitions().get(tp.partition()).leaderEpoch;
+            if (epoch > localEpoch - LEADER_EPOCH_BUMP_THRESHOLD) {
+                int newEpoch = Math.addExact(epoch, LEADER_EPOCH_BUMP_INCREMENT);
+                leaderEpochFromMetadata.put(tp, newEpoch);
+            }
+        }
+    }
+
+    /**
+     * Pre-populates sourceLeaders for discovered topics so that when onMetadataUpdate fires
+     * after the destination topic is created, the fetcher can connect to the correct source
+     * broker immediately. Without this, the fetcher starts with a bootstrap broker, gets a
+     * redirect it cannot resolve, and cycles through FAILED/retry until the next periodic
+     * syncSourceTopicState populates the cache.
+     */
+    private void cacheSourceLeaders(String mirrorName, Collection<TopicDescription> descriptions) {
+        var partitionLeaders = manager.sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
+        descriptions.forEach(td -> td.partitions().forEach(pi -> {
+            if (pi.leader() != null) {
+                partitionLeaders.put(new TopicPartition(td.name(), pi.partition()),
+                        new LeaderInfo(pi.leader(), pi.leaderEpoch().orElse(0)));
+            }
+        }));
+    }
+
+    /**
+     * Validates that all partitions about to be mirrored are in STOPPED state on the source cluster,
+     * for any source mirror that was previously mirroring from this local cluster. This prevents
+     * starting replication while the reverse direction is still active.
+     *
+     * @param sourceDescription   described mirrors from the source cluster
+     * @param sourceMirrors       listed mirrors from the source cluster
+     * @param topicPartitionToBeMirrored partitions about to start mirroring
+     * @throws IllegalStateException if any partition is not STOPPED
+     */
+    private void validateSourcePartitionsAreStopped(
+            Map<String, ClusterMirrorDescription> sourceDescription,
+            Collection<ClusterMirrorListing> sourceMirrors,
+            Set<TopicPartition> topicPartitionToBeMirrored) {
+        Set<TopicPartition> partitionsNotStopped = new HashSet<>();
+        List<String> localClusterSourceMirrors = sourceMirrors.stream()
+                .filter(sm -> sm.sourceClusterId().equals(manager.clusterId()))
+                .map(ClusterMirrorListing::mirrorName)
+                .toList();
+
+        for (String mirrorName : localClusterSourceMirrors) {
+            ClusterMirrorDescription desc = sourceDescription.get(mirrorName);
+            if (desc == null) {
+                continue;
+            }
+            for (TopicPartition tp : topicPartitionToBeMirrored) {
+                Set<ClusterMirrorDescription.LeaderStateDescription> leaderStates = desc.topics().get(tp.topic());
+                if (leaderStates == null) {
+                    continue;
+                }
+                boolean notStopped = leaderStates.stream()
+                        .anyMatch(lsd -> lsd.topicPartition().equals(tp)
+                                && (!MirrorPartitionState.STOPPED.name().equals(lsd.state())));
+                if (notStopped) {
+                    partitionsNotStopped.add(tp);
+                }
+            }
+        }
+
+        if (!partitionsNotStopped.isEmpty()) {
+            log.error("Source mirror(s) {} mirroring from this cluster ({}) have not stopped for partition(s) {}",
+                    localClusterSourceMirrors, manager.clusterId(), partitionsNotStopped);
+            throw new IllegalStateException("Source mirror(s) " + localClusterSourceMirrors
+                    + " mirroring from this cluster (" + manager.clusterId() + ") have not stopped for partition(s) "
+                    + partitionsNotStopped + ".");
+        }
+    }
+
+    /** Looks up last mirror epochs from the source cluster for failback truncation. */
+    CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(
+            String mirrorName, Set<TopicPartition> topicPartitionSet, Collection<ClusterMirrorListing> sourceMirrors) {
+        Admin admin = manager.getOrCreateSourceAdmin(mirrorName);
+        List<DescribeClusterMirrorsRequestData.LastMirrorEpochLookup> lookups = buildLastMirrorEpochLookups(topicPartitionSet);
+        log.info("Last mirror epoch lookup request for mirror {}: {}", mirrorName, lookups);
+        DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
+                .clusterId(manager.clusterId())
+                .lastMirrorEpochLookups(lookups);
+        DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(), options);
+
+        var describeFuture = result.allDescriptions().toCompletionStage().toCompletableFuture();
+        var lookupEpochsFuture = result.lookupEpochs().toCompletionStage().toCompletableFuture();
+        return describeFuture.thenApply(desc -> {
+            validateSourcePartitionsAreStopped(desc, sourceMirrors, topicPartitionSet);
+            return null;
+        })
+            .thenCompose(__ -> lookupEpochsFuture)
+            .thenApply(lookupEpochs -> {
+                Map<TopicPartition, Integer> epochs = new HashMap<>();
+                if (!lookupEpochs.isEmpty()) {
+                    lookupEpochs.forEach((topicId, partitionEpochs) -> {
+                        Optional<String> topicName = metadataCache.getTopicName(topicId);
+                        topicName.ifPresent(name ->
+                                partitionEpochs.forEach((partIdx, lme) ->
+                                        epochs.put(new TopicPartition(name, partIdx), lme)));
+                    });
+                }
+                log.info("Last mirror epoch lookup response for mirror {}: {}", mirrorName, epochs);
+                return epochs;
+            })
+            .orTimeout(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Builds LME lookup entries with only this cluster's own ID.
+     * The source matches this against its mirror configs to find cases
+     * where it previously mirrored from us (direct failback).
+     */
+    private List<DescribeClusterMirrorsRequestData.LastMirrorEpochLookup> buildLastMirrorEpochLookups(
+            Set<TopicPartition> topicPartitionSet) {
+        Map<Uuid, List<Integer>> partitionsByTopicId = new HashMap<>();
+        for (TopicPartition tp : topicPartitionSet) {
+            Uuid topicId = metadataCache.getTopicId(tp.topic());
+            partitionsByTopicId.computeIfAbsent(topicId, k -> new ArrayList<>()).add(tp.partition());
+        }
+
+        List<DescribeClusterMirrorsRequestData.LastMirrorEpochLookup> lookups = new ArrayList<>();
+        for (Map.Entry<Uuid, List<Integer>> entry : partitionsByTopicId.entrySet()) {
+            lookups.add(new DescribeClusterMirrorsRequestData.LastMirrorEpochLookup()
+                    .setTopicId(entry.getKey())
+                    .setPartitions(entry.getValue()));
+        }
+        return lookups;
+    }
+
+    record TimeoutHandler(Logger log) implements ControllerRequestCompletionHandler {
+        @Override
+        public void onTimeout() {
+            log.warn("Controller request timed out");
+        }
+
+        @Override
+        public void onComplete(ClientResponse response) {
+            log.debug("Controller request completed: {}", response);
+        }
+    }
+
+    record SourceTopicState(String topic, Uuid topicId, boolean exists, List<SourcePartitionState> partitions) { }
+    record SourcePartitionState(TopicPartition topicPartition, Node leader, Optional<Integer> leaderEpoch) { }
+    record SourceAclChanges(List<AclBinding> aclsToAdd, List<AclBinding> aclsToDelete) { }
+}

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherManager.scala
@@ -150,7 +150,7 @@ class MirrorFetcherManager(brokerConfig: KafkaConfig,
       replicaManager, quotaManager, metadataVersionSupplier, brokerEpochSupplier, isClusterMirror = true,
       mirrorConfig = Some(mirrorConfig))
     val mirrorFetchBackoffMs = mirrorConfig.fetchBackoffMs().toInt
-    new MirrorFetcherThread(threadName, endpoint, brokerConfig, failedPartitions, replicaManager,
+    new MirrorFetcherThread(threadName, endpoint, failedPartitions, replicaManager,
       quotaManager, logContext.logPrefix, mirrorName, mirrorFetchBackoffMs)
   }
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -33,11 +33,10 @@ import scala.collection.{Map, Set}
 import scala.jdk.CollectionConverters.SetHasAsJava
 
 /**
- * Fetcher thread for cross-cluster mirroring.
+ * Fetcher thread for Cluster Mirroring.
  */
 class MirrorFetcherThread(name: String,
                           leader: LeaderEndPoint,
-                          brokerConfig: KafkaConfig,
                           failedPartitions: FailedPartitions,
                           replicaMgr: ReplicaManager,
                           quota: ReplicaQuota,


### PR DESCRIPTION
Split MirrorMetadataManager into two components with distinct responsibilities and threading models:

MirrorMetadataManager keeps the MetadataPublisher implementation, handling KRaft metadata updates and state transitions on the publisher thread. It owns shared state (partition cache, source leader cache, admin clients) and coordinator communication.

MirrorSourceSyncer handles all periodic sync from source clusters on the scheduler thread: topic metadata, configs, group offsets, ACLs, pattern discovery, epoch bumping, LME lookups, and mirror loop detection.

The syncer is created during initialize() and accesses shared state through the manager. External callers (ClusterMirrorCoordinator, MirrorFetcherThread, BrokerServer) are unchanged as thin delegation methods on the manager forward to the syncer.