### PR TITLE
MetadataCache: add getAllConfigs

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -21,7 +21,6 @@ import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinat
 import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.{QuotaManagers, UNBOUNDED_QUOTA}
 import kafka.server.handlers.DescribeTopicPartitionsRequestHandler
-import kafka.server.metadata.KRaftMetadataCache
 import kafka.server.mirror.MirrorMetadataManager
 import org.apache.kafka.coordinator.mirror.ClusterMirrorCoordinatorService.MirrorStateWrite
 import org.apache.kafka.coordinator.mirror.{ClusterMirrorCoordinatorService, MirrorPartitionKey}
@@ -3099,16 +3098,12 @@ class KafkaApis(val requestChannel: RequestChannel,
         )
       }
       if (resourceTypes.contains(ConfigResource.Type.CLUSTER_MIRROR.id)) {
-        metadataCache match {
-          case kraftMetadataCache: KRaftMetadataCache if (kraftMetadataCache.currentImage().configs() != null) =>
-            kraftMetadataCache.currentImage().configs().resourceData.keySet().stream()
-              .filter(resource => resource.`type`() == ConfigResource.Type.CLUSTER_MIRROR)
-              .forEach(configResource =>
-                result.add(new ListConfigResourcesResponseData.ConfigResource()
-                  .setResourceName(configResource.name())
-                  .setResourceType(ConfigResource.Type.CLUSTER_MIRROR.id)))
-          case _ =>
-        }
+        metadataCache.getAllConfigs.stream()
+          .filter(resource => resource.`type`() == ConfigResource.Type.CLUSTER_MIRROR)
+          .forEach(configResource =>
+            result.add(new ListConfigResourcesResponseData.ConfigResource()
+              .setResourceName(configResource.name())
+              .setResourceType(ConfigResource.Type.CLUSTER_MIRROR.id)))
       }
       data.setConfigResources(result)
       requestHelper.sendMaybeThrottle(request, new ListConfigResourcesResponse(data))

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -322,6 +322,8 @@ class KRaftMetadataCache(
 
   override def getAllTopics(): util.Set[String] = _currentImage.topics().topicsByName().keySet()
 
+  override def getAllConfigs(): util.Set[ConfigResource] = _currentImage.configs().resourceData().keySet();
+
   override def getTopicId(topicName: String): Uuid = util.Optional.ofNullable(_currentImage.topics.topicsByName.get(topicName))
     .map(_.id)
     .orElse(Uuid.ZERO_UUID)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -11594,10 +11594,12 @@ class KafkaApisTest extends Logging {
 
       val clientMetrics = util.Set.of("client-metric1", "client-metric2")
       val topics = util.Set.of("topic1", "topic2")
+      val configs: util.Set[ConfigResource] = util.Set.of()
       val groupIds = util.List.of("group1", "group2")
       val nodeIds = util.List.of(1, 2)
       when(clientMetricsManager.listClientMetricsResources).thenReturn(clientMetrics)
       when(metadataCache.getAllTopics).thenReturn(topics)
+      when(metadataCache.getAllConfigs).thenReturn(configs)
       when(groupConfigManager.groupIds).thenReturn(groupIds)
       when(metadataCache.getBrokerNodes(any())).thenReturn(
         nodeIds.stream().map(id => new Node(id, "localhost", 1234)).collect(java.util.stream.Collectors.toList()))
@@ -11761,6 +11763,7 @@ class KafkaApisTest extends Logging {
 
     when(clientMetricsManager.listClientMetricsResources).thenReturn(util.Set.of)
     when(metadataCache.getAllTopics).thenReturn(util.Set.of)
+    when(metadataCache.getAllConfigs).thenReturn(util.Set.of)
     when(groupConfigManager.groupIds).thenReturn(util.List.of)
     when(metadataCache.getBrokerNodes(any())).thenReturn(util.List.of)
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/MetadataCache.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/MetadataCache.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.DescribeClientQuotasRequestData;
 import org.apache.kafka.common.message.DescribeClientQuotasResponseData;
@@ -69,6 +70,8 @@ public interface MetadataCache extends ConfigRepository {
         boolean errorUnavailableListeners);
 
     Set<String> getAllTopics();
+
+    Set<ConfigResource> getAllConfigs();
 
     boolean hasAliveBroker(int brokerId);
 


### PR DESCRIPTION
Fixes some tests in KafkaApisTest which failed due to a NPE on `metadataCache.currentImage()`.

This change introduces a `getAllConfigs` method on the interface which `KRaftMetadataCache` implements. The method is then mocked in the test.
