### PR TITLE
Add state epoch fencing for the mirror coordinator

### DIFF
--- a/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/ReadMirrorStatesResponse.json
@@ -39,6 +39,8 @@
           "about": "The last mirrored leader epoch, or -1 if not yet recorded." },
         { "name": "State", "type": "int8", "versions": "0+",
           "about": "The mirror partition state byte value." },
+        { "name": "StateEpoch", "type": "int32", "versions": "0+", "default": "0",
+          "about": "The current state epoch for the partition." },
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
           "about": "The per-partition error code (e.g. NOT_COORDINATOR), or 0 if there was no error." },
         { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",

--- a/clients/src/main/resources/common/message/WriteMirrorStatesRequest.json
+++ b/clients/src/main/resources/common/message/WriteMirrorStatesRequest.json
@@ -35,7 +35,9 @@
         { "name": "LastMirrorEpoch", "type": "int32", "versions": "0+", "default": "-1",
           "about": "The last mirrored leader epoch, or -1 if not available." },
         { "name": "State", "type": "int8", "versions": "0+",
-          "about": "The mirror partition state." }
+          "about": "The mirror partition state." },
+        { "name": "StateEpoch", "type": "int32", "versions": "0+", "default": "-1",
+          "about": "The expected state epoch for fencing, or -1 to skip the check." }
       ]}
     ]},
     { "name": "StoppedTopics", "type": "[]string", "versions": "0+", "about": "The topic names to be stopped." }

--- a/clients/src/main/resources/common/message/WriteMirrorStatesResponse.json
+++ b/clients/src/main/resources/common/message/WriteMirrorStatesResponse.json
@@ -35,6 +35,8 @@
         "about": "The results for the partitions.", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
+        { "name": "StateEpoch", "type": "int32", "versions": "0+", "default": "-1",
+          "about": "The new state epoch after the write, or -1 if the write failed." },
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
           "about": "The error code, or 0 if there was no error." },
         { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",

--- a/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorMetadataManager.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
+import org.apache.kafka.common.errors.FencedStateEpochException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.DeleteClusterMirrorRequestData;
 import org.apache.kafka.common.message.MetadataResponseData;
@@ -683,14 +684,20 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                 }
                 MirrorPartitionKey key = MirrorPartitionKey.of(
                         mirrorName, metadataCache.getTopicId(tp.topic()), tp.partition());
+                int stateEpoch = state == MirrorPartitionState.FAILED
+                        ? -1 : MirrorPartition.orEmpty(mirrorCache.getPartition(key)).stateEpoch();
                 if (isLocalCoordinator(mirrorName, tp.topic(), tp.partition())) {
-                    writer.writePartitionState(mirrorName, tp, state, errorMessage, nonRetryable)
+                    writer.writePartitionState(mirrorName, tp, state, stateEpoch, errorMessage, nonRetryable)
                             .whenComplete((v, ex) -> {
                                 if (ex != null) {
                                     Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
                                             ? ex.getCause() : ex;
                                     if (cause instanceof CoordinatorLoadInProgressException) {
                                         log.debug("Transition to {} deferred for {} (shard loading).", state, tp);
+                                        return;
+                                    }
+                                    if (cause instanceof FencedStateEpochException) {
+                                        log.debug("Transition to {} fenced for {} (stale state epoch).", state, tp);
                                         return;
                                     }
                                     log.error("Transition to {} failed for {}", state, tp, ex);
@@ -705,14 +712,18 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                             });
                 } else {
                     Map<String, Set<MirrorStateWrite>> topicMetadata =
-                            Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), state, -1)));
+                            Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), state, stateEpoch, -1)));
                     writeStateToRemoteCoordinator(mirrorName, topicMetadata, Set.of(),
                             res -> res.data().topics().forEach(topic -> topic.partitions().forEach(par -> {
                                 if (par.errorCode() == Errors.NONE.code()) {
                                     updateLocalFailedState(key, state, errorMessage, nonRetryable);
                                     mirrorCache.setPartition(key,
-                                            MirrorPartition.orEmpty(mirrorCache.getPartition(key)).withState(state));
+                                            MirrorPartition.orEmpty(mirrorCache.getPartition(key))
+                                                    .withState(state)
+                                                    .withStateEpoch(par.stateEpoch()));
                                     onStateTransition(mirrorName, tp, state);
+                                } else if (par.errorCode() == Errors.FENCED_STATE_EPOCH.code()) {
+                                    log.debug("Transition to {} fenced for {} (stale state epoch).", state, tp);
                                 } else {
                                     log.error("Failed to write partition state to remote coordinator: {}",
                                             par.errorCode());
@@ -796,7 +807,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
             return coordinatorWriter.get().writeLastMirrorEpoch(mirrorName, tp, epoch);
         } else {
             writeStateToRemoteCoordinator(mirrorName,
-                Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), null, epoch))),
+                Map.of(tp.topic(), Set.of(new MirrorStateWrite(tp.partition(), null, -1, epoch))),
                 Set.of(), res -> { });
             return CompletableFuture.completedFuture(null);
         }
@@ -1035,8 +1046,9 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
                                 topic.partitions().forEach(partition -> {
                                     MirrorPartitionKey mpk = MirrorPartitionKey.of(
                                             mirrorName, metadataCache.getTopicId(topic.name()), partition.partitionIndex());
-                                    mirrorCache.mergePartition(mpk, partition.state(), partition.lastMirrorEpoch(),
-                                            partition.errorMessage(), partition.retryAttempt(), partition.previousState());
+                                    mirrorCache.mergePartition(mpk, partition.state(), partition.stateEpoch(),
+                                            partition.lastMirrorEpoch(), partition.errorMessage(),
+                                            partition.retryAttempt(), partition.previousState());
                                 }));
 
                             callback.accept(readMirrorStatesResponse);
@@ -1067,6 +1079,7 @@ public class MirrorMetadataManager implements MetadataPublisher, AutoCloseable {
 
                 WriteMirrorStatesRequestData.PartitionData partitionData = new WriteMirrorStatesRequestData.PartitionData();
                 partitionData.setState(m.state() == null ? MirrorPartitionState.UNKNOWN.value() : m.state().value());
+                partitionData.setStateEpoch(m.stateEpoch());
                 partitionData.setLastMirrorEpoch(m.leaderEpoch());
                 partitionData.setPartitionIndex(m.partition());
 

--- a/core/src/main/java/kafka/server/mirror/MirrorStateCache.java
+++ b/core/src/main/java/kafka/server/mirror/MirrorStateCache.java
@@ -61,11 +61,12 @@ public class MirrorStateCache {
         partitions.put(key, partition);
     }
 
-    public void mergePartition(MirrorPartitionKey key, byte state, int lastMirrorEpoch,
+    public void mergePartition(MirrorPartitionKey key, byte state, int stateEpoch, int lastMirrorEpoch,
                                String errorMessage, int retryAttempt, byte previousState) {
         partitions.compute(key, (k, existing) -> {
             MirrorPartition result = MirrorPartition.orEmpty(existing);
             if (state != -1) result = result.withState(MirrorPartitionState.fromValue(state));
+            if (stateEpoch >= 0) result = result.withStateEpoch(stateEpoch);
             if (lastMirrorEpoch != -1) result = result.withLastMirrorEpoch(lastMirrorEpoch);
             if (state == MirrorPartitionState.FAILED.value()) {
                 result = result.withError(errorMessage, retryAttempt, MirrorPartitionState.fromValue(previousState));

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -4603,7 +4603,8 @@ class KafkaApis(val requestChannel: RequestChannel,
     writeMirrorStatesRequest.data().topics().forEach(topic => {
       val topicState = new util.HashSet[MirrorStateWrite]()
       topic.partitions().forEach(part => {
-        topicState.add(new MirrorStateWrite(part.partitionIndex(), MirrorPartitionState.fromValue(part.state()), part.lastMirrorEpoch()))
+        topicState.add(new MirrorStateWrite(part.partitionIndex(),
+          MirrorPartitionState.fromValue(part.state()), part.stateEpoch(), part.lastMirrorEpoch()))
       })
       mirrorState.put(topic.name(), topicState)
     })

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorService.java
@@ -192,9 +192,9 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
             new CoreBridge.CoordinatorWriter() {
                 @Override
                 public CompletableFuture<Void> writePartitionState(String mirrorName, TopicPartition tp,
-                        MirrorPartitionState state, String errorMessage, boolean nonRetryable) {
+                        MirrorPartitionState state, int stateEpoch, String errorMessage, boolean nonRetryable) {
                     return ClusterMirrorCoordinatorService.this.writePartitionState(
-                        mirrorName, tp, state, errorMessage, nonRetryable);
+                        mirrorName, tp, state, stateEpoch, errorMessage, nonRetryable);
                 }
 
                 @Override
@@ -339,7 +339,7 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
             tps.put(topic, partitionIndices);
         });
 
-        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        List<CompletableFuture<Map<TopicPartition, ClusterMirrorCoordinatorShard.PartitionWriteResult>>> futures = new ArrayList<>();
         byCoordPartition.forEach((cp, states) -> {
             TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME, cp);
             futures.add(runtime.scheduleWriteOperation("write-states", mirrorStateTp,
@@ -355,14 +355,22 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
                     data.setErrorCode(Errors.forException(e).code());
                     data.setErrorMessage(e.getMessage());
                 } else {
+                    Map<TopicPartition, ClusterMirrorCoordinatorShard.PartitionWriteResult> allResults = new HashMap<>();
+                    futures.forEach(f -> allResults.putAll(f.join()));
+
                     List<WriteMirrorStatesResponseData.TopicResult> topicResults = new ArrayList<>();
                     tps.forEach((topic, indices) -> {
                         List<WriteMirrorStatesResponseData.PartitionResult> partitionResults = new ArrayList<>();
                         indices.forEach(i -> {
+                            TopicPartition tp = new TopicPartition(topic, i);
+                            ClusterMirrorCoordinatorShard.PartitionWriteResult pwr = allResults.get(tp);
                             WriteMirrorStatesResponseData.PartitionResult pr =
                                     new WriteMirrorStatesResponseData.PartitionResult();
                             pr.setPartitionIndex(i);
-                            pr.setErrorCode((short) 0);
+                            if (pwr != null) {
+                                pr.setStateEpoch(pwr.stateEpoch());
+                                pr.setErrorCode(pwr.error().code());
+                            }
                             partitionResults.add(pr);
                         });
                         topicResults.add(new WriteMirrorStatesResponseData.TopicResult()
@@ -377,14 +385,14 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
     /** Persists a partition state record. Called from {@code MirrorMetadataManager#transitionTo}. */
     private CompletableFuture<Void> writePartitionState(
             String mirrorName, TopicPartition tp, MirrorPartitionState state,
-            String errorMessage, boolean nonRetryable
+            int stateEpoch, String errorMessage, boolean nonRetryable
     ) {
         throwIfNotActive();
         TopicPartition mirrorStateTp = new TopicPartition(MIRROR_STATE_TOPIC_NAME,
                 partitionFor(MirrorPartitionKey.of(mirrorName, bridge.getTopicId(tp.topic()), tp.partition())));
         return runtime.scheduleWriteOperation("write-partition-state", mirrorStateTp,
                 Duration.ofMillis(config.coordinatorWriteTimeoutMs()),
-                shard -> shard.writePartitionState(mirrorName, tp, state, errorMessage, nonRetryable));
+                shard -> shard.writePartitionState(mirrorName, tp, state, stateEpoch, errorMessage, nonRetryable));
     }
 
     /** Persists a last mirror epoch record. Called from {@code MirrorMetadataManager#updateLastMirrorEpoch}. */
@@ -414,5 +422,5 @@ public class ClusterMirrorCoordinatorService implements ClusterMirrorCoordinator
     }
 
     /** A single partition state or LME write entry for inter-broker WriteMirrorStates RPCs. */
-    public record MirrorStateWrite(int partition, MirrorPartitionState state, Integer leaderEpoch) { }
+    public record MirrorStateWrite(int partition, MirrorPartitionState state, int stateEpoch, Integer leaderEpoch) { }
 }

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShard.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShard.java
@@ -18,9 +18,11 @@ package org.apache.kafka.coordinator.mirror;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.FencedStateEpochException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ReadMirrorStatesResponseData;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorExecutor;
@@ -40,10 +42,12 @@ import org.apache.kafka.coordinator.mirror.generated.MirrorPartitionStateValue;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MirrorPartitionState;
 import org.apache.kafka.timeline.SnapshotRegistry;
+import org.apache.kafka.timeline.TimelineHashMap;
 
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,12 +61,14 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
     private final CoreBridge coreBridge;
     private final TopicPartition topicPartition;
     private final int numPartitions;
+    private final TimelineHashMap<MirrorPartitionKey, Integer> stateEpochMap;
 
     public static class Builder implements CoordinatorShardBuilder<ClusterMirrorCoordinatorShard, CoordinatorRecord> {
         private final CoreBridge coreBridge;
         private final int numPartitions;
         private LogContext logContext;
         private TopicPartition topicPartition;
+        private SnapshotRegistry snapshotRegistry;
 
         public Builder(CoreBridge coreBridge, int numPartitions) {
             this.coreBridge = coreBridge;
@@ -71,6 +77,7 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
 
         @Override
         public CoordinatorShardBuilder<ClusterMirrorCoordinatorShard, CoordinatorRecord> withSnapshotRegistry(SnapshotRegistry snapshotRegistry) {
+            this.snapshotRegistry = snapshotRegistry;
             return this;
         }
 
@@ -110,7 +117,8 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
         public ClusterMirrorCoordinatorShard build() {
             if (logContext == null) throw new IllegalArgumentException("LogContext must not be null.");
             if (topicPartition == null) throw new IllegalArgumentException("TopicPartition must not be null.");
-            return new ClusterMirrorCoordinatorShard(logContext, coreBridge, topicPartition, numPartitions);
+            if (snapshotRegistry == null) throw new IllegalArgumentException("SnapshotRegistry must not be null.");
+            return new ClusterMirrorCoordinatorShard(logContext, coreBridge, topicPartition, numPartitions, snapshotRegistry);
         }
     }
 
@@ -118,12 +126,14 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
         LogContext logContext,
         CoreBridge coreBridge,
         TopicPartition topicPartition,
-        int numPartitions
+        int numPartitions,
+        SnapshotRegistry snapshotRegistry
     ) {
         this.log = logContext.logger(ClusterMirrorCoordinatorShard.class);
         this.coreBridge = coreBridge;
         this.topicPartition = topicPartition;
         this.numPartitions = numPartitions;
+        this.stateEpochMap = new TimelineHashMap<>(snapshotRegistry, 0);
     }
 
     @Override
@@ -153,7 +163,10 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
             MirrorPartitionStateValue stateValue = (MirrorPartitionStateValue) value.message();
             MirrorPartitionState state = MirrorPartitionState.fromValue(stateValue.state());
             MirrorPartitionState previousState = MirrorPartitionState.fromValue(stateValue.previousState());
-            MirrorPartition mp = MirrorPartition.orEmpty(coreBridge.getPartition(pk)).withState(state);
+            maybeUpdateStateEpochMap(pk, stateValue.stateEpoch());
+            MirrorPartition mp = MirrorPartition.orEmpty(coreBridge.getPartition(pk))
+                    .withState(state)
+                    .withStateEpoch(stateValue.stateEpoch());
             if (state == MirrorPartitionState.FAILED) {
                 mp = mp.withError(stateValue.errorMessage(), stateValue.retryAttempt(), previousState);
             } else if (state == MirrorPartitionState.LOG_TRUNCATION
@@ -164,6 +177,14 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
             coreBridge.setPartition(pk, mp);
         } else {
             coreBridge.removePartition(pk);
+            stateEpochMap.remove(pk);
+        }
+    }
+
+    private void maybeUpdateStateEpochMap(MirrorPartitionKey pk, int stateEpoch) {
+        stateEpochMap.putIfAbsent(pk, stateEpoch);
+        if (stateEpochMap.get(pk) < stateEpoch) {
+            stateEpochMap.put(pk, stateEpoch);
         }
     }
 
@@ -208,7 +229,9 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
                 ReadMirrorStatesResponseData.PartitionResult pr = new ReadMirrorStatesResponseData.PartitionResult()
                         .setPartitionIndex(part)
                         .setState(mp.state().value())
-                        .setPreviousState(mp.prevState() != null ? mp.prevState().value() : MirrorPartitionState.UNKNOWN.value())
+                        .setStateEpoch(mp.stateEpoch())
+                        .setPreviousState(mp.prevState() != null ?
+                                mp.prevState().value() : MirrorPartitionState.UNKNOWN.value())
                         .setLastMirrorEpoch(mp.lastMirrorEpoch())
                         .setRetryAttempt((short) mp.retryAttempt())
                         .setErrorMessage(mp.errorMessage());
@@ -221,28 +244,44 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
         return data;
     }
 
-    public CoordinatorResult<Void, CoordinatorRecord> writeState(
+    public CoordinatorResult<Map<TopicPartition, PartitionWriteResult>, CoordinatorRecord> writeState(
         String mirrorName,
         Map<String, Set<ClusterMirrorCoordinatorService.MirrorStateWrite>> mirrorStates
     ) {
         List<CoordinatorRecord> records = new ArrayList<>();
+        Map<TopicPartition, PartitionWriteResult> results = new HashMap<>();
         mirrorStates.forEach((topic, partitions) -> partitions.forEach(partition -> {
             TopicPartition tp = new TopicPartition(topic, partition.partition());
             if (partition.state() != null && partition.state() != MirrorPartitionState.UNKNOWN) {
-                records.addAll(writePartitionState(mirrorName, tp, partition.state(), null, false).records());
+                try {
+                    CoordinatorResult<Void, CoordinatorRecord> result =
+                            writePartitionState(mirrorName, tp, partition.state(), partition.stateEpoch(), null, false);
+                    records.addAll(result.records());
+                    int newEpoch = stateEpochMap.getOrDefault(
+                            MirrorPartitionKey.of(mirrorName, coreBridge.getTopicId(topic), tp.partition()), 0);
+                    results.put(tp, new PartitionWriteResult(Errors.NONE, newEpoch));
+                } catch (FencedStateEpochException e) {
+                    results.put(tp, new PartitionWriteResult(Errors.FENCED_STATE_EPOCH, -1));
+                    return;
+                }
             }
             if (partition.leaderEpoch() != -1) {
                 records.addAll(writeLastMirrorEpoch(mirrorName, tp, partition.leaderEpoch()).records());
             }
         }));
-        return new CoordinatorResult<>(records, null);
+        return new CoordinatorResult<>(records, results);
     }
 
     public CoordinatorResult<Void, CoordinatorRecord> writePartitionState(
             String mirrorName, TopicPartition tp, MirrorPartitionState state,
-            String errorMessage, boolean nonRetryable
+            int expectedStateEpoch, String errorMessage, boolean nonRetryable
     ) {
         MirrorPartitionKey pk = MirrorPartitionKey.of(mirrorName, coreBridge.getTopicId(tp.topic()), tp.partition());
+        int currentStateEpoch = stateEpochMap.getOrDefault(pk, 0);
+        if (expectedStateEpoch != -1 && currentStateEpoch > expectedStateEpoch) {
+            log.info("Write fenced for {}: current epoch {} > expected {}.", tp, currentStateEpoch, expectedStateEpoch);
+            throw Errors.FENCED_STATE_EPOCH.exception();
+        }
         MirrorPartitionState currentState = MirrorPartition.orEmpty(coreBridge.getPartition(pk)).state();
         if (!MirrorPartitionState.isValidTransition(currentState, state)) {
             log.warn("Skipping invalid transition from {} to {} for {}.", currentState, state, tp);
@@ -251,6 +290,9 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
         log.debug("Transitioning partition {} from {} to {}.", tp, currentState, state);
         coreBridge.updateFailedInfo(pk, currentState, state, errorMessage, nonRetryable);
 
+        int newEpoch = currentStateEpoch + 1;
+        stateEpochMap.put(pk, newEpoch);
+
         MirrorPartition mp = MirrorPartition.orEmpty(coreBridge.getPartition(pk));
         var key = new MirrorPartitionStateKey()
                 .setMirrorName(mirrorName)
@@ -258,6 +300,7 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
                 .setPartition(pk.partition());
         var val = new MirrorPartitionStateValue()
                 .setState(state.value())
+                .setStateEpoch(newEpoch)
                 .setPreviousState(mp.prevState() != null ? mp.prevState().value() : MirrorPartitionState.UNKNOWN.value())
                 .setRetryAttempt((short) mp.retryAttempt())
                 .setErrorMessage(mp.errorMessage());
@@ -294,4 +337,7 @@ public class ClusterMirrorCoordinatorShard implements CoordinatorShard<Coordinat
         }
         return new CoordinatorResult<>(records, null);
     }
+
+    /** Per-partition result from {@link #writeState}, carrying the outcome error and the new state epoch. */
+    public record PartitionWriteResult(Errors error, int stateEpoch) { }
 }

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/CoreBridge.java
@@ -72,6 +72,7 @@ public interface CoreBridge {
             String mirrorName,
             TopicPartition tp,
             MirrorPartitionState state,
+            int stateEpoch,
             String errorMessage,
             boolean nonRetryable
         );

--- a/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/MirrorPartition.java
+++ b/mirror-coordinator/src/main/java/org/apache/kafka/coordinator/mirror/MirrorPartition.java
@@ -22,15 +22,16 @@ import org.apache.kafka.server.common.MirrorPartitionState;
  * Immutable snapshot of a mirror partition.
  *
  * @param state            the current lifecycle state, or null if unknown
+ * @param stateEpoch       monotonically increasing epoch incremented on every state transition
  * @param lastMirrorEpoch  the last mirrored leader epoch, or -1 if not yet recorded
  * @param errorMessage     the failure reason when in FAILED state, or null otherwise
  * @param retryAttempt     the retry count in FAILED state, 0 if not failed,
  *                         or {@link #NON_RETRYABLE_ATTEMPT} if non-retryable
  * @param prevState        the state before entering FAILED, or null if not applicable
  */
-public record MirrorPartition(MirrorPartitionState state, int lastMirrorEpoch,
+public record MirrorPartition(MirrorPartitionState state, int stateEpoch, int lastMirrorEpoch,
                               String errorMessage, int retryAttempt, MirrorPartitionState prevState) {
-    public static final MirrorPartition EMPTY = new MirrorPartition(MirrorPartitionState.UNKNOWN, -1, null, 0, null);
+    public static final MirrorPartition EMPTY = new MirrorPartition(MirrorPartitionState.UNKNOWN, 0, -1, null, 0, null);
     public static final int NON_RETRYABLE_ATTEMPT = -1;
 
     public static MirrorPartition orEmpty(MirrorPartition mp) {
@@ -38,19 +39,23 @@ public record MirrorPartition(MirrorPartitionState state, int lastMirrorEpoch,
     }
 
     public MirrorPartition withState(MirrorPartitionState newState) {
-        return new MirrorPartition(newState, lastMirrorEpoch, errorMessage, retryAttempt, prevState);
+        return new MirrorPartition(newState, stateEpoch, lastMirrorEpoch, errorMessage, retryAttempt, prevState);
+    }
+
+    public MirrorPartition withStateEpoch(int newStateEpoch) {
+        return new MirrorPartition(state, newStateEpoch, lastMirrorEpoch, errorMessage, retryAttempt, prevState);
     }
 
     public MirrorPartition withLastMirrorEpoch(int newEpoch) {
-        return new MirrorPartition(state, newEpoch, errorMessage, retryAttempt, prevState);
+        return new MirrorPartition(state, stateEpoch, newEpoch, errorMessage, retryAttempt, prevState);
     }
 
     public MirrorPartition withError(String errorMessage, int retryAttempt, MirrorPartitionState previousState) {
-        return new MirrorPartition(state, lastMirrorEpoch, errorMessage, retryAttempt, previousState);
+        return new MirrorPartition(state, stateEpoch, lastMirrorEpoch, errorMessage, retryAttempt, previousState);
     }
 
     public MirrorPartition clearError() {
-        return new MirrorPartition(state, lastMirrorEpoch, null, 0, null);
+        return new MirrorPartition(state, stateEpoch, lastMirrorEpoch, null, 0, null);
     }
 
     public int nextAttempt(boolean nonRetryable) {

--- a/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
+++ b/mirror-coordinator/src/main/resources/common/message/MirrorPartitionStateValue.json
@@ -26,6 +26,8 @@
   "fields": [
     { "name": "State", "type": "int8", "versions": "0+",
       "about": "The mirror partition state." },
+    { "name": "StateEpoch", "type": "int32", "versions": "0+", "default": "0",
+      "about": "Monotonically increasing epoch incremented on every state transition." },
     { "name": "PreviousState", "type": "int8",  "versions": "0+", "default": 16,
       "about": "The mirror partition state before this transition; UNKNOWN if not recorded." },
     { "name": "RetryAttempt", "type": "int16", "versions": "0+", "default": "0",

--- a/mirror-coordinator/src/test/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShardTest.java
+++ b/mirror-coordinator/src/test/java/org/apache/kafka/coordinator/mirror/ClusterMirrorCoordinatorShardTest.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.mirror;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.FencedStateEpochException;
+import org.apache.kafka.common.message.ReadMirrorStatesResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
+import org.apache.kafka.coordinator.common.runtime.CoordinatorResult;
+import org.apache.kafka.coordinator.mirror.generated.MirrorPartitionStateKey;
+import org.apache.kafka.coordinator.mirror.generated.MirrorPartitionStateValue;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.MirrorPartitionState;
+import org.apache.kafka.timeline.SnapshotRegistry;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import static org.apache.kafka.common.internals.Topic.MIRROR_STATE_TOPIC_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClusterMirrorCoordinatorShardTest {
+    private static final String MIRROR_NAME = "my-mirror";
+    private static final Uuid TOPIC_ID = Uuid.randomUuid();
+    private static final String TOPIC_NAME = "my-topic";
+    private static final TopicPartition TP0 = new TopicPartition(TOPIC_NAME, 0);
+    private static final TopicPartition TP1 = new TopicPartition(TOPIC_NAME, 1);
+
+    private SnapshotRegistry snapshotRegistry;
+    private TestCoreBridge coreBridge;
+    private ClusterMirrorCoordinatorShard shard;
+
+    @BeforeEach
+    void setUp() {
+        LogContext logContext = new LogContext();
+        snapshotRegistry = new SnapshotRegistry(logContext);
+        coreBridge = new TestCoreBridge();
+        shard = new ClusterMirrorCoordinatorShard.Builder(coreBridge, 1)
+                .withLogContext(logContext)
+                .withTopicPartition(new TopicPartition(MIRROR_STATE_TOPIC_NAME, 0))
+                .withSnapshotRegistry(snapshotRegistry)
+                .build();
+    }
+
+    @Test
+    void testWritePartitionStateIncrementsEpoch() {
+        CoordinatorResult<Void, CoordinatorRecord> result =
+                shard.writePartitionState(MIRROR_NAME, TP0, MirrorPartitionState.LOG_TRUNCATION, -1, null, false);
+
+        assertEquals(1, result.records().size());
+        MirrorPartitionStateValue val = (MirrorPartitionStateValue) result.records().get(0).value().message();
+        assertEquals(1, val.stateEpoch());
+    }
+
+    @Test
+    void testWritePartitionStateIncrementsEpochSequentially() {
+        CoordinatorResult<Void, CoordinatorRecord> first =
+                shard.writePartitionState(MIRROR_NAME, TP0, MirrorPartitionState.LOG_TRUNCATION, -1, null, false);
+        replayRecords(first);
+
+        CoordinatorResult<Void, CoordinatorRecord> second =
+                shard.writePartitionState(MIRROR_NAME, TP0, MirrorPartitionState.MIRRORING, -1, null, false);
+
+        assertEquals(1, second.records().size());
+        MirrorPartitionStateValue val = (MirrorPartitionStateValue) second.records().get(0).value().message();
+        assertEquals(2, val.stateEpoch());
+    }
+
+    @Test
+    void testWritePartitionStateFencedEpoch() {
+        replayState(TP0, MirrorPartitionState.LOG_TRUNCATION, 5);
+
+        assertThrows(FencedStateEpochException.class, () ->
+                shard.writePartitionState(MIRROR_NAME, TP0, MirrorPartitionState.MIRRORING, 3, null, false));
+    }
+
+    @Test
+    void testWritePartitionStateFencedProducesNoRecords() {
+        replayState(TP0, MirrorPartitionState.LOG_TRUNCATION, 5);
+
+        try {
+            shard.writePartitionState(MIRROR_NAME, TP0, MirrorPartitionState.MIRRORING, 3, null, false);
+        } catch (FencedStateEpochException ignored) {
+        }
+
+        MirrorPartition mp = coreBridge.getPartition(
+                MirrorPartitionKey.of(MIRROR_NAME, TOPIC_ID, 0));
+        assertEquals(MirrorPartitionState.LOG_TRUNCATION, mp.state());
+        assertEquals(5, mp.stateEpoch());
+    }
+
+    @Test
+    void testWritePartitionStateSkipsCheckWhenMinusOne() {
+        replayState(TP0, MirrorPartitionState.LOG_TRUNCATION, 10);
+
+        CoordinatorResult<Void, CoordinatorRecord> result =
+                shard.writePartitionState(MIRROR_NAME, TP0, MirrorPartitionState.MIRRORING, -1, null, false);
+
+        assertEquals(1, result.records().size());
+        MirrorPartitionStateValue val = (MirrorPartitionStateValue) result.records().get(0).value().message();
+        assertEquals(11, val.stateEpoch());
+    }
+
+    @Test
+    void testWriteStateBatchedFencing() {
+        replayState(TP0, MirrorPartitionState.LOG_TRUNCATION, 5);
+        replayState(TP1, MirrorPartitionState.LOG_TRUNCATION, 3);
+
+        Map<String, Set<ClusterMirrorCoordinatorService.MirrorStateWrite>> mirrorStates = Map.of(
+                TOPIC_NAME, Set.of(
+                        new ClusterMirrorCoordinatorService.MirrorStateWrite(0, MirrorPartitionState.MIRRORING, 2, -1),
+                        new ClusterMirrorCoordinatorService.MirrorStateWrite(1, MirrorPartitionState.MIRRORING, 3, -1)));
+
+        CoordinatorResult<Map<TopicPartition, ClusterMirrorCoordinatorShard.PartitionWriteResult>, CoordinatorRecord> result =
+                shard.writeState(MIRROR_NAME, mirrorStates);
+
+        Map<TopicPartition, ClusterMirrorCoordinatorShard.PartitionWriteResult> results = result.response();
+
+        assertEquals(Errors.FENCED_STATE_EPOCH, results.get(TP0).error());
+        assertEquals(-1, results.get(TP0).stateEpoch());
+
+        assertEquals(Errors.NONE, results.get(TP1).error());
+        assertEquals(4, results.get(TP1).stateEpoch());
+
+        assertFalse(result.records().isEmpty());
+    }
+
+    @Test
+    void testReplayPopulatesStateEpoch() {
+        replayState(TP0, MirrorPartitionState.LOG_TRUNCATION, 7);
+
+        MirrorPartition mp = coreBridge.getPartition(
+                MirrorPartitionKey.of(MIRROR_NAME, TOPIC_ID, 0));
+        assertEquals(7, mp.stateEpoch());
+        assertEquals(MirrorPartitionState.LOG_TRUNCATION, mp.state());
+    }
+
+    @Test
+    void testReadStateIncludesEpoch() {
+        replayState(TP0, MirrorPartitionState.LOG_TRUNCATION, 4);
+
+        ReadMirrorStatesResponseData data = shard.readState(MIRROR_NAME,
+                Map.of(TOPIC_NAME, Set.of(0)));
+
+        ReadMirrorStatesResponseData.PartitionResult pr =
+                data.topics().get(0).partitions().get(0);
+        assertEquals(4, pr.stateEpoch());
+        assertEquals(MirrorPartitionState.LOG_TRUNCATION.value(), pr.state());
+    }
+
+    @Test
+    void testTombstoneRemovesEpoch() {
+        replayState(TP0, MirrorPartitionState.LOG_TRUNCATION, 5);
+
+        MirrorPartitionStateKey key = new MirrorPartitionStateKey()
+                .setMirrorName(MIRROR_NAME)
+                .setTopicId(TOPIC_ID)
+                .setPartition(0);
+        shard.replay(0, -1, (short) -1,
+                CoordinatorRecord.tombstone(key));
+
+        MirrorPartition mp = coreBridge.getPartition(
+                MirrorPartitionKey.of(MIRROR_NAME, TOPIC_ID, 0));
+        assertTrue(mp == null || mp.stateEpoch() == 0);
+    }
+
+    @Test
+    void testBrokersRaceSimulation() {
+        replayState(TP0, MirrorPartitionState.LOG_TRUNCATION, 5);
+
+        CoordinatorResult<Void, CoordinatorRecord> firstWrite =
+                shard.writePartitionState(MIRROR_NAME, TP0, MirrorPartitionState.FAILED, 5, "error", false);
+        assertEquals(1, firstWrite.records().size());
+
+        assertThrows(FencedStateEpochException.class, () ->
+                shard.writePartitionState(MIRROR_NAME, TP0, MirrorPartitionState.MIRRORING, 5, null, false));
+    }
+
+    private void replayRecords(CoordinatorResult<?, CoordinatorRecord> result) {
+        for (CoordinatorRecord record : result.records()) {
+            shard.replay(0, -1, (short) -1, record);
+        }
+    }
+
+    private void replayState(TopicPartition tp, MirrorPartitionState state, int stateEpoch) {
+        MirrorPartitionStateKey key = new MirrorPartitionStateKey()
+                .setMirrorName(MIRROR_NAME)
+                .setTopicId(TOPIC_ID)
+                .setPartition(tp.partition());
+        MirrorPartitionStateValue val = new MirrorPartitionStateValue()
+                .setState(state.value())
+                .setStateEpoch(stateEpoch)
+                .setPreviousState(MirrorPartitionState.UNKNOWN.value());
+        shard.replay(0, -1, (short) -1,
+                CoordinatorRecord.record(key, new ApiMessageAndVersion(val, (short) 0)));
+    }
+
+    private static class TestCoreBridge implements CoreBridge {
+        private final Map<MirrorPartitionKey, MirrorPartition> partitions = new ConcurrentHashMap<>();
+
+        @Override
+        public void initialize(CoordinatorWriter coordinatorWriter,
+                               Function<MirrorPartitionKey, Integer> coordPartFinder) {
+        }
+
+        @Override
+        public void closeSourceAdmins() {
+        }
+
+        @Override
+        public void onShardLoaded() {
+        }
+
+        @Override
+        public void onShardUnloaded(int coordPartition, int coordPartitionCount) {
+        }
+
+        @Override
+        public MirrorPartition getPartition(MirrorPartitionKey key) {
+            return partitions.get(key);
+        }
+
+        @Override
+        public void setPartition(MirrorPartitionKey key, MirrorPartition partition) {
+            partitions.put(key, partition);
+        }
+
+        @Override
+        public void removePartition(MirrorPartitionKey key) {
+            partitions.remove(key);
+        }
+
+        @Override
+        public void updateFailedInfo(MirrorPartitionKey key, MirrorPartitionState curState,
+                                     MirrorPartitionState newState, String errorMessage, boolean nonRetryable) {
+            if (newState == MirrorPartitionState.FAILED) {
+                MirrorPartition existing = MirrorPartition.orEmpty(getPartition(key));
+                int attempt = existing.nextAttempt(nonRetryable);
+                MirrorPartitionState previousState = existing.resolvePrevState(curState);
+                partitions.compute(key, (k, e) ->
+                        MirrorPartition.orEmpty(e).withError(errorMessage, attempt, previousState));
+            } else if (newState == MirrorPartitionState.LOG_TRUNCATION
+                    || newState == MirrorPartitionState.STOPPED
+                    || newState == MirrorPartitionState.PAUSED) {
+                partitions.computeIfPresent(key, (k, existing) -> existing.clearError());
+            }
+        }
+
+        @Override
+        public void setLastMirrorEpoch(String mirrorName, String topic, int partition, int epoch) {
+        }
+
+        @Override
+        public Uuid getTopicId(String topicName) {
+            return TOPIC_ID;
+        }
+
+        @Override
+        public Optional<String> getTopicName(Uuid topicId) {
+            return Optional.of(TOPIC_NAME);
+        }
+    }
+}


### PR DESCRIPTION
There is a cross-broker race in MirrorMetadataManager. Two brokers can independently read mirror partition state, decide on a transition, and write back concurrently. The coordinator serializes individual operations but not the read-decide-write sequence. A broker can overwrite another broker's legitimate state transition because its read was stale.

The fix adds a monotonically increasing stateEpoch counter to each mirror partition. Every state transition increments it. Writes carry the expected epoch; the coordinator rejects writes where the expected epoch is behind the current value, returning FENCED_STATE_EPOCH (error code 124, already exists for the share coordinator). The fenced broker drops the stale write; the next metadata cycle re-reads and re-evaluates.

FAILED transitions must never be blocked by fencing. FAILED is the safety net for error recovery. When it gets fenced, errors are silently lost and the partition gets stuck.