### PR TITLE
Route readMirrorStates through scheduleReadOperation

### DIFF
--- a/core/src/main/java/kafka/server/mirror/CoreBridgeImpl.java
+++ b/core/src/main/java/kafka/server/mirror/CoreBridgeImpl.java
@@ -21,7 +21,6 @@ import kafka.server.ReplicaManager;
 import org.apache.kafka.clients.admin.ClusterMirrorListing;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.requests.ReadMirrorStatesResponse;
 import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
 import org.apache.kafka.coordinator.mirror.ClusterMirrorCoordinatorService.MirrorStateWrite;
 import org.apache.kafka.coordinator.mirror.CoreBridge;
@@ -81,48 +80,33 @@ public class CoreBridgeImpl implements CoreBridge {
 
     @Override
     public void onShardUnloaded(int coordPartition, int coordPartitionCount) {
-        metadataManager.cache().clearPartition(coordPartition, coordPartitionCount);
+        metadataManager.clearPartition(coordPartition, coordPartitionCount);
     }
 
     @Override
-    public MirrorPartitionState getPartitionState(String mirrorName, TopicPartition tp) {
-        return metadataManager.getPartitionState(mirrorName, tp);
+    public MirrorPartition getPartition(MirrorPartitionKey key) {
+        return metadataManager.getPartition(key);
     }
 
     @Override
-    public void setPartitionState(MirrorPartitionKey key, MirrorPartitionState state) {
-        metadataManager.cache().setPartitionState(key, state);
+    public void setPartition(MirrorPartitionKey key, MirrorPartition partition) {
+        metadataManager.setPartition(key, partition);
     }
 
     @Override
-    public void removePartitionState(MirrorPartitionKey key) {
-        metadataManager.cache().remove(key);
-    }
-
-    @Override
-    public MirrorPartition getFailedInfo(MirrorPartitionKey key) {
-        return metadataManager.cache().get(key);
-    }
-
-    @Override
-    public void setFailedInfo(MirrorPartitionKey key, MirrorPartition info) {
-        metadataManager.cache().setFailedInfo(key, info.errorMessage(), info.retryAttempt(), info.prevState());
-    }
-
-    @Override
-    public void clearFailedInfo(MirrorPartitionKey key) {
-        metadataManager.cache().clearFailedInfo(key);
+    public void removePartition(MirrorPartitionKey key) {
+        metadataManager.removePartition(key);
     }
 
     @Override
     public void updateFailedInfo(
         MirrorPartitionKey key,
-        MirrorPartitionState currentState,
+        MirrorPartitionState curState,
         MirrorPartitionState newState,
         String errorMessage,
         boolean nonRetryable
     ) {
-        metadataManager.cache().updateFailedInfo(key, currentState, newState, errorMessage, nonRetryable);
+        metadataManager.updateFailedInfo(key, curState, newState, errorMessage, nonRetryable);
     }
 
     @Override
@@ -138,15 +122,6 @@ public class CoreBridgeImpl implements CoreBridge {
         Consumer<WriteMirrorStatesResponse> callback
     ) {
         metadataManager.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, stoppedTopics, callback);
-    }
-
-    @Override
-    public void readStatesFromLocalCoordinator(
-        String mirrorName,
-        Map<String, Set<Integer>> partitions,
-        Consumer<ReadMirrorStatesResponse> callback
-    ) {
-        metadataManager.readMirrorStates(mirrorName, partitions, callback);
     }
 
     @Override
@@ -190,12 +165,12 @@ public class CoreBridgeImpl implements CoreBridge {
 
     @Override
     public void removeMirror(String mirrorName) {
-        metadataManager.cache().removeMirror(mirrorName);
+        metadataManager.removeMirror(mirrorName);
     }
 
     @Override
     public void removePendingEpochBumps(Set<TopicPartition> partitions) {
-        metadataManager.cache().removePendingEpochBumps(partitions);
+        metadataManager.removePendingEpochBumps(partitions);
     }
 
     @Override

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -35,7 +35,6 @@ import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.MirrorPidResetRecord;
 import org.apache.kafka.common.message.PauseMirrorTopicsRequestData;
 import org.apache.kafka.common.message.ReadMirrorStatesRequestData;
-import org.apache.kafka.common.message.ReadMirrorStatesResponseData;
 import org.apache.kafka.common.message.ResumeMirrorTopicsRequestData;
 import org.apache.kafka.common.message.StartMirrorTopicsRequestData;
 import org.apache.kafka.common.message.StopMirrorTopicsRequestData;
@@ -246,8 +245,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             mirrorStateSender.start();
         }
 
-        this.sourceSyncer = new MirrorSourceSyncer(brokerConfig, this, channelManager,
-                metadataCache, scheduler, metadataRefreshError, topicConfigSyncError,
+        this.sourceSyncer = new MirrorSourceSyncer(brokerConfig, this, cache,
+                channelManager, metadataCache, scheduler, metadataRefreshError, topicConfigSyncError,
                 consumerGroupOffsetSyncError, shareGroupOffsetSyncError, aclSyncError);
         sourceSyncer.scheduleMetadataRefresh(brokerConfig.mirrorConfig().metadataRefreshIntervalMs());
 
@@ -345,8 +344,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return replicaManagerSupplier;
     }
 
-    public MirrorStateCache cache() {
-        return cache;
+    public void scheduleMetadataRefresh(long intervalMs) {
+        sourceSyncer.scheduleMetadataRefresh(intervalMs);
     }
 
     /**
@@ -436,59 +435,68 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
         if (delta.topicsDelta() != null) {
             LocalReplicaChanges localReplicaChanges = delta.topicsDelta().localChanges(nodeId);
-
-            // Phase 1: collect partitions where this broker gained mirror leadership
-            localReplicaChanges.leaders().keySet().forEach(tp -> {
-                String mirrorName = image.topics().getTopic(tp.topic()).mirrorName();
-                if (mirrorName != null && configuredMirrors.contains(mirrorName)) {
-                    partitionsToTransition.add(tp);
-                }
-            });
-            localReplicaChanges.mirrorTopicStates().keySet().forEach(topicId -> {
-                TopicImage topicImage = image.topics().getTopic(topicId);
-                if (topicImage != null && topicImage.mirrorName() != null
-                        && configuredMirrors.contains(topicImage.mirrorName())) {
-                    topicImage.partitions().forEach((partitionId, partition) -> {
-                        if (partition.leader == nodeId) {
-                            partitionsToTransition.add(new TopicPartition(topicImage.name(), partitionId));
-                        }
-                    });
-                }
-            });
-
-            // Phase 2: clean up state for partitions where this broker lost leadership
-            localReplicaChanges.followers().keySet().forEach(tp -> {
-                String mirrorName = image.topics().getTopic(tp.topic()).mirrorName();
-                if (mirrorName == null) {
-                    return;
-                }
-                cache.getPendingEpochBumps().removeIf(bump -> {
-                    bump.partitionToEpoch().remove(tp);
-                    if (bump.partitionToEpoch().isEmpty()) {
-                        bump.future().complete(null);
-                        return true;
-                    }
-                    return false;
-                });
-                if (!isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
-                    MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
-                    cache.remove(key);
-                }
-            });
+            collectGainedLeaderPartitions(localReplicaChanges, image, configuredMirrors, partitionsToTransition);
+            cleanupLostLeaderPartitions(localReplicaChanges, image);
         }
 
-        // Phase 3: re-add MIRRORING partitions for mirrors whose source connection was recreated
-        if (!reconnectedMirrors.isEmpty()) {
-            log.info("Re-evaluating MIRRORING partitions for reconnected mirrors: {}", reconnectedMirrors);
-            cache.forEach((key, entry) -> {
-                if (reconnectedMirrors.contains(key.mirrorName()) && entry.state() == MirrorPartitionState.MIRRORING) {
-                    metadataCache.getTopicName(key.topicId()).ifPresent(topicName ->
-                            partitionsToTransition.add(new TopicPartition(topicName, key.partition())));
-                }
-            });
-        }
-
+        collectReconnectedMirrorPartitions(reconnectedMirrors, partitionsToTransition);
         return partitionsToTransition;
+    }
+
+    private void collectGainedLeaderPartitions(LocalReplicaChanges changes, MetadataImage image,
+                                               Set<String> configuredMirrors, Set<TopicPartition> result) {
+        changes.leaders().keySet().forEach(tp -> {
+            String mirrorName = image.topics().getTopic(tp.topic()).mirrorName();
+            if (mirrorName != null && configuredMirrors.contains(mirrorName)) {
+                result.add(tp);
+            }
+        });
+        changes.mirrorTopicStates().keySet().forEach(topicId -> {
+            TopicImage topicImage = image.topics().getTopic(topicId);
+            if (topicImage != null && topicImage.mirrorName() != null
+                    && configuredMirrors.contains(topicImage.mirrorName())) {
+                topicImage.partitions().forEach((partitionId, partition) -> {
+                    if (partition.leader == nodeId) {
+                        result.add(new TopicPartition(topicImage.name(), partitionId));
+                    }
+                });
+            }
+        });
+    }
+
+    private void cleanupLostLeaderPartitions(LocalReplicaChanges changes, MetadataImage image) {
+        changes.followers().keySet().forEach(tp -> {
+            String mirrorName = image.topics().getTopic(tp.topic()).mirrorName();
+            if (mirrorName == null) {
+                return;
+            }
+            cache.getPendingLederEpochBumps().removeIf(bump -> {
+                bump.partitionToEpoch().remove(tp);
+                if (bump.partitionToEpoch().isEmpty()) {
+                    bump.future().complete(null);
+                    return true;
+                }
+                return false;
+            });
+            if (!isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
+                MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
+                cache.removePartition(key);
+            }
+        });
+    }
+
+    private void collectReconnectedMirrorPartitions(Set<String> reconnectedMirrors, Set<TopicPartition> result) {
+        if (reconnectedMirrors.isEmpty()) {
+            return;
+        }
+        log.info("Re-evaluating MIRRORING partitions for reconnected mirrors: {}", reconnectedMirrors);
+        cache.partitionKeys().forEach(key -> {
+            MirrorPartition entry = cache.getPartition(key);
+            if (entry != null && reconnectedMirrors.contains(key.mirrorName()) && entry.state() == MirrorPartitionState.MIRRORING) {
+                metadataCache.getTopicName(key.topicId()).ifPresent(topicName ->
+                        result.add(new TopicPartition(topicName, key.partition())));
+            }
+        });
     }
 
     /**
@@ -534,7 +542,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
             MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
             if (isLocalCoordinator(key.mirrorName(), tp.topic(), tp.partition())) {
-                MirrorPartition entry = cache.get(key);
+                MirrorPartition entry = cache.getPartition(key);
                 MirrorPartitionState curState = entry != null ? entry.state() : MirrorPartitionState.UNKNOWN;
                 log.debug("Local transition for {} (current: {})", tp, curState);
                 applyStateTransition(key.mirrorName(), tp, curState, null, stopRequested, pauseRequested);
@@ -564,7 +572,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 boolean stopRequested = desired == MirrorPartitionState.STOPPED.value();
                                 boolean pauseRequested = desired == MirrorPartitionState.PAUSED.value();
                                 MirrorPartitionKey mpk = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(resTp.topic()), resTp.partition());
-                                MirrorPartition curEntry = cache.get(mpk);
+                                MirrorPartition curEntry = cache.getPartition(mpk);
                                 MirrorPartitionState curState = curEntry != null ? curEntry.state() : MirrorPartitionState.UNKNOWN;
                                 applyStateTransition(mirrorName, resTp, curState, state, stopRequested, pauseRequested);
                             })));
@@ -573,7 +581,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     /** Completes epoch bump futures whose requested epochs are now reflected in the metadata image. */
     void maybeCompletePendingEpochBumps() {
-        cache.getPendingEpochBumps().removeIf(bumpLeaderEpoch -> {
+        cache.getPendingLederEpochBumps().removeIf(bumpLeaderEpoch -> {
             Set<TopicPartition> pendingPartitions = bumpLeaderEpoch.partitionToEpoch().entrySet().stream().filter(entry -> {
                 TopicPartition tp = entry.getKey();
                 int epoch = entry.getValue();
@@ -587,7 +595,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 bumpLeaderEpoch.future().complete(null);
                 return true;
             } else {
-                log.info("bumpLeaderEpoch future is pending for partitions: {}, all: {}", pendingPartitions, bumpLeaderEpoch.partitionToEpoch().keySet());
+                log.info("bumpLeaderEpoch future is pending for partitions: {}, all: {}",
+                        pendingPartitions, bumpLeaderEpoch.partitionToEpoch().keySet());
                 return false;
             }
         });
@@ -727,40 +736,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    /** Reads partition states and offsets from local cache. Used when this broker is the coordinator. */
-    public void readMirrorStates(String mirrorName, Map<String, Set<Integer>> partitions,
-                                 Consumer<ReadMirrorStatesResponse> responseCallback) {
-        ReadMirrorStatesResponseData data = new ReadMirrorStatesResponseData();
-        List<ReadMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
-        partitions.forEach((tp, parts) -> {
-            ReadMirrorStatesResponseData.TopicResult topicResult = new ReadMirrorStatesResponseData.TopicResult().setName(tp);
-            List<ReadMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();
-            parts.forEach(part -> {
-                MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp), part);
-                ReadMirrorStatesResponseData.PartitionResult partitionResult = new ReadMirrorStatesResponseData.PartitionResult();
-                if (!isLocalCoordinator(mirrorName, tp, part)) {
-                    partitionResult.setErrorCode(Errors.NOT_COORDINATOR.code());
-                    partitionResult.setErrorMessage(Errors.NOT_COORDINATOR.message());
-                } else {
-                    MirrorPartition entry = cache.get(pk);
-                    partitionResult.setPartitionIndex(part);
-                    partitionResult.setLastMirrorEpoch(entry != null ? entry.lastMirrorEpoch() : -1);
-                    MirrorPartitionState state = entry != null && entry.state() != null ? entry.state() : MirrorPartitionState.UNKNOWN;
-                    partitionResult.setState(state.value());
-                    partitionResult.setPreviousState(
-                            entry != null && entry.prevState() != null ? entry.prevState().value() : MirrorPartitionState.UNKNOWN.value());
-                    partitionResult.setRetryAttempt(entry != null ? (short) entry.retryAttempt() : (short) 0);
-                    partitionResult.setErrorMessage(entry != null ? entry.errorMessage() : null);
-                }
-                partitionResults.add(partitionResult);
-            });
-            topicResult.setPartitions(partitionResults);
-            topicResults.add(topicResult);
-        });
-        data.setTopics(topicResults);
-        responseCallback.accept(new ReadMirrorStatesResponse(data));
-    }
-
     /**
      * Reads partition states from remote coordinators, batching requests per coordinator node.
      * Updates the local {@link MirrorStateCache} with each response.
@@ -816,7 +791,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 topic.partitions().forEach(partition -> {
                                     MirrorPartitionKey mpk = MirrorPartitionKey.of(
                                             mirrorName, metadataCache.getTopicId(topic.name()), partition.partitionIndex());
-                                    cache.merge(mpk, partition.state(), partition.lastMirrorEpoch(),
+                                    cache.mergePartition(mpk, partition.state(), partition.lastMirrorEpoch(),
                                             partition.errorMessage(), partition.retryAttempt(), partition.previousState());
                                 }));
 
@@ -885,21 +860,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         });
     }
 
-    /** Returns the cached partition state, or null if not tracked. */
-    public MirrorPartitionState getPartitionState(String mirrorName, TopicPartition topicPartition) {
-        MirrorPartition entry = cache.get(
-                MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topicPartition.topic()), topicPartition.partition()));
-        return entry != null ? entry.state() : null;
-    }
-
-    public CompletableFuture<Void> scheduleBumpLeaderEpoch(String mirrorName, TopicPartition tp) {
-        return sourceSyncer.scheduleBumpLeaderEpoch(mirrorName, tp);
-    }
-
-    public CompletableFuture<Void> bumpLeaderEpochs(Map<TopicPartition, Integer> partitionMinEpochs) {
-        return sourceSyncer.sendBumpLeaderEpochs(partitionMinEpochs);
-    }
-
     public CompletableFuture<Void> abortOngoingTransactions(TopicPartition tp) {
         ReplicaManager rm = replicaManagerSupplier.get();
         var record = rm.getLog(tp).map(UnifiedLog::buildEndTransactionRecords);
@@ -932,30 +892,30 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         CompletableFuture<Void> result = new CompletableFuture<>();
         CompletableFuture<ProduceResponse.PartitionResponse> future = new CompletableFuture<>();
         MirrorPidResetRecord pidResetRecord = new MirrorPidResetRecord()
-            .setVersion(ControlRecordUtils.MIRROR_PID_RESET_CURRENT_VERSION)
-            .setSourceClusterId(sourceClusterId);
+                .setVersion(ControlRecordUtils.MIRROR_PID_RESET_CURRENT_VERSION)
+                .setSourceClusterId(sourceClusterId);
         try {
             var topicIdPartition = rm.topicIdPartition(tp);
             int bufferSize = DefaultRecordBatch.RECORD_BATCH_OVERHEAD + 256;
             ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
             MemoryRecords records = MemoryRecords.withMirrorPidResetRecord(
-                0, timestampMs, 0, buffer, pidResetRecord);
+                    0, timestampMs, 0, buffer, pidResetRecord);
             rm.appendRecords(
-                5000L,
-                (short) -1,
-                true,
-                AppendOrigin.COORDINATOR,
-                CollectionConverters.asScala(Map.of(topicIdPartition, records)),
-                partitionResponses -> {
-                    partitionResponses.foreach(partitionRes -> {
-                        future.complete(partitionRes._2);
+                    5000L,
+                    (short) -1,
+                    true,
+                    AppendOrigin.COORDINATOR,
+                    CollectionConverters.asScala(Map.of(topicIdPartition, records)),
+                    partitionResponses -> {
+                        partitionResponses.foreach(partitionRes -> {
+                            future.complete(partitionRes._2);
+                            return null;
+                        });
                         return null;
-                    });
-                    return null;
-                },
-                ignored -> null,
-                RequestLocal.noCaching(),
-                CollectionConverters.asScala(Map.of()));
+                    },
+                    ignored -> null,
+                    RequestLocal.noCaching(),
+                    CollectionConverters.asScala(Map.of()));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -965,7 +925,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             } else if (pr == null || pr.error.code() != 0) {
                 String errorMsg = pr != null ? pr.error.message() : "no response";
                 result.completeExceptionally(new RuntimeException(
-                    "PID reset barrier error for " + tp + ": " + errorMsg));
+                        "PID reset barrier error for " + tp + ": " + errorMsg));
             } else {
                 result.complete(null);
             }
@@ -973,17 +933,43 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return result;
     }
 
-    public void scheduleMetadataRefresh(long intervalMs) {
-        sourceSyncer.scheduleMetadataRefresh(intervalMs);
+    public CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(
+            String mirrorName, TopicPartition tp, Collection<ClusterMirrorListing> sourceMirrors) {
+        return sourceSyncer.sendLastMirrorEpochLookup(mirrorName, tp, sourceMirrors);
     }
 
-    /** Returns the source cluster ID from the mirror config, or null if not yet resolved. */
+    /**
+     * Local-only LME lookup. Returns LME from the local coordinator cache
+     * for partitions this broker coordinates, and -1 for the rest. The admin
+     * client broadcasts DescribeClusterMirrors to all brokers and takes the
+     * max, so each broker only needs its local view.
+     *
+     * @param mirrorPartitions mirrorName -> topicName -> partition indices
+     * @return mirrorName -> (TopicPartition -> LME)
+     */
+    public Map<String, Map<TopicPartition, Integer>> processLastMirrorEpochLookup(
+            Map<String, Map<String, Set<Integer>>> mirrorPartitions) {
+        Map<String, Map<TopicPartition, Integer>> result = new HashMap<>();
+        mirrorPartitions.forEach((mirrorName, topicParts) -> {
+            topicParts.forEach((topic, parts) -> {
+                parts.forEach(part -> {
+                    MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), part);
+                    MirrorPartition cached = cache.getPartition(pk);
+                    int lme = isLocalCoordinator(mirrorName, topic, part) && cached != null
+                            ? cached.lastMirrorEpoch() : -1;
+                    result.computeIfAbsent(mirrorName, k -> new HashMap<>())
+                            .put(new TopicPartition(topic, part), lme);
+                });
+            });
+        });
+        return result;
+    }
+
     public String getSourceClusterId(String mirrorName) {
         Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName));
         return (String) props.get(CommonClientConfigs.MIRROR_SOURCE_CLUSTER_ID_CONFIG);
     }
 
-    /** Returns the source bootstrap servers from the mirror config, or null if not set. */
     public String getSourceBootstrap(String mirrorName) {
         Properties props = metadataCache.config(new ConfigResource(ConfigResource.Type.CLUSTER_MIRROR, mirrorName));
         return Optional.ofNullable(props.get(BOOTSTRAP_SERVERS_CONFIG))
@@ -991,7 +977,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .orElse(null);
     }
 
-    /** Returns all mirror names present in the metadata image. */
     public Set<String> getConfiguredMirrors() {
         return metadataImage.configs().resourceData().keySet().stream()
                 .filter(resource -> resource.type() == ConfigResource.Type.CLUSTER_MIRROR)
@@ -999,13 +984,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 .collect(Collectors.toSet());
     }
 
-    /** Returns the cached partition states for all partitions of the given mirror. */
     public Map<TopicPartition, MirrorPartitionState> getMirrorStates(String mirrorName) {
         Map<TopicPartition, MirrorPartitionState> result = new HashMap<>();
-        cache.forEach((key, entry) -> {
-            if (key.mirrorName().equals(mirrorName) && entry.state() != null) {
-                metadataCache.getTopicName(key.topicId()).ifPresent(topicName ->
-                        result.put(new TopicPartition(topicName, key.partition()), entry.state()));
+        cache.partitionKeys().forEach(key -> {
+            if (key.mirrorName().equals(mirrorName)) {
+                MirrorPartition entry = cache.getPartition(key);
+                if (entry != null && entry.state() != null) {
+                    metadataCache.getTopicName(key.topicId()).ifPresent(topicName ->
+                            result.put(new TopicPartition(topicName, key.partition()), entry.state()));
+                }
             }
         });
         return result;
@@ -1041,8 +1028,64 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return getConfiguredTopics(mirrorName, false, false).size();
     }
 
+    public MirrorPartition getPartition(MirrorPartitionKey key) {
+        return cache.getPartition(key);
+    }
+
+    public MirrorPartitionState getPartitionState(String mirrorName, TopicPartition topicPartition) {
+        MirrorPartition entry = cache.getPartition(
+                MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topicPartition.topic()), topicPartition.partition()));
+        return entry != null ? entry.state() : null;
+    }
+
+    public void setPartition(MirrorPartitionKey key, MirrorPartition partition) {
+        cache.setPartition(key, partition);
+    }
+
+    public void removePartition(MirrorPartitionKey key) {
+        cache.removePartition(key);
+    }
+
+    public void clearPartition(int coordPartition, int coordPartitionCount) {
+        cache.clearPartition(coordPartition, coordPartitionCount);
+    }
+
+    public void setLastMirrorEpoch(String mirrorName, String topic, int partition, int epoch) {
+        MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), partition);
+        cache.setLastMirrorEpoch(key, epoch);
+    }
+
+    public void removeMirror(String mirrorName) {
+        cache.removeMirror(mirrorName);
+    }
+
+    public void updateFailedInfo(MirrorPartitionKey key, MirrorPartitionState currentState,
+                                 MirrorPartitionState newState, String errorMessage, boolean nonRetryable) {
+        cache.updateFailedInfo(key, currentState, newState, errorMessage, nonRetryable);
+    }
+
     public void clearFailedInfo(String mirrorName, TopicPartition tp) {
         cache.clearFailedInfo(MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition()));
+    }
+
+    public void removePendingEpochBumps(Set<TopicPartition> partitions) {
+        cache.clearPendingLeaderEpochBumps(partitions);
+    }
+
+    public MirrorStateCache.SourceLeader resolveSourceLeader(String mirrorName, TopicPartition tp) {
+        return cache.resolveSourceLeader(mirrorName, tp);
+    }
+
+    public void updateSourceLeader(String mirrorName, TopicPartition tp, MirrorStateCache.SourceLeader leader) {
+        cache.updateSourceLeader(mirrorName, tp, leader);
+    }
+
+    public CompletableFuture<Void> scheduleBumpLeaderEpoch(String mirrorName, TopicPartition tp) {
+        return sourceSyncer.scheduleBumpLeaderEpoch(mirrorName, tp);
+    }
+
+    public CompletableFuture<Void> bumpLeaderEpochs(Map<TopicPartition, Integer> partitionMinEpochs) {
+        return sourceSyncer.sendBumpLeaderEpochs(partitionMinEpochs);
     }
 
     public void validateDeleteMirrorStates(DeleteClusterMirrorRequestData data, Consumer<Optional<Errors>> callback) {
@@ -1160,7 +1203,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
             for (int i = 0; i < topicImage.partitions().size(); i++) {
                 if (isLocalCoordinator(mirrorName, topic, i)) {
-                    MirrorPartition cachedEntry = cache.get(
+                    MirrorPartition cachedEntry = cache.getPartition(
                             MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), i));
                     MirrorPartitionState state = cachedEntry != null && cachedEntry.state() != null
                             ? cachedEntry.state() : MirrorPartitionState.UNKNOWN;
@@ -1203,43 +1246,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
         }
         return Optional.empty();
-    }
-
-    public CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(
-            String mirrorName, TopicPartition tp, Collection<ClusterMirrorListing> sourceMirrors) {
-        return sourceSyncer.sendLastMirrorEpochLookup(mirrorName, tp, sourceMirrors);
-    }
-
-    /**
-     * Local-only LME lookup. Returns LME from the local coordinator cache
-     * for partitions this broker coordinates, and -1 for the rest. The admin
-     * client broadcasts DescribeClusterMirrors to all brokers and takes the
-     * max, so each broker only needs its local view.
-     *
-     * @param mirrorPartitions mirrorName -> topicName -> partition indices
-     * @return mirrorName -> (TopicPartition -> LME)
-     */
-    public Map<String, Map<TopicPartition, Integer>> processLastMirrorEpochLookup(
-            Map<String, Map<String, Set<Integer>>> mirrorPartitions) {
-        Map<String, Map<TopicPartition, Integer>> result = new HashMap<>();
-        mirrorPartitions.forEach((mirrorName, topicParts) -> {
-            topicParts.forEach((topic, parts) -> {
-                parts.forEach(part -> {
-                    MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), part);
-                    MirrorPartition cached = cache.get(pk);
-                    int lme = isLocalCoordinator(mirrorName, topic, part) && cached != null
-                            ? cached.lastMirrorEpoch() : -1;
-                    result.computeIfAbsent(mirrorName, k -> new HashMap<>())
-                            .put(new TopicPartition(topic, part), lme);
-                });
-            });
-        });
-        return result;
-    }
-
-    public void setLastMirrorEpoch(String mirrorName, String topic, int partition, int epoch) {
-        MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), partition);
-        cache.setLastMirrorEpoch(key, epoch);
     }
 
     /** Callback for partition state transitions triggered by the coordinator. */

--- a/core/src/main/java/kafka/server/mirror/MirrorSourceSyncer.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorSourceSyncer.java
@@ -119,6 +119,7 @@ class MirrorSourceSyncer {
 
     private final Logger log;
     private final MirrorMetadataManager manager;
+    private final MirrorStateCache cache;
     private final KafkaConfig brokerConfig;
     private final int nodeId;
     private final NodeToControllerChannelManager channelManager;
@@ -135,6 +136,7 @@ class MirrorSourceSyncer {
     MirrorSourceSyncer(
         KafkaConfig brokerConfig,
         MirrorMetadataManager manager,
+        MirrorStateCache cache,
         NodeToControllerChannelManager channelManager,
         MetadataCache metadataCache,
         KafkaScheduler scheduler,
@@ -145,6 +147,7 @@ class MirrorSourceSyncer {
         AtomicLong aclSyncError
     ) {
         this.manager = manager;
+        this.cache = cache;
         this.brokerConfig = brokerConfig;
         this.nodeId = brokerConfig.nodeId();
         this.channelManager = channelManager;
@@ -210,7 +213,7 @@ class MirrorSourceSyncer {
             return;
         }
         Set<String> configuredMirrors = manager.getConfiguredMirrors();
-        Set<String> staleMirrors = manager.cache().keySet().stream()
+        Set<String> staleMirrors = cache.partitionKeys().stream()
                 .map(MirrorPartitionKey::mirrorName)
                 .filter(name -> !configuredMirrors.contains(name))
                 .collect(Collectors.toSet());
@@ -377,13 +380,11 @@ class MirrorSourceSyncer {
         var createPartitionsTopics = new CreatePartitionsRequestData.CreatePartitionsTopicCollection();
 
         sourceTopicStates.forEach(ti -> {
-            var partitionLeaders = manager.cache().getOrCreateSourceLeaders(mirrorName);
-
             int sourcePartitionCount = ti.partitions().size();
 
             ti.partitions().forEach(pi -> {
                 if (pi.leader() != null) {
-                    partitionLeaders.put(pi.topicPartition(),
+                    cache.updateSourceLeader(mirrorName, pi.topicPartition(),
                             new SourceLeader(pi.leader(), pi.leaderEpoch().orElse(0)));
                 }
             });
@@ -402,7 +403,7 @@ class MirrorSourceSyncer {
             } else if (destTopic == null &&
                     manager.metadataImage().topics().getTopic(ti.topic()) == null &&
                     ti.exists() && sourcePartitionCount > 0) {
-                if (manager.cache().addPendingTopicCreation(ti.topic())) {
+                if (cache.addPendingTopicCreation(ti.topic())) {
                     creatableTopics.add(new CreateTopicsRequestData.CreatableTopic()
                             .setName(ti.topic())
                             .setNumPartitions(sourcePartitionCount)
@@ -445,13 +446,13 @@ class MirrorSourceSyncer {
         ControllerRequestCompletionHandler requestCompletionHandler = new ControllerRequestCompletionHandler() {
             @Override
             public void onTimeout() {
-                topicNames.forEach(manager.cache()::removePendingTopicCreation);
+                topicNames.forEach(cache::removePendingTopicCreation);
                 log.warn("Create mirror topics timed out for {}", topicNames);
             }
 
             @Override
             public void onComplete(ClientResponse response) {
-                topicNames.forEach(manager.cache()::removePendingTopicCreation);
+                topicNames.forEach(cache::removePendingTopicCreation);
                 if (response.responseBody() instanceof CreateTopicsResponse createTopicsResponse) {
                     createTopicsResponse.data().topics().forEach(topic -> {
                         var error = Errors.forCode(topic.errorCode());
@@ -531,13 +532,13 @@ class MirrorSourceSyncer {
      * widens the window in which the source leader is not yet known.
      */
     private void maybeStartMissedPartitions(String mirrorName) {
-        var partitionLeaders = manager.cache().getSourceLeaders(mirrorName);
+        var partitionLeaders = cache.getSourceLeaders(mirrorName);
         if (partitionLeaders == null) {
             return;
         }
         partitionLeaders.keySet().forEach(tp -> {
             var key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
-            var cachedEntry = manager.cache().get(key);
+            var cachedEntry = cache.getPartition(key);
             if (cachedEntry != null && cachedEntry.state() != null && cachedEntry.state() != MirrorPartitionState.UNKNOWN) {
                 return;
             }
@@ -1110,7 +1111,7 @@ class MirrorSourceSyncer {
             topicStates.add(topicState);
         });
 
-        manager.cache().addPendingEpochBump(new MirrorStateCache.PendingLeaderEpochBump(future, new ConcurrentHashMap<>(partitionMinEpochs)));
+        cache.addPendingEpochBump(new MirrorStateCache.PendingLeaderEpochBump(future, new ConcurrentHashMap<>(partitionMinEpochs)));
         manager.maybeCompletePendingEpochBumps();
 
         channelManager.sendRequest(new BumpLeaderEpochsRequest.Builder(
@@ -1179,10 +1180,9 @@ class MirrorSourceSyncer {
      * syncSourceTopicState populates the cache.
      */
     private void cacheSourceLeaders(String mirrorName, Collection<TopicDescription> descriptions) {
-        var sourceLeaders = manager.cache().getOrCreateSourceLeaders(mirrorName);
         descriptions.forEach(td -> td.partitions().forEach(pi -> {
             if (pi.leader() != null) {
-                sourceLeaders.put(new TopicPartition(td.name(), pi.partition()),
+                cache.updateSourceLeader(mirrorName, new TopicPartition(td.name(), pi.partition()),
                         new SourceLeader(pi.leader(), pi.leaderEpoch().orElse(0)));
             }
         }));

--- a/core/src/main/java/kafka/server/mirror/MirrorStateCache.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorStateCache.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiConsumer;
 
 /**
  * Thread-safe cache for mirror partition state, source leaders,
@@ -36,7 +35,7 @@ public class MirrorStateCache {
     private final Map<MirrorPartitionKey, MirrorPartition> partitions = new ConcurrentHashMap<>();
     private final Map<String, Map<TopicPartition, SourceLeader>> sourceLeaders = new ConcurrentHashMap<>();
     private final Set<String> pendingTopicCreations = ConcurrentHashMap.newKeySet();
-    private final Set<PendingLeaderEpochBump> pendingEpochBumps = ConcurrentHashMap.newKeySet();
+    private final Set<PendingLeaderEpochBump> pendingLederEpochBumps = ConcurrentHashMap.newKeySet();
 
     public static MirrorStateCache empty() {
         return new MirrorStateCache();
@@ -45,15 +44,25 @@ public class MirrorStateCache {
     private MirrorStateCache() {
     }
 
+    public void clear() {
+        partitions.clear();
+        sourceLeaders.clear();
+        pendingTopicCreations.clear();
+        pendingLederEpochBumps.clear();
+    }
+
     // -- Partition cache operations --
 
-    public MirrorPartition get(MirrorPartitionKey key) {
+    public MirrorPartition getPartition(MirrorPartitionKey key) {
         return partitions.get(key);
     }
 
-    /** Merges a coordinator response into the local cache entry for the given key. */
-    public void merge(MirrorPartitionKey key, byte state, int lastMirrorEpoch,
-                      String errorMessage, int retryAttempt, byte previousState) {
+    public void setPartition(MirrorPartitionKey key, MirrorPartition partition) {
+        partitions.put(key, partition);
+    }
+
+    public void mergePartition(MirrorPartitionKey key, byte state, int lastMirrorEpoch,
+                               String errorMessage, int retryAttempt, byte previousState) {
         partitions.compute(key, (k, existing) -> {
             MirrorPartition result = MirrorPartition.orEmpty(existing);
             if (state != -1) result = result.withState(MirrorPartitionState.fromValue(state));
@@ -65,33 +74,13 @@ public class MirrorStateCache {
         });
     }
 
-    public void setPartitionState(MirrorPartitionKey key, MirrorPartitionState newState) {
-        partitions.compute(key, (k, existing) -> MirrorPartition.orEmpty(existing).withState(newState));
-    }
-
-    public void setLastMirrorEpoch(MirrorPartitionKey key, int epoch) {
-        partitions.compute(key, (k, existing) -> MirrorPartition.orEmpty(existing).withLastMirrorEpoch(epoch));
-    }
-
-    public void remove(MirrorPartitionKey key) {
+    public void removePartition(MirrorPartitionKey key) {
         partitions.remove(key);
     }
 
-    public void removeMirror(String mirrorName) {
-        partitions.keySet().removeIf(key -> key.mirrorName().equals(mirrorName));
-    }
-
-    /** Clears all caches. */
-    public void clear() {
-        partitions.clear();
-        sourceLeaders.clear();
-        pendingTopicCreations.clear();
-        pendingEpochBumps.clear();
-    }
-
-    public void clearPartition(int coordinatorPartition, int coordinatorPartitionCount) {
+    public void clearPartition(int coordPartition, int coordPartitionCount) {
         partitions.keySet().removeIf(key ->
-            key.coordinatorPartition(coordinatorPartitionCount) == coordinatorPartition);
+            key.coordinatorPartition(coordPartitionCount) == coordPartition);
     }
 
     public long partitionStateCount(MirrorPartitionState state) {
@@ -100,36 +89,25 @@ public class MirrorStateCache {
                 .count();
     }
 
-    public void forEach(BiConsumer<MirrorPartitionKey, MirrorPartition> action) {
-        partitions.forEach(action);
-    }
-
-    public Set<MirrorPartitionKey> keySet() {
+    public Set<MirrorPartitionKey> partitionKeys() {
         return partitions.keySet();
     }
 
-    // -- Failed info operations --
-
-    public void setFailedInfo(MirrorPartitionKey key, String errorMessage, int retryAttempt, MirrorPartitionState prevState) {
-        partitions.compute(key, (k, existing) -> MirrorPartition.orEmpty(existing).withError(errorMessage, retryAttempt, prevState));
+    public void setLastMirrorEpoch(MirrorPartitionKey key, int epoch) {
+        partitions.compute(key, (k, existing) -> MirrorPartition.orEmpty(existing).withLastMirrorEpoch(epoch));
     }
 
-    public void clearFailedInfo(MirrorPartitionKey key) {
-        partitions.computeIfPresent(key, (k, existing) -> existing.withError(null, 0, null));
+    public void removeMirror(String mirrorName) {
+        partitions.keySet().removeIf(key -> key.mirrorName().equals(mirrorName));
     }
 
-    /**
-     * Updates failed partition info for a state transition. Sets retry attempt and previous
-     * state on FAILED transitions, clears on LOG_TRUNCATION/STOPPED/PAUSED. Preserves the
-     * non-retryable marker when a FAILED partition is re-transitioned with nonRetryable=false.
-     */
-    public void updateFailedInfo(MirrorPartitionKey key, MirrorPartitionState state,
+    public void updateFailedInfo(MirrorPartitionKey key, MirrorPartitionState currentState,
                                  MirrorPartitionState newState, String errorMessage, boolean nonRetryable) {
         if (newState == MirrorPartitionState.FAILED) {
-            MirrorPartition existing = MirrorPartition.orEmpty(get(key));
+            MirrorPartition existing = MirrorPartition.orEmpty(getPartition(key));
             int attempt = existing.nextAttempt(nonRetryable);
-            MirrorPartitionState previousState = existing.resolvePreviousState(state);
-            setFailedInfo(key, errorMessage, attempt, previousState);
+            MirrorPartitionState previousState = existing.resolvePrevState(currentState);
+            partitions.compute(key, (k, e) -> MirrorPartition.orEmpty(e).withError(errorMessage, attempt, previousState));
         } else if (newState == MirrorPartitionState.LOG_TRUNCATION
                 || newState == MirrorPartitionState.STOPPED
                 || newState == MirrorPartitionState.PAUSED) {
@@ -137,13 +115,16 @@ public class MirrorStateCache {
         }
     }
 
-    // -- Source leader operations --
-
-    public void updateSourceLeader(String mirrorName, TopicPartition tp, SourceLeader leader) {
-        sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>()).put(tp, leader);
+    public void clearFailedInfo(MirrorPartitionKey key) {
+        partitions.computeIfPresent(key, (k, existing) -> existing.clearError());
     }
 
-    /** Resolves the cached source leader for a partition, throwing if no metadata is available. */
+    // -- Source leader operations --
+
+    public Map<TopicPartition, SourceLeader> getSourceLeaders(String mirrorName) {
+        return sourceLeaders.get(mirrorName);
+    }
+
     public SourceLeader resolveSourceLeader(String mirrorName, TopicPartition tp) {
         var partitionLeaders = sourceLeaders.get(mirrorName);
         if (partitionLeaders != null) {
@@ -156,16 +137,12 @@ public class MirrorStateCache {
                 "for mirror " + mirrorName + " partition:" + tp);
     }
 
+    public void updateSourceLeader(String mirrorName, TopicPartition tp, SourceLeader leader) {
+        sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>()).put(tp, leader);
+    }
+
     public void removeSourceLeaders(String mirrorName) {
         sourceLeaders.remove(mirrorName);
-    }
-
-    public Map<TopicPartition, SourceLeader> getOrCreateSourceLeaders(String mirrorName) {
-        return sourceLeaders.computeIfAbsent(mirrorName, k -> new ConcurrentHashMap<>());
-    }
-
-    public Map<TopicPartition, SourceLeader> getSourceLeaders(String mirrorName) {
-        return sourceLeaders.get(mirrorName);
     }
 
     // -- Pending topic creation operations --
@@ -181,15 +158,15 @@ public class MirrorStateCache {
     // -- Pending leader epoch bump operations --
 
     public void addPendingEpochBump(PendingLeaderEpochBump bump) {
-        pendingEpochBumps.add(bump);
+        pendingLederEpochBumps.add(bump);
     }
 
-    public Set<PendingLeaderEpochBump> getPendingEpochBumps() {
-        return pendingEpochBumps;
+    public Set<PendingLeaderEpochBump> getPendingLederEpochBumps() {
+        return pendingLederEpochBumps;
     }
 
-    public void removePendingEpochBumps(Set<TopicPartition> partitions) {
-        pendingEpochBumps.removeIf(bump -> {
+    public void clearPendingLeaderEpochBumps(Set<TopicPartition> partitions) {
+        pendingLederEpochBumps.removeIf(bump -> {
             bump.partitionToEpoch().keySet().removeAll(partitions);
             if (bump.partitionToEpoch().isEmpty()) {
                 bump.future().cancel(false);

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -4456,7 +4456,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
             val state = partitionStates.getOrElse(topicPartition, MirrorPartitionState.UNKNOWN)
             val isMirroring = state == MirrorPartitionState.MIRRORING
-            val mp = mirrorMetadataManager.cache().get(
+            val mp = mirrorMetadataManager.getPartition(
               MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topicPartition.topic()), topicPartition.partition()))
             val partitionDetail = new DescribeClusterMirrorsResponseData.PartitionDetail()
               .setPartitionIndex(topicPartition.partition())

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2649,7 +2649,7 @@ class ReplicaManager(val config: KafkaConfig,
           try {
             if (mirrorName != null) {
               // Get the source partition leader
-              val sourceLeader = mirrorMetadataManager.get.cache().resolveSourceLeader(mirrorName, tp)
+              val sourceLeader = mirrorMetadataManager.get.resolveSourceLeader(mirrorName, tp)
               val sourceLeaderNode = sourceLeader.node()
               val leaderEndpoint = new BrokerEndPoint(sourceLeaderNode.id(), sourceLeaderNode.host(), sourceLeaderNode.port())
 

--- a/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/mirror/MirrorFetcherThread.scala
@@ -63,7 +63,7 @@ class MirrorFetcherThread(name: String,
   override protected def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit = {
     replicaMgr.mirrorMetadataManager.foreach { mmm =>
       partitionAndOffsets.foreach { case (tp, state) =>
-        mmm.cache().updateSourceLeader(mirrorName, tp,
+        mmm.updateSourceLeader(mirrorName, tp,
           new SourceLeader(new Node(state.leader.id(), state.leader.host(), state.leader.port()), state.currentLeaderEpoch))
       }
     }
@@ -181,7 +181,7 @@ class MirrorFetcherThread(name: String,
   }
 
   override def leaderEpochFromSource(tp: TopicPartition): Option[Int] = {
-    replicaMgr.mirrorMetadataManager.map(mmm => mmm.cache().resolveSourceLeader(mirrorName, tp).leaderEpoch())
+    replicaMgr.mirrorMetadataManager.map(mmm => mmm.resolveSourceLeader(mirrorName, tp).leaderEpoch())
   }
 
   // Returns the mirror partition lag

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.ReadMirrorStatesResponseData;
 import org.apache.kafka.common.message.WriteMirrorStatesResponseData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
@@ -250,8 +251,26 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         }
     }
 
+    private int partitionFor(String mirrorName) {
+        throwIfNotActive();
+        return Utils.abs(mirrorName.hashCode()) % config.stateTopicNumPartitions();
+    }
+
+    public int partitionFor(MirrorPartitionKey key) {
+        throwIfNotActive();
+        return key.coordinatorPartition(config.stateTopicNumPartitions());
+    }
+
+    /** Returns true if this broker leads the __mirror_state partition for the given mirror partition. */
+    private boolean isLocal(String mirrorName, TopicPartition tp) {
+        int partition = partitionFor(MirrorPartitionKey.of(
+                mirrorName, bridge.getTopicId(tp.topic()), tp.partition()));
+        int leader = bridge.getLeaderForPartition(MIRROR_STATE_TOPIC_NAME, partition);
+        return leader == nodeId;
+    }
+
     // ---------------------------------------------------------------
-    // Side effects (after successful write commit)
+    // State transitions
     // ---------------------------------------------------------------
 
     private void onStateTransition(String mirrorName, TopicPartition tp, MirrorPartitionState newState) {
@@ -312,32 +331,6 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         }
     }
 
-    // ---------------------------------------------------------------
-    // Partition routing
-    // ---------------------------------------------------------------
-
-    private int partitionFor(String mirrorName) {
-        throwIfNotActive();
-        return Utils.abs(mirrorName.hashCode()) % config.stateTopicNumPartitions();
-    }
-
-    public int partitionFor(MirrorPartitionKey key) {
-        throwIfNotActive();
-        return key.coordinatorPartition(config.stateTopicNumPartitions());
-    }
-
-    /** Returns true if this broker leads the __mirror_state partition for the given mirror partition. */
-    private boolean isLocal(String mirrorName, TopicPartition tp) {
-        int partition = partitionFor(MirrorPartitionKey.of(
-                mirrorName, bridge.getTopicId(tp.topic()), tp.partition()));
-        int leader = bridge.getLeaderForPartition(MIRROR_STATE_TOPIC_NAME, partition);
-        return leader == nodeId;
-    }
-
-    // ---------------------------------------------------------------
-    // State transitions
-    // ---------------------------------------------------------------
-
     public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
                              MirrorPartitionState newState) {
         transitionTo(mirrorName, topicPartitions, newState, null, false);
@@ -374,9 +367,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
                         }
                         MirrorPartitionKey key = MirrorPartitionKey.of(
                             mirrorName, bridge.getTopicId(tp.topic()), tp.partition());
-                        MirrorPartitionState currentState = bridge.getPartitionState(
-                            key.mirrorName(), tp);
-                        if (currentState == newState) {
+                        if (MirrorPartition.orEmpty(bridge.getPartition(key)).state() == newState) {
                             onStateTransition(mirrorName, tp, newState);
                         }
                     });
@@ -389,7 +380,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
                             MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName,
                                 bridge.getTopicId(tp.topic()), tp.partition());
                             updateLocalFailedState(key, newState, errorMessage, nonRetryable);
-                            bridge.setPartitionState(key, newState);
+                            bridge.setPartition(key, MirrorPartition.orEmpty(bridge.getPartition(key)).withState(newState));
                             onStateTransition(mirrorName, tp, newState);
                         } else {
                             log.error("Failed to write partition state to remote coordinator: {}", par.errorCode());
@@ -402,10 +393,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
     private void updateLocalFailedState(MirrorPartitionKey key,
                                         MirrorPartitionState newState,
                                         String errorMessage, boolean nonRetryable) {
-        throwIfNotActive();
-        MirrorPartitionState curState = bridge.getPartitionState(
-                key.mirrorName(), new TopicPartition(
-                        bridge.getTopicName(key.topicId()).orElse(""), key.partition()));
+        MirrorPartitionState curState = MirrorPartition.orEmpty(bridge.getPartition(key)).state();
         bridge.updateFailedInfo(key, curState, newState, errorMessage, nonRetryable);
     }
 
@@ -413,49 +401,86 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
     // Inter-broker RPC handling
     // ---------------------------------------------------------------
 
+    /**
+     * Reads partition states from the local coordinator cache. Partitions are grouped
+     * by their {@code __mirror_state} coordinator partition and each group is submitted
+     * as a read operation through the runtime event queue, guaranteeing that reads are
+     * ordered after any preceding writes to the same coordinator partition.
+     */
     public void readMirrorStates(String mirrorName,
                                  Map<String, Set<Integer>> partitions,
                                  Consumer<ReadMirrorStatesResponse> callback) {
         throwIfNotActive();
-        bridge.readStatesFromLocalCoordinator(mirrorName, partitions, callback);
+
+        Map<Integer, Map<String, Set<Integer>>> byCoordPartition = new HashMap<>();
+        partitions.forEach((topic, parts) -> parts.forEach(part -> {
+            int cp = partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(topic), part));
+            byCoordPartition.computeIfAbsent(cp, k -> new HashMap<>())
+                .computeIfAbsent(topic, k -> new HashSet<>()).add(part);
+        }));
+
+        List<CompletableFuture<ReadMirrorStatesResponseData>> futures = new ArrayList<>();
+        byCoordPartition.forEach((cp, tps) -> {
+            TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME, cp);
+            futures.add(runtime.scheduleReadOperation("read-mirror-states", mirrorStateTp,
+                (shard, offset) -> shard.readMirrorStates(mirrorName, tps)));
+        });
+
+        CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+            .whenComplete((v, e) -> {
+                ReadMirrorStatesResponseData data = new ReadMirrorStatesResponseData();
+                if (e != null) {
+                    log.error("Failed to read mirror states for {}", mirrorName, e);
+                    data.setErrorCode(Errors.forException(e).code());
+                    data.setErrorMessage(e.getMessage());
+                } else {
+                    List<ReadMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
+                    futures.forEach(f -> topicResults.addAll(f.join().topics()));
+                    data.setTopics(topicResults);
+                }
+                callback.accept(new ReadMirrorStatesResponse(data));
+            });
     }
 
+    /**
+     * Writes partition states and last mirror epochs received from a remote coordinator.
+     * Partitions are grouped by their {@code __mirror_state} coordinator partition and
+     * each group is submitted as a single write operation through the runtime event queue,
+     * batching state transitions and LME updates into one atomic write per coordinator partition.
+     */
     public void writeMirrorStates(String mirrorName,
                                   Map<String, Set<MirrorStateWrite>> mirrorStates,
                                   Consumer<WriteMirrorStatesResponse> callback) {
         throwIfNotActive();
-        List<CompletableFuture<?>> stateFutures = new ArrayList<>();
-        List<CompletableFuture<Void>> lmeFutures = new ArrayList<>();
+
+        Map<Integer, Map<String, Set<MirrorStateWrite>>> byCoordPartition = new HashMap<>();
         Map<String, Set<Integer>> tps = new HashMap<>();
 
         mirrorStates.forEach((topic, partitions) -> {
             Set<Integer> partitionIndices = new HashSet<>();
             partitions.forEach(partition -> {
-                TopicPartition tp = new TopicPartition(topic, partition.partition());
-                partitionIndices.add(tp.partition());
-                if (partition.state() != null && partition.state() != MirrorPartitionState.UNKNOWN) {
-                    TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
-                        partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
-                    stateFutures.add(runtime.scheduleWriteOperation("write-state", mirrorStateTp,
-                            Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
-                            shard -> shard.transitionTo(mirrorName, tp, partition.state(), null, false)));
-                }
-                if (partition.leaderEpoch() != -1) {
-                    TopicPartition lmeTp = new TopicPartition(topic, partition.partition());
-                    lmeFutures.add(updateLastMirrorEpoch(mirrorName, lmeTp, partition.leaderEpoch()));
-                }
+                partitionIndices.add(partition.partition());
+                int cp = partitionFor(MirrorPartitionKey.of(
+                    mirrorName, bridge.getTopicId(topic), partition.partition()));
+                byCoordPartition.computeIfAbsent(cp, k -> new HashMap<>())
+                    .computeIfAbsent(topic, k -> new HashSet<>()).add(partition);
             });
             tps.put(topic, partitionIndices);
         });
 
-        CompletableFuture<Void> lmeFuture = CompletableFuture.allOf(
-            lmeFutures.toArray(CompletableFuture[]::new));
-        CompletableFuture.allOf(stateFutures.toArray(CompletableFuture[]::new))
-            .thenCompose(v -> lmeFuture)
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        byCoordPartition.forEach((cp, states) -> {
+            TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME, cp);
+            futures.add(runtime.scheduleWriteOperation("write-mirror-states", mirrorStateTp,
+                Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
+                shard -> shard.writeMirrorStates(mirrorName, states)));
+        });
+
+        CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
             .whenComplete((v, e) -> {
                 WriteMirrorStatesResponseData data = new WriteMirrorStatesResponseData();
                 if (e != null) {
-                    log.error("Failed to update partition state and LME for {}: {}", mirrorName, e);
+                    log.error("Failed to write mirror states for {}", mirrorName, e);
                     data.setErrorCode(Errors.forException(e).code());
                     data.setErrorMessage(e.getMessage());
                 } else {
@@ -572,9 +597,9 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
 
     private void scheduleFailedRetry(String mirrorName, TopicPartition tp) {
         int maxAttempts = config.failedRetryMaxAttempts();
-        MirrorPartition mp = bridge.getFailedInfo(
-                MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition()));
-        int attempt = mp != null ? mp.retryAttempt() : 1;
+        MirrorPartition mp = MirrorPartition.orEmpty(bridge.getPartition(
+                MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
+        int attempt = mp.retryAttempt() != 0 ? mp.retryAttempt() : 1;
         if (attempt == MirrorPartition.NON_RETRYABLE_ATTEMPT) {
             log.debug("Skipping retry for partition {} because it is in non-retryable failed state.", tp);
             return;
@@ -590,9 +615,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
                 CommonClientConfigs.RETRY_BACKOFF_JITTER);
         long delay = failedRetryBackoff.backoff(attempt);
         MirrorPartitionState targetState;
-        if (mp == null) {
-            targetState = MirrorPartitionState.MIRRORING;
-        } else if (mp.prevState() == MirrorPartitionState.UNKNOWN) {
+        if (mp.prevState() == null || mp.prevState() == MirrorPartitionState.UNKNOWN) {
             targetState = MirrorPartitionState.LOG_TRUNCATION;
         } else {
             targetState = mp.prevState();
@@ -623,7 +646,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
 
         if (coordPartitionToMirrorPartitions.isEmpty()) {
             states.keySet().forEach(tp ->
-                    bridge.removePartitionState(
+                    bridge.removePartition(
                             MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
             return;
         }
@@ -639,7 +662,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
                             log.warn("Failed to write tombstone to {}: {}. Will retry later.",
                                     mirrorStateTp, ex.getMessage());
                         } else {
-                            tps.forEach(tp -> bridge.removePartitionState(
+                            tps.forEach(tp -> bridge.removePartition(
                                     MirrorPartitionKey.of(mirrorName,
                                             bridge.getTopicId(tp.topic()), tp.partition())));
                         }

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShard.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShard.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.mirror;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.ReadMirrorStatesResponseData;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -44,6 +45,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -145,6 +147,38 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
         }
     }
 
+    private void replayPartitionState(MirrorPartitionStateKey key, ApiMessageAndVersion value) {
+        MirrorPartitionKey pk = MirrorPartitionKey.of(key.mirrorName(), key.topicId(), key.partition());
+        if (value != null) {
+            MirrorPartitionStateValue stateValue = (MirrorPartitionStateValue) value.message();
+            MirrorPartitionState state = MirrorPartitionState.fromValue(stateValue.state());
+            MirrorPartitionState previousState = MirrorPartitionState.fromValue(stateValue.previousState());
+            MirrorPartition mp = MirrorPartition.orEmpty(coreBridge.getPartition(pk)).withState(state);
+            if (state == MirrorPartitionState.FAILED) {
+                mp = mp.withError(stateValue.errorMessage(), stateValue.retryAttempt(), previousState);
+            } else if (state == MirrorPartitionState.LOG_TRUNCATION
+                    || state == MirrorPartitionState.STOPPED
+                    || state == MirrorPartitionState.PAUSED) {
+                mp = mp.clearError();
+            }
+            coreBridge.setPartition(pk, mp);
+        } else {
+            coreBridge.removePartition(pk);
+        }
+    }
+
+    private void replayLastMirrorEpochs(LastMirrorEpochsKey key, ApiMessageAndVersion value) {
+        MirrorPartitionKey pk = MirrorPartitionKey.of(key.mirrorName(), key.topicId(), key.partition());
+        if (value != null) {
+            LastMirrorEpochsValue epochsValue = (LastMirrorEpochsValue) value.message();
+            coreBridge.getTopicName(key.topicId()).ifPresent(topicName ->
+                    coreBridge.setLastMirrorEpoch(key.mirrorName(),
+                            topicName, key.partition(), epochsValue.lastMirrorEpoch()));
+        } else {
+            coreBridge.removePartition(pk);
+        }
+    }
+
     @Override
     public void onLoaded(CoordinatorMetadataImage newImage) {
         log.info("Loaded shard for {}.", topicPartition);
@@ -161,14 +195,60 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
     public void onNewMetadataImage(CoordinatorMetadataImage newImage, CoordinatorMetadataDelta delta) {
     }
 
-    public CoordinatorResult<Void, CoordinatorRecord> transitionTo(
+    public ReadMirrorStatesResponseData readMirrorStates(String mirrorName, Map<String, Set<Integer>> partitions) {
+        ReadMirrorStatesResponseData data = new ReadMirrorStatesResponseData();
+        List<ReadMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
+        partitions.forEach((topic, parts) -> {
+            List<ReadMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();
+            parts.forEach(part -> {
+                MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, coreBridge.getTopicId(topic), part);
+                MirrorPartition mp = MirrorPartition.orEmpty(coreBridge.getPartition(pk));
+                ReadMirrorStatesResponseData.PartitionResult pr = new ReadMirrorStatesResponseData.PartitionResult()
+                        .setPartitionIndex(part)
+                        .setState(mp.state().value())
+                        .setPreviousState(mp.prevState() != null ? mp.prevState().value() : MirrorPartitionState.UNKNOWN.value())
+                        .setLastMirrorEpoch(mp.lastMirrorEpoch())
+                        .setRetryAttempt((short) mp.retryAttempt())
+                        .setErrorMessage(mp.errorMessage());
+                partitionResults.add(pr);
+            });
+            topicResults.add(new ReadMirrorStatesResponseData.TopicResult()
+                    .setName(topic).setPartitions(partitionResults));
+        });
+        data.setTopics(topicResults);
+        return data;
+    }
+
+    public CoordinatorResult<Void, CoordinatorRecord> writeMirrorStates(
         String mirrorName,
-        TopicPartition tp,
-        MirrorPartitionState newState,
-        String errorMessage,
-        boolean nonRetryable
+        Map<String, Set<ClusterMirrorCoordinatorService.MirrorStateWrite>> mirrorStates
     ) {
-        MirrorPartitionState currentState = coreBridge.getPartitionState(mirrorName, tp);
+        List<CoordinatorRecord> records = new ArrayList<>();
+        mirrorStates.forEach((topic, partitions) -> partitions.forEach(partition -> {
+            TopicPartition tp = new TopicPartition(topic, partition.partition());
+            if (partition.state() != null && partition.state() != MirrorPartitionState.UNKNOWN) {
+                CoordinatorResult<Void, CoordinatorRecord> result =
+                    transitionTo(mirrorName, tp, partition.state(), null, false);
+                records.addAll(result.records());
+            }
+            if (partition.leaderEpoch() != -1) {
+                CoordinatorResult<Void, CoordinatorRecord> result =
+                    updateLastMirrorEpoch(mirrorName, tp, partition.leaderEpoch());
+                records.addAll(result.records());
+            }
+        }));
+        return new CoordinatorResult<>(records, null);
+    }
+
+    public CoordinatorResult<Void, CoordinatorRecord> transitionTo(
+            String mirrorName,
+            TopicPartition tp,
+            MirrorPartitionState newState,
+            String errorMessage,
+            boolean nonRetryable
+    ) {
+        MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
+        MirrorPartitionState currentState = MirrorPartition.orEmpty(coreBridge.getPartition(pk)).state();
         if (!MirrorPartitionState.isValidTransition(currentState, newState)) {
             log.warn("Skipping invalid transition from {} to {} for partition {}.", currentState, newState, tp);
             return new CoordinatorResult<>(List.of(), null);
@@ -180,13 +260,47 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
         return new CoordinatorResult<>(List.of(record), null);
     }
 
+    private void updateFailedState(String mirrorName, TopicPartition tp,
+                                   MirrorPartitionState currentState, MirrorPartitionState newState,
+                                   String errorMessage, boolean nonRetryable) {
+        MirrorPartitionKey pk = MirrorPartitionKey.of(
+                mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
+        coreBridge.updateFailedInfo(pk, currentState, newState, errorMessage, nonRetryable);
+    }
+
+    private CoordinatorRecord buildPartitionStateRecord(String mirrorName, TopicPartition tp,
+                                                        MirrorPartitionState newState) {
+        MirrorPartitionKey pk = MirrorPartitionKey.of(
+                mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
+        MirrorPartition mp = MirrorPartition.orEmpty(coreBridge.getPartition(pk));
+        var key = new MirrorPartitionStateKey()
+                .setMirrorName(mirrorName)
+                .setTopicId(pk.topicId())
+                .setPartition(pk.partition());
+        var val = new MirrorPartitionStateValue()
+                .setState(newState.value())
+                .setPreviousState(mp.prevState() != null ? mp.prevState().value() : MirrorPartitionState.UNKNOWN.value())
+                .setRetryAttempt((short) mp.retryAttempt())
+                .setErrorMessage(mp.errorMessage());
+        return CoordinatorRecord.record(key, new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION));
+    }
+
     public CoordinatorResult<Void, CoordinatorRecord> updateLastMirrorEpoch(
-        String mirrorName, TopicPartition tp, int epoch
+            String mirrorName, TopicPartition tp, int epoch
     ) {
         MirrorPartitionKey pk = MirrorPartitionKey.of(
-            mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
+                mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
         CoordinatorRecord record = buildLastMirrorEpochsRecord(pk, epoch);
         return new CoordinatorResult<>(List.of(record), null);
+    }
+
+    private CoordinatorRecord buildLastMirrorEpochsRecord(MirrorPartitionKey pk, int lastMirrorEpoch) {
+        var key = new LastMirrorEpochsKey()
+                .setMirrorName(pk.mirrorName())
+                .setTopicId(pk.topicId())
+                .setPartition(pk.partition());
+        var val = new LastMirrorEpochsValue().setLastMirrorEpoch(lastMirrorEpoch);
+        return CoordinatorRecord.record(key, new ApiMessageAndVersion(val, LastMirrorEpochsValue.HIGHEST_SUPPORTED_VERSION));
     }
 
     public CoordinatorResult<Void, CoordinatorRecord> tombstoneMirrorRecords(
@@ -202,75 +316,5 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
                 .setMirrorName(mirrorName).setTopicId(topicId).setPartition(tp.partition())));
         }
         return new CoordinatorResult<>(records, null);
-    }
-
-    private void replayPartitionState(MirrorPartitionStateKey key, ApiMessageAndVersion value) {
-        MirrorPartitionKey pk = MirrorPartitionKey.of(key.mirrorName(), key.topicId(), key.partition());
-        if (value != null) {
-            MirrorPartitionStateValue stateValue = (MirrorPartitionStateValue) value.message();
-            MirrorPartitionState state = MirrorPartitionState.fromValue(stateValue.state());
-            MirrorPartitionState previousState = MirrorPartitionState.fromValue(stateValue.previousState());
-            coreBridge.setPartitionState(pk, state);
-            restoreFailedState(pk, state, stateValue.retryAttempt(), stateValue.errorMessage(), previousState);
-        } else {
-            coreBridge.removePartitionState(pk);
-        }
-    }
-
-    private void replayLastMirrorEpochs(LastMirrorEpochsKey key, ApiMessageAndVersion value) {
-        MirrorPartitionKey pk = MirrorPartitionKey.of(key.mirrorName(), key.topicId(), key.partition());
-        if (value != null) {
-            LastMirrorEpochsValue epochsValue = (LastMirrorEpochsValue) value.message();
-            coreBridge.getTopicName(key.topicId()).ifPresent(topicName ->
-                coreBridge.setLastMirrorEpoch(key.mirrorName(),
-                    topicName, key.partition(), epochsValue.lastMirrorEpoch()));
-        } else {
-            coreBridge.removePartitionState(pk);
-        }
-    }
-
-    private void updateFailedState(String mirrorName, TopicPartition tp,
-                                   MirrorPartitionState currentState, MirrorPartitionState newState,
-                                   String errorMessage, boolean nonRetryable) {
-        MirrorPartitionKey pk = MirrorPartitionKey.of(
-            mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
-        coreBridge.updateFailedInfo(pk, currentState, newState, errorMessage, nonRetryable);
-    }
-
-    private void restoreFailedState(MirrorPartitionKey pk, MirrorPartitionState state,
-                                    int retryAttempt, String errorMessage, MirrorPartitionState previousState) {
-        if (state == MirrorPartitionState.FAILED) {
-            coreBridge.setFailedInfo(pk, MirrorPartition.EMPTY.withError(errorMessage, retryAttempt, previousState));
-        } else if (state == MirrorPartitionState.LOG_TRUNCATION
-                || state == MirrorPartitionState.STOPPED
-                || state == MirrorPartitionState.PAUSED) {
-            coreBridge.clearFailedInfo(pk);
-        }
-    }
-
-    private CoordinatorRecord buildPartitionStateRecord(String mirrorName, TopicPartition tp,
-                                                        MirrorPartitionState newState) {
-        MirrorPartitionKey pk = MirrorPartitionKey.of(
-            mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
-        MirrorPartition mp = coreBridge.getFailedInfo(pk);
-        var key = new MirrorPartitionStateKey()
-            .setMirrorName(mirrorName)
-            .setTopicId(pk.topicId())
-            .setPartition(pk.partition());
-        var val = new MirrorPartitionStateValue()
-            .setState(newState.value())
-            .setPreviousState(mp != null && mp.prevState() != null ? mp.prevState().value() : MirrorPartitionState.UNKNOWN.value())
-            .setRetryAttempt(mp != null ? (short) mp.retryAttempt() : (short) 0)
-            .setErrorMessage(mp != null ? mp.errorMessage() : null);
-        return CoordinatorRecord.record(key, new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION));
-    }
-
-    private CoordinatorRecord buildLastMirrorEpochsRecord(MirrorPartitionKey pk, int lastMirrorEpoch) {
-        var key = new LastMirrorEpochsKey()
-            .setMirrorName(pk.mirrorName())
-            .setTopicId(pk.topicId())
-            .setPartition(pk.partition());
-        var val = new LastMirrorEpochsValue().setLastMirrorEpoch(lastMirrorEpoch);
-        return CoordinatorRecord.record(key, new ApiMessageAndVersion(val, LastMirrorEpochsValue.HIGHEST_SUPPORTED_VERSION));
     }
 }

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
@@ -19,7 +19,6 @@ package org.apache.kafka.coordinator.mirror;
 import org.apache.kafka.clients.admin.ClusterMirrorListing;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.requests.ReadMirrorStatesResponse;
 import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
 import org.apache.kafka.server.common.MirrorPartitionState;
 
@@ -51,21 +50,15 @@ public interface CoreBridge {
 
     void onShardUnloaded(int coordPartition, int coordPartitionCount);
 
-    MirrorPartitionState getPartitionState(String mirrorName, TopicPartition tp);
+    MirrorPartition getPartition(MirrorPartitionKey key);
 
-    void setPartitionState(MirrorPartitionKey key, MirrorPartitionState state);
+    void setPartition(MirrorPartitionKey key, MirrorPartition partition);
 
-    void removePartitionState(MirrorPartitionKey key);
-
-    MirrorPartition getFailedInfo(MirrorPartitionKey key);
-
-    void setFailedInfo(MirrorPartitionKey key, MirrorPartition info);
-
-    void clearFailedInfo(MirrorPartitionKey key);
+    void removePartition(MirrorPartitionKey key);
 
     void updateFailedInfo(
         MirrorPartitionKey key,
-        MirrorPartitionState currentState,
+        MirrorPartitionState curState,
         MirrorPartitionState newState,
         String errorMessage,
         boolean nonRetryable
@@ -78,12 +71,6 @@ public interface CoreBridge {
         Map<String, Set<ClusterMirrorCoordinatorService.MirrorStateWrite>> topicMetadata,
         Set<String> stoppedTopics,
         Consumer<WriteMirrorStatesResponse> callback
-    );
-
-    void readStatesFromLocalCoordinator(
-        String mirrorName,
-        Map<String, Set<Integer>> partitions,
-        Consumer<ReadMirrorStatesResponse> callback
     );
 
     CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/MirrorPartition.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/MirrorPartition.java
@@ -30,7 +30,7 @@ import org.apache.kafka.server.common.MirrorPartitionState;
  */
 public record MirrorPartition(MirrorPartitionState state, int lastMirrorEpoch,
                               String errorMessage, int retryAttempt, MirrorPartitionState prevState) {
-    public static final MirrorPartition EMPTY = new MirrorPartition(null, -1, null, 0, null);
+    public static final MirrorPartition EMPTY = new MirrorPartition(MirrorPartitionState.UNKNOWN, -1, null, 0, null);
     public static final int NON_RETRYABLE_ATTEMPT = -1;
 
     public static MirrorPartition orEmpty(MirrorPartition mp) {
@@ -49,6 +49,10 @@ public record MirrorPartition(MirrorPartitionState state, int lastMirrorEpoch,
         return new MirrorPartition(state, lastMirrorEpoch, errorMessage, retryAttempt, previousState);
     }
 
+    public MirrorPartition clearError() {
+        return new MirrorPartition(state, lastMirrorEpoch, null, 0, null);
+    }
+
     public int nextAttempt(boolean nonRetryable) {
         if (nonRetryable || retryAttempt == NON_RETRYABLE_ATTEMPT) {
             return NON_RETRYABLE_ATTEMPT;
@@ -56,10 +60,10 @@ public record MirrorPartition(MirrorPartitionState state, int lastMirrorEpoch,
         return retryAttempt != 0 ? retryAttempt + 1 : 1;
     }
 
-    public MirrorPartitionState resolvePreviousState(MirrorPartitionState currentState) {
-        if (currentState == MirrorPartitionState.FAILED && prevState != null) {
+    public MirrorPartitionState resolvePrevState(MirrorPartitionState currState) {
+        if (currState == MirrorPartitionState.FAILED && prevState != null) {
             return prevState;
         }
-        return currentState;
+        return currState;
     }
 }


### PR DESCRIPTION
Route readMirrorStates through scheduleReadOperation and writeMirrorStates through a batched scheduleWriteOperation per coordinator partition, ensuring read after write ordering through the event queue. This also completes previous changes.