### PR TITLE
Improve failed state handling

### DIFF
--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -444,7 +444,10 @@ public class ClusterMirrorCoordinator {
                 targetState = fpi.previousState();
             }
             log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
-            ScheduledFuture<?> future = scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
+            ScheduledFuture<?> future = scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> {
+                transitionTo(mirrorName, Set.of(tp), targetState);
+                metadataManager.pendingRetryFutures.remove(tp);
+            }, delay);
             metadataManager.pendingRetryFutures.put(tp, future);
         });
     }

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -86,6 +86,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -407,6 +408,8 @@ public class ClusterMirrorCoordinator {
     private void scheduleFailedRetries(String mirrorName, Set<TopicPartition> topicPartitions) {
         int maxAttempts = brokerConfig.mirrorConfig().failedRetryMaxAttempts();
         topicPartitions.forEach(tp -> {
+            if (metadataManager.pendingRetryFutures.containsKey(tp))
+                return;
             FailedPartitionInfo fpi = metadataManager.getFailedInfo(ClusterMirrorRecordKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition()));
             int attempt = fpi != null ? fpi.retryAttempt() : 1;
             if (attempt == NON_RETRYABLE_ATTEMPT) {
@@ -436,7 +439,8 @@ public class ClusterMirrorCoordinator {
                 targetState = fpi.previousState();
             }
             log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.", attempt, tp, delay, targetState);
-            scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
+            ScheduledFuture<?> future = scheduler.scheduleOnce("MirrorFailedRetry-" + tp, () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
+            metadataManager.pendingRetryFutures.put(tp, future);
         });
     }
 

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -404,6 +404,7 @@ public class ClusterMirrorCoordinator {
             // 1. new state is STOPPED or PAUSED state
             // 2. there is state change, but not change from/to FAILED
             // we already filter out the newState == FAILED case above, so skip the check
+            // 3. For MIRRORING, it'll clean up after the first successful fetch response in MirrorFetcherThread.
             metadataManager.clearFailedInfo(pk);
         }
     }

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -397,9 +397,13 @@ public class ClusterMirrorCoordinator {
                 }
                 return new FailedPartitionInfo(attempt, errorMessage, previousState);
             });
-        } else if (newState == MirrorPartitionState.LOG_TRUNCATION
+        } else if ((currentState != MirrorPartitionState.FAILED && currentState != newState)
                 || newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
+            // clean up the state when:
+            // 1. new state is STOPPED or PAUSED state
+            // 2. there is state change, but not change from/to FAILED
+            // we already filter out the newState == FAILED case above, so skip the check
             metadataManager.clearFailedInfo(pk);
         }
     }

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -465,7 +465,7 @@ public class ClusterMirrorCoordinator {
         topicPartitions.forEach(tp -> {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
-                log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
+                log.debug("Transitioning partition {} from {} to {} due to {}.", tp, currentState, newState, errorMessage);
                 updateFailedState(mirrorName, tp, currentState, newState, errorMessage, nonRetryable);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {

--- a/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
+++ b/core/src/main/java/kafka/server/mirror/ClusterMirrorCoordinator.java
@@ -468,7 +468,11 @@ public class ClusterMirrorCoordinator {
         topicPartitions.forEach(tp -> {
             MirrorPartitionState currentState = metadataManager.getPartitionState(mirrorName, tp);
             if (MirrorPartitionState.isValidTransition(currentState, newState)) {
-                log.debug("Transitioning partition {} from {} to {} due to {}.", tp, currentState, newState, errorMessage);
+                if (newState == MirrorPartitionState.FAILED) {
+                    log.info("Transitioning partition {} from {} to {} due to {} with nonRetryable: {}.", tp, currentState, newState, errorMessage, nonRetryable);
+                } else {
+                    log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
+                }
                 updateFailedState(mirrorName, tp, currentState, newState, errorMessage, nonRetryable);
                 updateMirrorPartitionState(mirrorName, tp, newState)
                         .whenComplete((optTp, ex) -> {

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -578,7 +578,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     private void removePendingRetryFuture(TopicPartition tp) {
         var future = pendingRetryFutures.remove(tp);
-        future.cancel(false);
+        if (future != null)
+            future.cancel(false);
     }
 
     /**

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -87,6 +87,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -144,6 +145,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
     private final Map<TopicPartition, MirrorPartitionState> pendingPartitionStates = new ConcurrentHashMap<>();
     final Set<LeaderEpochBump> pendingLeaderEpochBumps = ConcurrentHashMap.newKeySet();
+    final Map<TopicPartition, ScheduledFuture<?>> pendingRetryFutures = new ConcurrentHashMap<>();
 
     // Functions
     private Optional<StateTransitioner> stateTransitioner = Optional.empty();
@@ -459,6 +461,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                     return;
                 }
                 pendingPartitionStates.remove(tp);
+                removePendingRetryFuture(tp);
                 pendingLeaderEpochBumps.removeIf(bump -> {
                     bump.partitionToEpoch().remove(tp);
                     if (bump.partitionToEpoch().isEmpty()) {
@@ -565,6 +568,17 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         sourceLeaders.clear();
         pendingLeaderEpochBumps.clear();
         pendingPartitionStates.clear();
+        removePendingRetryFutures();
+    }
+
+    private void removePendingRetryFutures() {
+        pendingRetryFutures.values().forEach(f -> f.cancel(false));
+        pendingRetryFutures.clear();
+    }
+
+    private void removePendingRetryFuture(TopicPartition tp) {
+        var future = pendingRetryFutures.remove(tp);
+        future.cancel(false);
     }
 
     /**
@@ -1043,6 +1057,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     public void clearFailedInfo(ClusterMirrorRecordKey key) {
         partitionCache.computeIfPresent(key, (k, existing) ->
                 new PartitionCacheEntry(existing.state(), existing.lastMirrorEpoch(), null));
+        metadataCache.getTopicName(key.topicId()).ifPresent(topicName ->
+                removePendingRetryFuture(new TopicPartition(topicName, key.partition())));
     }
 
     public void clearFailedInfo(String mirrorName, TopicPartition tp) {


### PR DESCRIPTION
Address https://docs.google.com/document/d/17RztIcPM8_3KlJ3ySCYQcG0w-XXxt0fsqzdjKe8RlnE/edit?disco=AAAB9PK8TX4

Two improvements:
a. If a partition is in FAILED state and already `scheduleFailedRetries` for backoff ms, later a new metadata update comes and the partition enters FAILED state again, it'll `scheduleFailedRetries` again, so there will be > 1 threads doing failed retry, so the retry attempt will be incremented by many threads.
b. When the previousState is `LOG_TRUNCATION` in FAILED state, it might enter this indefinite loop:
1. a partition enters `LOG_TRUNCATION`
2. Connection error when query the LME from source cluster, entering FAILED state (retry attempt: 1)
3. Backoff completes, re-entering `LOG_TRUNCATION`
4. enter `updateFailedState` and clean up the `failedPartitionInfo` due to `state == LOG_TRUNCATION`
5. Connection still fail, entering FAILED state again, but retry attempt is still 1
6. Backoff completes, re-entering `LOG_TRUNCATION`
7. ...

So you can see, it'll be an infinite loop here as long as the connection error not recovered.

I think cleaning up  for `STOPPED` and `PAUSED` states make sense because these 2 are the no-op states. There will be no error during these states. But it doesn't apply for other states, including `LOG_TRUNCATION` and `MIRRORING`.

So I think for `LOG_TRUNCATION`, we can clean up the `failedInfo` when it moves to `MIRRORING`. This can be done by adding one more if condition:

```
// clean up the state as long as there is state change, but not change from FAILED
// we already filter out the newState == FAILED case above, so it's fine
else if ((currentState != MirrorPartitionState.FAILED && currentState != newState)
        || newState == MirrorPartitionState.STOPPED
        || newState == MirrorPartitionState.PAUSED) {
    metadataManager.clearFailedInfo(pk);
}
```

For `MIRRORING`, because it is similar to a terminal state, but we cannot treat it as STOPPED/PAUSED because `MIRRORING` might fail due to connection error or something. So we clean up the `failedInfo` after there is one successful fetch response. This is already done in `MirrorFetcherThread#validateLeaderEpoch`. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
