### PR TITLE
Move transitionTo and side-effect to MMM

### DIFF
--- a/core/src/main/java/kafka/server/mirror/CoreBridgeImpl.java
+++ b/core/src/main/java/kafka/server/mirror/CoreBridgeImpl.java
@@ -38,13 +38,9 @@ public class CoreBridgeImpl implements CoreBridge {
     @Override
     public void initialize(
         CoordinatorWriter coordinatorWriter,
-        Function<MirrorPartitionKey, Integer> coordPartFinderByKey,
-        Function<String, Integer> coordPartFinderByName
+        Function<MirrorPartitionKey, Integer> coordPartFinder
     ) {
-        metadataManager.initialize(
-                coordinatorWriter,
-                coordPartFinderByKey,
-                coordPartFinderByName);
+        metadataManager.initialize(coordinatorWriter, coordPartFinder);
     }
 
     @Override

--- a/core/src/main/java/kafka/server/mirror/CoreBridgeImpl.java
+++ b/core/src/main/java/kafka/server/mirror/CoreBridgeImpl.java
@@ -16,56 +16,35 @@
  */
 package kafka.server.mirror;
 
-import kafka.server.ReplicaManager;
-
-import org.apache.kafka.clients.admin.ClusterMirrorListing;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
-import org.apache.kafka.coordinator.mirror.ClusterMirrorCoordinatorService.MirrorStateWrite;
 import org.apache.kafka.coordinator.mirror.CoreBridge;
 import org.apache.kafka.coordinator.mirror.MirrorPartition;
 import org.apache.kafka.coordinator.mirror.MirrorPartitionKey;
-import org.apache.kafka.metadata.LeaderAndIsr;
 import org.apache.kafka.metadata.MetadataCache;
 import org.apache.kafka.server.common.MirrorPartitionState;
 
-import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Consumer;
 import java.util.function.Function;
-
-import scala.jdk.javaapi.CollectionConverters;
 
 public class CoreBridgeImpl implements CoreBridge {
     private final MirrorMetadataManager metadataManager;
     private final MetadataCache metadataCache;
-    private final ReplicaManager replicaManager;
 
-    public CoreBridgeImpl(MirrorMetadataManager metadataManager, MetadataCache metadataCache,
-                          ReplicaManager replicaManager) {
+    public CoreBridgeImpl(MirrorMetadataManager metadataManager, MetadataCache metadataCache) {
         this.metadataManager = metadataManager;
         this.metadataCache = metadataCache;
-        this.replicaManager = replicaManager;
     }
 
     @Override
     public void initialize(
-        StateTransitioner stateTransitioner,
-        Consumer<String> tombstoneWriter,
-        Function<MirrorPartitionKey, Integer> coordPartitionByKeyFinder,
-        Function<String, Integer> coordPartitionByNameFinder
+        CoordinatorWriter coordinatorWriter,
+        Function<MirrorPartitionKey, Integer> coordPartFinderByKey,
+        Function<String, Integer> coordPartFinderByName
     ) {
         metadataManager.initialize(
-            stateTransitioner::transitionTo,
-            tombstoneWriter,
-            coordPartitionByKeyFinder,
-            coordPartitionByNameFinder);
+                coordinatorWriter,
+                coordPartFinderByKey,
+                coordPartFinderByName);
     }
 
     @Override
@@ -115,65 +94,6 @@ public class CoreBridgeImpl implements CoreBridge {
     }
 
     @Override
-    public void writeStatesToRemoteCoordinator(
-        String mirrorName,
-        Map<String, Set<MirrorStateWrite>> topicMetadata,
-        Set<String> stoppedTopics,
-        Consumer<WriteMirrorStatesResponse> callback
-    ) {
-        metadataManager.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, stoppedTopics, callback);
-    }
-
-    @Override
-    public CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(
-        String mirrorName,
-        TopicPartition tp,
-        Collection<ClusterMirrorListing> sourceMirrors
-    ) {
-        return metadataManager.sendLastMirrorEpochLookup(mirrorName, tp, sourceMirrors);
-    }
-
-    @Override
-    public CompletableFuture<Void> bumpLeaderEpochs(Map<TopicPartition, Integer> partitionMinEpochs) {
-        return metadataManager.bumpLeaderEpochs(partitionMinEpochs);
-    }
-
-    @Override
-    public CompletableFuture<Void> scheduleBumpLeaderEpoch(String mirrorName, TopicPartition tp) {
-        return metadataManager.scheduleBumpLeaderEpoch(mirrorName, tp);
-    }
-
-    @Override
-    public Collection<ClusterMirrorListing> listSourceClusterMirrors(String mirrorName) {
-        return metadataManager.listSourceClusterMirrors(mirrorName);
-    }
-
-    @Override
-    public boolean hasMirrorLoop(String mirrorName, TopicPartition tp, Collection<ClusterMirrorListing> sourceMirrors) {
-        return metadataManager.hasMirrorLoop(mirrorName, tp, sourceMirrors);
-    }
-
-    @Override
-    public String getSourceClusterId(String mirrorName) {
-        return metadataManager.getSourceClusterId(mirrorName);
-    }
-
-    @Override
-    public Map<TopicPartition, MirrorPartitionState> getMirrorStates(String mirrorName) {
-        return metadataManager.getMirrorStates(mirrorName);
-    }
-
-    @Override
-    public void removeMirror(String mirrorName) {
-        metadataManager.removeMirror(mirrorName);
-    }
-
-    @Override
-    public void removePendingEpochBumps(Set<TopicPartition> partitions) {
-        metadataManager.removePendingEpochBumps(partitions);
-    }
-
-    @Override
     public Uuid getTopicId(String topicName) {
         return metadataCache.getTopicId(topicName);
     }
@@ -181,53 +101,5 @@ public class CoreBridgeImpl implements CoreBridge {
     @Override
     public Optional<String> getTopicName(Uuid topicId) {
         return metadataCache.getTopicName(topicId);
-    }
-
-    @Override
-    public int getLeaderForPartition(String topic, int partition) {
-        return metadataCache.getLeaderAndIsr(topic, partition)
-                .map(LeaderAndIsr::leader)
-                .orElse(-1);
-    }
-
-    @Override
-    public void maybeCreateMirrorFetchers(String mirrorName, Set<TopicPartition> partitions) {
-        replicaManager.maybeCreateMirrorFetchers(mirrorName, partitions);
-    }
-
-    @Override
-    public void removeFetcherForPartitions(Set<TopicPartition> partitions) {
-        replicaManager.mirrorFetcherManager().removeFetcherForPartitions(
-            CollectionConverters.asScala(partitions));
-    }
-
-    @Override
-    public OptionalInt getLatestEpoch(TopicPartition tp) {
-        var logOpt = replicaManager.getPartitionOrException(tp).log();
-        if (logOpt.isDefined()) {
-            return OptionalInt.of(logOpt.get().latestEpoch().orElse(-1));
-        }
-        return OptionalInt.empty();
-    }
-
-    @Override
-    public Map<TopicPartition, Integer> getLatestLocalEpoch(TopicPartition tp) {
-        int epoch = replicaManager.logManager().getLog(tp, false).get().latestEpoch().orElse(-1);
-        return Map.of(tp, epoch);
-    }
-
-    @Override
-    public void maybeTruncateForLeaderEpoch(Map<TopicPartition, Integer> epochs, Consumer<TopicPartition> callback) {
-        replicaManager.maybeTruncateForLeaderEpoch(epochs, callback);
-    }
-
-    @Override
-    public CompletableFuture<Void> abortOngoingTransactions(TopicPartition tp) {
-        return metadataManager.abortOngoingTransactions(tp);
-    }
-
-    @Override
-    public CompletableFuture<Void> appendPidResetBarrier(TopicPartition tp, String sourceClusterId, long timestampMs) {
-        return metadataManager.appendPidResetBarrier(tp, sourceClusterId, timestampMs);
     }
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -676,43 +676,49 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                               MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
         coordinatorWriter.ifPresent(writer -> {
             for (TopicPartition tp : topicPartitions) {
-                MirrorPartitionKey key = MirrorPartitionKey.of(
-                    mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
-                if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
-                    writer.writePartitionState(mirrorName, tp, state, errorMessage, nonRetryable)
-                        .whenComplete((v, ex) -> {
-                            if (ex != null) {
-                                Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
-                                    ? ex.getCause() : ex;
-                                if (cause instanceof CoordinatorLoadInProgressException) {
-                                    log.debug("Transition to {} deferred for {} (shard loading).", state, tp);
-                                    return;
-                                }
-                                log.error("Transition to {} failed for {}", state, tp, ex);
-                                if (state != MirrorPartitionState.FAILED) {
-                                    transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
-                                }
-                                return;
-                            }
-                            if (MirrorPartition.orEmpty(mirrorCache.getPartition(key)).state() == state) {
-                                onStateTransition(mirrorName, tp, state);
-                            }
-                        });
+                MirrorPartitionState currentState = getPartitionState(mirrorName, tp);
+                if (MirrorPartitionState.isValidTransition(currentState, state)) {
+                    MirrorPartitionKey key = MirrorPartitionKey.of(
+                            mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
+                    if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
+                        writer.writePartitionState(mirrorName, tp, state, errorMessage, nonRetryable)
+                                .whenComplete((v, ex) -> {
+                                    if (ex != null) {
+                                        Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
+                                                ? ex.getCause() : ex;
+                                        if (cause instanceof CoordinatorLoadInProgressException) {
+                                            log.debug("Transition to {} deferred for {} (shard loading).", state, tp);
+                                            return;
+                                        }
+                                        log.error("Transition to {} failed for {}", state, tp, ex);
+                                        if (state != MirrorPartitionState.FAILED) {
+                                            transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
+                                        }
+                                        return;
+                                    }
+                                    if (MirrorPartition.orEmpty(mirrorCache.getPartition(key)).state() == state) {
+                                        onStateTransition(mirrorName, tp, state);
+                                    }
+                                });
+                    } else {
+                        Map<String, Set<MirrorStateWrite>> topicMetadata =
+                                Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), state, -1)));
+                        writeStateToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
+                                res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
+                                    if (par.errorCode() == Errors.NONE.code()) {
+                                        updateLocalFailedState(key, state, errorMessage, nonRetryable);
+                                        mirrorCache.setPartition(key,
+                                                MirrorPartition.orEmpty(mirrorCache.getPartition(key)).withState(state));
+                                        onStateTransition(mirrorName, tp, state);
+                                    } else {
+                                        log.error("Failed to write partition state to remote coordinator: {}",
+                                                par.errorCode());
+                                    }
+                                })));
+                    }
                 } else {
-                    Map<String, Set<MirrorStateWrite>> topicMetadata =
-                        Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), state, -1)));
-                    writeStateToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
-                        res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
-                            if (par.errorCode() == Errors.NONE.code()) {
-                                updateLocalFailedState(key, state, errorMessage, nonRetryable);
-                                mirrorCache.setPartition(key,
-                                    MirrorPartition.orEmpty(mirrorCache.getPartition(key)).withState(state));
-                                onStateTransition(mirrorName, tp, state);
-                            } else {
-                                log.error("Failed to write partition state to remote coordinator: {}",
-                                    par.errorCode());
-                            }
-                        })));
+                    log.warn("Ignoring state transition from {} to {} for partition {}: invalid transition",
+                            currentState, state, tp);
                 }
             }
         });

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -30,6 +30,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.DeleteClusterMirrorRequestData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.MirrorPidResetRecord;
@@ -53,10 +55,12 @@ import org.apache.kafka.common.requests.ReadMirrorStatesResponse;
 import org.apache.kafka.common.requests.WriteMirrorStatesRequest;
 import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.mirror.ClusterMirrorConfig;
 import org.apache.kafka.coordinator.mirror.ClusterMirrorCoordinatorService.MirrorStateWrite;
+import org.apache.kafka.coordinator.mirror.CoreBridge;
 import org.apache.kafka.coordinator.mirror.MirrorPartition;
 import org.apache.kafka.coordinator.mirror.MirrorPartitionKey;
 import org.apache.kafka.image.LocalReplicaChanges;
@@ -89,6 +93,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -141,10 +146,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     private volatile Map<String, Admin> srcAdmins;
     private volatile Admin dstAdmin;
 
-    private Optional<StateTransitioner> stateTransitioner = Optional.empty();
-    Optional<Consumer<String>> tombstoneWriter = Optional.empty();
-    private Optional<Function<MirrorPartitionKey, Integer>> coordPartitionFinderByKey = Optional.empty();
-    private Optional<Function<String, Integer>> coordPartitionFinderByName = Optional.empty();
+    private Optional<CoreBridge.CoordinatorWriter> coordinatorWriter = Optional.empty();
+    private Optional<Function<MirrorPartitionKey, Integer>> coordPartFinderByKey = Optional.empty();
+    private Optional<Function<String, Integer>> coordPartFinderByName = Optional.empty();
 
     private final AtomicLong metadataRefreshError;
     private final AtomicLong topicConfigSyncError;
@@ -205,9 +209,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * by a single broker per mirror.
      */
     boolean isLocalCoordinator(String mirrorName) {
-        if (coordPartitionFinderByName.isPresent() && metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME) != null) {
+        if (coordPartFinderByName.isPresent() && metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME) != null) {
             int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
-                    .partitions().get(coordPartitionFinderByName.get().apply(mirrorName)).leader;
+                    .partitions().get(coordPartFinderByName.get().apply(mirrorName)).leader;
             return activeCoordinator == brokerConfig.nodeId();
         }
         return false;
@@ -219,9 +223,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * coordination across brokers so a mirror with many partitions does not bottleneck on one node.
      */
     private boolean isLocalCoordinator(String mirrorName, String topic, int partition) {
-        if (metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME) != null && coordPartitionFinderByKey.isPresent()) {
+        if (metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME) != null && coordPartFinderByKey.isPresent()) {
             int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
-                    .partitions().get(coordPartitionFinderByKey.get().apply(
+                    .partitions().get(coordPartFinderByKey.get().apply(
                             MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), partition))).leader;
             return activeCoordinator == brokerConfig.nodeId();
         }
@@ -234,10 +238,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Wires in the state transitioner, tombstone handler, and coordinator partition finders.
      * Creates the {@link MirrorSourceSyncer} and schedules periodic metadata refresh.
      */
-    public void initialize(StateTransitioner stateTransitioner,
-                           Consumer<String> tombstoneWriter,
-                           Function<MirrorPartitionKey, Integer> coordPartitionByKeyFinder,
-                           Function<String, Integer> coordPartitionByNameFinder) {
+    public void initialize(CoreBridge.CoordinatorWriter coordinatorWriter,
+                           Function<MirrorPartitionKey, Integer> coordPartFinderByKey,
+                           Function<String, Integer> coordPartFinderByName) {
         if (mirrorStateSender == null) {
             this.mirrorStateSender = new MirrorStateSender(MirrorStateSender.class.getSimpleName(),
                     NetworkUtils.buildNetworkClient(MirrorMetadataManager.class.getSimpleName(), brokerConfig, metrics, time, new LogContext(name())),
@@ -250,10 +253,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 consumerGroupOffsetSyncError, shareGroupOffsetSyncError, aclSyncError);
         sourceSyncer.scheduleMetadataRefresh(brokerConfig.mirrorConfig().metadataRefreshIntervalMs());
 
-        this.stateTransitioner = Optional.of(stateTransitioner);
-        this.tombstoneWriter = Optional.of(tombstoneWriter);
-        this.coordPartitionFinderByKey = Optional.of(coordPartitionByKeyFinder);
-        this.coordPartitionFinderByName = Optional.of(coordPartitionByNameFinder);
+        this.coordinatorWriter = Optional.of(coordinatorWriter);
+        this.coordPartFinderByKey = Optional.of(coordPartFinderByKey);
+        this.coordPartFinderByName = Optional.of(coordPartFinderByName);
 
         this.isInitialized = true;
     }
@@ -400,7 +402,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         boolean mirrorDeleted = newImage.configs().configProperties(e.getKey()).isEmpty();
                         if (mirrorDeleted) {
                             log.info("Mirror '{}' has been deleted. Writing tombstone records.", mirrorName);
-                            tombstoneWriter.ifPresent(h -> h.accept(mirrorName));
+                            tombstoneMirror(mirrorName);
                         }
 
                         boolean connectionConfigChanged = e.getValue().changes().keySet().stream()
@@ -680,16 +682,294 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         }
     }
 
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state) {
-        transitionTo(mirrorName, topicPartition, state, null, false);
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState state) {
+        transitionTo(mirrorName, topicPartitions, state, null, false);
     }
 
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage) {
-        transitionTo(mirrorName, topicPartition, state, errorMessage, false);
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions, MirrorPartitionState state, String errorMessage) {
+        transitionTo(mirrorName, topicPartitions, state, errorMessage, false);
     }
 
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
-        stateTransitioner.ifPresent(st -> st.transitionTo(mirrorName, topicPartition, state, errorMessage, nonRetryable));
+    /**
+     * Writes a state transition for each partition, routing to either the local coordinator
+     * shard (via {@link CoreBridge.CoordinatorWriter}) or a remote coordinator (via
+     * {@link #writeStatesToRemoteCoordinator}). On successful write, dispatches side effects
+     * through {@link #onStateTransition}.
+     */
+    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
+                              MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
+        coordinatorWriter.ifPresent(writer -> {
+            for (TopicPartition tp : topicPartitions) {
+                MirrorPartitionKey key = MirrorPartitionKey.of(
+                    mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
+                if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
+                    writer.writeTransition(mirrorName, tp, state, errorMessage, nonRetryable)
+                        .whenComplete((v, ex) -> {
+                            if (ex != null) {
+                                Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
+                                    ? ex.getCause() : ex;
+                                if (cause instanceof CoordinatorLoadInProgressException) {
+                                    log.debug("Transition to {} deferred for {} (shard loading).", state, tp);
+                                    return;
+                                }
+                                log.error("Transition to {} failed for {}", state, tp, ex);
+                                if (state != MirrorPartitionState.FAILED) {
+                                    transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
+                                }
+                                return;
+                            }
+                            if (MirrorPartition.orEmpty(cache.getPartition(key)).state() == state) {
+                                onStateTransition(mirrorName, tp, state);
+                            }
+                        });
+                } else {
+                    Map<String, Set<MirrorStateWrite>> topicMetadata =
+                        Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), state, -1)));
+                    writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
+                        res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
+                            if (par.errorCode() == Errors.NONE.code()) {
+                                updateLocalFailedState(key, state, errorMessage, nonRetryable);
+                                cache.setPartition(key,
+                                    MirrorPartition.orEmpty(cache.getPartition(key)).withState(state));
+                                onStateTransition(mirrorName, tp, state);
+                            } else {
+                                log.error("Failed to write partition state to remote coordinator: {}",
+                                    par.errorCode());
+                            }
+                        })));
+                }
+            }
+        });
+    }
+
+    // ---------------------------------------------------------------
+    // Side-effect dispatch (triggered after coordinator writes commit)
+    // ---------------------------------------------------------------
+
+    /**
+     * Dispatches side effects after a coordinator write commits.
+     * Each state triggers a specific action: LOG_TRUNCATION starts truncation,
+     * EPOCH_FENCING bumps the leader epoch, MIRRORING creates fetchers,
+     * PAUSING/STOPPING removes fetchers, FAILED schedules a retry.
+     */
+    private void onStateTransition(String mirrorName, TopicPartition tp, MirrorPartitionState newState) {
+        switch (newState) {
+            case LOG_TRUNCATION:
+                scheduleTruncation(mirrorName, tp);
+                break;
+            case EPOCH_FENCING:
+                scheduleBumpLeaderEpoch(mirrorName, tp)
+                    .whenComplete((v, ex) -> {
+                        if (ex != null) {
+                            transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
+                        } else {
+                            transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.MIRRORING);
+                        }
+                    });
+                break;
+            case MIRRORING:
+                replicaManagerSupplier.get().maybeCreateMirrorFetchers(mirrorName, Set.of(tp));
+                break;
+            case PAUSING:
+                replicaManagerSupplier.get().mirrorFetcherManager()
+                    .removeFetcherForPartitions(CollectionConverters.asScala(Set.of(tp)));
+                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED);
+                break;
+            case STOPPING:
+                handleStoppingTransition(mirrorName, tp);
+                break;
+            case PAUSED, STOPPED:
+                break;
+            case FAILED:
+                scheduleFailedRetry(mirrorName, tp);
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal state transition to " + newState);
+        }
+    }
+
+    /**
+     * Handles the STOPPING lifecycle: removes fetchers, updates the last mirror epoch,
+     * bumps the leader epoch, aborts ongoing transactions, writes PID reset barrier,
+     * and finally transitions to STOPPED. On any failure, transitions to FAILED.
+     */
+    private void handleStoppingTransition(String mirrorName, TopicPartition tp) {
+        ReplicaManager rm = replicaManagerSupplier.get();
+        rm.mirrorFetcherManager().removeFetcherForPartitions(CollectionConverters.asScala(Set.of(tp)));
+        var logOpt = rm.getPartitionOrException(tp).log();
+        int latestEpoch = logOpt.isDefined() ? logOpt.get().latestEpoch().orElse(-1) : -1;
+        updateLastMirrorEpoch(mirrorName, tp, latestEpoch)
+            .thenCompose(v -> bumpLeaderEpochs(getLatestLocalEpoch(tp)))
+            .thenCompose(v -> abortOngoingTransactions(tp))
+            .thenCompose(v -> writePidResetBarrier(mirrorName, tp))
+            .thenAccept(v -> transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED))
+            .exceptionally(ex -> {
+                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
+                return null;
+            });
+    }
+
+    /** Updates the last mirror epoch in the local cache and persists it to the coordinator shard. */
+    private CompletableFuture<Void> updateLastMirrorEpoch(String mirrorName, TopicPartition tp, int epoch) {
+        if (epoch == -1) {
+            return CompletableFuture.completedFuture(null);
+        }
+        setLastMirrorEpoch(mirrorName, tp.topic(), tp.partition(), epoch);
+        if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
+            return coordinatorWriter.get().writeLastMirrorEpoch(mirrorName, tp, epoch);
+        } else {
+            writeStatesToRemoteCoordinator(mirrorName,
+                Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), null, epoch))),
+                Set.of(), res -> { });
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private void scheduleTruncation(String mirrorName, TopicPartition tp) {
+        final Consumer<TopicPartition> truncateCallback =
+            partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING);
+        scheduler.scheduleOnce("truncation-" + mirrorName + "-" + tp,
+            () -> {
+                try {
+                    var sourceMirrors = listSourceClusterMirrors(mirrorName);
+                    if (hasMirrorLoop(mirrorName, tp, sourceMirrors)) {
+                        transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED,
+                            "Detected mirror loop for mirror:" + mirrorName);
+                        return;
+                    }
+                    sendLastMirrorEpochLookup(mirrorName, tp, sourceMirrors)
+                        .whenComplete((epochs, rawError) -> {
+                            if (rawError != null) {
+                                Throwable error = rawError instanceof CompletionException && rawError.getCause() != null
+                                    ? rawError.getCause() : rawError;
+                                if (error instanceof UnsupportedVersionException) {
+                                    log.warn("Source cluster doesn't support DescribeClusterMirror API. " +
+                                        "Replication will be one-way without failback");
+                                    replicaManagerSupplier.get().maybeTruncateForLeaderEpoch(
+                                        Map.of(tp, -1), truncateCallback);
+                                } else {
+                                    log.warn("Failed to truncate to last mirrored epoch for mirror {}",
+                                        mirrorName, error);
+                                    transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED,
+                                        error.getMessage());
+                                }
+                                return;
+                            }
+                            if (!epochs.containsKey(tp)) {
+                                log.warn("No epoch returned for {}. Using -1.", tp);
+                                epochs.put(tp, -1);
+                            }
+                            replicaManagerSupplier.get().maybeTruncateForLeaderEpoch(
+                                epochs, truncateCallback);
+                        });
+                } catch (Exception e) {
+                    log.warn("Failed to truncate to last mirror epochs for mirror {}", mirrorName, e);
+                    transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, e.getMessage());
+                }
+            }, 0);
+    }
+
+    private void scheduleFailedRetry(String mirrorName, TopicPartition tp) {
+        ClusterMirrorConfig mirrorConfig = brokerConfig.mirrorConfig();
+        int maxAttempts = mirrorConfig.failedRetryMaxAttempts();
+        MirrorPartitionKey key = MirrorPartitionKey.of(
+            mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
+        MirrorPartition mp = MirrorPartition.orEmpty(cache.getPartition(key));
+        int attempt = mp.retryAttempt() != 0 ? mp.retryAttempt() : 1;
+        if (attempt == MirrorPartition.NON_RETRYABLE_ATTEMPT) {
+            log.debug("Skipping retry for partition {} (non-retryable failed state).", tp);
+            return;
+        }
+        if (attempt >= maxAttempts) {
+            log.error("Partition {} exceeded max retry attempts ({}), requires manual intervention.",
+                tp, maxAttempts);
+            return;
+        }
+        ExponentialBackoff backoff = new ExponentialBackoff(
+            mirrorConfig.failedRetryInitialBackoffMs(),
+            CommonClientConfigs.RETRY_BACKOFF_EXP_BASE,
+            mirrorConfig.failedRetryMaxBackoffMs(),
+            CommonClientConfigs.RETRY_BACKOFF_JITTER);
+        long delay = backoff.backoff(attempt);
+        MirrorPartitionState targetState = (mp.prevState() == null || mp.prevState() == MirrorPartitionState.UNKNOWN)
+            ? MirrorPartitionState.LOG_TRUNCATION : mp.prevState();
+        log.info("Scheduling retry #{} for {} in {} ms targeting {}.", attempt, tp, delay, targetState);
+        scheduler.scheduleOnce("failed-retry-" + tp,
+            () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
+    }
+
+    private CompletableFuture<Void> writePidResetBarrier(String mirrorName, TopicPartition tp) {
+        String sourceClusterId = getSourceClusterId(mirrorName);
+        if (sourceClusterId == null) {
+            log.warn("Source cluster ID not available for mirror {}. Skipping PID reset barrier.", mirrorName);
+            return CompletableFuture.completedFuture(null);
+        }
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        appendPidResetBarrier(tp, sourceClusterId, time.milliseconds())
+            .whenComplete((v, ex) -> {
+                if (ex != null) {
+                    log.error("Failed to write PID reset record for {} in mirror {}", tp, mirrorName, ex);
+                    scheduler.scheduleOnce("pid-reset-retry-" + tp,
+                        () -> writePidResetBarrier(mirrorName, tp).thenAccept(r -> result.complete(null)), 5000);
+                } else {
+                    result.complete(null);
+                }
+            });
+        return result;
+    }
+
+    private void updateLocalFailedState(MirrorPartitionKey key, MirrorPartitionState newState,
+                                        String errorMessage, boolean nonRetryable) {
+        MirrorPartitionState curState = MirrorPartition.orEmpty(cache.getPartition(key)).state();
+        cache.updateFailedInfo(key, curState, newState, errorMessage, nonRetryable);
+    }
+
+    private Map<TopicPartition, Integer> getLatestLocalEpoch(TopicPartition tp) {
+        int epoch = replicaManagerSupplier.get().logManager().getLog(tp, false).get().latestEpoch().orElse(-1);
+        return Map.of(tp, epoch);
+    }
+
+    /**
+     * Writes tombstone records for all locally coordinated partitions of a deleted mirror,
+     * then removes the mirror's cache entries. Called from {@link #handleMirrorConfigDeltas}
+     * when a mirror config deletion is detected.
+     */
+    void tombstoneMirror(String mirrorName) {
+        Map<TopicPartition, MirrorPartitionState> states = getMirrorStates(mirrorName);
+        Map<Integer, Set<TopicPartition>> coordPartitionToMirrorPartitions = new HashMap<>();
+        states.forEach((tp, state) -> {
+            if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
+                coordPartitionToMirrorPartitions.computeIfAbsent(
+                    coordPartFinderByKey.get().apply(
+                        MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition())),
+                    v -> new HashSet<>()).add(tp);
+            }
+        });
+
+        cache.removeMirror(mirrorName);
+        cache.clearPendingLeaderEpochBumps(states.keySet());
+
+        if (coordPartitionToMirrorPartitions.isEmpty()) {
+            states.keySet().forEach(tp ->
+                cache.removePartition(
+                    MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition())));
+            return;
+        }
+
+        for (Map.Entry<Integer, Set<TopicPartition>> entry : coordPartitionToMirrorPartitions.entrySet()) {
+            Set<TopicPartition> tps = entry.getValue();
+            coordinatorWriter.get().writeTombstone(mirrorName, tps)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.warn("Failed to write tombstone for mirror '{}': {}. Will retry later.",
+                            mirrorName, ex.getMessage());
+                    } else {
+                        tps.forEach(tp -> cache.removePartition(
+                            MirrorPartitionKey.of(mirrorName,
+                                metadataCache.getTopicId(tp.topic()), tp.partition())));
+                    }
+                });
+        }
     }
 
     public void scheduleSourceTopicStateSync(String mirrorName) {
@@ -712,7 +992,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      */
     private Node findCoordinatorNode(MirrorPartitionKey key) {
         try {
-            if (coordPartitionFinderByKey.isEmpty() || !metadataCache.contains(MIRROR_STATE_TOPIC_NAME)) {
+            if (coordPartFinderByKey.isEmpty() || !metadataCache.contains(MIRROR_STATE_TOPIC_NAME)) {
                 return Node.noNode();
             }
 
@@ -724,7 +1004,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 return Node.noNode();
             }
 
-            int partition = coordPartitionFinderByKey.get().apply(key);
+            int partition = coordPartFinderByKey.get().apply(key);
             return topicMetadata.get(0).partitions().stream()
                     .filter(p -> p.partitionIndex() == partition && p.leaderId() != MetadataResponse.NO_LEADER_ID)
                     .findFirst()
@@ -1055,10 +1335,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         cache.setLastMirrorEpoch(key, epoch);
     }
 
-    public void removeMirror(String mirrorName) {
-        cache.removeMirror(mirrorName);
-    }
-
     public void updateFailedInfo(MirrorPartitionKey key, MirrorPartitionState currentState,
                                  MirrorPartitionState newState, String errorMessage, boolean nonRetryable) {
         cache.updateFailedInfo(key, currentState, newState, errorMessage, nonRetryable);
@@ -1066,10 +1342,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public void clearFailedInfo(String mirrorName, TopicPartition tp) {
         cache.clearFailedInfo(MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition()));
-    }
-
-    public void removePendingEpochBumps(Set<TopicPartition> partitions) {
-        cache.clearPendingLeaderEpochBumps(partitions);
     }
 
     public MirrorStateCache.SourceLeader resolveSourceLeader(String mirrorName, TopicPartition tp) {
@@ -1248,8 +1520,4 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return Optional.empty();
     }
 
-    /** Callback for partition state transitions triggered by the coordinator. */
-    public interface StateTransitioner {
-        void transitionTo(String mirrorName, Set<TopicPartition> topicPartition, MirrorPartitionState state, String errorMessage, boolean nonRetryable);
-    }
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -109,14 +109,10 @@ import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CON
 import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
 
 /**
- * <p>Implements {@link MetadataPublisher} to react to KRaft leadership and config changes,
- * triggering mirror partition state transitions. Routes state reads and writes to the
- * appropriate coordinator broker via {@link MirrorStateSender}. Mirror partition state,
- * source leaders, and pending operations are held in a {@link MirrorStateCache}.
- *
- * <p>Periodic source cluster synchronization (topic metadata, configs, group offsets, ACLs,
- * pattern discovery, epoch bumping) is handled by {@link MirrorSourceSyncer}, which is
- * created during {@link #initialize} and accesses shared state through the cache.
+ * Reacts to KRaft metadata changes, decides mirror partition state transitions,
+ * persists them via {@link CoreBridge.CoordinatorWriter}, and executes the
+ * resulting side effects (truncation, fetcher lifecycle, epoch bumps, retries).
+ * Delegates periodic source cluster synchronization to {@link MirrorSourceSyncer}.
  */
 @SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
 public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
@@ -127,28 +123,27 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     private final Logger log;
     private volatile boolean isInitialized = false;
-    private final String name;
     private final String clusterId;
     private final KafkaConfig brokerConfig;
+    private final String name;
     private final int nodeId;
 
-    private volatile MirrorSourceSyncer sourceSyncer;
     private final NodeToControllerChannelManager channelManager;
     private final Supplier<ReplicaManager> replicaManagerSupplier;
     private volatile MetadataImage metadataImage = MetadataImage.EMPTY;
     private final MetadataCache metadataCache;
+    private final MirrorStateCache mirrorCache;
     private final KafkaScheduler scheduler;
     private final Metrics metrics;
     private final Time time;
-    private final MirrorStateCache cache;
 
+    private volatile MirrorSourceSyncer sourceSyncer;
     private volatile MirrorStateSender mirrorStateSender;
     private volatile Map<String, Admin> srcAdmins;
     private volatile Admin dstAdmin;
 
     private Optional<CoreBridge.CoordinatorWriter> coordinatorWriter = Optional.empty();
-    private Optional<Function<MirrorPartitionKey, Integer>> coordPartFinderByKey = Optional.empty();
-    private Optional<Function<String, Integer>> coordPartFinderByName = Optional.empty();
+    private Optional<Function<MirrorPartitionKey, Integer>> coordPartFinder = Optional.empty();
 
     private final AtomicLong metadataRefreshError;
     private final AtomicLong topicConfigSyncError;
@@ -168,18 +163,18 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     ) {
         this.clusterId = clusterId;
         this.brokerConfig = brokerConfig;
+        this.nodeId = brokerConfig.nodeId();
         this.name = "[" + MirrorMetadataManager.class.getSimpleName() + " id=" + brokerConfig.nodeId() + "] ";
         this.log = new LogContext(name).logger(MirrorMetadataManager.class);
-        this.nodeId = brokerConfig.nodeId();
 
         this.channelManager = channelManager;
         this.replicaManagerSupplier = replicaManagerSupplier;
         this.metadataCache = metadataCache;
+        this.mirrorCache = MirrorStateCache.empty();
 
         this.scheduler = scheduler;
         this.metrics = metrics;
         this.time = time;
-        this.cache = MirrorStateCache.empty();
 
         KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(this.getClass());
         this.metadataRefreshError = new AtomicLong();
@@ -193,28 +188,14 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         metricsGroup.newGauge("ShareGroupOffsetSyncError", shareGroupOffsetSyncError::get);
         metricsGroup.newGauge("AclSyncError", aclSyncError::get);
         metricsGroup.newGauge("TopicMetadataRefreshError", metadataRefreshError::get);
-        metricsGroup.newGauge("LogTruncationPartitionState", () -> cache.partitionStateCount(MirrorPartitionState.LOG_TRUNCATION));
-        metricsGroup.newGauge("EpochFencingPartitionState", () -> cache.partitionStateCount(MirrorPartitionState.EPOCH_FENCING));
-        metricsGroup.newGauge("MirroringPartitionState", () -> cache.partitionStateCount(MirrorPartitionState.MIRRORING));
-        metricsGroup.newGauge("PausingPartitionState", () -> cache.partitionStateCount(MirrorPartitionState.PAUSING));
-        metricsGroup.newGauge("PausedPartitionState", () -> cache.partitionStateCount(MirrorPartitionState.PAUSED));
-        metricsGroup.newGauge("StoppingPartitionState", () -> cache.partitionStateCount(MirrorPartitionState.STOPPING));
-        metricsGroup.newGauge("StoppedPartitionState", () -> cache.partitionStateCount(MirrorPartitionState.STOPPED));
-        metricsGroup.newGauge("FailedPartitionState", () -> cache.partitionStateCount(MirrorPartitionState.FAILED));
-    }
-
-    /**
-     * Checks whether this broker leads the __mirror_state partition for the given mirror name.
-     * Hashes by mirror name only, so all mirror-level work (source sync, config sync) is handled
-     * by a single broker per mirror.
-     */
-    boolean isLocalCoordinator(String mirrorName) {
-        if (coordPartFinderByName.isPresent() && metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME) != null) {
-            int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
-                    .partitions().get(coordPartFinderByName.get().apply(mirrorName)).leader;
-            return activeCoordinator == brokerConfig.nodeId();
-        }
-        return false;
+        metricsGroup.newGauge("LogTruncationPartitionState", () -> mirrorCache.partitionStateCount(MirrorPartitionState.LOG_TRUNCATION));
+        metricsGroup.newGauge("EpochFencingPartitionState", () -> mirrorCache.partitionStateCount(MirrorPartitionState.EPOCH_FENCING));
+        metricsGroup.newGauge("MirroringPartitionState", () -> mirrorCache.partitionStateCount(MirrorPartitionState.MIRRORING));
+        metricsGroup.newGauge("PausingPartitionState", () -> mirrorCache.partitionStateCount(MirrorPartitionState.PAUSING));
+        metricsGroup.newGauge("PausedPartitionState", () -> mirrorCache.partitionStateCount(MirrorPartitionState.PAUSED));
+        metricsGroup.newGauge("StoppingPartitionState", () -> mirrorCache.partitionStateCount(MirrorPartitionState.STOPPING));
+        metricsGroup.newGauge("StoppedPartitionState", () -> mirrorCache.partitionStateCount(MirrorPartitionState.STOPPED));
+        metricsGroup.newGauge("FailedPartitionState", () -> mirrorCache.partitionStateCount(MirrorPartitionState.FAILED));
     }
 
     /**
@@ -223,9 +204,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * coordination across brokers so a mirror with many partitions does not bottleneck on one node.
      */
     private boolean isLocalCoordinator(String mirrorName, String topic, int partition) {
-        if (metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME) != null && coordPartFinderByKey.isPresent()) {
+        if (metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME) != null && coordPartFinder.isPresent()) {
             int activeCoordinator = metadataImage.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
-                    .partitions().get(coordPartFinderByKey.get().apply(
+                    .partitions().get(coordPartFinder.get().apply(
                             MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), partition))).leader;
             return activeCoordinator == brokerConfig.nodeId();
         }
@@ -239,8 +220,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Creates the {@link MirrorSourceSyncer} and schedules periodic metadata refresh.
      */
     public void initialize(CoreBridge.CoordinatorWriter coordinatorWriter,
-                           Function<MirrorPartitionKey, Integer> coordPartFinderByKey,
-                           Function<String, Integer> coordPartFinderByName) {
+                           Function<MirrorPartitionKey, Integer> coordPartFinder) {
         if (mirrorStateSender == null) {
             this.mirrorStateSender = new MirrorStateSender(MirrorStateSender.class.getSimpleName(),
                     NetworkUtils.buildNetworkClient(MirrorMetadataManager.class.getSimpleName(), brokerConfig, metrics, time, new LogContext(name())),
@@ -248,15 +228,15 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             mirrorStateSender.start();
         }
 
-        this.sourceSyncer = new MirrorSourceSyncer(brokerConfig, this, cache,
-                channelManager, metadataCache, scheduler, metadataRefreshError, topicConfigSyncError,
-                consumerGroupOffsetSyncError, shareGroupOffsetSyncError, aclSyncError);
+        this.sourceSyncer = new MirrorSourceSyncer(brokerConfig, this,
+                channelManager, metadataCache, mirrorCache, scheduler, metadataRefreshError,
+                topicConfigSyncError, consumerGroupOffsetSyncError, shareGroupOffsetSyncError, aclSyncError);
         sourceSyncer.scheduleMetadataRefresh(brokerConfig.mirrorConfig().metadataRefreshIntervalMs());
 
+        // MMM call the writer whenever it needs to persist state to the __mirror_state shard
         this.coordinatorWriter = Optional.of(coordinatorWriter);
-        this.coordPartFinderByKey = Optional.of(coordPartFinderByKey);
-        this.coordPartFinderByName = Optional.of(coordPartFinderByName);
 
+        this.coordPartFinder = Optional.of(coordPartFinder);
         this.isInitialized = true;
     }
 
@@ -346,10 +326,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return replicaManagerSupplier;
     }
 
-    public void scheduleMetadataRefresh(long intervalMs) {
-        sourceSyncer.scheduleMetadataRefresh(intervalMs);
-    }
-
     /**
      * Called when cluster metadata is updated and it is executed in the KRaft metadata publisher thread.
      * Detects mirror partition leadership changes and triggers state transitions via batched coordinator reads.
@@ -411,7 +387,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                             log.info("Mirror '{}' has connection config changed. Recreating connections.", mirrorName);
                         }
                         if (connectionConfigChanged || mirrorDeleted) {
-                            cache.removeSourceLeaders(mirrorName);
+                            mirrorCache.removeSourceLeaders(mirrorName);
                             closeAndRemoveSourceAdmin(mirrorName);
                             var mirrorFetcherManager = replicaManagerSupplier.get().mirrorFetcherManager();
                             mirrorFetcherManager.removeFetchersForMirror(mirrorName);
@@ -472,7 +448,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             if (mirrorName == null) {
                 return;
             }
-            cache.getPendingLederEpochBumps().removeIf(bump -> {
+            mirrorCache.getPendingLederEpochBumps().removeIf(bump -> {
                 bump.partitionToEpoch().remove(tp);
                 if (bump.partitionToEpoch().isEmpty()) {
                     bump.future().complete(null);
@@ -482,7 +458,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             });
             if (!isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
                 MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
-                cache.removePartition(key);
+                mirrorCache.removePartition(key);
             }
         });
     }
@@ -492,8 +468,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
         log.info("Re-evaluating MIRRORING partitions for reconnected mirrors: {}", reconnectedMirrors);
-        cache.partitionKeys().forEach(key -> {
-            MirrorPartition entry = cache.getPartition(key);
+        mirrorCache.partitionKeys().forEach(key -> {
+            MirrorPartition entry = mirrorCache.getPartition(key);
             if (entry != null && reconnectedMirrors.contains(key.mirrorName()) && entry.state() == MirrorPartitionState.MIRRORING) {
                 metadataCache.getTopicName(key.topicId()).ifPresent(topicName ->
                         result.add(new TopicPartition(topicName, key.partition())));
@@ -544,7 +520,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
             MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
             if (isLocalCoordinator(key.mirrorName(), tp.topic(), tp.partition())) {
-                MirrorPartition entry = cache.getPartition(key);
+                MirrorPartition entry = mirrorCache.getPartition(key);
                 MirrorPartitionState curState = entry != null ? entry.state() : MirrorPartitionState.UNKNOWN;
                 log.debug("Local transition for {} (current: {})", tp, curState);
                 applyStateTransition(key.mirrorName(), tp, curState, null, stopRequested, pauseRequested);
@@ -574,7 +550,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 boolean stopRequested = desired == MirrorPartitionState.STOPPED.value();
                                 boolean pauseRequested = desired == MirrorPartitionState.PAUSED.value();
                                 MirrorPartitionKey mpk = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(resTp.topic()), resTp.partition());
-                                MirrorPartition curEntry = cache.getPartition(mpk);
+                                MirrorPartition curEntry = mirrorCache.getPartition(mpk);
                                 MirrorPartitionState curState = curEntry != null ? curEntry.state() : MirrorPartitionState.UNKNOWN;
                                 applyStateTransition(mirrorName, resTp, curState, state, stopRequested, pauseRequested);
                             })));
@@ -583,7 +559,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     /** Completes epoch bump futures whose requested epochs are now reflected in the metadata image. */
     void maybeCompletePendingEpochBumps() {
-        cache.getPendingLederEpochBumps().removeIf(bumpLeaderEpoch -> {
+        mirrorCache.getPendingLederEpochBumps().removeIf(bumpLeaderEpoch -> {
             Set<TopicPartition> pendingPartitions = bumpLeaderEpoch.partitionToEpoch().entrySet().stream().filter(entry -> {
                 TopicPartition tp = entry.getKey();
                 int epoch = entry.getValue();
@@ -613,7 +589,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (dstAdmin != null) {
             dstAdmin.close(Duration.ZERO);
         }
-        cache.clear();
+        mirrorCache.clear();
     }
 
     public void closeSourceAdmins() {
@@ -718,7 +694,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 }
                                 return;
                             }
-                            if (MirrorPartition.orEmpty(cache.getPartition(key)).state() == state) {
+                            if (MirrorPartition.orEmpty(mirrorCache.getPartition(key)).state() == state) {
                                 onStateTransition(mirrorName, tp, state);
                             }
                         });
@@ -729,8 +705,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
                             if (par.errorCode() == Errors.NONE.code()) {
                                 updateLocalFailedState(key, state, errorMessage, nonRetryable);
-                                cache.setPartition(key,
-                                    MirrorPartition.orEmpty(cache.getPartition(key)).withState(state));
+                                mirrorCache.setPartition(key,
+                                    MirrorPartition.orEmpty(mirrorCache.getPartition(key)).withState(state));
                                 onStateTransition(mirrorName, tp, state);
                             } else {
                                 log.error("Failed to write partition state to remote coordinator: {}",
@@ -874,7 +850,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         int maxAttempts = mirrorConfig.failedRetryMaxAttempts();
         MirrorPartitionKey key = MirrorPartitionKey.of(
             mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
-        MirrorPartition mp = MirrorPartition.orEmpty(cache.getPartition(key));
+        MirrorPartition mp = MirrorPartition.orEmpty(mirrorCache.getPartition(key));
         int attempt = mp.retryAttempt() != 0 ? mp.retryAttempt() : 1;
         if (attempt == MirrorPartition.NON_RETRYABLE_ATTEMPT) {
             log.debug("Skipping retry for partition {} (non-retryable failed state).", tp);
@@ -920,8 +896,8 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     private void updateLocalFailedState(MirrorPartitionKey key, MirrorPartitionState newState,
                                         String errorMessage, boolean nonRetryable) {
-        MirrorPartitionState curState = MirrorPartition.orEmpty(cache.getPartition(key)).state();
-        cache.updateFailedInfo(key, curState, newState, errorMessage, nonRetryable);
+        MirrorPartitionState curState = MirrorPartition.orEmpty(mirrorCache.getPartition(key)).state();
+        mirrorCache.updateFailedInfo(key, curState, newState, errorMessage, nonRetryable);
     }
 
     private Map<TopicPartition, Integer> getLatestLocalEpoch(TopicPartition tp) {
@@ -940,18 +916,18 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         states.forEach((tp, state) -> {
             if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
                 coordPartitionToMirrorPartitions.computeIfAbsent(
-                    coordPartFinderByKey.get().apply(
+                    coordPartFinder.get().apply(
                         MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition())),
                     v -> new HashSet<>()).add(tp);
             }
         });
 
-        cache.removeMirror(mirrorName);
-        cache.clearPendingLeaderEpochBumps(states.keySet());
+        mirrorCache.removeMirror(mirrorName);
+        mirrorCache.clearPendingLeaderEpochBumps(states.keySet());
 
         if (coordPartitionToMirrorPartitions.isEmpty()) {
             states.keySet().forEach(tp ->
-                cache.removePartition(
+                mirrorCache.removePartition(
                     MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition())));
             return;
         }
@@ -964,25 +940,12 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                         log.warn("Failed to write tombstone for mirror '{}': {}. Will retry later.",
                             mirrorName, ex.getMessage());
                     } else {
-                        tps.forEach(tp -> cache.removePartition(
+                        tps.forEach(tp -> mirrorCache.removePartition(
                             MirrorPartitionKey.of(mirrorName,
                                 metadataCache.getTopicId(tp.topic()), tp.partition())));
                     }
                 });
         }
-    }
-
-    public void scheduleSourceTopicStateSync(String mirrorName) {
-        sourceSyncer.scheduleSourceTopicStateSync(mirrorName);
-    }
-
-    boolean hasMirrorLoop(String mirrorName, TopicPartition tp,
-                          Collection<ClusterMirrorListing> sourceMirrors) {
-        return sourceSyncer.hasMirrorLoop(mirrorName, tp, sourceMirrors);
-    }
-
-    Collection<ClusterMirrorListing> listSourceClusterMirrors(String mirrorName) {
-        return sourceSyncer.listSourceClusterMirrors(mirrorName);
     }
 
     /**
@@ -992,7 +955,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      */
     private Node findCoordinatorNode(MirrorPartitionKey key) {
         try {
-            if (coordPartFinderByKey.isEmpty() || !metadataCache.contains(MIRROR_STATE_TOPIC_NAME)) {
+            if (coordPartFinder.isEmpty() || !metadataCache.contains(MIRROR_STATE_TOPIC_NAME)) {
                 return Node.noNode();
             }
 
@@ -1004,7 +967,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 return Node.noNode();
             }
 
-            int partition = coordPartFinderByKey.get().apply(key);
+            int partition = coordPartFinder.get().apply(key);
             return topicMetadata.get(0).partitions().stream()
                     .filter(p -> p.partitionIndex() == partition && p.leaderId() != MetadataResponse.NO_LEADER_ID)
                     .findFirst()
@@ -1071,7 +1034,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 topic.partitions().forEach(partition -> {
                                     MirrorPartitionKey mpk = MirrorPartitionKey.of(
                                             mirrorName, metadataCache.getTopicId(topic.name()), partition.partitionIndex());
-                                    cache.mergePartition(mpk, partition.state(), partition.lastMirrorEpoch(),
+                                    mirrorCache.mergePartition(mpk, partition.state(), partition.lastMirrorEpoch(),
                                             partition.errorMessage(), partition.retryAttempt(), partition.previousState());
                                 }));
 
@@ -1213,11 +1176,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return result;
     }
 
-    public CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(
-            String mirrorName, TopicPartition tp, Collection<ClusterMirrorListing> sourceMirrors) {
-        return sourceSyncer.sendLastMirrorEpochLookup(mirrorName, tp, sourceMirrors);
-    }
-
     /**
      * Local-only LME lookup. Returns LME from the local coordinator cache
      * for partitions this broker coordinates, and -1 for the rest. The admin
@@ -1234,7 +1192,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             topicParts.forEach((topic, parts) -> {
                 parts.forEach(part -> {
                     MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), part);
-                    MirrorPartition cached = cache.getPartition(pk);
+                    MirrorPartition cached = mirrorCache.getPartition(pk);
                     int lme = isLocalCoordinator(mirrorName, topic, part) && cached != null
                             ? cached.lastMirrorEpoch() : -1;
                     result.computeIfAbsent(mirrorName, k -> new HashMap<>())
@@ -1266,9 +1224,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public Map<TopicPartition, MirrorPartitionState> getMirrorStates(String mirrorName) {
         Map<TopicPartition, MirrorPartitionState> result = new HashMap<>();
-        cache.partitionKeys().forEach(key -> {
+        mirrorCache.partitionKeys().forEach(key -> {
             if (key.mirrorName().equals(mirrorName)) {
-                MirrorPartition entry = cache.getPartition(key);
+                MirrorPartition entry = mirrorCache.getPartition(key);
                 if (entry != null && entry.state() != null) {
                     metadataCache.getTopicName(key.topicId()).ifPresent(topicName ->
                             result.put(new TopicPartition(topicName, key.partition()), entry.state()));
@@ -1306,58 +1264,6 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
     public int getActiveTopicCount(String mirrorName) {
         return getConfiguredTopics(mirrorName, false, false).size();
-    }
-
-    public MirrorPartition getPartition(MirrorPartitionKey key) {
-        return cache.getPartition(key);
-    }
-
-    public MirrorPartitionState getPartitionState(String mirrorName, TopicPartition topicPartition) {
-        MirrorPartition entry = cache.getPartition(
-                MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topicPartition.topic()), topicPartition.partition()));
-        return entry != null ? entry.state() : null;
-    }
-
-    public void setPartition(MirrorPartitionKey key, MirrorPartition partition) {
-        cache.setPartition(key, partition);
-    }
-
-    public void removePartition(MirrorPartitionKey key) {
-        cache.removePartition(key);
-    }
-
-    public void clearPartition(int coordPartition, int coordPartitionCount) {
-        cache.clearPartition(coordPartition, coordPartitionCount);
-    }
-
-    public void setLastMirrorEpoch(String mirrorName, String topic, int partition, int epoch) {
-        MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), partition);
-        cache.setLastMirrorEpoch(key, epoch);
-    }
-
-    public void updateFailedInfo(MirrorPartitionKey key, MirrorPartitionState currentState,
-                                 MirrorPartitionState newState, String errorMessage, boolean nonRetryable) {
-        cache.updateFailedInfo(key, currentState, newState, errorMessage, nonRetryable);
-    }
-
-    public void clearFailedInfo(String mirrorName, TopicPartition tp) {
-        cache.clearFailedInfo(MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition()));
-    }
-
-    public MirrorStateCache.SourceLeader resolveSourceLeader(String mirrorName, TopicPartition tp) {
-        return cache.resolveSourceLeader(mirrorName, tp);
-    }
-
-    public void updateSourceLeader(String mirrorName, TopicPartition tp, MirrorStateCache.SourceLeader leader) {
-        cache.updateSourceLeader(mirrorName, tp, leader);
-    }
-
-    public CompletableFuture<Void> scheduleBumpLeaderEpoch(String mirrorName, TopicPartition tp) {
-        return sourceSyncer.scheduleBumpLeaderEpoch(mirrorName, tp);
-    }
-
-    public CompletableFuture<Void> bumpLeaderEpochs(Map<TopicPartition, Integer> partitionMinEpochs) {
-        return sourceSyncer.sendBumpLeaderEpochs(partitionMinEpochs);
     }
 
     public void validateDeleteMirrorStates(DeleteClusterMirrorRequestData data, Consumer<Optional<Errors>> callback) {
@@ -1475,7 +1381,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             }
             for (int i = 0; i < topicImage.partitions().size(); i++) {
                 if (isLocalCoordinator(mirrorName, topic, i)) {
-                    MirrorPartition cachedEntry = cache.getPartition(
+                    MirrorPartition cachedEntry = mirrorCache.getPartition(
                             MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), i));
                     MirrorPartitionState state = cachedEntry != null && cachedEntry.state() != null
                             ? cachedEntry.state() : MirrorPartitionState.UNKNOWN;
@@ -1520,4 +1426,81 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         return Optional.empty();
     }
 
+    // -- MirrorCache proxy --
+
+    public MirrorPartition getPartition(MirrorPartitionKey key) {
+        return mirrorCache.getPartition(key);
+    }
+
+    public MirrorPartitionState getPartitionState(String mirrorName, TopicPartition topicPartition) {
+        MirrorPartition entry = mirrorCache.getPartition(
+                MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topicPartition.topic()), topicPartition.partition()));
+        return entry != null ? entry.state() : null;
+    }
+
+    public void setPartition(MirrorPartitionKey key, MirrorPartition partition) {
+        mirrorCache.setPartition(key, partition);
+    }
+
+    public void removePartition(MirrorPartitionKey key) {
+        mirrorCache.removePartition(key);
+    }
+
+    public void clearPartition(int coordPartition, int coordPartitionCount) {
+        mirrorCache.clearPartition(coordPartition, coordPartitionCount);
+    }
+
+    public void setLastMirrorEpoch(String mirrorName, String topic, int partition, int epoch) {
+        MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(topic), partition);
+        mirrorCache.setLastMirrorEpoch(key, epoch);
+    }
+
+    public void updateFailedInfo(MirrorPartitionKey key, MirrorPartitionState currentState,
+                                 MirrorPartitionState newState, String errorMessage, boolean nonRetryable) {
+        mirrorCache.updateFailedInfo(key, currentState, newState, errorMessage, nonRetryable);
+    }
+
+    public void clearFailedInfo(String mirrorName, TopicPartition tp) {
+        mirrorCache.clearFailedInfo(MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition()));
+    }
+
+    public MirrorStateCache.SourceLeader resolveSourceLeader(String mirrorName, TopicPartition tp) {
+        return mirrorCache.resolveSourceLeader(mirrorName, tp);
+    }
+
+    public void updateSourceLeader(String mirrorName, TopicPartition tp, MirrorStateCache.SourceLeader leader) {
+        mirrorCache.updateSourceLeader(mirrorName, tp, leader);
+    }
+
+    // -- Source syncer proxy --
+
+    public void scheduleMetadataRefresh(long intervalMs) {
+        sourceSyncer.scheduleMetadataRefresh(intervalMs);
+    }
+
+    public void scheduleSourceTopicStateSync(String mirrorName) {
+        sourceSyncer.scheduleSourceTopicStateSync(mirrorName);
+    }
+
+    boolean hasMirrorLoop(String mirrorName, TopicPartition tp,
+                          Collection<ClusterMirrorListing> sourceMirrors) {
+        return sourceSyncer.hasMirrorLoop(mirrorName, tp, sourceMirrors);
+    }
+
+    Collection<ClusterMirrorListing> listSourceClusterMirrors(String mirrorName) {
+        return sourceSyncer.listSourceClusterMirrors(mirrorName);
+    }
+
+    public CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(
+            String mirrorName, TopicPartition tp, Collection<ClusterMirrorListing> sourceMirrors) {
+        return sourceSyncer.sendLastMirrorEpochLookup(mirrorName, tp, sourceMirrors);
+    }
+
+    public CompletableFuture<Void> scheduleBumpLeaderEpoch(String mirrorName, TopicPartition tp) {
+        return sourceSyncer.scheduleBumpLeaderEpoch(mirrorName, tp);
+    }
+
+    public CompletableFuture<Void> bumpLeaderEpochs(Map<TopicPartition, Integer> partitionMinEpochs) {
+        return sourceSyncer.sendBumpLeaderEpochs(partitionMinEpochs);
+    }
 }

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -536,7 +536,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             desiredStates.keySet().forEach(tp ->
                     partitions.computeIfAbsent(tp.topic(), k -> new HashSet<>()).add(tp.partition()));
             log.debug("Reading remote coordinator state for mirror '{}': {}", mirrorName, partitions);
-            readStatesFromRemoteCoordinator(mirrorName, partitions, res ->
+            readStateFromRemoteCoordinator(mirrorName, partitions, res ->
                     res.data().topics().forEach(topic ->
                             topic.partitions().forEach(partition -> {
                                 if (partition.errorCode() != Errors.NONE.code()) {
@@ -669,7 +669,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     /**
      * Writes a state transition for each partition, routing to either the local coordinator
      * shard (via {@link CoreBridge.CoordinatorWriter}) or a remote coordinator (via
-     * {@link #writeStatesToRemoteCoordinator}). On successful write, dispatches side effects
+     * {@link #writeStateToRemoteCoordinator}). On successful write, dispatches side effects
      * through {@link #onStateTransition}.
      */
     public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
@@ -679,7 +679,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 MirrorPartitionKey key = MirrorPartitionKey.of(
                     mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
                 if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
-                    writer.writeTransition(mirrorName, tp, state, errorMessage, nonRetryable)
+                    writer.writePartitionState(mirrorName, tp, state, errorMessage, nonRetryable)
                         .whenComplete((v, ex) -> {
                             if (ex != null) {
                                 Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
@@ -701,7 +701,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 } else {
                     Map<String, Set<MirrorStateWrite>> topicMetadata =
                         Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), state, -1)));
-                    writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
+                    writeStateToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
                         res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
                             if (par.errorCode() == Errors.NONE.code()) {
                                 updateLocalFailedState(key, state, errorMessage, nonRetryable);
@@ -794,7 +794,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
             return coordinatorWriter.get().writeLastMirrorEpoch(mirrorName, tp, epoch);
         } else {
-            writeStatesToRemoteCoordinator(mirrorName,
+            writeStateToRemoteCoordinator(mirrorName,
                 Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), null, epoch))),
                 Set.of(), res -> { });
             return CompletableFuture.completedFuture(null);
@@ -983,9 +983,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
      * Reads partition states from remote coordinators, batching requests per coordinator node.
      * Updates the local {@link MirrorStateCache} with each response.
      */
-    void readStatesFromRemoteCoordinator(String mirrorName,
-                                         Map<String, Set<Integer>> partitions,
-                                         Consumer<ReadMirrorStatesResponse> callback) {
+    void readStateFromRemoteCoordinator(String mirrorName,
+                                        Map<String, Set<Integer>> partitions,
+                                        Consumer<ReadMirrorStatesResponse> callback) {
         log.debug("Reading states from remote coordinator: {} {}", mirrorName, partitions);
 
         // Group partitions by coordinator node for batching
@@ -1046,10 +1046,10 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
     }
 
     /** Writes partition states to remote coordinators, batching requests per coordinator node. */
-    public void writeStatesToRemoteCoordinator(String mirrorName,
-                                        Map<String, Set<MirrorStateWrite>> topicMetadata,
-                                        Set<String> stoppedTopics,
-                                        Consumer<WriteMirrorStatesResponse> callback) {
+    public void writeStateToRemoteCoordinator(String mirrorName,
+                                              Map<String, Set<MirrorStateWrite>> topicMetadata,
+                                              Set<String> stoppedTopics,
+                                              Consumer<WriteMirrorStatesResponse> callback) {
         log.debug("Writing states to remote coordinator: {} {} {}", mirrorName, topicMetadata, stoppedTopics);
 
         // Group partitions by coordinator node for batching
@@ -1344,7 +1344,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return;
         }
 
-        readStatesFromRemoteCoordinator(mirrorName, remotePartitions, response -> {
+        readStateFromRemoteCoordinator(mirrorName, remotePartitions, response -> {
             Optional<Errors> remoteError = validateRemotePartitions(response, validStates);
             if (remoteError.isPresent()) {
                 resultHandler.accept(remoteError);

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -677,56 +677,51 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
         coordinatorWriter.ifPresent(writer -> {
             for (TopicPartition tp : topicPartitions) {
                 MirrorPartitionState currentState = getPartitionState(mirrorName, tp);
-                if (MirrorPartitionState.isValidTransition(currentState, state)) {
-                    MirrorPartitionKey key = MirrorPartitionKey.of(
-                            mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
-                    if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
-                        writer.writePartitionState(mirrorName, tp, state, errorMessage, nonRetryable)
-                                .whenComplete((v, ex) -> {
-                                    if (ex != null) {
-                                        Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
-                                                ? ex.getCause() : ex;
-                                        if (cause instanceof CoordinatorLoadInProgressException) {
-                                            log.debug("Transition to {} deferred for {} (shard loading).", state, tp);
-                                            return;
-                                        }
-                                        log.error("Transition to {} failed for {}", state, tp, ex);
-                                        if (state != MirrorPartitionState.FAILED) {
-                                            transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
-                                        }
+                if (!MirrorPartitionState.isValidTransition(currentState, state)) {
+                    log.warn("Skipping invalid transition from {} to {} for {}.", currentState, state, tp);
+                    continue;
+                }
+                MirrorPartitionKey key = MirrorPartitionKey.of(
+                        mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
+                if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
+                    writer.writePartitionState(mirrorName, tp, state, errorMessage, nonRetryable)
+                            .whenComplete((v, ex) -> {
+                                if (ex != null) {
+                                    Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
+                                            ? ex.getCause() : ex;
+                                    if (cause instanceof CoordinatorLoadInProgressException) {
+                                        log.debug("Transition to {} deferred for {} (shard loading).", state, tp);
                                         return;
                                     }
-                                    if (MirrorPartition.orEmpty(mirrorCache.getPartition(key)).state() == state) {
-                                        onStateTransition(mirrorName, tp, state);
+                                    log.error("Transition to {} failed for {}", state, tp, ex);
+                                    if (state != MirrorPartitionState.FAILED) {
+                                        transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
                                     }
-                                });
-                    } else {
-                        Map<String, Set<MirrorStateWrite>> topicMetadata =
-                                Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), state, -1)));
-                        writeStateToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
-                                res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
-                                    if (par.errorCode() == Errors.NONE.code()) {
-                                        updateLocalFailedState(key, state, errorMessage, nonRetryable);
-                                        mirrorCache.setPartition(key,
-                                                MirrorPartition.orEmpty(mirrorCache.getPartition(key)).withState(state));
-                                        onStateTransition(mirrorName, tp, state);
-                                    } else {
-                                        log.error("Failed to write partition state to remote coordinator: {}",
-                                                par.errorCode());
-                                    }
-                                })));
-                    }
+                                    return;
+                                }
+                                if (MirrorPartition.orEmpty(mirrorCache.getPartition(key)).state() == state) {
+                                    onStateTransition(mirrorName, tp, state);
+                                }
+                            });
                 } else {
-                    log.warn("Ignoring state transition from {} to {} for partition {}: invalid transition",
-                            currentState, state, tp);
+                    Map<String, Set<MirrorStateWrite>> topicMetadata =
+                            Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), state, -1)));
+                    writeStateToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
+                            res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
+                                if (par.errorCode() == Errors.NONE.code()) {
+                                    updateLocalFailedState(key, state, errorMessage, nonRetryable);
+                                    mirrorCache.setPartition(key,
+                                            MirrorPartition.orEmpty(mirrorCache.getPartition(key)).withState(state));
+                                    onStateTransition(mirrorName, tp, state);
+                                } else {
+                                    log.error("Failed to write partition state to remote coordinator: {}",
+                                            par.errorCode());
+                                }
+                            })));
                 }
             }
         });
     }
-
-    // ---------------------------------------------------------------
-    // Side-effect dispatch (triggered after coordinator writes commit)
-    // ---------------------------------------------------------------
 
     /**
      * Dispatches side effects after a coordinator write commits.

--- a/core/src/main/java/kafka/server/mirror/MirrorSourceSyncer.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorSourceSyncer.java
@@ -208,10 +208,6 @@ class MirrorSourceSyncer {
     }
 
     private void retryPendingTombstoneWrites() {
-        if (manager.tombstoneWriter.isEmpty()) {
-            log.warn("Mirror deletion handler not configured. Tombstone record writes will be skipped.");
-            return;
-        }
         Set<String> configuredMirrors = manager.getConfiguredMirrors();
         Set<String> staleMirrors = cache.partitionKeys().stream()
                 .map(MirrorPartitionKey::mirrorName)
@@ -219,7 +215,7 @@ class MirrorSourceSyncer {
                 .collect(Collectors.toSet());
         for (String mirrorName : staleMirrors) {
             log.info("Found stale partition states for deleted mirror '{}'. Writing tombstones.", mirrorName);
-            manager.tombstoneWriter.ifPresent(h -> h.accept(mirrorName));
+            manager.tombstoneMirror(mirrorName);
         }
     }
 

--- a/core/src/main/java/kafka/server/mirror/MirrorSourceSyncer.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorSourceSyncer.java
@@ -66,8 +66,10 @@ import org.apache.kafka.common.requests.DeleteAclsRequest;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.mirror.ClusterMirrorConfig;
 import org.apache.kafka.coordinator.mirror.MirrorPartitionKey;
+import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.metadata.MetadataCache;
 import org.apache.kafka.metadata.authorizer.StandardAcl;
@@ -101,30 +103,28 @@ import java.util.stream.Collectors;
 
 import scala.Option;
 
+import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
+
 /**
- * Periodically syncs topic metadata, configurations, group offsets, and ACLs from
- * source clusters for Cluster Mirroring.
- *
- * <p>Runs on the {@link KafkaScheduler} thread. Source topic state sync (leader caches,
- * deletion detection, missed partition recovery) runs on every broker. Topic creation,
- * partition scaling, config sync, offset sync, ACL sync, and pattern discovery run only
- * on the coordinator broker for a given mirror.
+ * Periodically syncs source cluster state (topic metadata, configs, group offsets, ACLs)
+ * on every broker, and runs coordinator-only operations (topic creation, partition scaling,
+ * pattern discovery) on the broker that leads the mirror's {@code __mirror_state} partition.
  */
 @SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
 class MirrorSourceSyncer {
-    /** Number of epoch bumps after which the increment grows. */
     static final int LEADER_EPOCH_BUMP_THRESHOLD = 3;
-    /** Leader epoch increment applied per bump. */
     static final int LEADER_EPOCH_BUMP_INCREMENT = 10;
 
     private final Logger log;
-    private final MirrorMetadataManager manager;
-    private final MirrorStateCache cache;
     private final KafkaConfig brokerConfig;
     private final int nodeId;
+
+    private final MirrorMetadataManager metadataManager;
     private final NodeToControllerChannelManager channelManager;
+    private final MirrorStateCache mirrorCache;
     private final MetadataCache metadataCache;
     private final KafkaScheduler scheduler;
+
     private volatile ScheduledFuture<?> metadataRefreshFuture;
 
     private final AtomicLong metadataRefreshError;
@@ -135,10 +135,10 @@ class MirrorSourceSyncer {
 
     MirrorSourceSyncer(
         KafkaConfig brokerConfig,
-        MirrorMetadataManager manager,
-        MirrorStateCache cache,
+        MirrorMetadataManager metadataManager,
         NodeToControllerChannelManager channelManager,
         MetadataCache metadataCache,
+        MirrorStateCache mirrorCache,
         KafkaScheduler scheduler,
         AtomicLong metadataRefreshError,
         AtomicLong topicConfigSyncError,
@@ -146,21 +146,39 @@ class MirrorSourceSyncer {
         AtomicLong shareGroupOffsetSyncError,
         AtomicLong aclSyncError
     ) {
-        this.manager = manager;
-        this.cache = cache;
         this.brokerConfig = brokerConfig;
         this.nodeId = brokerConfig.nodeId();
+        String name = "[" + MirrorSourceSyncer.class.getSimpleName() + " id=" + nodeId + "] ";
+        this.log = new LogContext(name).logger(MirrorSourceSyncer.class);
+
+        this.metadataManager = metadataManager;
         this.channelManager = channelManager;
+        this.mirrorCache = mirrorCache;
         this.metadataCache = metadataCache;
         this.scheduler = scheduler;
+
         this.metadataRefreshError = metadataRefreshError;
         this.topicConfigSyncError = topicConfigSyncError;
         this.consumerGroupOffsetSyncError = consumerGroupOffsetSyncError;
         this.shareGroupOffsetSyncError = shareGroupOffsetSyncError;
         this.aclSyncError = aclSyncError;
+    }
 
-        String prefix = "[" + MirrorSourceSyncer.class.getSimpleName() + " id=" + nodeId + "] ";
-        this.log = new LogContext(prefix).logger(MirrorSourceSyncer.class);
+    /**
+     * Checks whether this broker leads the __mirror_state partition for the given mirror name.
+     * Hashes by mirror name only, so all mirror-level work (source sync, config sync) is handled
+     * by a single broker per mirror.
+     */
+    boolean isLocalCoordinator(String mirrorName) {
+        MetadataImage image = metadataManager.metadataImage();
+        if (image.topics().getTopic(MIRROR_STATE_TOPIC_NAME) != null) {
+            int partition = Utils.abs(mirrorName.hashCode())
+                % brokerConfig.mirrorConfig().stateTopicNumPartitions();
+            int leader = image.topics().getTopic(MIRROR_STATE_TOPIC_NAME)
+                    .partitions().get(partition).leader;
+            return leader == nodeId;
+        }
+        return false;
     }
 
     /**
@@ -186,7 +204,7 @@ class MirrorSourceSyncer {
     private void runMetadataRefresh() {
         retryPendingTombstoneWrites();
 
-        Set<String> mirrors = manager.getConfiguredMirrors();
+        Set<String> mirrors = metadataManager.getConfiguredMirrors();
         if (mirrors.isEmpty()) {
             return;
         }
@@ -208,24 +226,24 @@ class MirrorSourceSyncer {
     }
 
     private void retryPendingTombstoneWrites() {
-        Set<String> configuredMirrors = manager.getConfiguredMirrors();
-        Set<String> staleMirrors = cache.partitionKeys().stream()
+        Set<String> configuredMirrors = metadataManager.getConfiguredMirrors();
+        Set<String> staleMirrors = mirrorCache.partitionKeys().stream()
                 .map(MirrorPartitionKey::mirrorName)
                 .filter(name -> !configuredMirrors.contains(name))
                 .collect(Collectors.toSet());
         for (String mirrorName : staleMirrors) {
             log.info("Found stale partition states for deleted mirror '{}'. Writing tombstones.", mirrorName);
-            manager.tombstoneMirror(mirrorName);
+            metadataManager.tombstoneMirror(mirrorName);
         }
     }
 
     private void validateSourceClusterId(String mirrorName) {
-        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        Admin srcAdmin = metadataManager.getOrCreateSourceAdmin(mirrorName);
         try {
             var clusterResult = srcAdmin.describeCluster();
             String newClusterId = clusterResult.clusterId().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
             if (newClusterId != null && !newClusterId.isEmpty()) {
-                String previousClusterId = manager.getSourceClusterId(mirrorName);
+                String previousClusterId = metadataManager.getSourceClusterId(mirrorName);
                 if (previousClusterId != null && !previousClusterId.equals(newClusterId)) {
                     String errMsg = "Source cluster ID changed for mirror " + mirrorName
                             + ": expected " + previousClusterId + ", got " + newClusterId
@@ -233,11 +251,11 @@ class MirrorSourceSyncer {
                             + "Moving all partitions to non-retryable failed state.";
                     log.error(errMsg);
 
-                    Set<String> mirroredTopics = manager.getConfiguredTopics(mirrorName, true);
+                    Set<String> mirroredTopics = metadataManager.getConfiguredTopics(mirrorName, true);
                     if (!mirroredTopics.isEmpty()) {
                         Set<TopicPartition> mirroredLeaderPartitions = new HashSet<>();
                         for (String topic : mirroredTopics) {
-                            TopicImage topicImage = manager.metadataImage().topics().getTopic(topic);
+                            TopicImage topicImage = metadataManager.metadataImage().topics().getTopic(topic);
                             if (topicImage != null) {
                                 topicImage.partitions().forEach((partitionId, partition) -> {
                                     if (partition.leader == nodeId) {
@@ -247,7 +265,7 @@ class MirrorSourceSyncer {
                             }
                         }
                         if (!mirroredLeaderPartitions.isEmpty()) {
-                            manager.transitionTo(mirrorName, mirroredLeaderPartitions, MirrorPartitionState.FAILED, errMsg, true);
+                            metadataManager.transitionTo(mirrorName, mirroredLeaderPartitions, MirrorPartitionState.FAILED, errMsg, true);
                         }
                     }
                 }
@@ -270,7 +288,7 @@ class MirrorSourceSyncer {
      * @throws IllegalStateException if the request fails
      */
     Collection<ClusterMirrorListing> listSourceClusterMirrors(String mirrorName) {
-        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        Admin srcAdmin = metadataManager.getOrCreateSourceAdmin(mirrorName);
         try {
             return srcAdmin
                     .listClusterMirrors(new ListClusterMirrorsOptions().shouldIncludeTopicNames(true))
@@ -310,7 +328,7 @@ class MirrorSourceSyncer {
         }
         String topicName = tp.topic();
         for (ClusterMirrorListing sourceMirror : sourceMirrors) {
-            if (!manager.clusterId().equals(sourceMirror.sourceClusterId())) {
+            if (!metadataManager.clusterId().equals(sourceMirror.sourceClusterId())) {
                 continue;
             }
             if (sourceMirror.topics().contains(topicName)) {
@@ -333,12 +351,12 @@ class MirrorSourceSyncer {
      */
     Optional<List<SourceTopicState>> syncSourceTopicState(String mirrorName) {
         log.info("Syncing source topic state for mirror {}", mirrorName);
-        Set<String> topics = manager.getConfiguredTopics(mirrorName, false);
+        Set<String> topics = metadataManager.getConfiguredTopics(mirrorName, false);
         if (topics.isEmpty()) {
             return Optional.empty();
         }
 
-        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        Admin srcAdmin = metadataManager.getOrCreateSourceAdmin(mirrorName);
 
         try {
             Map<String, KafkaFuture<TopicDescription>> futures = srcAdmin.describeTopics(topics).topicNameValues();
@@ -380,15 +398,15 @@ class MirrorSourceSyncer {
 
             ti.partitions().forEach(pi -> {
                 if (pi.leader() != null) {
-                    cache.updateSourceLeader(mirrorName, pi.topicPartition(),
+                    mirrorCache.updateSourceLeader(mirrorName, pi.topicPartition(),
                             new SourceLeader(pi.leader(), pi.leaderEpoch().orElse(0)));
                 }
             });
 
             // Pre-KIP-516 sources (Kafka < 2.8) return ZERO_UUID; fall back to name-based lookup
             TopicImage destTopic = !ti.topicId().equals(Uuid.ZERO_UUID)
-                    ? manager.metadataImage().topics().getTopic(ti.topicId())
-                    : manager.metadataImage().topics().getTopic(ti.topic());
+                    ? metadataManager.metadataImage().topics().getTopic(ti.topicId())
+                    : metadataManager.metadataImage().topics().getTopic(ti.topic());
 
             if (destTopic != null && destTopic.partitions().size() < sourcePartitionCount) {
                 createPartitionsTopics.add(new CreatePartitionsRequestData.CreatePartitionsTopic()
@@ -397,9 +415,9 @@ class MirrorSourceSyncer {
                         .setAssignments(null)
                 );
             } else if (destTopic == null &&
-                    manager.metadataImage().topics().getTopic(ti.topic()) == null &&
+                    metadataManager.metadataImage().topics().getTopic(ti.topic()) == null &&
                     ti.exists() && sourcePartitionCount > 0) {
-                if (cache.addPendingTopicCreation(ti.topic())) {
+                if (mirrorCache.addPendingTopicCreation(ti.topic())) {
                     creatableTopics.add(new CreateTopicsRequestData.CreatableTopic()
                             .setName(ti.topic())
                             .setNumPartitions(sourcePartitionCount)
@@ -408,15 +426,15 @@ class MirrorSourceSyncer {
                                     ti.topicId().equals(Uuid.ZERO_UUID) ? Uuid.randomUuid() : ti.topicId())));
                 }
             } else if (destTopic == null &&
-                    manager.metadataImage().topics().getTopic(ti.topic()) != null &&
+                    metadataManager.metadataImage().topics().getTopic(ti.topic()) != null &&
                     ti.exists()) {
                 log.error("Mirror topic {} exists on destination with TopicId {} but source has TopicId {}. "
                                 + "Delete the topic on destination and let auto-creation recreate it with the correct TopicId.",
-                        ti.topic(), manager.metadataImage().topics().getTopic(ti.topic()).id(), ti.topicId());
+                        ti.topic(), metadataManager.metadataImage().topics().getTopic(ti.topic()).id(), ti.topicId());
             }
         });
 
-        if (manager.isLocalCoordinator(mirrorName)) {
+        if (isLocalCoordinator(mirrorName)) {
             if (!creatableTopics.isEmpty()) {
                 createMirrorTopics(creatableTopics);
             }
@@ -442,13 +460,13 @@ class MirrorSourceSyncer {
         ControllerRequestCompletionHandler requestCompletionHandler = new ControllerRequestCompletionHandler() {
             @Override
             public void onTimeout() {
-                topicNames.forEach(cache::removePendingTopicCreation);
+                topicNames.forEach(mirrorCache::removePendingTopicCreation);
                 log.warn("Create mirror topics timed out for {}", topicNames);
             }
 
             @Override
             public void onComplete(ClientResponse response) {
-                topicNames.forEach(cache::removePendingTopicCreation);
+                topicNames.forEach(mirrorCache::removePendingTopicCreation);
                 if (response.responseBody() instanceof CreateTopicsResponse createTopicsResponse) {
                     createTopicsResponse.data().topics().forEach(topic -> {
                         var error = Errors.forCode(topic.errorCode());
@@ -487,7 +505,7 @@ class MirrorSourceSyncer {
 
         // In old cluster, it is possible the broker metadata update in progress, and the returned metadata response is stale.
         // list topic again to make sure it is indeed deleted.
-        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        Admin srcAdmin = metadataManager.getOrCreateSourceAdmin(mirrorName);
         try {
             Set<String> allTopics = srcAdmin.listTopics().names().get();
             log.debug("Source topic name list: {}", allTopics);
@@ -497,13 +515,13 @@ class MirrorSourceSyncer {
             return;
         }
 
-        manager.getConfiguredTopics(mirrorName, true).forEach(name -> {
+        metadataManager.getConfiguredTopics(mirrorName, true).forEach(name -> {
             if (deletedSourceTopicNames.contains(name)) {
                 log.info("Detected topic {} deleted in remote cluster {}, marking mirror partitions as non-retryable", name, mirrorName);
-                TopicImage topicImage = manager.metadataImage().topics().getTopic(name);
+                TopicImage topicImage = metadataManager.metadataImage().topics().getTopic(name);
                 if (topicImage != null) {
                     topicImage.partitions().forEach((partitionId, partition) ->
-                            manager.transitionTo(mirrorName, Set.of(new TopicPartition(name, partitionId)),
+                            metadataManager.transitionTo(mirrorName, Set.of(new TopicPartition(name, partitionId)),
                                     MirrorPartitionState.FAILED, "The source topic is deleted.", true));
                 }
             }
@@ -528,17 +546,17 @@ class MirrorSourceSyncer {
      * widens the window in which the source leader is not yet known.
      */
     private void maybeStartMissedPartitions(String mirrorName) {
-        var partitionLeaders = cache.getSourceLeaders(mirrorName);
+        var partitionLeaders = mirrorCache.getSourceLeaders(mirrorName);
         if (partitionLeaders == null) {
             return;
         }
         partitionLeaders.keySet().forEach(tp -> {
             var key = MirrorPartitionKey.of(mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
-            var cachedEntry = cache.getPartition(key);
+            var cachedEntry = mirrorCache.getPartition(key);
             if (cachedEntry != null && cachedEntry.state() != null && cachedEntry.state() != MirrorPartitionState.UNKNOWN) {
                 return;
             }
-            TopicImage topicImage = manager.metadataImage().topics().getTopic(tp.topic());
+            TopicImage topicImage = metadataManager.metadataImage().topics().getTopic(tp.topic());
             if (topicImage == null) {
                 return;
             }
@@ -550,7 +568,7 @@ class MirrorSourceSyncer {
             var partition = topicImage.partitions().get(tp.partition());
             if (partition != null && partition.leader == nodeId) {
                 log.info("Source leader for {} discovered after initial onMetadataUpdate, transitioning to LOG_TRUNCATION", tp);
-                manager.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
+                metadataManager.transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.LOG_TRUNCATION);
             }
         });
     }
@@ -560,7 +578,7 @@ class MirrorSourceSyncer {
      * from the source cluster. Runs only on the coordinator broker for each mirror.
      */
     private void syncSourceConfigsAndOffsets(String mirrorName, Optional<List<SourceTopicState>> sourceTopicStates) {
-        if (!manager.isLocalCoordinator(mirrorName)) {
+        if (!isLocalCoordinator(mirrorName)) {
             return;
         }
 
@@ -572,7 +590,7 @@ class MirrorSourceSyncer {
             syncTopicConfigs(mirrorName, mirrorConfig);
             syncGroupOffsets(mirrorName, mirrorConfig);
             syncAcls(mirrorName, mirrorConfig);
-            if (!manager.getConfiguredTopics(mirrorName, false, false).isEmpty()) {
+            if (!metadataManager.getConfiguredTopics(mirrorName, false, false).isEmpty()) {
                 maybeBumpLeaderEpochs(mirrorName, sourceTopicStates, Set.of());
             }
             discoverTopicsByPattern(mirrorName, mirrorConfig);
@@ -583,9 +601,9 @@ class MirrorSourceSyncer {
     }
 
     private void syncTopicConfigs(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        Admin srcAdmin = metadataManager.getOrCreateSourceAdmin(mirrorName);
 
-        Set<String> topics = manager.getConfiguredTopics(mirrorName, false);
+        Set<String> topics = metadataManager.getConfiguredTopics(mirrorName, false);
         log.debug("Describing topic configs for topics: {}", topics);
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         topicConfigSyncError.incrementAndGet();
@@ -675,9 +693,9 @@ class MirrorSourceSyncer {
      * the same name on the destination (or vice versa).
      */
     private void syncGroupOffsets(String mirrorName, ClusterMirrorConfig mirrorConfig) {
-        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        Admin srcAdmin = metadataManager.getOrCreateSourceAdmin(mirrorName);
 
-        Set<String> mirrorTopics = manager.getConfiguredTopics(mirrorName, false, false);
+        Set<String> mirrorTopics = metadataManager.getConfiguredTopics(mirrorName, false, false);
         if (mirrorTopics.isEmpty()) {
             return;
         }
@@ -723,8 +741,8 @@ class MirrorSourceSyncer {
                         .filter(e -> mirrorTopics.contains(e.getKey().topic()))
                         .forEach(ent -> {
                             TopicPartition topicPartition = ent.getKey();
-                            Option<Long> logStartOffset = manager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
-                            Option<Long> logEndOffset = manager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
+                            Option<Long> logStartOffset = metadataManager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
+                            Option<Long> logEndOffset = metadataManager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
                             if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
                                 log.debug("Cannot get the log start offset or log end offset for partition {}, skip consumer group sync for it.", topicPartition);
                                 return;
@@ -737,7 +755,7 @@ class MirrorSourceSyncer {
                             if (finalOffset == sourceGroupOffsetAndMetadata.offset()) {
                                 filtered.put(topicPartition, sourceGroupOffsetAndMetadata);
                             } else if (finalOffset == logEndOffset.get()) {
-                                int logEndEpoch = manager.replicaManagerSupplier().get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logEndOffset.get()).orElse(-1)).getOrElse(() -> -1);
+                                int logEndEpoch = metadataManager.replicaManagerSupplier().get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logEndOffset.get()).orElse(-1)).getOrElse(() -> -1);
                                 if (logEndEpoch < 0) {
                                     log.debug("Cannot get the log end epoch for partition {}, skip consumer group sync for it.", topicPartition);
                                 } else {
@@ -745,7 +763,7 @@ class MirrorSourceSyncer {
                                 }
                             } else {
                                 // finalOffset == logStartOffset
-                                int logStartEpoch = manager.replicaManagerSupplier().get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logStartOffset.get()).orElse(-1)).getOrElse(() -> -1);
+                                int logStartEpoch = metadataManager.replicaManagerSupplier().get().getLog(topicPartition).map(l -> l.leaderEpochCache().epochForOffset(logStartOffset.get()).orElse(-1)).getOrElse(() -> -1);
                                 if (logStartEpoch < 0) {
                                     log.debug("Cannot get the log start epoch for partition {}, skip consumer group sync for it.", topicPartition);
                                 } else {
@@ -760,7 +778,7 @@ class MirrorSourceSyncer {
 
                 try {
                     log.debug("Committing consumer group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
-                    manager.getOrCreateDestAdmin().alterConsumerGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                    metadataManager.getOrCreateDestAdmin().alterConsumerGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
                 } catch (Exception e) {
                     log.warn("Failed to commit consumer group offsets for group {} in mirror {}: {}", groupId, mirrorName, e.getMessage());
                 }
@@ -814,8 +832,8 @@ class MirrorSourceSyncer {
                         .filter(e -> mirrorTopics.contains(e.getKey().topic()))
                         .forEach(ent -> {
                             TopicPartition topicPartition = ent.getKey();
-                            Option<Long> logStartOffset = manager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
-                            Option<Long> logEndOffset = manager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
+                            Option<Long> logStartOffset = metadataManager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logStartOffset);
+                            Option<Long> logEndOffset = metadataManager.replicaManagerSupplier().get().getLog(topicPartition).map(UnifiedLog::logEndOffset);
                             if (logStartOffset.isEmpty() ||  logEndOffset.isEmpty()) {
                                 log.debug("Cannot get the log start offset or log end offset for partition {}, skip share group offset sync for it.", topicPartition);
                                 return;
@@ -831,7 +849,7 @@ class MirrorSourceSyncer {
 
                 try {
                     log.debug("Committing share group offsets for group {} on destination, partitions={}", groupId, filtered.keySet());
-                    manager.getOrCreateDestAdmin().alterShareGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
+                    metadataManager.getOrCreateDestAdmin().alterShareGroupOffsets(groupId, filtered).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
                 } catch (Exception e) {
                     log.warn("Failed to commit share group offsets for group {} in mirror {}: {}", groupId, mirrorName, e);
                 }
@@ -865,7 +883,7 @@ class MirrorSourceSyncer {
                     GroupState.COMPLETING_REBALANCE,
                     GroupState.ASSIGNING,
                     GroupState.RECONCILING));
-            return Optional.of(manager.getOrCreateDestAdmin().listGroups(options).all()
+            return Optional.of(metadataManager.getOrCreateDestAdmin().listGroups(options).all()
                     .get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS).stream()
                     .map(GroupListing::groupId)
                     .collect(Collectors.toSet()));
@@ -883,7 +901,7 @@ class MirrorSourceSyncer {
         // TODO: How do we disambiguate ACLs that reference the same resource name
         //       when multiple cluster mirrors exist?
 
-        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        Admin srcAdmin = metadataManager.getOrCreateSourceAdmin(mirrorName);
 
         // TODO: This is incremented on every metadata refresh for testing purpose, as we don't have error handling at this stage
         aclSyncError.incrementAndGet();
@@ -914,7 +932,7 @@ class MirrorSourceSyncer {
     private SourceAclChanges detectAclChanges(List<AclBinding> sourceAcls) {
         var addACLsList = new ArrayList<AclBinding>();
         var deleteACLsList = new ArrayList<AclBinding>();
-        var current = manager.metadataImage().acls().acls().values();
+        var current = metadataManager.metadataImage().acls().acls().values();
 
         sourceAcls.forEach(acl -> {
             if (current.stream().map(StandardAcl::toBinding).noneMatch(a -> a.equals(acl))) {
@@ -922,7 +940,7 @@ class MirrorSourceSyncer {
             }
         });
 
-        manager.metadataImage().acls().acls().values().forEach(acl -> {
+        metadataManager.metadataImage().acls().acls().values().forEach(acl -> {
             if (acl.resourceType() != ResourceType.CLUSTER_MIRROR && !sourceAcls.contains(acl.toBinding())) {
                 deleteACLsList.add(acl.toBinding());
             }
@@ -975,9 +993,9 @@ class MirrorSourceSyncer {
             return;
         }
 
-        Admin srcAdmin = manager.getOrCreateSourceAdmin(mirrorName);
+        Admin srcAdmin = metadataManager.getOrCreateSourceAdmin(mirrorName);
 
-        Set<String> configuredTopics = manager.getConfiguredTopics(mirrorName, true);
+        Set<String> configuredTopics = metadataManager.getConfiguredTopics(mirrorName, true);
         final Pattern topicsExcludePattern = mirrorConfig.topicsExcludePattern();
 
         List<StartMirrorTopicsRequestData.TopicMetadata> newTopics;
@@ -1021,7 +1039,7 @@ class MirrorSourceSyncer {
         // TODO: creation failures from auto-discovery are silently lost here (fire-and-forget).
         //  Add per-topic status tracking so describeMirror can surface failed topics to users.
         try {
-            manager.getOrCreateDestAdmin().startMirrorTopics(
+            metadataManager.getOrCreateDestAdmin().startMirrorTopics(
                     mirrorName,
                     newTopics.stream().map(StartMirrorTopicsRequestData.TopicMetadata::topicName).collect(Collectors.toSet()),
                     new StartMirrorTopicsOptions()).all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
@@ -1039,7 +1057,7 @@ class MirrorSourceSyncer {
         Pattern excludePattern = mirrorConfig.topicsExcludePattern();
         if (excludePattern == null) return;
 
-        Set<String> activeTopics = manager.getConfiguredTopics(mirrorName, false, false);
+        Set<String> activeTopics = metadataManager.getConfiguredTopics(mirrorName, false, false);
         Set<String> excludedTopics = activeTopics.stream()
                 .filter(topic -> excludePattern.matcher(topic).matches())
                 .collect(Collectors.toSet());
@@ -1050,7 +1068,7 @@ class MirrorSourceSyncer {
                 excludedTopics.size(), mirrorName, excludedTopics);
 
         try {
-            manager.getOrCreateDestAdmin().stopMirrorTopics(mirrorName, excludedTopics, new StopMirrorTopicsOptions())
+            metadataManager.getOrCreateDestAdmin().stopMirrorTopics(mirrorName, excludedTopics, new StopMirrorTopicsOptions())
                     .all().get(brokerConfig.requestTimeoutMs(), TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             log.warn("Failed to stop excluded topics for mirror {}: {}", mirrorName, e.getMessage());
@@ -1107,8 +1125,8 @@ class MirrorSourceSyncer {
             topicStates.add(topicState);
         });
 
-        cache.addPendingEpochBump(new MirrorStateCache.PendingLeaderEpochBump(future, new ConcurrentHashMap<>(partitionMinEpochs)));
-        manager.maybeCompletePendingEpochBumps();
+        mirrorCache.addPendingEpochBump(new MirrorStateCache.PendingLeaderEpochBump(future, new ConcurrentHashMap<>(partitionMinEpochs)));
+        metadataManager.maybeCompletePendingEpochBumps();
 
         channelManager.sendRequest(new BumpLeaderEpochsRequest.Builder(
                 new BumpLeaderEpochsRequestData().setTopics(topicStates)
@@ -1127,7 +1145,7 @@ class MirrorSourceSyncer {
     }
 
     private Map<TopicPartition, Integer> buildSourceEpochBumpTargets(String mirrorName, List<SourceTopicState> sourceTopicStates, Set<TopicPartition> topicPartitions) {
-        Set<String> mirrorTopics = topicPartitions.isEmpty() ? manager.getConfiguredTopics(mirrorName, false) : Set.of();
+        Set<String> mirrorTopics = topicPartitions.isEmpty() ? metadataManager.getConfiguredTopics(mirrorName, false) : Set.of();
         Map<TopicPartition, Integer> leaderEpochFromMetadata = new HashMap<>();
         for (SourceTopicState ts : sourceTopicStates) {
             if (!ts.exists()) {
@@ -1155,7 +1173,7 @@ class MirrorSourceSyncer {
             if (ps.leaderEpoch().isEmpty()) {
                 continue;
             }
-            TopicImage topicImage = manager.metadataImage().topics().getTopic(tp.topic());
+            TopicImage topicImage = metadataManager.metadataImage().topics().getTopic(tp.topic());
             if (topicImage == null || topicImage.partitions().get(tp.partition()) == null) {
                 continue;
             }
@@ -1178,7 +1196,7 @@ class MirrorSourceSyncer {
     private void cacheSourceLeaders(String mirrorName, Collection<TopicDescription> descriptions) {
         descriptions.forEach(td -> td.partitions().forEach(pi -> {
             if (pi.leader() != null) {
-                cache.updateSourceLeader(mirrorName, new TopicPartition(td.name(), pi.partition()),
+                mirrorCache.updateSourceLeader(mirrorName, new TopicPartition(td.name(), pi.partition()),
                         new SourceLeader(pi.leader(), pi.leaderEpoch().orElse(0)));
             }
         }));
@@ -1199,7 +1217,7 @@ class MirrorSourceSyncer {
             Collection<ClusterMirrorListing> sourceMirrors,
             TopicPartition tp) {
         List<String> localClusterSourceMirrors = sourceMirrors.stream()
-                .filter(sm -> sm.sourceClusterId().equals(manager.clusterId()))
+                .filter(sm -> sm.sourceClusterId().equals(metadataManager.clusterId()))
                 .map(ClusterMirrorListing::mirrorName)
                 .toList();
 
@@ -1217,9 +1235,9 @@ class MirrorSourceSyncer {
                             && (!MirrorPartitionState.STOPPED.name().equals(lsd.state())));
             if (notStopped) {
                 log.error("Source mirror(s) {} mirroring from this cluster ({}) have not stopped for partition {}",
-                        localClusterSourceMirrors, manager.clusterId(), tp);
+                        localClusterSourceMirrors, metadataManager.clusterId(), tp);
                 throw new IllegalStateException("Source mirror(s) " + localClusterSourceMirrors
-                        + " mirroring from this cluster (" + manager.clusterId() + ") have not stopped for partition "
+                        + " mirroring from this cluster (" + metadataManager.clusterId() + ") have not stopped for partition "
                         + tp + ".");
             }
         }
@@ -1228,11 +1246,11 @@ class MirrorSourceSyncer {
     /** Looks up last mirror epochs from the source cluster for failback truncation. */
     CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(
             String mirrorName, TopicPartition tp, Collection<ClusterMirrorListing> sourceMirrors) {
-        Admin admin = manager.getOrCreateSourceAdmin(mirrorName);
+        Admin admin = metadataManager.getOrCreateSourceAdmin(mirrorName);
         List<DescribeClusterMirrorsRequestData.LastMirrorEpochLookup> lookups = buildLastMirrorEpochLookup(tp);
         log.info("Last mirror epoch lookup request for mirror {}: {}", mirrorName, lookups);
         DescribeClusterMirrorsOptions options = new DescribeClusterMirrorsOptions()
-                .clusterId(manager.clusterId())
+                .clusterId(metadataManager.clusterId())
                 .lastMirrorEpochLookups(lookups);
         DescribeClusterMirrorsResult result = admin.describeClusterMirrors(List.of(), options);
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -707,12 +707,14 @@ abstract class AbstractFetcherThread(name: String,
   private def partitionFetchState(tp: TopicPartition, initialFetchState: InitialFetchState, currentState: PartitionFetchState): PartitionFetchState = {
     if (currentState != null && currentState.currentLeaderEpoch == initialFetchState.currentLeaderEpoch) {
       currentState
+    } else if (currentState != null && mirrorName.nonEmpty && initialFetchState.currentLeaderEpoch < currentState.currentLeaderEpoch) {
+      // Skip stale epoch downgrades for mirror partitions to avoid an infinite truncation loop.
+      currentState
     } else if (initialFetchState.initOffset < 0) {
       fetchOffsetAndTruncate(tp, initialFetchState.topicId, initialFetchState.currentLeaderEpoch, initialFetchState.mirrorLeaderEpoch)
     } else if (leader.isTruncationOnFetchSupported && mirrorName.isBlank) {
-      // With old message format, `latestEpoch` will be empty and we use Truncating state to truncate to high watermark
+      // With old message format, latestEpoch will be empty and we use Truncating state to truncate to high watermark
       val lastFetchedEpoch: Optional[Integer] = latestEpoch(tp)
-
       val state = if (lastFetchedEpoch.isPresent) ReplicaState.FETCHING else ReplicaState.TRUNCATING
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
         state, lastFetchedEpoch, initialFetchState.mirrorName, initialFetchState.mirrorLeaderEpoch)

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -740,7 +740,7 @@ class BrokerServer(
     val writer = new CoordinatorPartitionWriter(replicaManager)
 
     val runtimeMetrics = new ClusterMirrorCoordinatorRuntimeMetrics(metrics)
-    val bridge = new CoreBridgeImpl(mirrorMetadataManager, metadataCache, replicaManager)
+    val bridge = new CoreBridgeImpl(mirrorMetadataManager, metadataCache)
 
     new ClusterMirrorCoordinatorService.Builder(config.brokerId, config.mirrorConfig)
       .withTime(time)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -4486,11 +4486,9 @@ class KafkaApis(val requestChannel: RequestChannel,
    * Returns -1 for partitions not coordinated by this broker. The admin client
    * broadcasts to all brokers and takes the max LME per partition.
    */
-  private def maybeProcessLastMirrorEpochLookup(
-                                                 requestData: DescribeClusterMirrorsRequestData,
-                                                 responseData: DescribeClusterMirrorsResponseData,
-                                                 sendResponse: Runnable
-                                               ): Unit = {
+  private def maybeProcessLastMirrorEpochLookup(requestData: DescribeClusterMirrorsRequestData,
+                                                responseData: DescribeClusterMirrorsResponseData,
+                                                sendResponse: Runnable): Unit = {
     val requestClusterId = requestData.clusterId
     val lastMirrorEpochLookups = requestData.lastMirrorEpochLookups
     if (requestClusterId == null || lastMirrorEpochLookups == null || lastMirrorEpochLookups.isEmpty) {
@@ -4583,7 +4581,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       })
       mirrorPartitions.put(topic.name(), parts)
     })
-    clusterMirrorCoordinator.readMirrorStates(mirrorName, mirrorPartitions,
+    clusterMirrorCoordinator.readState(mirrorName, mirrorPartitions,
       res => requestHelper.sendMaybeThrottle(request, res))
   }
 
@@ -4609,7 +4607,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       })
       mirrorState.put(topic.name(), topicState)
     })
-    clusterMirrorCoordinator.writeMirrorStates(mirrorName, mirrorState, res => requestHelper.sendMaybeThrottle(request, res))
+    clusterMirrorCoordinator.writeState(mirrorName, mirrorState, res => requestHelper.sendMaybeThrottle(request, res))
   }
 }
 

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
@@ -262,16 +262,6 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         return key.coordinatorPartition(config.stateTopicNumPartitions());
     }
 
-    private boolean isValidTransition(String mirrorName, TopicPartition tp, MirrorPartitionState newState) {
-        MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition());
-        MirrorPartitionState currentState = MirrorPartition.orEmpty(bridge.getPartition(pk)).state();
-        if (!MirrorPartitionState.isValidTransition(currentState, newState)) {
-            log.warn("Skipping invalid transition from {} to {} for {}.", currentState, newState, tp);
-            return false;
-        }
-        return true;
-    }
-
     /**
      * Reads partition states from the local coordinator cache. Called from
      * {@code MirrorMetadataManager#readStatesFromRemoteCoordinator} of a
@@ -340,12 +330,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         mirrorStates.forEach((topic, partitions) -> {
             Set<Integer> partitionIndices = new HashSet<>();
             partitions.forEach(partition -> {
-                TopicPartition tp = new TopicPartition(topic, partition.partition());
                 partitionIndices.add(partition.partition());
-                if (partition.state() != null && partition.state() != MirrorPartitionState.UNKNOWN
-                        && !isValidTransition(mirrorName, tp, partition.state())) {
-                    return;
-                }
                 int cp = partitionFor(MirrorPartitionKey.of(
                     mirrorName, bridge.getTopicId(topic), partition.partition()));
                 byCoordPartition.computeIfAbsent(cp, k -> new HashMap<>())
@@ -395,9 +380,6 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
             String errorMessage, boolean nonRetryable
     ) {
         throwIfNotActive();
-        if (!isValidTransition(mirrorName, tp, state)) {
-            return CompletableFuture.completedFuture(null);
-        }
         TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
                 partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
         return runtime.scheduleWriteOperation("write-partition-state", mirrorStateTp,

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
@@ -191,9 +191,9 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         bridge.initialize(
             new CoreBridge.CoordinatorWriter() {
                 @Override
-                public CompletableFuture<Void> writeTransition(String mirrorName, TopicPartition tp,
+                public CompletableFuture<Void> writePartitionState(String mirrorName, TopicPartition tp,
                         MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
-                    return ClusterMirrorCoordinatorService.this.writeTransition(
+                    return ClusterMirrorCoordinatorService.this.writePartitionState(
                         mirrorName, tp, state, errorMessage, nonRetryable);
                 }
 
@@ -262,48 +262,26 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         return key.coordinatorPartition(config.stateTopicNumPartitions());
     }
 
-    /** Persists a partition state transition record to the coordinator shard. */
-    private CompletableFuture<Void> writeTransition(String mirrorName, TopicPartition tp,
-            MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
-        throwIfNotActive();
-        TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
-            partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
-        return runtime.scheduleWriteOperation("transition-" + state, mirrorStateTp,
-            Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
-            shard -> shard.transitionTo(mirrorName, tp, state, errorMessage, nonRetryable));
-    }
-
-    /** Persists a last mirror epoch record to the coordinator shard. */
-    private CompletableFuture<Void> writeLastMirrorEpoch(String mirrorName, TopicPartition tp, int epoch) {
-        throwIfNotActive();
-        TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
-            partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
-        return runtime.scheduleWriteOperation("update-lme", mirrorStateTp,
-            Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
-            shard -> shard.updateLastMirrorEpoch(mirrorName, tp, epoch));
-    }
-
-    /** Persists tombstone records for the given partitions of a deleted mirror. */
-    private CompletableFuture<Void> writeTombstone(String mirrorName, Set<TopicPartition> partitions) {
-        throwIfNotActive();
-        int coordPartition = partitionFor(MirrorPartitionKey.of(
-                mirrorName, bridge.getTopicId(partitions.iterator().next().topic()),
-                partitions.iterator().next().partition()));
-        TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME, coordPartition);
-        return runtime.scheduleWriteOperation("tombstone-mirror", mirrorStateTp,
-                Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
-                shard -> shard.tombstoneMirrorRecords(mirrorName, partitions));
+    private boolean isValidTransition(String mirrorName, TopicPartition tp, MirrorPartitionState newState) {
+        MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition());
+        MirrorPartitionState currentState = MirrorPartition.orEmpty(bridge.getPartition(pk)).state();
+        if (!MirrorPartitionState.isValidTransition(currentState, newState)) {
+            log.warn("Skipping invalid transition from {} to {} for {}.", currentState, newState, tp);
+            return false;
+        }
+        return true;
     }
 
     /**
-     * Reads partition states from the local coordinator cache. Partitions are grouped
-     * by their {@code __mirror_state} coordinator partition and each group is submitted
-     * as a read operation through the runtime event queue, guaranteeing that reads are
-     * ordered after any preceding writes to the same coordinator partition.
+     * Reads partition states from the local coordinator cache. Called from
+     * {@code MirrorMetadataManager#readStatesFromRemoteCoordinator} of a
+     * remote broker.
      */
-    public void readMirrorStates(String mirrorName,
-                                 Map<String, Set<Integer>> partitions,
-                                 Consumer<ReadMirrorStatesResponse> callback) {
+    public void readState(
+            String mirrorName,
+            Map<String, Set<Integer>> partitions,
+            Consumer<ReadMirrorStatesResponse> callback
+    ) {
         throwIfNotActive();
 
         Map<Integer, Map<String, Set<Integer>>> byCoordPartition = new HashMap<>();
@@ -317,7 +295,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         byCoordPartition.forEach((cp, tps) -> {
             TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME, cp);
             futures.add(runtime.scheduleReadOperation("read-mirror-states", mirrorStateTp,
-                (shard, offset) -> shard.readMirrorStates(mirrorName, tps)));
+                (shard, offset) -> shard.readState(mirrorName, tps)));
         });
 
         CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
@@ -345,14 +323,15 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
     }
 
     /**
-     * Writes partition states and last mirror epochs received from a remote coordinator.
-     * Partitions are grouped by their {@code __mirror_state} coordinator partition and
-     * each group is submitted as a single write operation through the runtime event queue,
-     * batching state transitions and LME updates into one atomic write per coordinator partition.
+     * Writes partition states and last mirror epochs received from a remote broker.
+     * Called from {@code MirrorMetadataManager#writeStatesToRemoteCoordinator} of
+     * a remote broker.
      */
-    public void writeMirrorStates(String mirrorName,
-                                  Map<String, Set<MirrorStateWrite>> mirrorStates,
-                                  Consumer<WriteMirrorStatesResponse> callback) {
+    public void writeState(
+            String mirrorName,
+            Map<String, Set<MirrorStateWrite>> mirrorStates,
+            Consumer<WriteMirrorStatesResponse> callback
+    ) {
         throwIfNotActive();
 
         Map<Integer, Map<String, Set<MirrorStateWrite>>> byCoordPartition = new HashMap<>();
@@ -361,7 +340,12 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         mirrorStates.forEach((topic, partitions) -> {
             Set<Integer> partitionIndices = new HashSet<>();
             partitions.forEach(partition -> {
+                TopicPartition tp = new TopicPartition(topic, partition.partition());
                 partitionIndices.add(partition.partition());
+                if (partition.state() != null && partition.state() != MirrorPartitionState.UNKNOWN
+                        && !isValidTransition(mirrorName, tp, partition.state())) {
+                    return;
+                }
                 int cp = partitionFor(MirrorPartitionKey.of(
                     mirrorName, bridge.getTopicId(topic), partition.partition()));
                 byCoordPartition.computeIfAbsent(cp, k -> new HashMap<>())
@@ -373,9 +357,9 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         byCoordPartition.forEach((cp, states) -> {
             TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME, cp);
-            futures.add(runtime.scheduleWriteOperation("write-mirror-states", mirrorStateTp,
+            futures.add(runtime.scheduleWriteOperation("write-states", mirrorStateTp,
                 Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
-                shard -> shard.writeMirrorStates(mirrorName, states)));
+                shard -> shard.writeState(mirrorName, states)));
         });
 
         CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
@@ -390,7 +374,8 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
                     tps.forEach((topic, indices) -> {
                         List<WriteMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();
                         indices.forEach(i -> {
-                            WriteMirrorStatesResponseData.PartitionResult pr = new WriteMirrorStatesResponseData.PartitionResult();
+                            WriteMirrorStatesResponseData.PartitionResult pr =
+                                    new WriteMirrorStatesResponseData.PartitionResult();
                             pr.setPartitionIndex(i);
                             pr.setErrorCode((short) 0);
                             partitionResults.add(pr);
@@ -402,6 +387,48 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
                 }
                 callback.accept(new WriteMirrorStatesResponse(data));
             });
+    }
+
+    /** Persists a partition state record. Called from {@code MirrorMetadataManager#transitionTo}. */
+    private CompletableFuture<Void> writePartitionState(
+            String mirrorName, TopicPartition tp, MirrorPartitionState state,
+            String errorMessage, boolean nonRetryable
+    ) {
+        throwIfNotActive();
+        if (!isValidTransition(mirrorName, tp, state)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
+                partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
+        return runtime.scheduleWriteOperation("write-partition-state", mirrorStateTp,
+                Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
+                shard -> shard.writePartitionState(mirrorName, tp, state, errorMessage, nonRetryable));
+    }
+
+    /** Persists a last mirror epoch record. Called from {@code MirrorMetadataManager#updateLastMirrorEpoch}. */
+    private CompletableFuture<Void> writeLastMirrorEpoch(
+            String mirrorName, TopicPartition tp, int epoch
+    ) {
+        throwIfNotActive();
+        TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
+                partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
+        return runtime.scheduleWriteOperation("write-lme", mirrorStateTp,
+                Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
+                shard -> shard.writeLastMirrorEpoch(mirrorName, tp, epoch));
+    }
+
+    /** Persists tombstone records for a deleted mirror. Called from {@code MirrorMetadataManager#tombstoneMirror}. */
+    private CompletableFuture<Void> writeTombstone(
+            String mirrorName, Set<TopicPartition> partitions
+    ) {
+        throwIfNotActive();
+        int coordPartition = partitionFor(MirrorPartitionKey.of(
+                mirrorName, bridge.getTopicId(partitions.iterator().next().topic()),
+                partitions.iterator().next().partition()));
+        TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME, coordPartition);
+        return runtime.scheduleWriteOperation("write-tombstone", mirrorStateTp,
+                Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
+                shard -> shard.writeTombstone(mirrorName, partitions));
     }
 
     /** A single partition state or LME write entry for inter-broker WriteMirrorStates RPCs. */

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
@@ -211,7 +211,6 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
                         mirrorName, partitions);
                 }
             },
-            this::partitionFor,
             this::partitionFor);
         log.info("Startup complete.");
     }
@@ -261,11 +260,6 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
     public int partitionFor(MirrorPartitionKey key) {
         throwIfNotActive();
         return key.coordinatorPartition(config.stateTopicNumPartitions());
-    }
-
-    private int partitionFor(String mirrorName) {
-        throwIfNotActive();
-        return Utils.abs(mirrorName.hashCode()) % config.stateTopicNumPartitions();
     }
 
     /** Persists a partition state transition record to the coordinator shard. */

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
@@ -17,17 +17,13 @@
 package org.apache.kafka.coordinator.mirror;
 
 
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ReadMirrorStatesResponseData;
 import org.apache.kafka.common.message.WriteMirrorStatesResponseData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ReadMirrorStatesResponse;
 import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
-import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -55,7 +51,6 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -63,22 +58,21 @@ import java.util.function.Consumer;
 import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
 
 /**
- * Service layer for the cluster mirror coordinator.
+ * Persistence layer for the cluster mirror coordinator.
  * Implements the {@link ClusterMirrorCoordinator} lifecycle interface and
  * delegates record persistence to the {@link CoordinatorRuntime}.
- * Side effects (fetcher management, epoch bumps, truncation) are triggered
- * after writes commit (via {@code .whenComplete} on the runtime futures).
+ * Exposes shard write operations via {@link CoreBridge.CoordinatorWriter}
+ * so that {@code MirrorMetadataManager} can trigger side effects after
+ * writes commit.
  */
 public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator {
     private final Logger log;
     private final AtomicBoolean isActive = new AtomicBoolean(false);
-    private final int nodeId;
     private final ClusterMirrorConfig config;
     private final CoordinatorRuntime<ClusterMirrorCoordinatorShard, CoordinatorRecord> runtime;
     private final CoreBridge bridge;
     private final Scheduler scheduler;
     private final Metrics metrics;
-    private final Time time;
 
     public static class Builder {
         private final int nodeId;
@@ -166,7 +160,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
 
             return new ClusterMirrorCoordinatorService(
                     nodeId, config, runtime, bridge,
-                    scheduler, metrics, time);
+                    scheduler, metrics);
         }
     }
 
@@ -176,23 +170,16 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         CoordinatorRuntime<ClusterMirrorCoordinatorShard, CoordinatorRecord> runtime,
         CoreBridge bridge,
         Scheduler scheduler,
-        Metrics metrics,
-        Time time
+        Metrics metrics
     ) {
         String name = "[ClusterMirrorCoordinatorService id=" + nodeId + "] ";
         this.log = new LogContext(name).logger(ClusterMirrorCoordinatorService.class);
-        this.nodeId = nodeId;
         this.config = config;
         this.runtime = runtime;
         this.bridge = bridge;
         this.scheduler = scheduler;
         this.metrics = metrics;
-        this.time = time;
     }
-
-    // ---------------------------------------------------------------
-    // Lifecycle (ClusterMirrorCoordinator interface)
-    // ---------------------------------------------------------------
 
     @Override
     public void startup() {
@@ -202,8 +189,28 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         }
         log.info("Starting up.");
         bridge.initialize(
-            this::transitionTo,
-            this::tombstoneMirror,
+            new CoreBridge.CoordinatorWriter() {
+                @Override
+                public CompletableFuture<Void> writeTransition(String mirrorName, TopicPartition tp,
+                        MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
+                    return ClusterMirrorCoordinatorService.this.writeTransition(
+                        mirrorName, tp, state, errorMessage, nonRetryable);
+                }
+
+                @Override
+                public CompletableFuture<Void> writeLastMirrorEpoch(String mirrorName,
+                        TopicPartition tp, int epoch) {
+                    return ClusterMirrorCoordinatorService.this.writeLastMirrorEpoch(
+                        mirrorName, tp, epoch);
+                }
+
+                @Override
+                public CompletableFuture<Void> writeTombstone(String mirrorName,
+                        Set<TopicPartition> partitions) {
+                    return ClusterMirrorCoordinatorService.this.writeTombstone(
+                        mirrorName, partitions);
+                }
+            },
             this::partitionFor,
             this::partitionFor);
         log.info("Startup complete.");
@@ -251,155 +258,48 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
         }
     }
 
-    private int partitionFor(String mirrorName) {
-        throwIfNotActive();
-        return Utils.abs(mirrorName.hashCode()) % config.stateTopicNumPartitions();
-    }
-
     public int partitionFor(MirrorPartitionKey key) {
         throwIfNotActive();
         return key.coordinatorPartition(config.stateTopicNumPartitions());
     }
 
-    /** Returns true if this broker leads the __mirror_state partition for the given mirror partition. */
-    private boolean isLocal(String mirrorName, TopicPartition tp) {
-        int partition = partitionFor(MirrorPartitionKey.of(
-                mirrorName, bridge.getTopicId(tp.topic()), tp.partition()));
-        int leader = bridge.getLeaderForPartition(MIRROR_STATE_TOPIC_NAME, partition);
-        return leader == nodeId;
-    }
-
-    // ---------------------------------------------------------------
-    // State transitions
-    // ---------------------------------------------------------------
-
-    private void onStateTransition(String mirrorName, TopicPartition tp, MirrorPartitionState newState) {
+    private int partitionFor(String mirrorName) {
         throwIfNotActive();
-        switch (newState) {
-            case LOG_TRUNCATION:
-                log.info("Mirror '{}' transitioning {} to LOG_TRUNCATION.", mirrorName, tp);
-                scheduleTruncation(mirrorName, tp);
-                break;
-            case EPOCH_FENCING:
-                log.info("Mirror '{}' transitioning {} to EPOCH_FENCING.", mirrorName, tp);
-                bridge.scheduleBumpLeaderEpoch(mirrorName, tp)
-                        .whenComplete((v, ex) -> {
-                            if (ex != null) {
-                                log.error("Mirror '{}' failed to bump leader epoch for {}.", mirrorName, tp, ex);
-                                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
-                            } else {
-                                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.MIRRORING);
-                            }
-                        });
-                break;
-            case MIRRORING:
-                log.info("Mirror '{}' transitioning {} to MIRRORING.", mirrorName, tp);
-                bridge.maybeCreateMirrorFetchers(mirrorName, Set.of(tp));
-                break;
-            case PAUSING:
-                log.info("Mirror '{}' transitioning {} to PAUSING.", mirrorName, tp);
-                bridge.removeFetcherForPartitions(Set.of(tp));
-                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.PAUSED);
-                break;
-            case PAUSED:
-                log.info("Mirror '{}' transitioning {} to PAUSED.", mirrorName, tp);
-                break;
-            case STOPPING:
-                log.info("Mirror '{}' transitioning {} to STOPPING.", mirrorName, tp);
-                bridge.removeFetcherForPartitions(Set.of(tp));
-                int latestEpoch = bridge.getLatestEpoch(tp).orElse(-1);
-                updateLastMirrorEpoch(mirrorName, tp, latestEpoch)
-                        .thenCompose(v -> bumpLeaderEpoch(tp))
-                        .thenCompose(v -> abortOngoingTransactions(tp))
-                        .thenCompose(v -> writePidResetBarrier(mirrorName, tp))
-                        .thenAccept(v -> transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.STOPPED))
-                        .exceptionally(ex -> {
-                            log.error("Mirror '{}' STOPPING transition failed for {}.", mirrorName, tp, ex);
-                            transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
-                            return null;
-                        });
-                break;
-            case STOPPED:
-                log.info("Mirror '{}' transitioning {} to STOPPED.", mirrorName, tp);
-                break;
-            case FAILED:
-                log.info("Mirror '{}' transitioning {} to FAILED.", mirrorName, tp);
-                scheduleFailedRetry(mirrorName, tp);
-                break;
-            default:
-                throw new IllegalArgumentException("Illegal state transition to " + newState);
-        }
+        return Utils.abs(mirrorName.hashCode()) % config.stateTopicNumPartitions();
     }
 
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
-                             MirrorPartitionState newState) {
-        transitionTo(mirrorName, topicPartitions, newState, null, false);
-    }
-
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
-                             MirrorPartitionState newState, String errorMessage) {
-        transitionTo(mirrorName, topicPartitions, newState, errorMessage, false);
-    }
-
-    public void transitionTo(String mirrorName, Set<TopicPartition> topicPartitions,
-                             MirrorPartitionState newState, String errorMessage, boolean nonRetryable) {
+    /** Persists a partition state transition record to the coordinator shard. */
+    private CompletableFuture<Void> writeTransition(String mirrorName, TopicPartition tp,
+            MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
         throwIfNotActive();
-        topicPartitions.forEach(tp -> {
-            if (isLocal(mirrorName, tp)) {
-                TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
-                    partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
-                runtime.scheduleWriteOperation("transition-" + newState, mirrorStateTp,
-                                Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
-                                shard -> shard.transitionTo(mirrorName, tp, newState, errorMessage, nonRetryable))
-                    .whenComplete((result, ex) -> {
-                        if (ex != null) {
-                            Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
-                                ? ex.getCause() : ex;
-                            if (cause instanceof CoordinatorLoadInProgressException) {
-                                log.debug("Transition to {} deferred for {} (shard loading).", newState, tp);
-                                return;
-                            }
-                            log.error("Transition to {} failed for {}", newState, tp, ex);
-                            if (newState != MirrorPartitionState.FAILED) {
-                                transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, ex.getMessage());
-                            }
-                            return;
-                        }
-                        MirrorPartitionKey key = MirrorPartitionKey.of(
-                            mirrorName, bridge.getTopicId(tp.topic()), tp.partition());
-                        if (MirrorPartition.orEmpty(bridge.getPartition(key)).state() == newState) {
-                            onStateTransition(mirrorName, tp, newState);
-                        }
-                    });
-            } else {
-                Map<String, Set<MirrorStateWrite>> topicMetadata =
-                    Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), newState, -1)));
-                bridge.writeStatesToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
-                    res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
-                        if (par.errorCode() == Errors.NONE.code()) {
-                            MirrorPartitionKey key = MirrorPartitionKey.of(mirrorName,
-                                bridge.getTopicId(tp.topic()), tp.partition());
-                            updateLocalFailedState(key, newState, errorMessage, nonRetryable);
-                            bridge.setPartition(key, MirrorPartition.orEmpty(bridge.getPartition(key)).withState(newState));
-                            onStateTransition(mirrorName, tp, newState);
-                        } else {
-                            log.error("Failed to write partition state to remote coordinator: {}", par.errorCode());
-                        }
-                    })));
-            }
-        });
+        TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
+            partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
+        return runtime.scheduleWriteOperation("transition-" + state, mirrorStateTp,
+            Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
+            shard -> shard.transitionTo(mirrorName, tp, state, errorMessage, nonRetryable));
     }
 
-    private void updateLocalFailedState(MirrorPartitionKey key,
-                                        MirrorPartitionState newState,
-                                        String errorMessage, boolean nonRetryable) {
-        MirrorPartitionState curState = MirrorPartition.orEmpty(bridge.getPartition(key)).state();
-        bridge.updateFailedInfo(key, curState, newState, errorMessage, nonRetryable);
+    /** Persists a last mirror epoch record to the coordinator shard. */
+    private CompletableFuture<Void> writeLastMirrorEpoch(String mirrorName, TopicPartition tp, int epoch) {
+        throwIfNotActive();
+        TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
+            partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
+        return runtime.scheduleWriteOperation("update-lme", mirrorStateTp,
+            Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
+            shard -> shard.updateLastMirrorEpoch(mirrorName, tp, epoch));
     }
 
-    // ---------------------------------------------------------------
-    // Inter-broker RPC handling
-    // ---------------------------------------------------------------
+    /** Persists tombstone records for the given partitions of a deleted mirror. */
+    private CompletableFuture<Void> writeTombstone(String mirrorName, Set<TopicPartition> partitions) {
+        throwIfNotActive();
+        int coordPartition = partitionFor(MirrorPartitionKey.of(
+                mirrorName, bridge.getTopicId(partitions.iterator().next().topic()),
+                partitions.iterator().next().partition()));
+        TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME, coordPartition);
+        return runtime.scheduleWriteOperation("tombstone-mirror", mirrorStateTp,
+                Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
+                shard -> shard.tombstoneMirrorRecords(mirrorName, partitions));
+    }
 
     /**
      * Reads partition states from the local coordinator cache. Partitions are grouped
@@ -510,173 +410,6 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
             });
     }
 
-    // ---------------------------------------------------------------
-    // Private: update LME, truncation, failed retries, stopping
-    // ---------------------------------------------------------------
-
-    public CompletableFuture<Void> updateLastMirrorEpoch(String mirrorName, TopicPartition tp, int epoch) {
-        throwIfNotActive();
-        if (epoch == -1) {
-            return CompletableFuture.completedFuture(null);
-        }
-        bridge.setLastMirrorEpoch(mirrorName, tp.topic(), tp.partition(), epoch);
-
-        if (isLocal(mirrorName, tp)) {
-            TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
-                    partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
-            return runtime.scheduleWriteOperation("update-lme", mirrorStateTp,
-                    Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
-                    shard -> shard.updateLastMirrorEpoch(mirrorName, tp, epoch));
-        } else {
-            bridge.writeStatesToRemoteCoordinator(mirrorName,
-                    Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), null, epoch))),
-                    Set.of(), res -> { });
-            return CompletableFuture.completedFuture(null);
-        }
-    }
-
-    private void scheduleTruncation(String mirrorName, TopicPartition tp) {
-        final Consumer<TopicPartition> truncateCallback =
-            partition -> transitionTo(mirrorName, Set.of(partition), MirrorPartitionState.MIRRORING);
-        scheduler.scheduleOnce("truncation-" + mirrorName + "-" + tp,
-            () -> {
-                try {
-                    var sourceMirrors = bridge.listSourceClusterMirrors(mirrorName);
-                    if (bridge.hasMirrorLoop(mirrorName, tp, sourceMirrors)) {
-                        transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED,
-                            "Detected mirror loop for mirror:" + mirrorName);
-                        return;
-                    }
-                    bridge.sendLastMirrorEpochLookup(mirrorName, tp, sourceMirrors)
-                        .whenComplete((epochs, rawError) -> {
-                            if (rawError != null) {
-                                Throwable error = rawError instanceof CompletionException && rawError.getCause() != null
-                                    ? rawError.getCause() : rawError;
-                                if (error instanceof UnsupportedVersionException) {
-                                    log.warn("Source cluster doesn't support DescribeClusterMirror API. " +
-                                        "Replication will be one-way without failback");
-                                    bridge.maybeTruncateForLeaderEpoch(Map.of(tp, -1), truncateCallback);
-                                } else {
-                                    log.warn("Failed to truncate to last mirrored epoch for mirror {}", mirrorName, error);
-                                    transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, error.getMessage());
-                                }
-                                return;
-                            }
-                            if (!epochs.containsKey(tp)) {
-                                log.warn("No epoch returned for {}. Using -1.", tp);
-                                epochs.put(tp, -1);
-                            }
-                            bridge.maybeTruncateForLeaderEpoch(epochs, truncateCallback);
-                        });
-                } catch (Exception e) {
-                    log.warn("Failed to truncate to last mirror epochs for mirror {}", mirrorName, e);
-                    transitionTo(mirrorName, Set.of(tp), MirrorPartitionState.FAILED, e.getMessage());
-                }
-            }, 0);
-    }
-
-    private CompletableFuture<Void> bumpLeaderEpoch(TopicPartition tp) {
-        return bridge.bumpLeaderEpochs(bridge.getLatestLocalEpoch(tp));
-    }
-
-    private CompletableFuture<Void> abortOngoingTransactions(TopicPartition tp) {
-        return bridge.abortOngoingTransactions(tp);
-    }
-
-    private CompletableFuture<Void> writePidResetBarrier(String mirrorName, TopicPartition tp) {
-        String sourceClusterId = bridge.getSourceClusterId(mirrorName);
-        if (sourceClusterId == null) {
-            log.warn("Source cluster ID not available for mirror {}. Skipping PID reset barrier.", mirrorName);
-            return CompletableFuture.completedFuture(null);
-        }
-        CompletableFuture<Void> result = new CompletableFuture<>();
-        bridge.appendPidResetBarrier(tp, sourceClusterId, time.milliseconds())
-            .whenComplete((v, ex) -> {
-                if (ex != null) {
-                    log.error("Failed to write PID reset record for {} in mirror {}", tp, mirrorName, ex);
-                    scheduler.scheduleOnce("pid-reset-retry-" + tp,
-                        () -> writePidResetBarrier(mirrorName, tp).thenAccept(r -> result.complete(null)), 5000);
-                } else {
-                    result.complete(null);
-                }
-            });
-        return result;
-    }
-
-    private void scheduleFailedRetry(String mirrorName, TopicPartition tp) {
-        int maxAttempts = config.failedRetryMaxAttempts();
-        MirrorPartition mp = MirrorPartition.orEmpty(bridge.getPartition(
-                MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
-        int attempt = mp.retryAttempt() != 0 ? mp.retryAttempt() : 1;
-        if (attempt == MirrorPartition.NON_RETRYABLE_ATTEMPT) {
-            log.debug("Skipping retry for partition {} because it is in non-retryable failed state.", tp);
-            return;
-        }
-        if (attempt >= maxAttempts) {
-            log.error("Partition {} exceeded max retry attempts ({}), requires manual intervention.", tp, maxAttempts);
-            return;
-        }
-        ExponentialBackoff failedRetryBackoff = new ExponentialBackoff(
-                config.failedRetryInitialBackoffMs(),
-                CommonClientConfigs.RETRY_BACKOFF_EXP_BASE,
-                config.failedRetryMaxBackoffMs(),
-                CommonClientConfigs.RETRY_BACKOFF_JITTER);
-        long delay = failedRetryBackoff.backoff(attempt);
-        MirrorPartitionState targetState;
-        if (mp.prevState() == null || mp.prevState() == MirrorPartitionState.UNKNOWN) {
-            targetState = MirrorPartitionState.LOG_TRUNCATION;
-        } else {
-            targetState = mp.prevState();
-        }
-        log.info("Scheduling retry attempt #{} for partition {} in {} ms with target state {}.",
-                attempt, tp, delay, targetState);
-        scheduler.scheduleOnce("failed-retry-" + tp,
-                () -> transitionTo(mirrorName, Set.of(tp), targetState), delay);
-    }
-
-    // ---------------------------------------------------------------
-    // Private: tombstones
-    // ---------------------------------------------------------------
-
-    private void tombstoneMirror(String mirrorName) {
-        Map<TopicPartition, MirrorPartitionState> states = bridge.getMirrorStates(mirrorName);
-        Map<Integer, Set<TopicPartition>> coordPartitionToMirrorPartitions = new HashMap<>();
-        states.forEach((tp, state) -> {
-            if (isLocal(mirrorName, tp)) {
-                coordPartitionToMirrorPartitions.computeIfAbsent(
-                        partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())),
-                        v -> new HashSet<>()).add(tp);
-            }
-        });
-
-        bridge.removeMirror(mirrorName);
-        bridge.removePendingEpochBumps(states.keySet());
-
-        if (coordPartitionToMirrorPartitions.isEmpty()) {
-            states.keySet().forEach(tp ->
-                    bridge.removePartition(
-                            MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
-            return;
-        }
-
-        for (Map.Entry<Integer, Set<TopicPartition>> entry : coordPartitionToMirrorPartitions.entrySet()) {
-            TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME, entry.getKey());
-            Set<TopicPartition> tps = entry.getValue();
-            runtime.scheduleWriteOperation("tombstone-mirror", mirrorStateTp,
-                            Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
-                            shard -> shard.tombstoneMirrorRecords(mirrorName, tps))
-                    .whenComplete((result, ex) -> {
-                        if (ex != null) {
-                            log.warn("Failed to write tombstone to {}: {}. Will retry later.",
-                                    mirrorStateTp, ex.getMessage());
-                        } else {
-                            tps.forEach(tp -> bridge.removePartition(
-                                    MirrorPartitionKey.of(mirrorName,
-                                            bridge.getTopicId(tp.topic()), tp.partition())));
-                        }
-                    });
-        }
-    }
-
+    /** A single partition state or LME write entry for inter-broker WriteMirrorStates RPCs. */
     public record MirrorStateWrite(int partition, MirrorPartitionState state, Integer leaderEpoch) { }
 }

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShard.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShard.java
@@ -195,7 +195,9 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
     public void onNewMetadataImage(CoordinatorMetadataImage newImage, CoordinatorMetadataDelta delta) {
     }
 
-    public ReadMirrorStatesResponseData readMirrorStates(String mirrorName, Map<String, Set<Integer>> partitions) {
+    public ReadMirrorStatesResponseData readState(
+            String mirrorName, Map<String, Set<Integer>> partitions
+    ) {
         ReadMirrorStatesResponseData data = new ReadMirrorStatesResponseData();
         List<ReadMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
         partitions.forEach((topic, parts) -> {
@@ -219,7 +221,7 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
         return data;
     }
 
-    public CoordinatorResult<Void, CoordinatorRecord> writeMirrorStates(
+    public CoordinatorResult<Void, CoordinatorRecord> writeState(
         String mirrorName,
         Map<String, Set<ClusterMirrorCoordinatorService.MirrorStateWrite>> mirrorStates
     ) {
@@ -227,85 +229,56 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
         mirrorStates.forEach((topic, partitions) -> partitions.forEach(partition -> {
             TopicPartition tp = new TopicPartition(topic, partition.partition());
             if (partition.state() != null && partition.state() != MirrorPartitionState.UNKNOWN) {
-                CoordinatorResult<Void, CoordinatorRecord> result =
-                    transitionTo(mirrorName, tp, partition.state(), null, false);
-                records.addAll(result.records());
+                records.addAll(writePartitionState(mirrorName, tp, partition.state(), null, false).records());
             }
             if (partition.leaderEpoch() != -1) {
-                CoordinatorResult<Void, CoordinatorRecord> result =
-                    updateLastMirrorEpoch(mirrorName, tp, partition.leaderEpoch());
-                records.addAll(result.records());
+                records.addAll(writeLastMirrorEpoch(mirrorName, tp, partition.leaderEpoch()).records());
             }
         }));
         return new CoordinatorResult<>(records, null);
     }
 
-    public CoordinatorResult<Void, CoordinatorRecord> transitionTo(
-            String mirrorName,
-            TopicPartition tp,
-            MirrorPartitionState newState,
-            String errorMessage,
-            boolean nonRetryable
+    public CoordinatorResult<Void, CoordinatorRecord> writePartitionState(
+            String mirrorName, TopicPartition tp, MirrorPartitionState state,
+            String errorMessage, boolean nonRetryable
     ) {
         MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
         MirrorPartitionState currentState = MirrorPartition.orEmpty(coreBridge.getPartition(pk)).state();
-        if (!MirrorPartitionState.isValidTransition(currentState, newState)) {
-            log.warn("Skipping invalid transition from {} to {} for partition {}.", currentState, newState, tp);
-            return new CoordinatorResult<>(List.of(), null);
-        }
+        log.debug("Transitioning partition {} from {} to {}.", tp, currentState, state);
+        coreBridge.updateFailedInfo(pk, currentState, state, errorMessage, nonRetryable);
 
-        log.debug("Transitioning partition {} from {} to {}.", tp, currentState, newState);
-        updateFailedState(mirrorName, tp, currentState, newState, errorMessage, nonRetryable);
-        CoordinatorRecord record = buildPartitionStateRecord(mirrorName, tp, newState);
-        return new CoordinatorResult<>(List.of(record), null);
-    }
-
-    private void updateFailedState(String mirrorName, TopicPartition tp,
-                                   MirrorPartitionState currentState, MirrorPartitionState newState,
-                                   String errorMessage, boolean nonRetryable) {
-        MirrorPartitionKey pk = MirrorPartitionKey.of(
-                mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
-        coreBridge.updateFailedInfo(pk, currentState, newState, errorMessage, nonRetryable);
-    }
-
-    private CoordinatorRecord buildPartitionStateRecord(String mirrorName, TopicPartition tp,
-                                                        MirrorPartitionState newState) {
-        MirrorPartitionKey pk = MirrorPartitionKey.of(
-                mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
         MirrorPartition mp = MirrorPartition.orEmpty(coreBridge.getPartition(pk));
         var key = new MirrorPartitionStateKey()
                 .setMirrorName(mirrorName)
                 .setTopicId(pk.topicId())
                 .setPartition(pk.partition());
         var val = new MirrorPartitionStateValue()
-                .setState(newState.value())
+                .setState(state.value())
                 .setPreviousState(mp.prevState() != null ? mp.prevState().value() : MirrorPartitionState.UNKNOWN.value())
                 .setRetryAttempt((short) mp.retryAttempt())
                 .setErrorMessage(mp.errorMessage());
-        return CoordinatorRecord.record(key, new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION));
+        CoordinatorRecord record = CoordinatorRecord.record(key,
+                new ApiMessageAndVersion(val, MirrorPartitionStateValue.HIGHEST_SUPPORTED_VERSION));
+        return new CoordinatorResult<>(List.of(record), null);
     }
 
-    public CoordinatorResult<Void, CoordinatorRecord> updateLastMirrorEpoch(
+    public CoordinatorResult<Void, CoordinatorRecord> writeLastMirrorEpoch(
             String mirrorName, TopicPartition tp, int epoch
     ) {
         MirrorPartitionKey pk = MirrorPartitionKey.of(
                 mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
-        CoordinatorRecord record = buildLastMirrorEpochsRecord(pk, epoch);
-        return new CoordinatorResult<>(List.of(record), null);
-    }
-
-    private CoordinatorRecord buildLastMirrorEpochsRecord(MirrorPartitionKey pk, int lastMirrorEpoch) {
         var key = new LastMirrorEpochsKey()
                 .setMirrorName(pk.mirrorName())
                 .setTopicId(pk.topicId())
                 .setPartition(pk.partition());
-        var val = new LastMirrorEpochsValue().setLastMirrorEpoch(lastMirrorEpoch);
-        return CoordinatorRecord.record(key, new ApiMessageAndVersion(val, LastMirrorEpochsValue.HIGHEST_SUPPORTED_VERSION));
+        var val = new LastMirrorEpochsValue().setLastMirrorEpoch(epoch);
+        CoordinatorRecord record = CoordinatorRecord.record(key,
+                new ApiMessageAndVersion(val, LastMirrorEpochsValue.HIGHEST_SUPPORTED_VERSION));
+        return new CoordinatorResult<>(List.of(record), null);
     }
 
-    public CoordinatorResult<Void, CoordinatorRecord> tombstoneMirrorRecords(
-        String mirrorName,
-        Set<TopicPartition> partitions
+    public CoordinatorResult<Void, CoordinatorRecord> writeTombstone(
+        String mirrorName, Set<TopicPartition> partitions
     ) {
         List<CoordinatorRecord> records = new ArrayList<>();
         for (TopicPartition tp : partitions) {

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShard.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShard.java
@@ -244,6 +244,10 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
     ) {
         MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
         MirrorPartitionState currentState = MirrorPartition.orEmpty(coreBridge.getPartition(pk)).state();
+        if (!MirrorPartitionState.isValidTransition(currentState, state)) {
+            log.warn("Skipping invalid transition from {} to {} for {}.", currentState, state, tp);
+            return new CoordinatorResult<>(List.of(), null);
+        }
         log.debug("Transitioning partition {} from {} to {}.", tp, currentState, state);
         coreBridge.updateFailedInfo(pk, currentState, state, errorMessage, nonRetryable);
 

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
@@ -16,20 +16,13 @@
  */
 package org.apache.kafka.coordinator.mirror;
 
-import org.apache.kafka.clients.admin.ClusterMirrorListing;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.requests.WriteMirrorStatesResponse;
 import org.apache.kafka.server.common.MirrorPartitionState;
 
-import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -38,10 +31,9 @@ import java.util.function.Function;
  */
 public interface CoreBridge {
     void initialize(
-        StateTransitioner stateTransitioner,
-        Consumer<String> tombstoneWriter,
-        Function<MirrorPartitionKey, Integer> coordPartitionByKeyFinder,
-        Function<String, Integer> coordPartitionByNameFinder
+        CoordinatorWriter coordinatorWriter,
+        Function<MirrorPartitionKey, Integer> coordPartFinderByKey,
+        Function<String, Integer> coordPartFinderByName
     );
 
     void closeSourceAdmins();
@@ -66,62 +58,37 @@ public interface CoreBridge {
 
     void setLastMirrorEpoch(String mirrorName, String topic, int partition, int epoch);
 
-    void writeStatesToRemoteCoordinator(
-        String mirrorName,
-        Map<String, Set<ClusterMirrorCoordinatorService.MirrorStateWrite>> topicMetadata,
-        Set<String> stoppedTopics,
-        Consumer<WriteMirrorStatesResponse> callback
-    );
-
-    CompletionStage<Map<TopicPartition, Integer>> sendLastMirrorEpochLookup(
-        String mirrorName,
-        TopicPartition tp,
-        Collection<ClusterMirrorListing> sourceMirrors
-    );
-
-    CompletableFuture<Void> bumpLeaderEpochs(Map<TopicPartition, Integer> partitionMinEpochs);
-
-    CompletableFuture<Void> scheduleBumpLeaderEpoch(String mirrorName, TopicPartition tp);
-
-    Collection<ClusterMirrorListing> listSourceClusterMirrors(String mirrorName);
-
-    boolean hasMirrorLoop(String mirrorName, TopicPartition tp, Collection<ClusterMirrorListing> sourceMirrors);
-
-    String getSourceClusterId(String mirrorName);
-
-    Map<TopicPartition, MirrorPartitionState> getMirrorStates(String mirrorName);
-
-    void removeMirror(String mirrorName);
-
-    void removePendingEpochBumps(Set<TopicPartition> partitions);
-
     Uuid getTopicId(String topicName);
 
     Optional<String> getTopicName(Uuid topicId);
 
-    int getLeaderForPartition(String topic, int partition);
-
-    void maybeCreateMirrorFetchers(String mirrorName, Set<TopicPartition> partitions);
-
-    void removeFetcherForPartitions(Set<TopicPartition> partitions);
-
-    OptionalInt getLatestEpoch(TopicPartition tp);
-
-    Map<TopicPartition, Integer> getLatestLocalEpoch(TopicPartition tp);
-
-    void maybeTruncateForLeaderEpoch(Map<TopicPartition, Integer> epochs, Consumer<TopicPartition> callback);
-
-    CompletableFuture<Void> abortOngoingTransactions(TopicPartition tp);
-
-    CompletableFuture<Void> appendPidResetBarrier(TopicPartition tp, String sourceClusterId, long timestampMs);
-
-    interface StateTransitioner {
-        void transitionTo(
+    /**
+     * Callback for writing coordinator records to the {@code __mirror_state} shard
+     * via the {@code CoordinatorRuntime}. Implemented by
+     * {@code ClusterMirrorCoordinatorService} and passed to
+     * {@code MirrorMetadataManager} during initialization.
+     */
+    interface CoordinatorWriter {
+        /** Persists a partition state transition record to the coordinator shard. */
+        CompletableFuture<Void> writeTransition(
             String mirrorName,
-            Set<TopicPartition> topicPartition,
+            TopicPartition tp,
             MirrorPartitionState state,
             String errorMessage,
             boolean nonRetryable
+        );
+
+        /** Persists a last mirror epoch record to the coordinator shard. */
+        CompletableFuture<Void> writeLastMirrorEpoch(
+            String mirrorName,
+            TopicPartition tp,
+            int epoch
+        );
+
+        /** Persists tombstone records for the given partitions of a deleted mirror. */
+        CompletableFuture<Void> writeTombstone(
+            String mirrorName,
+            Set<TopicPartition> partitions
         );
     }
 }

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
@@ -32,8 +32,7 @@ import java.util.function.Function;
 public interface CoreBridge {
     void initialize(
         CoordinatorWriter coordinatorWriter,
-        Function<MirrorPartitionKey, Integer> coordPartFinderByKey,
-        Function<String, Integer> coordPartFinderByName
+        Function<MirrorPartitionKey, Integer> coordPartFinder
     );
 
     void closeSourceAdmins();
@@ -64,12 +63,11 @@ public interface CoreBridge {
 
     /**
      * Callback for writing coordinator records to the {@code __mirror_state} shard
-     * via the {@code CoordinatorRuntime}. Implemented by
-     * {@code ClusterMirrorCoordinatorService} and passed to
-     * {@code MirrorMetadataManager} during initialization.
+     * via the {@code CoordinatorRuntime}. This is the seam between the two modules:
+     * MMM (core) decides what to write; the coordinator service (mirror-coordinator)
+     * knows how to write it.
      */
     interface CoordinatorWriter {
-        /** Persists a partition state transition record to the coordinator shard. */
         CompletableFuture<Void> writeTransition(
             String mirrorName,
             TopicPartition tp,
@@ -78,14 +76,12 @@ public interface CoreBridge {
             boolean nonRetryable
         );
 
-        /** Persists a last mirror epoch record to the coordinator shard. */
         CompletableFuture<Void> writeLastMirrorEpoch(
             String mirrorName,
             TopicPartition tp,
             int epoch
         );
 
-        /** Persists tombstone records for the given partitions of a deleted mirror. */
         CompletableFuture<Void> writeTombstone(
             String mirrorName,
             Set<TopicPartition> partitions

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
@@ -68,7 +68,7 @@ public interface CoreBridge {
      * knows how to write it.
      */
     interface CoordinatorWriter {
-        CompletableFuture<Void> writeTransition(
+        CompletableFuture<Void> writePartitionState(
             String mirrorName,
             TopicPartition tp,
             MirrorPartitionState state,


### PR DESCRIPTION
Move state transition lifecycle and side-effect dispatch (onStateTransition, scheduleTruncation, scheduleFailedRetry, writePidResetBarrier, handleStoppingTransition, tombstoneMirror) from ClusterMirrorCoordinatorService to MirrorMetadataManager, which already holds all required dependencies (ReplicaManager, KafkaScheduler, MirrorSourceSyncer, MirrorStateCache).

Replace the fire-and-forget StateTransitioner callback with a future-based CoordinatorWriter interface (writeTransition, writeLastMirrorEpoch, writeTombstone) so MMM can chain side effects after shard writes commit.

The coordinator service becomes a focused persistence and RPC layer: CoordinatorRuntime lifecycle, shard write operations via CoordinatorWriter, and inter-broker ReadMirrorStates/WriteMirrorStates RPC handlers.